### PR TITLE
fix: parse markdown from vault token description

### DIFF
--- a/apps/vaults/components/details/VaultDetailsTabAbout.tsx
+++ b/apps/vaults/components/details/VaultDetailsTabAbout.tsx
@@ -18,7 +18,7 @@ function	VaultDetailsAbout({currentVault, harvestData}: {currentVault: TYearnVau
 					<b className={'text-neutral-900'}>{'Description'}</b>
 					<p
 						className={'mt-4 text-neutral-600'}
-						dangerouslySetInnerHTML={{__html: parseMarkdown(currentVault?.token?.description) || 'Sorry, we don’t have a description for this asset right now. But did you know the correct word for a blob of toothpaste is a “nurdle”. Fascinating! We’ll work on updating the asset description, but at least you learnt something interesting. Catch ya later nurdles.'}} />
+						dangerouslySetInnerHTML={{__html: currentVault?.token?.description ? parseMarkdown(currentVault?.token?.description) : 'Sorry, we don’t have a description for this asset right now. But did you know the correct word for a blob of toothpaste is a “nurdle”. Fascinating! We’ll work on updating the asset description, but at least you learnt something interesting. Catch ya later nurdles.'}} />
 				</div>
 				<div>
 					<b className={'text-neutral-900'}>{'APY'}</b>


### PR DESCRIPTION
## Description

- Fix missing markdown parsing on vault token description

## Motivation and Context

- Display links correctly on all vault token description.

## How Has This Been Tested?

- Checking UI locally

## Screenshots (if appropriate):
issue:
![image](https://user-images.githubusercontent.com/18649057/214173479-ab4e3371-d2ae-44f6-b326-614a20e02c36.png)

fix:
![image](https://user-images.githubusercontent.com/18649057/214173384-1a2475c5-e344-41f8-b693-eaed54554923.png)


