### PR TITLE
fix: Renane `migrable` to `migratable`

### DIFF
--- a/apps/vaults/Wrapper.tsx
+++ b/apps/vaults/Wrapper.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import meta from 'public/apps/vaults-manifest.json';
 import {AppSettingsContextApp} from '@vaults/contexts/useAppSettings';
-import {MigrableContextApp} from '@vaults/contexts/useMigrable';
-import {MigrableWalletContextApp} from '@vaults/contexts/useMigrableWallet';
+import {MigratableContextApp} from '@vaults/contexts/useMigratable';
+import {MigratableWalletContextApp} from '@vaults/contexts/useMigratableWallet';
 import Meta from '@common/components/Meta';
 
 import type {ReactElement} from 'react';
@@ -12,11 +12,11 @@ export default function Wrapper({children}: {children: ReactElement}): ReactElem
 		<>
 			<Meta meta={meta} />
 			<AppSettingsContextApp>
-				<MigrableContextApp>
-					<MigrableWalletContextApp>
+				<MigratableContextApp>
+					<MigratableWalletContextApp>
 						{children}
-					</MigrableWalletContextApp>
-				</MigrableContextApp>
+					</MigratableWalletContextApp>
+				</MigratableContextApp>
 			</AppSettingsContextApp>
 		</>
 	);

--- a/apps/vaults/components/list/VaultsListMigrableRow.tsx
+++ b/apps/vaults/components/list/VaultsListMigrableRow.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo, useState} from 'react';
 import {ethers} from 'ethers';
-import {useMigrableWallet} from '@vaults/contexts/useMigrableWallet';
+import {useMigratableWallet} from '@vaults/contexts/useMigratableWallet';
 import {Button} from '@yearn-finance/web-lib/components/Button';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import {useChainID} from '@yearn-finance/web-lib/hooks/useChainID';
@@ -16,9 +16,9 @@ import {migrateShares} from '@common/utils/actions/migrateShares';
 import type {ReactElement} from 'react';
 import type {TYearnVault} from '@common/types/yearn';
 
-function	VaultsListMigrableRow({currentVault}: {currentVault: TYearnVault}): ReactElement {
+function	VaultsListMigratableRow({currentVault}: {currentVault: TYearnVault}): ReactElement {
 	const {isActive, provider} = useWeb3();
-	const {balances, refresh} = useMigrableWallet();
+	const {balances, refresh} = useMigratableWallet();
 	const {safeChainID} = useChainID();
 	const [txStatus, set_txStatus] = useState(defaultTxStatus);
 
@@ -90,4 +90,4 @@ function	VaultsListMigrableRow({currentVault}: {currentVault: TYearnVault}): Rea
 	);
 }
 
-export {VaultsListMigrableRow};
+export {VaultsListMigratableRow};

--- a/apps/vaults/contexts/useMigratable.tsx
+++ b/apps/vaults/contexts/useMigratable.tsx
@@ -11,17 +11,17 @@ import type {SWRResponse} from 'swr';
 import type {TDict} from '@yearn-finance/web-lib/utils/types';
 import type {TYearnVault} from '@common/types/yearn';
 
