### PR TITLE
fix: Error validating DOM nesting

### DIFF
--- a/apps/ycrv/components/list/GaugeListRow.tsx
+++ b/apps/ycrv/components/list/GaugeListRow.tsx
@@ -78,7 +78,7 @@ function GaugeListRow({gauge, gaugeVotes, votesState, votesDispatch}: TGaugeList
 
 				<div className={'yearn--table-data-section-item pt-2 md:col-span-5'}>
 					<label className={'yearn--table-data-section-item-label !font-aeonik'}>{'Put your votes'}</label>
-					<p className={'yearn--table-data-section-item-value w-full text-neutral-900'}>
+					<div className={'yearn--table-data-section-item-value w-full text-neutral-900'}>
 						<div className={'flex h-10 w-full flex-row items-center justify-between'}>
 							<QuickActions.Input
 								id={`${gauge.gauge}-votes`}
@@ -91,7 +91,7 @@ function GaugeListRow({gauge, gaugeVotes, votesState, votesDispatch}: TGaugeList
 								isMaxDisabled={isMaxDisabled}
 							/>
 						</div>
-					</p>
+					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Convert the `p` to `div` tag as `p` can only contain inline elements.

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/yearn.fi/issues/87

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Fix the error validating DOM nesting

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and the error was no longer displayed
