### PR TITLE
fix: React Hydration Error Globally

### DIFF
--- a/apps/common/components/AmountInput.tsx
+++ b/apps/common/components/AmountInput.tsx
@@ -66,8 +66,7 @@ function AmountInput({
 				<legend
 					role={onLegendClick ? 'button' : 'text'}
 					onClick={onLegendClick}
-					className={`mt-1 pl-2 text-xs md:mr-0 ${error ? 'text-[#EA5204]' : 'text-neutral-600'}`}
-					suppressHydrationWarning>
+					className={`mt-1 pl-2 text-xs md:mr-0 ${error ? 'text-[#EA5204]' : 'text-neutral-600'}`}>
 					{error ?? legend}
 				</legend>
 			)}

--- a/apps/common/components/HeroTimer.tsx
+++ b/apps/common/components/HeroTimer.tsx
@@ -20,7 +20,7 @@ function	HeroTimer({endTime}: TProps): ReactElement {
 			<div className={'mx-auto flex w-full max-w-6xl flex-col items-center justify-center'}>
 				<div className={'mt-10 w-[300px] md:w-full'}>
 					<div className={'flex w-full items-center justify-center text-center text-4xl font-bold uppercase text-neutral-900 md:text-8xl'}>
-						<b className={'font-number'} suppressHydrationWarning>
+						<b className={'font-number'}>
 							{time}
 						</b>
 					</div>

--- a/apps/common/components/ListHero.tsx
+++ b/apps/common/components/ListHero.tsx
@@ -44,7 +44,6 @@ function	SearchBar({searchLabel, searchPlaceholder, searchValue, set_searchValue
 	return (
 		<div className={'w-full'}>
 			<label
-				suppressHydrationWarning
 				htmlFor={'search'}
 				className={'text-neutral-600'}>
 				{searchLabel}
@@ -154,7 +153,7 @@ function	ListHero<T extends string>({
 	return (
 		<div className={'flex flex-col items-start justify-between space-x-0 px-4 pt-4 pb-2 md:px-10 md:pt-10 md:pb-8'}>
 			<div className={'mb-6'}>
-				<h2 className={'text-lg font-bold md:text-3xl'} suppressHydrationWarning>{headLabel}</h2>
+				<h2 className={'text-lg font-bold md:text-3xl'}>{headLabel}</h2>
 			</div>
 
 			<div className={'hidden w-full flex-row items-center justify-between space-x-4 md:flex'}>

--- a/apps/common/components/SummaryData.tsx
+++ b/apps/common/components/SummaryData.tsx
@@ -15,7 +15,7 @@ function SummaryData({items}: TTabsProps): ReactElement {
 		<div className={'align-center flex w-full flex-row flex-wrap justify-center gap-14'}>
 			{items.map((({label, content}): ReactElement => (
 				<div key={label} className={'flex flex-col items-center justify-center space-y-2'}>
-					<b className={'font-number text-3xl'} suppressHydrationWarning>
+					<b className={'font-number text-3xl'}>
 						{content}
 					</b>
 					<p className={'text-center text-xs text-neutral-600'}>

--- a/apps/common/components/ValueAnimation.tsx
+++ b/apps/common/components/ValueAnimation.tsx
@@ -102,8 +102,8 @@ function	ValueAnimation({
 		<>
 			<div className={'text'}>
 				<p className={'wordWrapper'}>
-					<span suppressHydrationWarning className={`${className} ${identifier}`}>{`${prefix ? `${prefix} ` : ''}${defaultValue}${suffix ? ` ${suffix}` : ''}`}</span>
-					<span suppressHydrationWarning className={`${className} ${identifier}`}>{`${prefix ? `${prefix} ` : ''}${value}${suffix ? ` ${suffix}` : ''}`}</span>
+					<span className={`${className} ${identifier}`}>{`${prefix ? `${prefix} ` : ''}${defaultValue}${suffix ? ` ${suffix}` : ''}`}</span>
+					<span className={`${className} ${identifier}`}>{`${prefix ? `${prefix} ` : ''}${value}${suffix ? ` ${suffix}` : ''}`}</span>
 				</p>
 			</div>
 		</>

--- a/apps/common/hooks/useBalances.tsx
+++ b/apps/common/hooks/useBalances.tsx
@@ -337,7 +337,6 @@ export function	useBalances(props?: TUseBalancesReq): TUseBalancesRes {
 		const	chainID = props?.chainID || web3ChainID || 1;
 		axios.post('/api/getBatchBalances', {chainID, address: web3Address, tokens})
 			.then((res: AxiosResponse<TGetBatchBalancesResp>): void => {
-				console.log(res.data);
 				updateBalancesCall(res.data.chainID, res.data.balances);
 			})
 			.catch((err): void => {

--- a/apps/common/hooks/useHasMounted.tsx
+++ b/apps/common/hooks/useHasMounted.tsx
@@ -1,0 +1,11 @@
+import {useEffect, useState} from 'react';
+
+export function useHasMounted(): boolean {
+	const [hasMounted, set_hasMounted] = useState(false);
+
+	useEffect((): void => {
+		set_hasMounted(true);
+	}, []);
+
+	return hasMounted;
+}

--- a/apps/vaults/components/details/VaultDetailsHeader.tsx
+++ b/apps/vaults/components/details/VaultDetailsHeader.tsx
@@ -10,6 +10,7 @@ import {formatAmount, formatPercent, formatUSD} from '@yearn-finance/web-lib/uti
 import {formatCounterValue} from '@yearn-finance/web-lib/utils/format.value';
 import {copyToClipboard} from '@yearn-finance/web-lib/utils/helpers';
 import {useBalance} from '@common/hooks/useBalance';
+import {useHasMounted} from '@common/hooks/useHasMounted';
 import {useTokenPrice} from '@common/hooks/useTokenPrice';
 import {getVaultName} from '@common/utils';
 
@@ -17,7 +18,7 @@ import type {ReactElement} from 'react';
 import type {SWRResponse} from 'swr';
 import type {TYdaemonEarned, TYearnVault} from '@common/types/yearn';
 
-function	VaultDetailsHeader({currentVault}: {currentVault: TYearnVault}): ReactElement {
+function	VaultDetailsHeader({currentVault}: {currentVault: TYearnVault}): ReactElement | null {
 	const {safeChainID} = useChainID();
 	const {address} = useWeb3();
 	const {settings: baseAPISettings} = useSettings();
@@ -26,6 +27,7 @@ function	VaultDetailsHeader({currentVault}: {currentVault: TYearnVault}): ReactE
 		baseFetcher,
 		{revalidateOnFocus: false}
 	) as SWRResponse as {data: TYdaemonEarned};
+	const hasMounted = useHasMounted();
 
 	const	normalizedVaultEarned = useMemo((): number => (
 		formatToNormalizedValue(
@@ -37,6 +39,10 @@ function	VaultDetailsHeader({currentVault}: {currentVault: TYearnVault}): ReactE
 	const	vaultBalance = useBalance(currentVault?.address)?.normalized;
 	const	vaultPrice = useTokenPrice(currentVault?.address);
 	const	vaultName = useMemo((): string => getVaultName(currentVault), [currentVault]);
+
+	if (!hasMounted) {
+		return null;
+	}
 
 	return (
 		<div aria-label={'Vault Header'} className={'col-span-12 flex w-full flex-col items-center justify-center'}>
@@ -55,10 +61,10 @@ function	VaultDetailsHeader({currentVault}: {currentVault: TYearnVault}): ReactE
 					<p className={'text-center text-xxs text-neutral-600 md:text-xs'}>
 						{`Total deposited, ${currentVault?.symbol || 'token'}`}
 					</p>
-					<b className={'font-number text-lg md:text-3xl'} suppressHydrationWarning>
+					<b className={'font-number text-lg md:text-3xl'}>
 						{formatAmount(formatToNormalizedValue(currentVault?.tvl?.total_assets, currentVault?.decimals))}
 					</b>
-					<legend className={'font-number text-xxs text-neutral-600 md:text-xs'} suppressHydrationWarning>
+					<legend className={'font-number text-xxs text-neutral-600 md:text-xs'}>
 						{formatUSD(currentVault?.tvl?.tvl)}
 					</legend>
 				</div>
@@ -67,7 +73,7 @@ function	VaultDetailsHeader({currentVault}: {currentVault: TYearnVault}): ReactE
 					<p className={'text-center text-xxs text-neutral-600 md:text-xs'}>
 						{'Net APY'}
 					</p>
-					<b className={'font-number text-lg md:text-3xl'} suppressHydrationWarning>
+					<b className={'font-number text-lg md:text-3xl'}>
 						{formatPercent((currentVault?.apy?.net_apy || 0) * 100, 2, 2, 500)}
 					</b>
 					<legend className={'text-xxs text-neutral-600 md:text-xs'}>&nbsp;</legend>
@@ -77,10 +83,10 @@ function	VaultDetailsHeader({currentVault}: {currentVault: TYearnVault}): ReactE
 					<p className={'text-center text-xxs text-neutral-600 md:text-xs'}>
 						{`Balance, ${currentVault?.symbol || 'token'}`}
 					</p>
-					<b className={'font-number text-lg md:text-3xl'} suppressHydrationWarning>
+					<b className={'font-number text-lg md:text-3xl'}>
 						{formatAmount(vaultBalance)}
 					</b>
-					<legend className={'font-number text-xxs text-neutral-600 md:text-xs'} suppressHydrationWarning>
+					<legend className={'font-number text-xxs text-neutral-600 md:text-xs'}>
 						{formatCounterValue(vaultBalance, vaultPrice)}
 					</legend>
 				</div>
@@ -89,10 +95,10 @@ function	VaultDetailsHeader({currentVault}: {currentVault: TYearnVault}): ReactE
 					<p className={'text-center text-xxs text-neutral-600 md:text-xs'}>
 						{`Earned, ${currentVault?.token?.symbol || 'token'}`}
 					</p>
-					<b className={'font-number text-lg md:text-3xl'} suppressHydrationWarning>
+					<b className={'font-number text-lg md:text-3xl'}>
 						{formatAmount(normalizedVaultEarned)}
 					</b>
-					<legend className={'font-number text-xxs text-neutral-600 md:text-xs'} suppressHydrationWarning>
+					<legend className={'font-number text-xxs text-neutral-600 md:text-xs'}>
 						{formatCounterValue(normalizedVaultEarned || 0, vaultPrice)}
 					</legend>
 				</div>

--- a/apps/vaults/components/details/actions/QuickActionsFrom.tsx
+++ b/apps/vaults/components/details/actions/QuickActionsFrom.tsx
@@ -8,20 +8,26 @@ import {handleInputChangeEventValue} from '@yearn-finance/web-lib/utils/handlers
 import {Dropdown} from '@common/components/TokenDropdown';
 import {useWallet} from '@common/contexts/useWallet';
 import {useBalance} from '@common/hooks/useBalance';
+import {useHasMounted} from '@common/hooks/useHasMounted';
 import {useTokenPrice} from '@common/hooks/useTokenPrice';
 
 import type {ChangeEvent, ReactElement} from 'react';
 
-function	VaultDetailsQuickActionsFrom(): ReactElement {
+function	VaultDetailsQuickActionsFrom(): ReactElement | null {
 	const {isActive} = useWeb3();
 	const {balances} = useWallet();
 	const {
 		possibleOptionsFrom, actionParams, onUpdateSelectedOptionFrom, onChangeAmount,
 		maxDepositPossible, isDepositing
 	} = useActionFlow();
+	const hasMounted = useHasMounted();
 
 	const selectedFromBalance = useBalance(toAddress(actionParams?.selectedOptionFrom?.value));
 	const selectedOptionFromPricePerToken = useTokenPrice(toAddress(actionParams?.selectedOptionFrom?.value));
+
+	if (!hasMounted) {
+		return null;
+	}
 
 	return (
 		<section aria-label={'FROM'} className={'flex w-full flex-col space-x-0 md:flex-row md:space-x-4'}>
@@ -30,7 +36,7 @@ function	VaultDetailsQuickActionsFrom(): ReactElement {
 					<label className={'text-base text-neutral-600'}>
 						{isDepositing ? 'From wallet' : 'From vault'}
 					</label>
-					<legend className={'font-number inline text-xs text-neutral-600 md:hidden'} suppressHydrationWarning>
+					<legend className={'font-number inline text-xs text-neutral-600 md:hidden'}>
 						{`You have ${formatAmount(selectedFromBalance.normalized)} ${actionParams?.selectedOptionFrom?.symbol || 'tokens'}`}
 					</legend>
 				</div>
@@ -52,7 +58,7 @@ function	VaultDetailsQuickActionsFrom(): ReactElement {
 						</div>
 					</div>
 				)}
-				<legend className={'font-number hidden text-xs text-neutral-600 md:inline'} suppressHydrationWarning>
+				<legend className={'font-number hidden text-xs text-neutral-600 md:inline'}>
 					{`You have ${formatAmount(selectedFromBalance.normalized)} ${actionParams?.selectedOptionFrom?.symbol || 'tokens'}`}
 				</legend>
 			</div>

--- a/apps/vaults/components/details/actions/QuickActionsTo.tsx
+++ b/apps/vaults/components/details/actions/QuickActionsTo.tsx
@@ -6,16 +6,22 @@ import {toAddress} from '@yearn-finance/web-lib/utils/address';
 import {formatPercent} from '@yearn-finance/web-lib/utils/format.number';
 import {formatCounterValue} from '@yearn-finance/web-lib/utils/format.value';
 import {Dropdown} from '@common/components/TokenDropdown';
+import {useHasMounted} from '@common/hooks/useHasMounted';
 import {useTokenPrice} from '@common/hooks/useTokenPrice';
 
 import type {ReactElement} from 'react';
 
-function	VaultDetailsQuickActionsTo(): ReactElement {
+function	VaultDetailsQuickActionsTo(): ReactElement | null {
 	const {isActive} = useWeb3();
 	const {currentVault, possibleOptionsTo, actionParams, onUpdateSelectedOptionTo, isDepositing} = useActionFlow();
 	const {expectedOut, isLoadingExpectedOut} = useSolver();
+	const hasMounted = useHasMounted();
 
 	const selectedOptionToPricePerToken = useTokenPrice(toAddress(actionParams?.selectedOptionTo?.value));
+
+	if (!hasMounted) {
+		return null;
+	}
 
 	return (
 		<section aria-label={'TO'} className={'flex w-full flex-col space-x-0 md:flex-row md:space-x-4'}>
@@ -24,7 +30,7 @@ function	VaultDetailsQuickActionsTo(): ReactElement {
 					<label className={'text-base text-neutral-600'}>
 						{isDepositing ? 'To vault' : 'To wallet'}
 					</label>
-					<legend className={'font-number inline text-xs text-neutral-600 md:hidden'} suppressHydrationWarning>
+					<legend className={'font-number inline text-xs text-neutral-600 md:hidden'}>
 						{`APY ${formatPercent((currentVault?.apy?.net_apy || 0) * 100, 2, 2, 500)}`}
 					</legend>
 				</div>
@@ -46,7 +52,7 @@ function	VaultDetailsQuickActionsTo(): ReactElement {
 						</div>
 					</div>
 				)}
-				<legend className={'font-number hidden text-xs text-neutral-600 md:inline'} suppressHydrationWarning>
+				<legend className={'font-number hidden text-xs text-neutral-600 md:inline'}>
 					{isDepositing ? (
 						formatPercent((currentVault?.apy?.net_apy || 0) * 100, 2, 2, 500)
 					) : ''}

--- a/apps/vaults/components/details/tabs/VaultDetailsAbout.tsx
+++ b/apps/vaults/components/details/tabs/VaultDetailsAbout.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 import {formatPercent} from '@yearn-finance/web-lib/utils/format.number';
 import {parseMarkdown} from '@yearn-finance/web-lib/utils/helpers';
+import {useHasMounted} from '@common/hooks/useHasMounted';
 
 import type {LoaderComponent} from 'next/dynamic';
 import type {ReactElement} from 'react';
@@ -11,7 +12,13 @@ import type {TGraphForVaultEarningsProps} from '@vaults/components/graphs/GraphF
 
 const GraphForVaultEarnings = dynamic<TGraphForVaultEarningsProps>(async (): LoaderComponent<TGraphForVaultEarningsProps> => import('@vaults/components/graphs/GraphForVaultEarnings'), {ssr: false});
 
-function	VaultDetailsAbout({currentVault, harvestData}: {currentVault: TYearnVault, harvestData: TGraphData[]}): ReactElement {
+function	VaultDetailsAbout({currentVault, harvestData}: {currentVault: TYearnVault, harvestData: TGraphData[]}): ReactElement | null {
+	const hasMounted = useHasMounted();
+	
+	if (!hasMounted) {
+		return null;
+	}
+
 	return (
 		<div className={'grid grid-cols-1 gap-10 bg-neutral-100 p-4 md:grid-cols-2 md:gap-32 md:p-8'}>
 			<div className={'col-span-1 w-full space-y-6'}>
@@ -27,19 +34,19 @@ function	VaultDetailsAbout({currentVault, harvestData}: {currentVault: TYearnVau
 						<div className={'space-y-2'}>
 							<div className={'flex flex-row items-center justify-between'}>
 								<p className={'text-sm text-neutral-500'}>{'Weekly APY'}</p>
-								<p className={'font-number text-sm text-neutral-900'} suppressHydrationWarning>
+								<p className={'font-number text-sm text-neutral-900'}>
 									{formatPercent((currentVault?.apy?.points?.week_ago || 0) * 100)}
 								</p>
 							</div>
 							<div className={'flex flex-row items-center justify-between'}>
 								<p className={'text-sm text-neutral-500'}>{'Monthly APY'}</p>
-								<p className={'font-number text-sm text-neutral-900'} suppressHydrationWarning>
+								<p className={'font-number text-sm text-neutral-900'}>
 									{formatPercent((currentVault?.apy?.points?.month_ago || 0) * 100)}
 								</p>
 							</div>
 							<div className={'flex flex-row items-center justify-between'}>
 								<p className={'text-sm text-neutral-500'}>{'Inception APY'}</p>
-								<p className={'font-number text-sm text-neutral-900'} suppressHydrationWarning>
+								<p className={'font-number text-sm text-neutral-900'}>
 									{formatPercent((currentVault?.apy?.points?.inception || 0) * 100)}
 								</p>
 							</div>
@@ -47,13 +54,13 @@ function	VaultDetailsAbout({currentVault, harvestData}: {currentVault: TYearnVau
 						<div className={'space-y-2'}>
 							<div className={'flex flex-row items-center justify-between'}>
 								<p className={'text-sm text-neutral-500'}>{'Gross APR'}</p>
-								<p className={'font-number text-sm text-neutral-900'} suppressHydrationWarning>
+								<p className={'font-number text-sm text-neutral-900'}>
 									{formatPercent((currentVault?.apy?.gross_apr || 0) * 100)}
 								</p>
 							</div>
 							<div className={'flex flex-row items-center justify-between'}>
 								<p className={'text-sm text-neutral-500'}>{'Net APY'}</p>
-								<p className={'font-number text-sm text-neutral-900'} suppressHydrationWarning>
+								<p className={'font-number text-sm text-neutral-900'}>
 									{`APY ${formatPercent((currentVault?.apy?.net_apy || 0) * 100, 2, 2, 500)}`}
 								</p>
 							</div>

--- a/apps/vaults/components/graphs/GraphForVaultEarnings.tsx
+++ b/apps/vaults/components/graphs/GraphForVaultEarnings.tsx
@@ -62,6 +62,9 @@ function	GraphForVaultEarnings({currentVault, harvestData, height = 312, isCumul
 						e.fill = '#5B5B5B';
 						e.className = 'text-xxs md:text-xs font-number';
 						e.alignmentBaseline = 'middle';
+						delete e.verticalAnchor;
+						delete e.visibleTicksCount;
+						delete e.tickFormatter;
 						const	formatedValue = formatWithUnit(value, 0, 0);
 						return <text {...e}>{formatedValue}</text>;
 					}} />

--- a/apps/ycrv/components/QuickActions.tsx
+++ b/apps/ycrv/components/QuickActions.tsx
@@ -43,7 +43,7 @@ function QASelect(props: TQASelect): ReactElement {
 		<div className={'relative z-10 w-full space-y-2'}>
 			<div className={'flex flex-row items-baseline justify-between'}>
 				<label className={'text-base text-neutral-600'}>{label}</label>
-				<legend className={'font-number inline text-xs text-neutral-600 md:hidden'} suppressHydrationWarning>
+				<legend className={'font-number inline text-xs text-neutral-600 md:hidden'}>
 					{legend}
 				</legend>
 			</div>
@@ -66,7 +66,7 @@ function QASelect(props: TQASelect): ReactElement {
 					</div>
 				</div>
 			)}
-			<legend className={'font-number hidden text-xs text-neutral-600 md:inline'} suppressHydrationWarning>
+			<legend className={'font-number hidden text-xs text-neutral-600 md:inline'}>
 				{legend}
 			</legend>
 		</div>

--- a/apps/ycrv/components/tabs/HowItWorks.vl-yCRV.tsx
+++ b/apps/ycrv/components/tabs/HowItWorks.vl-yCRV.tsx
@@ -10,9 +10,9 @@ function HowItWorks(): ReactElement {
 			aria-label={'Quick Actions'}
 			className={'col-span-12'}>
 			<Balancer>
-				<h2 suppressHydrationWarning className={'pb-2 text-lg font-bold md:pb-4 md:text-3xl'}>{'Deposit'}</h2>
+				<h2 className={'pb-2 text-lg font-bold md:pb-4 md:text-3xl'}>{'Deposit'}</h2>
 				<p>{'Deposit vanilla yCRV for vote locked yCRV (vl-yCRV) and gain vote power for Curve voting. Let’s learn about the fun way that Curve voting works. Each vote period lasts for two weeks, and once you vote in the ‘current period’ (as shown below) your tokens cannot be withdrawn until after the ‘next period’. Voting in the next period (once it becomes the current period) would again lock your tokens for a further period. Please note, vl-yCRV does not generate yield but maintains a 1:1 exchange rate with yCRV (so if yCRV increases in value, so will your vl-yCRV).'}</p>
-				<h2 suppressHydrationWarning className={'mt-4 pb-2 text-lg font-bold md:mt-8 md:pb-4 md:text-3xl'}>{'Withdraw'}</h2>
+				<h2 className={'mt-4 pb-2 text-lg font-bold md:mt-8 md:pb-4 md:text-3xl'}>{'Withdraw'}</h2>
 				<p>{'Once you vote in the ‘current period’ (as shown below), you must wait until the end of the ‘next period’ in order to withdraw your vl-yCRV back to yCRV. However, if you choose to also vote in the ‘next period’ once it becomes the ‘current period’ you would then have to wait until the end of the following period (without voting in it) in order to withdraw. In other words, once you vote in the ‘current period’ you must wait for the ‘next period’ to end without voting in it to withdraw. Who said DeFi was complicated...'}</p>
 			</Balancer>
 			<p className={'pt-8 md:pt-16 md:pb-0'}>

--- a/pages/ycrv/holdings.tsx
+++ b/pages/ycrv/holdings.tsx
@@ -122,7 +122,6 @@ function	Holdings(): ReactElement {
 					<div className={'grid w-full gap-6 md:col-span-5'}>
 						<div>
 							<b
-								suppressHydrationWarning
 								className={'font-number pb-2 text-3xl text-neutral-900'}>
 								{holdings?.treasury ? `${formatBigNumberOver10K(holdings?.treasury || 0)} ` : '- '}
 								<span className={'font-number text-base text-neutral-600 md:text-3xl md:text-neutral-900'}>{'veCRV'}</span>
@@ -131,7 +130,6 @@ function	Holdings(): ReactElement {
 						</div>
 						<div>
 							<b
-								suppressHydrationWarning
 								className={'font-number pb-2 text-3xl text-neutral-900'}>
 								{holdings?.legacy ? `${formatBigNumberOver10K(holdings?.legacy || 0)} ` : '- '}
 								<span className={'font-number text-base text-neutral-600 md:text-3xl md:text-neutral-900'}>{'yveCRV'}</span>
@@ -140,14 +138,12 @@ function	Holdings(): ReactElement {
 						</div>
 						<div>
 							<b
-								suppressHydrationWarning
 								className={'font-number pb-2 text-3xl text-neutral-900'}>
 								{holdings?.yCRVSupply ? `${formatBigNumberOver10K(holdings?.yCRVSupply || 0)} ` : '- '}
 								<span className={'font-number text-base text-neutral-600 md:text-3xl md:text-neutral-900'}>{'yCRV'}</span>
 							</b>
 
 							<p
-								suppressHydrationWarning
 								className={'text-lg text-neutral-500'}>
 								{`(Price = $${(formatAmount(ycrvPrice || 0))} | Peg = ${(
 									holdings?.crvYCRVPeg ? (formatPercent(
@@ -178,7 +174,6 @@ function	Holdings(): ReactElement {
 						<div className={'flex flex-row items-center justify-between'}>
 							<span className={'mr-auto inline font-normal text-neutral-400 md:hidden'}>{'APY: '}</span>
 							<b
-								suppressHydrationWarning
 								className={'font-number text-base text-neutral-900'}>
 								{styCRVAPY ? `${formatPercent(styCRVAPY)}*` : `${formatPercent(0)}`}
 							</b>
@@ -186,7 +181,6 @@ function	Holdings(): ReactElement {
 						<div className={'flex flex-row items-center justify-between'}>
 							<span className={'inline text-sm font-normal text-neutral-400 md:hidden'}>{'Total Assets: '}</span>
 							<p
-								suppressHydrationWarning
 								className={'font-number text-base text-neutral-900'}>
 								{holdings?.styCRVSupply ? formatCounterValue(
 									formatToNormalizedValue(holdings.styCRVSupply, 18),
@@ -197,7 +191,6 @@ function	Holdings(): ReactElement {
 						<div className={'flex flex-row items-center justify-between'}>
 							<span className={'inline text-sm font-normal text-neutral-400 md:hidden'}>{'yCRV Deposits: '}</span>
 							<p
-								suppressHydrationWarning
 								className={'font-number text-base text-neutral-900'}>
 								{formatBigNumberOver10K(holdings?.styCRVSupply || 0)}
 							</p>
@@ -206,12 +199,10 @@ function	Holdings(): ReactElement {
 							<span className={'inline text-sm font-normal text-neutral-400 md:hidden'}>{'My Balance: '}</span>
 							<div>
 								<p
-									suppressHydrationWarning
 									className={'font-number text-base text-neutral-900'}>
 									{formatNumberOver10K(balances[STYCRV_TOKEN_ADDRESS]?.normalized || 0)}
 								</p>
 								<p
-									suppressHydrationWarning
 									className={'font-number text-xs text-neutral-600'}>
 									{formatCounterValue(balanceOfStyCRV.normalized, stycrvPrice)}
 								</p>
@@ -229,7 +220,6 @@ function	Holdings(): ReactElement {
 						<div className={'flex flex-row items-center justify-between'}>
 							<span className={'mr-auto inline font-normal text-neutral-400 md:hidden'}>{'APY: '}</span>
 							<b
-								suppressHydrationWarning
 								className={'font-number text-base text-neutral-900'}>
 								{lpCRVAPY ? `${(lpCRVAPY || '').replace('APY', '')}` : `${formatPercent(0)}`}
 							</b>
@@ -237,7 +227,6 @@ function	Holdings(): ReactElement {
 						<div className={'flex flex-row items-center justify-between'}>
 							<span className={'inline text-sm font-normal text-neutral-400 md:hidden'}>{'Total Assets: '}</span>
 							<p
-								suppressHydrationWarning
 								className={'font-number text-base text-neutral-900'}>
 								{holdings?.lpyCRVSupply ? formatCounterValue(
 									formatToNormalizedValue(holdings?.lpyCRVSupply, 18),
@@ -248,7 +237,6 @@ function	Holdings(): ReactElement {
 						<div className={'flex flex-row items-center justify-between'}>
 							<span className={'inline text-sm font-normal text-neutral-400 md:hidden'}>{'yCRV Deposits: '}</span>
 							<p
-								suppressHydrationWarning
 								className={'font-number text-base text-neutral-900'}>
 								{formatBigNumberOver10K(holdings?.lpyCRVSupply || 0)}
 							</p>
@@ -257,12 +245,10 @@ function	Holdings(): ReactElement {
 							<span className={'inline text-sm font-normal text-neutral-400 md:hidden'}>{'My Balance: '}</span>
 							<div>
 								<p
-									suppressHydrationWarning
 									className={'font-number text-base text-neutral-900'}>
 									{formatNumberOver10K(balances[LPYCRV_TOKEN_ADDRESS]?.normalized || 0)}
 								</p>
 								<p
-									suppressHydrationWarning
 									className={'font-number text-xs text-neutral-600'}>
 									{formatCounterValue(
 										balanceOfLpyCRV?.normalized,
@@ -313,22 +299,18 @@ function	Holdings(): ReactElement {
 
 					<div>
 						<p
-							suppressHydrationWarning
 							className={'font-number text-sm text-neutral-400 md:text-base'}>
 							{styCRVAPY ? `*${formatPercent(styCRVAPY)} APY: ` : `*${formatPercent(0)} APY: `}
 						</p>
 						<p
-							suppressHydrationWarning
 							className={'font-number text-sm text-neutral-400 md:text-base'}>
 							{`∙ ${curveAdminFeePercent ? formatPercent(curveAdminFeePercent) : formatPercent(0)} Curve Admin Fees (${formatAmount(Number(holdings?.boostMultiplier) / 10000)}x boost)`}
 						</p>
 						<p
-							suppressHydrationWarning
 							className={'font-number text-sm text-neutral-400 md:text-base'}>
 							{`∙ ${styCRVAPY && curveAdminFeePercent && styCRVMegaBoost ? formatAmount(styCRVAPY - (curveAdminFeePercent + (styCRVMegaBoost * 100)), 2, 2) : '0.00'}% Gauge Voting Bribes`}
 						</p>
 						<p
-							suppressHydrationWarning
 							className={'font-number text-sm text-neutral-400 md:text-base'}>
 							{`∙ ${styCRVMegaBoost ? formatPercent(styCRVMegaBoost * 100) : formatPercent(0)} Mega Boost`}
 						</p>

--- a/pages/ycrv/vote.tsx
+++ b/pages/ycrv/vote.tsx
@@ -49,26 +49,26 @@ function Vote(): ReactElement {
 				</div>
 				<div className={'grid grid-cols-1 gap-6 md:grid-cols-3 md:gap-12'}>
 					<div className={'flex flex-col items-center justify-center space-y-1 md:space-y-2'}>
-						<b className={'font-number text-lg md:text-3xl'} suppressHydrationWarning>
+						<b className={'font-number text-lg md:text-3xl'}>
 							{totalVotes}
 						</b>
-						<legend className={'text-xxs text-neutral-600 md:text-xs'} suppressHydrationWarning>
+						<legend className={'text-xxs text-neutral-600 md:text-xs'}>
 							{'Your total votes'}
 						</legend>
 					</div>
 
 					<div className={'flex flex-col items-center justify-center space-y-1 md:space-y-2'}>
-						<b className={'font-number text-lg md:text-3xl'} suppressHydrationWarning>
+						<b className={'font-number text-lg md:text-3xl'}>
 							{remainingVotesForThisPeriod}
 						</b>
 						<legend className={'text-xxs text-neutral-600 md:text-xs'}>{'Your remaining votes'}</legend>
 					</div>
 
 					<div className={'flex flex-col items-center justify-center space-y-1 md:space-y-2'}>
-						<b className={'font-number text-lg md:text-3xl'} suppressHydrationWarning>
+						<b className={'font-number text-lg md:text-3xl'}>
 							{lastVoteTime ? formatDateShort(lastVoteTime * 1000) : '—'}
 						</b>
-						<legend className={'text-xxs text-neutral-600 md:text-xs'} suppressHydrationWarning>
+						<legend className={'text-xxs text-neutral-600 md:text-xs'}>
 							{'Your last vote'}
 						</legend>
 					</div>


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Fix react hydration error globally, follow up on https://github.com/yearn/yearn.fi/pull/84

Also addresses the following errors with https://github.com/yearn/yearn.fi/compare/fix/global-react-hydration-error?expand=1#diff-30a89c1d8535ebf7d1363a6734818dbd3fbd7cd1f5cf67f679f4115489e5c59fR65-R67:

> Warning: React does not recognize the `verticalAnchor` prop on a DOM element.
> Warning: React does not recognize the `visibleTicksCount` prop on a DOM element.
> Warning: React does not recognize the `tickFormatter` prop on a DOM element

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/85

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We are supressing hydration errors, but these should instead be addressed as there are inconsistencies between the React tree that was pre-rendered (SSR/SSG) and the React tree that rendered during the first render in the Browser.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally

## Screenshots (if appropriate):