-export type	TMigrableContext = {
-	migrable: TDict<TYearnVault | undefined>,
-	isLoadingMigrableList: boolean,
+export type	TMigratableContext = {
+	migratable: TDict<TYearnVault | undefined>,
+	isLoadingMigratableList: boolean,
 }
-const	defaultProps: TMigrableContext = {
-	migrable: {[ethers.constants.AddressZero]: undefined},
-	isLoadingMigrableList: false
+const	defaultProps: TMigratableContext = {
+	migratable: {[ethers.constants.AddressZero]: undefined},
+	isLoadingMigratableList: false
 };
 
-const	MigrableContext = createContext<TMigrableContext>(defaultProps);
-export const MigrableContextApp = memo(function MigrableContextApp({children}: {children: ReactElement}): ReactElement {
+const	MigratableContext = createContext<TMigratableContext>(defaultProps);
+export const MigratableContextApp = memo(function MigratableContextApp({children}: {children: ReactElement}): ReactElement {
 	const {safeChainID} = useChainID();
 	const {settings: baseAPISettings} = useSettings();
 
@@ -30,34 +30,34 @@ export const MigrableContextApp = memo(function MigrableContextApp({children}: {
 	**	we need to fetch the data from the API, especially to get the
 	**	apy.net_apy
 	***************************************************************************/
-	const	{data: migrableVaults, isLoading: isLoadingMigrableList} = useSWR(
-		`${baseAPISettings.yDaemonBaseURI}/${safeChainID}/vaults/all?migrable=nodust`,
+	const	{data: migratableVaults, isLoading: isLoadingMigratableList} = useSWR(
+		`${baseAPISettings.yDaemonBaseURI}/${safeChainID}/vaults/all?migratable=nodust`,
 		baseFetcher,
 		{revalidateOnFocus: false}
 	) as SWRResponse;
 
-	const	migrableVaultsObject = useMemo((): TDict<TYearnVault> => {
-		const	_migrableVaultsObject = (migrableVaults || []).reduce((acc: TDict<TYearnVault>, vault: TYearnVault): TDict<TYearnVault> => {
+	const	migratableVaultsObject = useMemo((): TDict<TYearnVault> => {
+		const	_migratableVaultsObject = (migratableVaults || []).reduce((acc: TDict<TYearnVault>, vault: TYearnVault): TDict<TYearnVault> => {
 			acc[toAddress(vault.address)] = vault;
 			return acc;
 		}, {});
-		return _migrableVaultsObject;
-	}, [migrableVaults]);
+		return _migratableVaultsObject;
+	}, [migratableVaults]);
 
 	/* 🔵 - Yearn Finance ******************************************************
 	**	Setup and render the Context provider to use in the app.
 	***************************************************************************/
-	const	contextValue = useMemo((): TMigrableContext => ({
-		migrable: {...migrableVaultsObject},
-		isLoadingMigrableList
-	}), [migrableVaultsObject, isLoadingMigrableList]);
+	const	contextValue = useMemo((): TMigratableContext => ({
+		migratable: {...migratableVaultsObject},
+		isLoadingMigratableList
+	}), [migratableVaultsObject, isLoadingMigratableList]);
 
 	return (
-		<MigrableContext.Provider value={contextValue}>
+		<MigratableContext.Provider value={contextValue}>
 			{children}
-		</MigrableContext.Provider>
+		</MigratableContext.Provider>
 	);
 });
 
-export const useMigrable = (): TMigrableContext => useContext(MigrableContext);
-export default useMigrable;
+export const useMigratable = (): TMigratableContext => useContext(MigratableContext);
+export default useMigratable;

--- a/apps/vaults/contexts/useMigratableWallet.tsx
+++ b/apps/vaults/contexts/useMigratableWallet.tsx
@@ -1,7 +1,7 @@
 import React, {createContext, memo, useCallback, useContext, useMemo, useState} from 'react';
 // eslint-disable-next-line import/no-named-as-default
 import NProgress from 'nprogress';
-import {useMigrable} from '@vaults/contexts/useMigrable';
+import {useMigratable} from '@vaults/contexts/useMigratable';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import {useBalances} from '@yearn-finance/web-lib/hooks/useBalances';
 import {useChainID} from '@yearn-finance/web-lib/hooks/useChainID';
@@ -14,7 +14,7 @@ import type {TBalanceData, TUseBalancesTokens} from '@yearn-finance/web-lib/hook
 import type {TDict} from '@yearn-finance/web-lib/utils/types';
 import type {TYearnVault} from '@common/types/yearn';
 
-export type	TMigrableWalletContext = {
+export type	TMigratableWalletContext = {
 	balances: TDict<TBalanceData>,
 	useWalletNonce: number,
 	isLoading: boolean,
@@ -33,27 +33,27 @@ const	defaultProps = {
 ** This context controls most of the user's wallet data we may need to
 ** interact with our app, aka mostly the balances and the token prices.
 ******************************************************************************/
-const	MigrableWalletContext = createContext<TMigrableWalletContext>(defaultProps);
-export const MigrableWalletContextApp = memo(function MigrableWalletContextApp({children}: {children: ReactElement}): ReactElement {
+const	MigratableWalletContext = createContext<TMigratableWalletContext>(defaultProps);
+export const MigratableWalletContextApp = memo(function MigratableWalletContextApp({children}: {children: ReactElement}): ReactElement {
 	const	[nonce, set_nonce] = useState<number>(0);
 	const	{provider} = useWeb3();
 	const	{prices} = useYearn();
 	const	{chainID} = useChainID();
-	const	{migrable, isLoadingMigrableList} = useMigrable();
+	const	{migratable, isLoadingMigratableList} = useMigratable();
 
 	const	availableTokens = useMemo((): TUseBalancesTokens[] => {
-		if (isLoadingMigrableList) {
+		if (isLoadingMigratableList) {
 			return [];
 		}
 		const	tokens: TUseBalancesTokens[] = [];
-		Object.values(migrable || {}).forEach((vault?: TYearnVault): void => {
+		Object.values(migratable || {}).forEach((vault?: TYearnVault): void => {
 			if (!vault) {
 				return;
 			}
 			tokens.push({token: vault?.address});
 		});
 		return tokens;
-	}, [migrable, isLoadingMigrableList]);
+	}, [migratable, isLoadingMigratableList]);
 
 	const	{data: balances, update: updateBalances, isLoading: isLoadingBalances} = useBalances({
 		key: chainID,
@@ -82,7 +82,7 @@ export const MigrableWalletContextApp = memo(function MigrableWalletContextApp({
 	/* 🔵 - Yearn Finance ******************************************************
 	**	Setup and render the Context provider to use in the app.
 	***************************************************************************/
-	const	contextValue = useMemo((): TMigrableWalletContext => ({
+	const	contextValue = useMemo((): TMigratableWalletContext => ({
 		balances: balances,
 		isLoading: isLoadingBalances,
 		refresh: onRefresh,
@@ -90,12 +90,12 @@ export const MigrableWalletContextApp = memo(function MigrableWalletContextApp({
 	}), [balances, isLoadingBalances, onRefresh, nonce]);
 
 	return (
-		<MigrableWalletContext.Provider value={contextValue}>
+		<MigratableWalletContext.Provider value={contextValue}>
 			{children}
-		</MigrableWalletContext.Provider>
+		</MigratableWalletContext.Provider>
 	);
 });
 
 
-export const useMigrableWallet = (): TMigrableWalletContext => useContext(MigrableWalletContext);
-export default useMigrableWallet;
+export const useMigratableWallet = (): TMigratableWalletContext => useContext(MigratableWalletContext);
+export default useMigratableWallet;

--- a/pages/vaults/index.tsx
+++ b/pages/vaults/index.tsx
@@ -2,11 +2,11 @@ import React, {Fragment, useCallback, useEffect, useMemo, useState} from 'react'
 import {ethers} from 'ethers';
 import VaultListOptions from '@vaults/components/list/VaultListOptions';
 import {VaultsListEmpty} from '@vaults/components/list/VaultsListEmpty';
-import {VaultsListMigrableRow} from '@vaults/components/list/VaultsListMigrableRow';
+import {VaultsListMigratableRow} from '@vaults/components/list/VaultsListMigratableRow';
 import {VaultsListRow} from '@vaults/components/list/VaultsListRow';
 import {useAppSettings} from '@vaults/contexts/useAppSettings';
-import {useMigrable} from '@vaults/contexts/useMigrable';
-import {useMigrableWallet} from '@vaults/contexts/useMigrableWallet';
+import {useMigratable} from '@vaults/contexts/useMigratable';
+import {useMigratableWallet} from '@vaults/contexts/useMigratableWallet';
 import {useFilteredVaults} from '@vaults/hooks/useFilteredVaults';
 import {useSortVaults} from '@vaults/hooks/useSortVaults';
 import Wrapper from '@vaults/Wrapper';
@@ -61,8 +61,8 @@ function	HeaderUserPosition(): ReactElement {
 function	Index(): ReactElement {
 	const	{balances} = useWallet();
 	const	{vaults, isLoadingVaultList} = useYearn();
-	const	{migrable, isLoadingMigrableList} = useMigrable();
-	const	{balances: migrableBalance} = useMigrableWallet();
+	const	{migratable, isLoadingMigratableList} = useMigratable();
+	const	{balances: migratableBalance} = useMigratableWallet();
 	const	{safeChainID} = useChainID();
 	const	[sortBy, set_sortBy] = useState<TPossibleSortBy>('apy');
 	const	[sortDirection, set_sortDirection] = useState<TPossibleSortDirection>('');
@@ -76,7 +76,7 @@ function	Index(): ReactElement {
 	const	stablesVaults = useFilteredVaults(vaults, ({category}): boolean => category === 'Stablecoin');
 	const	balancerVaults = useFilteredVaults(vaults, ({category}): boolean => category === 'Balancer');
 	const	cryptoVaults = useFilteredVaults(vaults, ({category}): boolean => category === 'Volatile');
-	const	migrableVaults = useFilteredVaults(migrable, ({address}): boolean => (migrableBalance?.[toAddress(address)]?.raw)?.gt(0));
+	const	migratableVaults = useFilteredVaults(migratable, ({address}): boolean => (migratableBalance?.[toAddress(address)]?.raw)?.gt(0));
 	const	holdingsVaults = useFilteredVaults(vaults, ({address}): boolean => {
 		const	holding = balances?.[toAddress(address)];
 		const	hasValidBalance = (holding?.raw || ethers.constants.Zero).gt(0);
@@ -170,10 +170,10 @@ function	Index(): ReactElement {
 	**	It contains either the list of vaults, is some are available, or a message to the user.
 	**********************************************************************************************/
 	const	VaultList = useMemo((): ReactNode => {
-		if (isLoadingMigrableList && category === 'Holdings') {
+		if (isLoadingMigratableList && category === 'Holdings') {
 			return (
 				<VaultsListEmpty
-					isLoading={isLoadingMigrableList}
+					isLoading={isLoadingMigratableList}
 					sortedVaultsToDisplay={sortedVaultsToDisplay}
 					currentCategory={category} />
 			);
@@ -194,7 +194,7 @@ function	Index(): ReactElement {
 				return <VaultsListRow key={vault.address} currentVault={vault} />;
 			})
 		);
-	}, [isLoadingMigrableList, category, isLoadingVaultList, sortedVaultsToDisplay]);
+	}, [isLoadingMigratableList, category, isLoadingVaultList, sortedVaultsToDisplay]);
 
 	return (
 		<section className={'mt-4 grid w-full grid-cols-12 gap-y-10 pb-10 md:mt-20 md:gap-x-10 md:gap-y-20'}>
@@ -225,7 +225,7 @@ function	Index(): ReactElement {
 								node: (
 									<Fragment>
 										{'Holdings'}
-										<span className={`absolute -top-1 -right-1 flex h-2 w-2 ${category === 'Holdings' || migrableVaults?.length === 0 ? 'opacity-0' : 'opacity-100'}`}>
+										<span className={`absolute -top-1 -right-1 flex h-2 w-2 ${category === 'Holdings' || migratableVaults?.length === 0 ? 'opacity-0' : 'opacity-100'}`}>
 											<span className={'absolute inline-flex h-full w-full animate-ping rounded-full bg-pink-600 opacity-75'}></span>
 											<span className={'relative inline-flex h-2 w-2 rounded-full bg-pink-500'}></span>
 										</span>
@@ -238,14 +238,14 @@ function	Index(): ReactElement {
 					searchValue={searchValue}
 					set_searchValue={set_searchValue} />
 
-				{category === 'Holdings' && migrableVaults?.length > 0 ? (
+				{category === 'Holdings' && migratableVaults?.length > 0 ? (
 					<div className={'my-4'}>
-						{migrableVaults.map((vault): ReactNode => {
+						{migratableVaults.map((vault): ReactNode => {
 							if (!vault) {
 								return (null);
 							}
 							return (
-								<VaultsListMigrableRow key={vault.address} currentVault={vault} />
+								<VaultsListMigratableRow key={vault.address} currentVault={vault} />
 							);
 						})}
 					</div>


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Renane `migrable` to `migratable`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The correct way of spelling is [migratable](https://en.wiktionary.org/wiki/migratable), not "migrable"

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally