### PR TITLE
refactor: Proof of concept tailwindcss logic

### DIFF
--- a/apps/common/utils/classNames.ts
+++ b/apps/common/utils/classNames.ts
@@ -1,0 +1,3 @@
+export function classNames(...classes: string[]): string {
+	return classes.filter(Boolean).join(' ');
+}

--- a/apps/vaults/components/details/VaultDetailsTabsWrapper.tsx
+++ b/apps/vaults/components/details/VaultDetailsTabsWrapper.tsx
@@ -16,6 +16,7 @@ import {baseFetcher} from '@yearn-finance/web-lib/utils/fetchers';
 import {formatBN, formatToNormalizedValue} from '@yearn-finance/web-lib/utils/format.bigNumber';
 import {formatDate} from '@yearn-finance/web-lib/utils/format.time';
 import IconChevron from '@common/icons/IconChevron';
+import {classNames} from '@common/utils/classNames';
 
 import type {ReactElement} from 'react';
 import type {SWRResponse} from 'swr';
@@ -96,7 +97,12 @@ function	Tabs({selectedAboutTabIndex, set_selectedAboutTabIndex}: TTabs): ReactE
 								</div>
 								<div className={'absolute right-0'}>
 									<IconChevron
-										className={`h-6 w-6 transition-transform ${open ? '-rotate-180' : 'rotate-0'}`} />
+										className={classNames(
+											open
+												? '-rotate-180'
+												: 'rotate-0',
+											'h-6 w-6 transition-transform'
+										)} />
 								</div>
 							</Listbox.Button>
 							<Transition


### PR DESCRIPTION
## Description

<!--- Describe your changes -->


Follow up on https://github.com/yearn/yearn.fi/pull/56#discussion_r1115591864

Util function `classNames` with the sole purpose of having more readable tailwindcss class names when there's logic involved. If approved we could refactor the codebase to use that instead, or potentially move this helper function to the web lib.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Having inline logic with tailwindcss makes it a bit hard to read sometimes.
