### PR TITLE
refactor: Make veYFI description 2 lines

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,7 +30,7 @@ const	apps = [
 	}, {
 		href: 'https://vote.yearn.finance',
 		title: 'veYFI',
-		description: 'stake YFI to take part in governance.',
+		description: 'stake YFI\nto take part in governance.',
 		icon: <LogoYearn
 			className={'h-[100px] w-[100px]'}
 			back={'text-primary'}


### PR DESCRIPTION
## Description

Make veYFI description on the homepage 2 lines

<img width="436" alt="Screenshot 2022-12-21 at 12 23 38" src="https://user-images.githubusercontent.com/78794805/208882538-88d33b27-01d9-4e6b-97f2-137e274728f4.png">
