### PR TITLE
feat: Strategies filter

### DIFF
--- a/apps/common/components/ListHero.tsx
+++ b/apps/common/components/ListHero.tsx
@@ -3,6 +3,8 @@ import {Switch as HeadlessSwitch} from '@headlessui/react';
 import {Button} from '@yearn-finance/web-lib/components/Button';
 import {isValidCategory} from '@common/types/category';
 
+import {SearchBar} from './SearchBar';
+
 import type {ChangeEvent, ReactElement, ReactNode} from 'react';
 
 export type TListHeroCategory<T> = {
@@ -28,58 +30,9 @@ export type TListHero<T> = {
 	set_searchValue: (searchValue: string) => void;
 }
 
-export type TListHeroSearchBar = {
-	searchLabel: string;
-	searchPlaceholder: string;
-	searchValue: string;
-	set_searchValue: (searchValue: string) => void;
-}
-
 export type TListHeroDesktopCategories<T> = {
 	categories: TListHeroCategory<T>[][];
 	onSelect: (category: T) => void;
-}
-
-function	SearchBar({searchLabel, searchPlaceholder, searchValue, set_searchValue}: TListHeroSearchBar): ReactElement {
-	return (
-		<div className={'w-full'}>
-			<label
-				htmlFor={'search'}
-				className={'text-neutral-600'}>
-				{searchLabel}
-			</label>
-			<div className={'mt-1 flex h-10 w-full max-w-md items-center border border-neutral-0 bg-neutral-0 p-2 md:w-2/3'}>
-				<div className={'relative flex h-10 w-full flex-row items-center justify-between'}>
-					<input
-						id={'search'}
-						className={'h-10 w-full overflow-x-scroll border-none bg-transparent py-2 px-0 text-base outline-none scrollbar-none placeholder:text-neutral-400'}
-						type={'text'}
-						placeholder={searchPlaceholder}
-						value={searchValue}
-						onChange={(e: ChangeEvent<HTMLInputElement>): void => {
-							if (set_searchValue) {
-								set_searchValue(e.target.value);
-							}
-						}} />
-					<div className={'absolute right-0 text-neutral-400'}>
-						<svg
-							width={'20'}
-							height={'20'}
-							viewBox={'0 0 24 24'}
-							fill={'none'}
-							xmlns={'http://www.w3.org/2000/svg'}>
-							<path
-								fillRule={'evenodd'}
-								clipRule={'evenodd'}
-								d={'M10 1C5.02972 1 1 5.02972 1 10C1 14.9703 5.02972 19 10 19C12.1249 19 14.0779 18.2635 15.6176 17.0318L21.2929 22.7071C21.6834 23.0976 22.3166 23.0976 22.7071 22.7071C23.0976 22.3166 23.0976 21.6834 22.7071 21.2929L17.0318 15.6176C18.2635 14.0779 19 12.1249 19 10C19 5.02972 14.9703 1 10 1ZM3 10C3 6.13428 6.13428 3 10 3C13.8657 3 17 6.13428 17 10C17 13.8657 13.8657 17 10 17C6.13428 17 3 13.8657 3 10Z'}
-								fill={'currentcolor'}/>
-						</svg>
-					</div>
-
-				</div>
-			</div>
-		</div>
-	);
 }
 
 function	DesktopCategories<T>({categories, onSelect}: TListHeroDesktopCategories<T>): ReactElement {

--- a/apps/common/components/SearchBar.tsx
+++ b/apps/common/components/SearchBar.tsx
@@ -1,0 +1,50 @@
+import type {ChangeEvent, ReactElement} from 'react';
+
+export type TSearchBar = {
+	searchLabel: string;
+	searchPlaceholder: string;
+	searchValue: string;
+	set_searchValue: (searchValue: string) => void;
+}
+
+export function	SearchBar({searchLabel, searchPlaceholder, searchValue, set_searchValue}: TSearchBar): ReactElement {
+	return (
+		<div className={'w-full'}>
+			<label
+				htmlFor={'search'}
+				className={'text-neutral-600'}>
+				{searchLabel}
+			</label>
+			<div className={'mt-1 flex h-10 w-full max-w-md items-center border border-neutral-0 bg-neutral-0 p-2 md:w-2/3'}>
+				<div className={'relative flex h-10 w-full flex-row items-center justify-between'}>
+					<input
+						id={'search'}
+						className={'h-10 w-full overflow-x-scroll border-none bg-transparent py-2 px-0 text-base outline-none scrollbar-none placeholder:text-neutral-400'}
+						type={'text'}
+						placeholder={searchPlaceholder}
+						value={searchValue}
+						onChange={(e: ChangeEvent<HTMLInputElement>): void => {
+							if (set_searchValue) {
+								set_searchValue(e.target.value);
+							}
+						}} />
+					<div className={'absolute right-0 text-neutral-400'}>
+						<svg
+							width={'20'}
+							height={'20'}
+							viewBox={'0 0 24 24'}
+							fill={'none'}
+							xmlns={'http://www.w3.org/2000/svg'}>
+							<path
+								fillRule={'evenodd'}
+								clipRule={'evenodd'}
+								d={'M10 1C5.02972 1 1 5.02972 1 10C1 14.9703 5.02972 19 10 19C12.1249 19 14.0779 18.2635 15.6176 17.0318L21.2929 22.7071C21.6834 23.0976 22.3166 23.0976 22.7071 22.7071C23.0976 22.3166 23.0976 21.6834 22.7071 21.2929L17.0318 15.6176C18.2635 14.0779 19 12.1249 19 10C19 5.02972 14.9703 1 10 1ZM3 10C3 6.13428 6.13428 3 10 3C13.8657 3 17 6.13428 17 10C17 13.8657 13.8657 17 10 17C6.13428 17 3 13.8657 3 10Z'}
+								fill={'currentcolor'}/>
+						</svg>
+					</div>
+
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Filter vault strategies by:
* name or display name in the search input field; and
* total debt, zero or non-zero total debt

Designs https://www.figma.com/file/KW1tyc6AFtctyjByfe336Z/yearn.fi?node-id=76-582&t=muDFnLh1y0uB1dIW-0

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/108

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Improve the way strategies can be found

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, tried it out

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot_2023-03-16_at_12_51_46" src="https://user-images.githubusercontent.com/78794805/225596775-717b0ba1-1f2d-4269-b8af-feb4a33cd822.png">

<img width="1582" alt="Screenshot_2023-03-16_at_12_56_23" src="https://user-images.githubusercontent.com/78794805/225596756-78f77fa3-c1c2-47fb-8559-987ec1e49ad0.png">