### PR TITLE
fix: Add missing value to dependency array

### DIFF
--- a/apps/vaults/hooks/useSolverCowswap.tsx
+++ b/apps/vaults/hooks/useSolverCowswap.tsx
@@ -122,7 +122,7 @@ export function useSolverCowswap(): TSolverContext {
 			return toNormalizedBN(quote?.quote?.buyAmount || 0, request?.current?.outputToken?.decimals || 18);
 		}
 		return toNormalizedBN(0);
-	}, [getQuote]);
+	}, [getBuyAmountWithSlippage, getQuote]);
 
 	/* 🔵 - Yearn Finance **************************************************************************
 	** signCowswapOrder is used to sign the order with the user's wallet. The signature is used


### PR DESCRIPTION
## Description

The purpose to this pull request is to fix the warnings present in the repo, including the missing dependency.

After executing `yarn lint` you can observe the following warnings in the terminal:

⚠️ `React Hook useCallback has missing dependencies: 'chainCoin', 'cowswap', 'internalMigration', 'partnerContract', 'vanilla', and 'wido'. Either include them or remove the dependency array. `  

⚠️ `React Hook useCallback has a missing dependency: 'getBuyAmountWithSlippage'. Either include it or remove the dependency array.`

The first warning has a textual commentary in the code: `//Ignore the warning, it's a false positive.`

So no adjustment was made. However, for the second there is no comment indicating that it should not be fixed. Therefore for the second warning the missing dependency was added. 

Is that an appropriate change? or on the contrary, is it another false positive? If it is also a false positive should we add the same comment so other know not to try to fix it in the future?

## Motivation and Context

Adjust the dependency array to fix current warning and avoid code inconsistencies

## How Has This Been Tested?

I confirmed that the warning was no longer present after making the change. 

## Screenshots (if appropriate):
N/A