### PR TITLE
Fix st-yCRV APY

### DIFF
--- a/apps/ycrv/contexts/useYCRV.tsx
+++ b/apps/ycrv/contexts/useYCRV.tsx
@@ -216,7 +216,8 @@ export const YCRVContextApp = ({children}: {children: ReactElement}): ReactEleme
 	** Compute the styCRV APY based on the experimental APY and the mega boost.
 	**************************************************************************/
 	const	styCRVAPY = useMemo((): number => {
-		return (((styCRVVault as TYearnVault)?.apy?.net_apy || 0) * 100) + (styCRVMegaBoost * 100);
+		return (((styCRVVault as TYearnVault)?.apy?.net_apy || 0) * 100);
+		// return (((styCRVVault as TYearnVault)?.apy?.net_apy || 0) * 100) + (styCRVMegaBoost * 100);
 		// return (styCRVExperimentalAPY * 100) + (styCRVMegaBoost * 100);
 	}, [styCRVVault, styCRVMegaBoost]);
 

--- a/pages/ycrv/holdings.tsx
+++ b/pages/ycrv/holdings.tsx
@@ -324,7 +324,7 @@ function	Holdings(): ReactElement {
 						<p
 							suppressHydrationWarning
 							className={'font-number text-sm text-neutral-400 md:text-base'}>
-							{`∙ ${styCRVAPY && curveAdminFeePercent ? formatPercent(styCRVAPY - curveAdminFeePercent) : formatPercent(0)} Gauge Voting Bribes`}
+							{`∙ ${styCRVAPY && curveAdminFeePercent && styCRVMegaBoost ? formatAmount(styCRVAPY - (curveAdminFeePercent + (styCRVMegaBoost * 100)), 2, 2) : '0.00'}% Gauge Voting Bribes`}
 						</p>
 						<p
 							suppressHydrationWarning


### PR DESCRIPTION
## Description

Removed mega boost from the headline figure and tweaked apy component breakdown to make the numbers add up correctly.

## Related Issue

<!--- Please link to the issue here -->

## Motivation and Context

APY was displaying incorrectly

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):
