### PR TITLE
feat: Deep link tabs

### DIFF
--- a/apps/vaults/components/details/VaultDetailsTabsWrapper.tsx
+++ b/apps/vaults/components/details/VaultDetailsTabsWrapper.tsx
@@ -1,4 +1,5 @@
-import React, {Fragment, useMemo, useState} from 'react';
+import React, {Fragment, useEffect, useMemo, useState} from 'react';
+import {useRouter} from 'next/router';
 import useSWR from 'swr';
 import {Listbox, Transition} from '@headlessui/react';
 import {useIsMounted} from '@react-hookz/web';
@@ -23,6 +24,7 @@ import type {TSettingsForNetwork, TYearnVault} from '@common/types/yearn';
 type TTabsOptions = {
 	value: number;
 	label: string;
+	slug?: string;
 }
 type TTabs = {
 	selectedAboutTabIndex: number,
@@ -35,11 +37,20 @@ type TExplorerLinkProps = {
 }
 
 function	Tabs({selectedAboutTabIndex, set_selectedAboutTabIndex}: TTabs): ReactElement {
-	const tabs: TTabsOptions[] = [
-		{value: 0, label: 'About'},
-		{value: 1, label: 'Strategies'},
-		{value: 2, label: 'Historical rates'}
-	];
+	const router = useRouter();
+
+	const tabs: TTabsOptions[] = useMemo((): TTabsOptions[] => [
+		{value: 0, label: 'About', slug: 'about'},
+		{value: 1, label: 'Strategies', slug: 'strategies'},
+		{value: 2, label: 'Historical rates', slug: 'historical-rates'}
+	], []);
+
+	useEffect((): void => {
+		const tab = tabs.find((tab): boolean => tab.slug === router.query.tab2);
+		if (tab?.value) {
+			set_selectedAboutTabIndex(tab?.value);
+		}
+	}, [router.query.tab2, set_selectedAboutTabIndex, tabs]);
 
 	return (
 		<>
@@ -47,7 +58,21 @@ function	Tabs({selectedAboutTabIndex, set_selectedAboutTabIndex}: TTabs): ReactE
 				{tabs.map((tab): ReactElement => (
 					<button
 						key={`desktop-${tab.value}`}
-						onClick={(): void => set_selectedAboutTabIndex(tab.value)}>
+						onClick={(): void => {
+							router.replace(
+								{
+									query: {
+										...router.query,
+										tab2: tab.slug
+									}
+								},
+								undefined,
+								{
+									shallow: true
+								}
+							);
+							set_selectedAboutTabIndex(tab.value);
+						}}>
 						<p
 							title={tab.label}
 							aria-selected={selectedAboutTabIndex === tab.value}


### PR DESCRIPTION
*Proof of concept*

## Description

<!--- Describe your changes -->

Implement deep linking for tabs in the `/vaults` page, if approved I'll expand to other tabs

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/100

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Allow for linking to a specific tab

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and navigated between tabs, was able to link to a specific tab combo, check screen recording below

## Screenshots (if appropriate):

https://user-images.githubusercontent.com/78794805/224009891-84c41d64-7745-4585-927c-0ec231da73e6.mp4
