### PR TITLE
refactor: Remove performance fee from strategies

### DIFF
--- a/apps/vaults/components/details/VaultDetailsTabStrategies.tsx
+++ b/apps/vaults/components/details/VaultDetailsTabStrategies.tsx
@@ -105,7 +105,7 @@ function	VaultDetailsStrategy({currentVault, strategy}: {currentVault: TYearnVau
 						</div>
 					</div>
 					<div className={'col-span-12 flex h-full w-full flex-col justify-between md:col-span-6'}>
-						<div className={'grid grid-cols-6 gap-6 md:gap-8'}>
+						<div className={'grid grid-cols-4 gap-6 md:gap-8'}>
 							<div className={'col-span-2 flex flex-col space-y-0 md:space-y-2'}>
 								<p className={'text-xxs text-neutral-600 md:text-xs'}>{'APR'}</p>
 								<b className={'font-number text-xl text-neutral-900'}>
@@ -119,13 +119,6 @@ function	VaultDetailsStrategy({currentVault, strategy}: {currentVault: TYearnVau
 								</p>
 								<b className={'font-number text-xl text-neutral-900'}>
 									{formatPercent((strategy?.details?.debtRatio || 0) / 100, 0)}
-								</b>
-							</div>
-
-							<div className={'col-span-2 flex flex-col space-y-0 md:space-y-2'}>
-								<p className={'text-xxs text-neutral-600 md:text-xs'}>{'Performance fee'}</p>
-								<b className={'font-number text-xl text-neutral-600'}>
-									{formatPercent((strategy?.details?.performanceFee || 0) * 100, 0)}
 								</b>
 							</div>
 						</div>


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Remove performance fee from strategies

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

1. they are set at the vault level; and
3. they are currently showing as 0%

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, refer to screenshot below

## Screenshots (if appropriate):

<img width="1238" alt="Screenshot 2023-01-11 at 11 34 26 am" src="https://user-images.githubusercontent.com/78794805/211770288-cb5e2018-19a3-4963-8fd9-a11b3d1c5a20.png">
