### PR TITLE
feat: Improve search UX

### DIFF
--- a/apps/common/components/ListHero.tsx
+++ b/apps/common/components/ListHero.tsx
@@ -13,6 +13,7 @@ export type TListHeroCategory<T> = {
 
 export type TListHero<T> = {
 	headLabel: string;
+	searchLabel: string;
 	searchPlaceholder: string;
 	categories: TListHeroCategory<T>[][];
 	onSelect: (category: T) => void;
@@ -21,6 +22,7 @@ export type TListHero<T> = {
 }
 
 export type TListHeroSearchBar = {
+	searchLabel: string;
 	searchPlaceholder: string;
 	searchValue: string;
 	set_searchValue: (searchValue: string) => void;
@@ -31,10 +33,10 @@ export type TListHeroDesktopCategories<T> = {
 	onSelect: (category: T) => void;
 }
 
-function	SearchBar({searchPlaceholder, searchValue, set_searchValue}: TListHeroSearchBar): ReactElement {
+function	SearchBar({searchLabel, searchPlaceholder, searchValue, set_searchValue}: TListHeroSearchBar): ReactElement {
 	return (
 		<div className={'w-full'}>
-			<label htmlFor={'search'} className={'text-neutral-600'}>{'Search'}</label>
+			<label htmlFor={'search'} className={'text-neutral-600'}>{searchLabel}</label>
 			<div className={'mt-1 flex h-10 w-full max-w-md items-center border border-neutral-0 bg-neutral-0 p-2 md:w-2/3'}>
 				<div className={'relative flex h-10 w-full flex-row items-center justify-between'}>
 					<input
@@ -101,6 +103,7 @@ function	DesktopCategories<T>({categories, onSelect}: TListHeroDesktopCategories
 
 function	ListHero<T extends string>({
 	headLabel,
+	searchLabel,
 	searchPlaceholder,
 	categories,
 	onSelect,
@@ -115,6 +118,7 @@ function	ListHero<T extends string>({
 
 			<div className={'hidden w-full flex-row items-center justify-between space-x-4 md:flex'}>
 				<SearchBar
+					searchLabel={searchLabel}
 					searchPlaceholder={searchPlaceholder}
 					searchValue={searchValue}
 					set_searchValue={set_searchValue} />

--- a/apps/vaults/components/list/VaultListFactory.tsx
+++ b/apps/vaults/components/list/VaultListFactory.tsx
@@ -128,6 +128,7 @@ function	VaultListFactory(): ReactElement {
 			</div>
 			<ListHero
 				headLabel={category}
+				searchLabel={`Search ${category}`}
 				searchPlaceholder={'YFI Vault'}
 				categories={[
 					[

--- a/apps/vaults/components/list/VaultsListEmpty.tsx
+++ b/apps/vaults/components/list/VaultsListEmpty.tsx
@@ -1,11 +1,13 @@
 
+import {useAppSettings} from '@vaults/contexts/useAppSettings';
+import {Button} from '@yearn-finance/web-lib/components/Button';
 import {useChainID} from '@yearn-finance/web-lib/hooks/useChainID';
 import CHAINS from '@yearn-finance/web-lib/utils/web3/chains';
 
 import type {ReactElement} from 'react';
 import type {TYearnVault} from '@common/types/yearn';
 
-export function	VaultsListEmpty({
+export function VaultsListEmpty({
 	sortedVaultsToDisplay,
 	currentCategory,
 	isLoading
@@ -15,6 +17,7 @@ export function	VaultsListEmpty({
 	isLoading: boolean
 }): ReactElement {
 	const {safeChainID} = useChainID();
+	const {searchValue, category, set_category} = useAppSettings();
 
 	if (isLoading && sortedVaultsToDisplay.length === 0) {
 		return (
@@ -36,7 +39,7 @@ export function	VaultsListEmpty({
 			</div>
 		);
 	} if (!isLoading && sortedVaultsToDisplay.length === 0 && safeChainID !== 1) {
-		const	chainName = CHAINS[safeChainID]?.name || 'this network';
+		const chainName = CHAINS[safeChainID]?.name || 'this network';
 		return (
 			<div className={'mx-auto flex h-96 w-full flex-col items-center justify-center py-2 px-10 md:w-3/4'}>
 				<b className={'text-center text-lg'}>{'👀 Where Vaults ser?'}</b>
@@ -47,18 +50,28 @@ export function	VaultsListEmpty({
 		);
 	} if (!isLoading && sortedVaultsToDisplay.length === 0) {
 		return (
-			<div className={'mx-auto flex h-96 w-full flex-col items-center justify-center py-2 px-10 md:w-3/4'}>
+			<div className={'mx-auto flex h-96 w-full flex-col items-center justify-center gap-4 py-2 px-10 md:w-3/4'}>
 				<b className={'text-center text-lg'}>{'No data, reeeeeeeeeeee'}</b>
-				<p className={'text-center text-neutral-600'}>
-					{'There doesn’t seem to be anything here. It might be because you searched for a token in the wrong category, or because there’s a rodent infestation in our server room. You check the search box, we’ll check the rodents. Deal?'}
-				</p>
+				{category === 'All Vaults' ?
+					<p className={'text-center text-neutral-600'}>{`The vault "${searchValue}" does not exist`}</p> :
+					<>
+						<p className={'text-center text-neutral-600'}>
+							{`There doesn’t seem to be anything here. It might be because you searched for a token in the ${currentCategory} category, or because there’s a rodent infestation in our server room. You check the search box, we’ll check the rodents. Deal?`}
+						</p>
+						<Button
+							className={'w-full md:w-48'}
+							onClick={(): void => set_category('All Vaults')}>
+							{'Search all vaults'}
+						</Button>
+					</>
+				}
 			</div>
 		);
 	}
 	return <div />;
 }
 
-export function	VaultListEmptyExternalMigration(): ReactElement {
+export function VaultListEmptyExternalMigration(): ReactElement {
 	return (
 		<div className={'mx-auto flex h-96 w-full flex-col items-center justify-center py-2 px-10 md:w-3/4'}>
 			<b className={'text-center text-lg'}>{'We looked under the cushions...'}</b>
@@ -69,7 +82,7 @@ export function	VaultListEmptyExternalMigration(): ReactElement {
 	);
 }
 
-export function	VaultsListEmptyFactory({
+export function VaultsListEmptyFactory({
 	sortedVaultsToDisplay,
 	currentCategory,
 	isLoading
@@ -100,7 +113,7 @@ export function	VaultsListEmptyFactory({
 			</div>
 		);
 	} if (!isLoading && sortedVaultsToDisplay.length === 0 && safeChainID !== 1) {
-		const	chainName = CHAINS[safeChainID]?.name || 'this network';
+		const chainName = CHAINS[safeChainID]?.name || 'this network';
 		return (
 			<div className={'mx-auto flex h-96 w-full flex-col items-center justify-center py-2 px-10 md:w-3/4'}>
 				<b className={'text-center text-lg'}>{'👀 Where Vaults ser?'}</b>

--- a/pages/vaults/index.tsx
+++ b/pages/vaults/index.tsx
@@ -205,6 +205,7 @@ function	Index(): ReactElement {
 				</div>
 				<ListHero
 					headLabel={category}
+					searchLabel={`Search ${category}`}
 					searchPlaceholder={'YFI Vault'}
 					categories={[
 						[

--- a/pages/ybribe/index.tsx
+++ b/pages/ybribe/index.tsx
@@ -122,6 +122,7 @@ function	GaugeList(): ReactElement {
 			<div className={'col-span-12 flex w-full flex-col bg-neutral-100'}>
 				<ListHero
 					headLabel={'Claim Bribe'}
+					searchLabel={`Search ${category}`}
 					searchPlaceholder={'f-yfieth'}
 					categories={[
 						[

--- a/pages/ybribe/offer-bribe.tsx
+++ b/pages/ybribe/offer-bribe.tsx
@@ -118,6 +118,7 @@ function	GaugeList(): ReactElement {
 			<div className={'col-span-12 flex w-full flex-col bg-neutral-100'}>
 				<ListHero
 					headLabel={'Offer Bribe'}
+					searchLabel={`Search ${category}`}
 					searchPlaceholder={'f-yfieth'}
 					categories={[
 						[


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

* Add a button in the empty result prompting the user to search for the vault in all categories;
* Add a "vault does not exist" when the user is already searching in the "All Vaults" category;
* Add a `searchLabel` that can be used to be a bit clearer what items are being searched.

## Related Issue

<!--- Please link to the issue here -->

Resolves https://github.com/yearn/yearn.fi/issues/42

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Improve vault search

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and tried different searches

## Screenshots (if appropriate):

<img width="1216" alt="Screenshot 2023-01-10 at 19 48 58" src="https://user-images.githubusercontent.com/78794805/211625196-3cd975fd-5494-4917-91c7-e5f0e9276e33.png">

<img width="1219" alt="Screenshot 2023-01-10 at 19 49 14" src="https://user-images.githubusercontent.com/78794805/211625204-01e2ffb5-056f-4c39-ab5c-48e4e113a528.png">

<img width="1214" alt="Screenshot 2023-01-10 at 19 50 42" src="https://user-images.githubusercontent.com/78794805/211625430-36cee192-00eb-4ccd-b094-fc64bc16fc05.png">

<img width="1214" alt="Screenshot 2023-01-10 at 19 50 01" src="https://user-images.githubusercontent.com/78794805/211625344-f9066da1-43b1-4fef-ae0d-e78a1f430b14.png">
