### PR TITLE
feat: Pattern for multiple external service support

### DIFF
--- a/apps/common/hooks/useExternalQuote.ts
+++ b/apps/common/hooks/useExternalQuote.ts
@@ -1,4 +1,4 @@
-import {quote as widoQuote} from 'wido';
+import {quote} from 'quote';
 
 import type {QuoteRequest as TWidoRequest, QuoteResult as TWidoResult} from 'wido';
 
@@ -21,9 +21,13 @@ type TPortalsResult = {
 
 export type TPortalsQuote = { req: { type: 'portals'; request: TPortalsRequest }; res: TPortalsResult };
 
+// TODO
+export type TCowQuote = { req: { type: 'cow'; request: unknown }; res: unknown };
+
 type TExternalService<T> =
     T extends 'wido' ? TWidoQuote :
     T extends 'portals' ? TPortalsQuote :
+    T extends 'cow' ? TCowQuote :
 	never;
 
 export async function useExternalQuote<T>({type, request}: TExternalService<T>['req']): Promise<TExternalService<T>['res']> {
@@ -32,13 +36,23 @@ export async function useExternalQuote<T>({type, request}: TExternalService<T>['
 		return widoQuote(request);
 	case 'portals':
 		return portalsQuote(request);
+	case 'cow':
+		return cowQuote(request);
 	default:
 		throw new Error(`Unknown service ${type}`);
 	}
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function portalsQuote(request: TPortalsRequest): Promise<TPortalsQuote['res']> {
+async function widoQuote(request: TWidoQuote['req']['request']): Promise<TWidoQuote['res']> {
+	return quote(request);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
+async function portalsQuote(_request: TPortalsQuote['req']['request']): Promise<TPortalsQuote['res']> {
 	throw new Error('Function not implemented.');
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
+async function cowQuote(_request: TCowQuote['req']['request']): Promise<TCowQuote['res']> {
+	throw new Error('Function not implemented.');
+}

--- a/apps/common/hooks/useExternalQuote.ts
+++ b/apps/common/hooks/useExternalQuote.ts
@@ -1,0 +1,44 @@
+import {quote as widoQuote} from 'wido';
+
+import type {QuoteRequest as TWidoRequest, QuoteResult as TWidoResult} from 'wido';
+
+export type TWidoQuote = { req: { type: 'wido'; request: TWidoRequest }; res: TWidoResult };
+
+type TPortalsRequest = {
+    network: string; // The network to use (ethereum, avalanche, etc.)
+    sellToken: string; // The ERC20 token address to spend
+    sellAmount: string; // The quantity of `sellToken` to spend
+    buyToken: string; // The ERC20 token address to buy (e.g. a Curve or Sushiswap pool, or a basic token like DAI). Use address(0) for the network token
+    slippagePercentage: number; // The maximum acceptable slippage for the portal. Must be a number between 0 and 1 (e.g. 0.005 for 0.5%)
+}
+
+type TPortalsResult = {
+    buyToken: string;
+    buyAmount: string;
+    minBuyAmount: string;
+    buyTokenDecimals: number;
+}
+
+export type TPortalsQuote = { req: { type: 'portals'; request: TPortalsRequest }; res: TPortalsResult };
+
+type TExternalService<T> =
+    T extends 'wido' ? TWidoQuote :
+    T extends 'portals' ? TPortalsQuote :
+	never;
+
+export async function useExternalQuote<T>({type, request}: TExternalService<T>['req']): Promise<TExternalService<T>['res']> {
+	switch (type) {
+	case 'wido':
+		return widoQuote(request);
+	case 'portals':
+		return portalsQuote(request);
+	default:
+		throw new Error(`Unknown service ${type}`);
+	}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+async function portalsQuote(request: TPortalsRequest): Promise<TPortalsQuote['res']> {
+	throw new Error('Function not implemented.');
+}
+

--- a/apps/common/hooks/useExternalQuote.ts
+++ b/apps/common/hooks/useExternalQuote.ts
@@ -31,6 +31,10 @@ type TExternalService<T> =
 	never;
 
 export async function useExternalQuote<T>({type, request}: TExternalService<T>['req']): Promise<TExternalService<T>['res']> {
+	const {quote: widoQuote} = useWidoQuote();
+	const {quote: portalsQuote} = usePortalsQuote();
+	const {quote: cowQuote} = useCowQuote();
+
 	switch (type) {
 	case 'wido':
 		return widoQuote(request);
@@ -43,16 +47,16 @@ export async function useExternalQuote<T>({type, request}: TExternalService<T>['
 	}
 }
 
-async function widoQuote(request: TWidoQuote['req']['request']): Promise<TWidoQuote['res']> {
-	return quote(request);
+function useWidoQuote(): { quote: (req: TWidoQuote['req']['request']) => Promise<TWidoQuote['res']>} {
+	return {quote: async (request): Promise<TWidoResult> => quote(request)};
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
-async function portalsQuote(_request: TPortalsQuote['req']['request']): Promise<TPortalsQuote['res']> {
+function usePortalsQuote(): { quote: (req: TPortalsQuote['req']['request']) => Promise<TPortalsQuote['res']>} {
 	throw new Error('Function not implemented.');
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
-async function cowQuote(_request: TCowQuote['req']['request']): Promise<TCowQuote['res']> {
+function useCowQuote(): { quote: (req: TCowQuote['req']['request']) => Promise<TCowQuote['res']>} {
 	throw new Error('Function not implemented.');
 }

--- a/apps/common/hooks/useExternalQuote.ts
+++ b/apps/common/hooks/useExternalQuote.ts
@@ -1,6 +1,17 @@
-import {quote} from 'quote';
+import {useCallback, useEffect, useMemo} from 'react';
+import {BigNumber} from 'ethers';
+import axios from 'axios';
+import useSWRMutation from 'swr/mutation';
+import {OrderKind} from '@gnosis.pm/gp-v2-contracts';
+import {isZeroAddress} from '@yearn-finance/web-lib/utils/address';
+import {formatBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
 
 import type {QuoteRequest as TWidoRequest, QuoteResult as TWidoResult} from 'wido';
+import type {TAddress} from '@yearn-finance/web-lib/utils/address';
+import type {TDict} from '@yearn-finance/web-lib/utils/types';
+import type {Order, QuoteQuery} from '@gnosis.pm/gp-v2-contracts';
+
+export type TPossibleExternalServices = 'wido' | 'portals' | 'cowswap';
 
 export type TWidoQuote = { req: { type: 'wido'; request: TWidoRequest }; res: TWidoResult };
 
@@ -11,52 +22,127 @@ type TPortalsRequest = {
     buyToken: string; // The ERC20 token address to buy (e.g. a Curve or Sushiswap pool, or a basic token like DAI). Use address(0) for the network token
     slippagePercentage: number; // The maximum acceptable slippage for the portal. Must be a number between 0 and 1 (e.g. 0.005 for 0.5%)
 }
-
 type TPortalsResult = {
     buyToken: string;
     buyAmount: string;
     minBuyAmount: string;
     buyTokenDecimals: number;
 }
-
 export type TPortalsQuote = { req: { type: 'portals'; request: TPortalsRequest }; res: TPortalsResult };
-
-// TODO
-export type TCowQuote = { req: { type: 'cow'; request: unknown }; res: unknown };
 
 type TExternalService<T> =
     T extends 'wido' ? TWidoQuote :
     T extends 'portals' ? TPortalsQuote :
-    T extends 'cow' ? TCowQuote :
+	T extends 'cowswap' ? TCowQuote :
 	never;
 
-export async function useExternalQuote<T>({type, request}: TExternalService<T>['req']): Promise<TExternalService<T>['res']> {
-	const {quote: widoQuote} = useWidoQuote();
-	const {quote: portalsQuote} = usePortalsQuote();
-	const {quote: cowQuote} = useCowQuote();
-
-	switch (type) {
-	case 'wido':
-		return widoQuote(request);
-	case 'portals':
-		return portalsQuote(request);
-	case 'cow':
-		return cowQuote(request);
-	default:
-		throw new Error(`Unknown service ${type}`);
-	}
-}
-
-function useWidoQuote(): { quote: (req: TWidoQuote['req']['request']) => Promise<TWidoQuote['res']>} {
-	return {quote: async (request): Promise<TWidoResult> => quote(request)};
-}
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
-function usePortalsQuote(): { quote: (req: TPortalsQuote['req']['request']) => Promise<TPortalsQuote['res']>} {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function usePortalsQuote(request: TPortalsRequest, provider?: string): TPortalsResult {
 	throw new Error('Function not implemented.');
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
-function useCowQuote(): { quote: (req: TCowQuote['req']['request']) => Promise<TCowQuote['res']>} {
-	throw new Error('Function not implemented.');
+
+/* 🔵 - Yearn Finance ******************************************************
+**	Cowswap Solver
+***************************************************************************/
+export type TCowRequest = {
+	from: TAddress,
+    sellToken: TAddress; // The ERC20 token address to spend
+    buyToken: TAddress; // The ERC20 token address to buy (e.g. a Curve or Sushiswap pool, or a basic token like DAI). Use address(0) for the network token
+    sellAmount: BigNumber; // The quantity of `sellToken` to spend
+}
+type TCowAPIResult = {
+	quote: Order;
+	from: string;
+	expiration: string;
+	id: number;
+}
+type TCowResult = {
+	result: TCowAPIResult | undefined,
+	isLoading: boolean,
+	error: Error | undefined
+}
+export type TCowQuote = { req: { type: 'cowswap'; request: TCowRequest }; res: TCowResult };
+
+async function fetchCowQuote(url: string, data: {arg: unknown}): Promise<TCowAPIResult> {
+	return (await axios.post(url, data.arg)).data;
+}
+
+export function useCowQuote(): [TCowResult, CallableFunction] {
+	const {data, error, trigger, isMutating} = useSWRMutation('https://api.cow.fi/mainnet/api/v1/quote', fetchCowQuote);
+
+	const	getQuote = useCallback(async (request: TCowRequest): Promise<void> => {
+		console.warn('TIME TO FETCH SOME DATA');
+		const	YEARN_APP_DATA = '0x2B8694ED30082129598720860E8E972F07AA10D9B81CAE16CA0E2CFB24743E24';
+		const	quote: QuoteQuery = ({
+			from: request.from, // receiver
+			sellToken: request.sellToken, // token to spend
+			buyToken: request.buyToken, // token to receive
+			receiver: request.from, // always the same as from
+			appData: YEARN_APP_DATA, // Always this
+			kind: OrderKind.SELL, // always sell
+			partiallyFillable: false, // always false
+			validTo: 0,
+			sellAmountBeforeFee: formatBN(request?.sellAmount || 0).toString() // amount to sell, in wei
+		});
+
+		const canExecuteFetch = !(isZeroAddress(quote.from) || isZeroAddress(quote.sellToken) || isZeroAddress(quote.buyToken)) && !formatBN(request?.sellAmount || 0).isZero();
+		if (canExecuteFetch) {
+			quote.validTo = Math.round((new Date().setMinutes(new Date().getMinutes() + 10) / 1000));
+			trigger(quote, {revalidate: false});
+		}
+	}, [trigger]);
+
+	return [
+		useMemo((): TCowResult => ({
+			result: data,
+			isLoading: isMutating,
+			error
+		}), [data, error, isMutating]),
+		getQuote
+	];
+}
+
+
+// export function useExternalService<T, TReq>(type: TPossibleExternalServices, request: TCowRequest): TExternalService<T>['res'] {
+// 	const	response = useCowQuote(request, type);
+// 	const	response2 = usePortalsQuote(request, type);
+
+// 	if (type === 'cowswap') {
+// 		return response;
+// 	} else if (type === 'portals') {
+// 		return response2;
+// 	}
+// 	throw new Error('Function not implemented.');
+// }
+
+export function useExternalServiceQuote<T>({type, request}: TExternalService<T>['req']): TExternalService<T>['res'] {
+	const [widoQuote, getWidoQuote] = useCowQuote()/*useWidoQuote()*/;
+	const [portalsQuote, getPortalsQuote] = useCowQuote()/*usePortalsQuote()*/;
+	const [cowQuote, getCowQuote] = useCowQuote();
+
+	const quoteMapping = useMemo((): TDict<[TExternalService<T>['res'], CallableFunction]> => ({
+		'wido': [widoQuote, getWidoQuote],
+		'portals': [portalsQuote, getPortalsQuote],
+		'cowswap': [cowQuote, getCowQuote]
+	}), [cowQuote, getCowQuote, getPortalsQuote, getWidoQuote, portalsQuote, widoQuote]);
+
+	const stringifiedRequest = JSON.stringify(request);
+	useEffect((): void => {
+		const	parsedRequest = JSON.parse(stringifiedRequest, (_key: string, value: T & { type?: string}): T | BigNumber => {
+			if (value?.type === 'BigNumber') {
+				return BigNumber.from(value);
+			}
+			return value;
+		});
+
+		const	[, fetcher] = quoteMapping[type];
+		if (fetcher) {
+			fetcher(parsedRequest);
+		} else {
+			throw new Error(`Unknown service ${type}`);
+		}
+	}, [stringifiedRequest, type]);
+
+	return quoteMapping[type][0];
 }

--- a/apps/common/hooks/useExternalQuote.ts
+++ b/apps/common/hooks/useExternalQuote.ts
@@ -6,14 +6,16 @@ import {OrderKind} from '@gnosis.pm/gp-v2-contracts';
 import {isZeroAddress} from '@yearn-finance/web-lib/utils/address';
 import {formatBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
 
-import type {QuoteRequest as TWidoRequest, QuoteResult as TWidoResult} from 'wido';
+import {useWido} from './useWido';
+
 import type {TAddress} from '@yearn-finance/web-lib/utils/address';
 import type {TDict} from '@yearn-finance/web-lib/utils/types';
 import type {Order, QuoteQuery} from '@gnosis.pm/gp-v2-contracts';
+import type {TUseWido, TWidoResult} from './useWido';
 
 export type TPossibleExternalServices = 'wido' | 'portals' | 'cowswap';
 
-export type TWidoQuote = { req: { type: 'wido'; request: TWidoRequest }; res: TWidoResult };
+export type TWidoQuote = { req: { type: 'wido'; request: TUseWido['getWidoQuote'] }; res: TWidoResult };
 
 type TPortalsRequest = {
     network: string; // The network to use (ethereum, avalanche, etc.)
@@ -117,7 +119,7 @@ export function useCowQuote(): [TCowResult, CallableFunction] {
 // }
 
 export function useExternalServiceQuote<T>({type, request}: TExternalService<T>['req']): TExternalService<T>['res'] {
-	const [widoQuote, getWidoQuote] = useCowQuote()/*useWidoQuote()*/;
+	const {widoQuote, getWidoQuote} = useWido();
 	const [portalsQuote, getPortalsQuote] = useCowQuote()/*usePortalsQuote()*/;
 	const [cowQuote, getCowQuote] = useCowQuote();
 
@@ -142,7 +144,7 @@ export function useExternalServiceQuote<T>({type, request}: TExternalService<T>[
 		} else {
 			throw new Error(`Unknown service ${type}`);
 		}
-	}, [stringifiedRequest, type]);
+	}, [quoteMapping, stringifiedRequest, type]);
 
 	return quoteMapping[type][0];
 }

--- a/apps/common/hooks/useExternalQuote.ts
+++ b/apps/common/hooks/useExternalQuote.ts
@@ -11,11 +11,11 @@ import {useWido} from './useWido';
 import type {TAddress} from '@yearn-finance/web-lib/utils/address';
 import type {TDict} from '@yearn-finance/web-lib/utils/types';
 import type {Order, QuoteQuery} from '@gnosis.pm/gp-v2-contracts';
-import type {TUseWido, TWidoResult} from './useWido';
+import type {TUseWido} from './useWido';
 
-export type TPossibleExternalServices = 'wido' | 'portals' | 'cowswap';
-
-export type TWidoQuote = { req: { type: 'wido'; request: TUseWido['getWidoQuote'] }; res: TWidoResult };
+export type TWidoQuote = { req: { type: 'wido'; request: TUseWido['getWidoQuote'] }; res: TUseWido['widoQuote'] };
+export type TPortalsQuote = { req: { type: 'portals'; request: TPortalsRequest }; res: TPortalsResult };
+export type TCowQuote = { req: { type: 'cowswap'; request: TCowRequest }; res: TCowResult };
 
 type TPortalsRequest = {
     network: string; // The network to use (ethereum, avalanche, etc.)
@@ -30,19 +30,12 @@ type TPortalsResult = {
     minBuyAmount: string;
     buyTokenDecimals: number;
 }
-export type TPortalsQuote = { req: { type: 'portals'; request: TPortalsRequest }; res: TPortalsResult };
 
 type TExternalService<T> =
     T extends 'wido' ? TWidoQuote :
     T extends 'portals' ? TPortalsQuote :
 	T extends 'cowswap' ? TCowQuote :
 	never;
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function usePortalsQuote(request: TPortalsRequest, provider?: string): TPortalsResult {
-	throw new Error('Function not implemented.');
-}
-
 
 /* 🔵 - Yearn Finance ******************************************************
 **	Cowswap Solver
@@ -64,7 +57,6 @@ type TCowResult = {
 	isLoading: boolean,
 	error: Error | undefined
 }
-export type TCowQuote = { req: { type: 'cowswap'; request: TCowRequest }; res: TCowResult };
 
 async function fetchCowQuote(url: string, data: {arg: unknown}): Promise<TCowAPIResult> {
 	return (await axios.post(url, data.arg)).data;

--- a/apps/common/hooks/useExternalQuote.ts
+++ b/apps/common/hooks/useExternalQuote.ts
@@ -6,30 +6,18 @@ import {OrderKind} from '@gnosis.pm/gp-v2-contracts';
 import {isZeroAddress} from '@yearn-finance/web-lib/utils/address';
 import {formatBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
 
+import {usePortals} from './usePortals';
 import {useWido} from './useWido';
 
 import type {TAddress} from '@yearn-finance/web-lib/utils/address';
 import type {TDict} from '@yearn-finance/web-lib/utils/types';
 import type {Order, QuoteQuery} from '@gnosis.pm/gp-v2-contracts';
+import type {TUsePortals} from './usePortals';
 import type {TUseWido} from './useWido';
 
 export type TWidoQuote = { req: { type: 'wido'; request: TUseWido['getWidoQuote'] }; res: TUseWido['widoQuote'] };
-export type TPortalsQuote = { req: { type: 'portals'; request: TPortalsRequest }; res: TPortalsResult };
+export type TPortalsQuote = { req: { type: 'portals'; request: TUsePortals['getPortalsQuote'] }; res: TUsePortals['portalsQuote'] };
 export type TCowQuote = { req: { type: 'cowswap'; request: TCowRequest }; res: TCowResult };
-
-type TPortalsRequest = {
-    network: string; // The network to use (ethereum, avalanche, etc.)
-    sellToken: string; // The ERC20 token address to spend
-    sellAmount: string; // The quantity of `sellToken` to spend
-    buyToken: string; // The ERC20 token address to buy (e.g. a Curve or Sushiswap pool, or a basic token like DAI). Use address(0) for the network token
-    slippagePercentage: number; // The maximum acceptable slippage for the portal. Must be a number between 0 and 1 (e.g. 0.005 for 0.5%)
-}
-type TPortalsResult = {
-    buyToken: string;
-    buyAmount: string;
-    minBuyAmount: string;
-    buyTokenDecimals: number;
-}
 
 type TExternalService<T> =
     T extends 'wido' ? TWidoQuote :
@@ -112,7 +100,7 @@ export function useCowQuote(): [TCowResult, CallableFunction] {
 
 export function useExternalServiceQuote<T>({type, request}: TExternalService<T>['req']): TExternalService<T>['res'] {
 	const {widoQuote, getWidoQuote} = useWido();
-	const [portalsQuote, getPortalsQuote] = useCowQuote()/*usePortalsQuote()*/;
+	const {portalsQuote, getPortalsQuote} = usePortals();
 	const [cowQuote, getCowQuote] = useCowQuote();
 
 	const quoteMapping = useMemo((): TDict<[TExternalService<T>['res'], CallableFunction]> => ({

--- a/apps/common/hooks/usePortals.ts
+++ b/apps/common/hooks/usePortals.ts
@@ -1,0 +1,35 @@
+export type TUsePortals = {
+	portalsQuote: TPortalsResult;
+    getPortalsQuote: (request: TRequest) => Promise<void>;
+}
+
+type TPortalsResult = {
+    isLoading: boolean,
+	result?: TResult;
+	error?: Error;
+}
+
+type TRequest = {
+    network: string; // The network to use (ethereum, avalanche, etc.)
+    sellToken: string; // The ERC20 token address to spend
+    sellAmount: string; // The quantity of `sellToken` to spend
+    buyToken: string; // The ERC20 token address to buy (e.g. a Curve or Sushiswap pool, or a basic token like DAI). Use address(0) for the network token
+    slippagePercentage: number; // The maximum acceptable slippage for the portal. Must be a number between 0 and 1 (e.g. 0.005 for 0.5%)
+}
+
+type TResult = {
+    buyToken: string;
+    buyAmount: string;
+    minBuyAmount: string;
+    buyTokenDecimals: number;
+}
+
+
+export function usePortals(): TUsePortals {
+	return ({
+		portalsQuote: {
+			isLoading: false
+		},
+		getPortalsQuote: async (): Promise<void> => undefined
+	});
+}

--- a/apps/common/hooks/useWido.ts
+++ b/apps/common/hooks/useWido.ts
@@ -8,14 +8,14 @@ import {formatBN} from '@yearn-finance/web-lib/utils/format.bigNumber';
 import type {ethers} from 'ethers';
 import type {QuoteRequest, QuoteResult, TokenAllowanceRequest} from 'wido';
 
-type TUseWido = {
+export type TUseWido = {
     allowance: (request: TokenAllowanceRequest) => Promise<BigNumber>;
 	widoQuote: TWidoResult;
     getWidoQuote: (request: QuoteRequest) => Promise<void>;
     zap: (provider: ethers.providers.Web3Provider, request: QuoteRequest) => Promise<boolean>;
 }
 
-type TWidoResult = {
+export type TWidoResult = {
 	isLoading: boolean,
 	result?: QuoteResult,
 	error?: Error

--- a/apps/common/hooks/useWido.ts
+++ b/apps/common/hooks/useWido.ts
@@ -1,0 +1,41 @@
+import {BigNumber, constants} from 'ethers';
+import {getTokenAllowance, quote} from 'wido';
+
+import type {ethers} from 'ethers';
+import type {QuoteRequest, QuoteResult, TokenAllowanceRequest} from 'wido';
+
+type TUseWido = {
+    allowance: (request: TokenAllowanceRequest) => Promise<BigNumber>;
+    quote: (request: QuoteRequest) => Promise<QuoteResult>;
+    zap: (provider: ethers.providers.Web3Provider, request: QuoteRequest) => Promise<boolean>;
+}
+
+export function useWido(): TUseWido {
+	async function allowance(request: TokenAllowanceRequest): Promise<BigNumber> {
+		try {
+			const {allowance} = await getTokenAllowance(request);
+			return BigNumber.from(allowance);
+		} catch (error) {
+			console.error(error);
+			return constants.Zero;
+		}
+	}
+
+	async function zap(provider: ethers.providers.Web3Provider, request: QuoteRequest): Promise<boolean> {
+		try {
+			const {data, to} = await quote(request);
+            
+			const signer = provider.getSigner();
+			const tx = await signer.sendTransaction({data, to});
+    
+			await tx.wait();
+    
+			return true;
+		} catch (error) {
+			console.error(error);
+			return false;
+		}
+	}
+    
+	return {quote, allowance, zap};
+}

--- a/apps/vaults/components/VaultDetailsQuickActions.tsx
+++ b/apps/vaults/components/VaultDetailsQuickActions.tsx
@@ -20,6 +20,7 @@ import {Dropdown} from '@common/components/TokenDropdown';
 import {useWallet} from '@common/contexts/useWallet';
 import {useYearn} from '@common/contexts/useYearn';
 import {useBalance} from '@common/hooks/useBalance';
+import {useExternalServiceQuote} from '@common/hooks/useExternalQuote';
 import {useTokenPrice} from '@common/hooks/useTokenPrice';
 import IconArrowRight from '@common/icons/IconArrowRight';
 import {formatPercent, handleInputChange} from '@common/utils';
@@ -88,6 +89,19 @@ function	ActionButton({
 	const isOutputTokenEth = selectedOptionTo?.value === ETH_TOKEN_ADDRESS;
 	const isPartnerAddressValid = useMemo((): boolean => !isZeroAddress(toAddress(networks?.[safeChainID]?.partnerContractAddress)), [networks, safeChainID]);
 	const isUsingPartnerContract = useMemo((): boolean => ((process?.env?.SHOULD_USE_PARTNER_CONTRACT || true) === true && isPartnerAddressValid), [isPartnerAddressValid]);
+
+
+	const	cowQuote = useExternalServiceQuote<'cowswap'>({
+		type: 'cowswap',
+		request: {
+			from: toAddress(address || ''),
+			sellToken: toAddress(selectedOptionFrom?.value),
+			buyToken: toAddress(selectedOptionTo?.value),
+			sellAmount: amount.raw
+		}
+	});
+
+	console.log(cowQuote);
 
 	/* 🔵 - Yearn Finance **************************************************************************
 	** Perform a smartContract call to the deposit contract to get the allowance for the deposit

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 		"react-dom": "^18.2.0",
 		"recharts": "^2.2.0",
 		"swr": "^2.0.0",
-		"tailwindcss": "^3.2.4"
+		"tailwindcss": "^3.2.4",
+		"wido": "^0.1.0"
 	},
 	"devDependencies": {
 		"@types/node": "^18.11.13",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"lint": "eslint . --ext .js,.jsx,.ts,.tsx"
 	},
 	"dependencies": {
+		"@gnosis.pm/gp-v2-contracts": "^1.1.2",
 		"@next/bundle-analyzer": "^13.0.6",
 		"@next/font": "^13.0.6",
 		"@yearn-finance/web-lib": "^0.17.52",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6863,6 +6863,11 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+wido@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/wido/-/wido-0.1.0.tgz#98104f85166a8cb49531e20cd7f44513abf74ea7"
+  integrity sha512-vlqyZ2huc+X/5svwOyAkBOWyPZimp5Q3nHcY5ZgQhc2KLOPbJ5CvkcPLoNJXCdiil0OUeuqgdT+0AJ7UVdr0wA==
+
 word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1335,6 +1335,11 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
 
+"@gnosis.pm/gp-v2-contracts@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/gp-v2-contracts/-/gp-v2-contracts-1.1.2.tgz#0453bb097377dc63cf46ee195f7e521d429f7e22"
+  integrity sha512-BvZMNS+fwITb+qs+trs2fyvYksa6MPjjLze9AOXPnvcKVYFEGwG6cfsecBswEMo+xevLIQNDyF7HZRhN7ply8w==
+
 "@gnosis.pm/safe-apps-provider@^0.11.3":
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.11.3.tgz#9e1ec2fb69a7fae8127631330f630662bd07a580"


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Add structure for supporting multiple external services, namely [wido](https://www.joinwido.com/), [portals.fi](https://portals.fi/) and [CoW](https://swap.cow.fi/#/1/swap/WETH).

## Related Issue

<!--- Please link to the issue here -->

N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Use multiple external services for related actions

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally

## Screenshots (if appropriate):
