### PR TITLE
fix: React Hydration Error

### DIFF
--- a/apps/common/hooks/useHasMounted.tsx
+++ b/apps/common/hooks/useHasMounted.tsx
@@ -1,0 +1,12 @@
+import {useEffect, useState} from 'react';
+
+export function useHasMounted(): boolean {
+	const [hasMounted, set_hasMounted] = useState(false);
+	
+	useEffect((): void => {
+		set_hasMounted(true);
+	}, []);
+
+	return hasMounted;
+}
+


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Fix React Hydration Error in the `VaultDetailsTabsWrapper` as there's a mismatch between the React tree that was pre-rendered (SSR/SSG) and the React tree that rendered during the first render in the Browser.

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/yearn.fi/issues/83

Steps to reproduce:

1. Change network to Optimism;
2. Refresh the page.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Get the correct explorer base URI when a network is selected

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally,

## Screenshots (if appropriate):

<img width="1498" alt="Screenshot_2023-03-06_at_13_54_17" src="https://user-images.githubusercontent.com/78794805/223113470-a552fdbe-ab6b-45d9-93d9-0b75fc1d0401.png">
