### PR TITLE
fix: Withdraw doing an approve

### DIFF
--- a/apps/vaults/contexts/useActionFlow.tsx
+++ b/apps/vaults/contexts/useActionFlow.tsx
@@ -1,4 +1,5 @@
 import React, {createContext, useCallback, useContext, useEffect, useMemo, useReducer, useState} from 'react';
+import {useRouter} from 'next/router';
 import {useMountEffect, useUpdateEffect} from '@react-hookz/web';
 import {isSolverDisabled, Solver} from '@vaults/contexts/useSolver';
 import {useWalletForZap} from '@vaults/contexts/useWalletForZaps';
@@ -70,13 +71,19 @@ const	DefaultActionFlowContext: TActionFlowContext = {
 	currentSolver: Solver?.VANILLA || 'Vanilla'
 };
 
-function useContextualIs(selectedTo: TDropdownOption | undefined, currentVault: TYearnVault): [boolean, boolean] {
+type TUseContextualIs = {
+	selectedTo?: TDropdownOption;
+	currentVault: TYearnVault;
+}
+
+function useContextualIs({selectedTo, currentVault}: TUseContextualIs): [boolean, boolean] {
 	const {networks} = useSettings();
 	const {safeChainID} = useChainID();
+	const router = useRouter();
 
 	const isDepositing = useMemo((): boolean => (
-		!selectedTo?.value || toAddress(selectedTo.value) === toAddress(currentVault.address)
-	), [selectedTo?.value, currentVault.address]);
+		router.query.action === 'deposit' && (!selectedTo?.value || toAddress(selectedTo?.value) === toAddress(currentVault.address))
+	), [selectedTo?.value, currentVault.address, router.query.action]);
 
 	const isPartnerAddressValid = useMemo((): boolean => (
 		!isZeroAddress(toAddress(networks?.[safeChainID]?.partnerContractAddress))
@@ -157,7 +164,11 @@ function ActionFlowContextApp({children, currentVault}: {children: ReactNode, cu
 		possibleOptionsTo: [],
 		amount: toNormalizedBN(0)
 	});
-	const [isDepositing, isUsingPartnerContract] = useContextualIs(actionParams?.selectedOptionTo, currentVault);
+
+	const [isDepositing, isUsingPartnerContract] = useContextualIs({
+		selectedTo: actionParams?.selectedOptionTo,
+		currentVault
+	});
 
 	const maxDepositPossible = getMaxDepositPossible({
 		vault: currentVault,
@@ -377,15 +388,27 @@ function ActionFlowContextApp({children, currentVault}: {children: ReactNode, cu
 		performBatchedUpdates((): void => {
 			set_possibleOptionsFrom(payloadFrom);
 			set_possibleOptionsTo(payloadTo);
-			actionParamsDispatcher({
-				type: 'options',
-				payload: {
-					selectedOptionFrom: _selectedFrom,
-					selectedOptionTo: _selectedTo,
-					possibleOptionsFrom: payloadFrom,
-					possibleOptionsTo: payloadTo
-				}
-			});
+			if (!isDepositing) {
+				actionParamsDispatcher({
+					type: 'options',
+					payload: {
+						selectedOptionFrom: _selectedTo,
+						selectedOptionTo: _selectedFrom,
+						possibleOptionsFrom: payloadTo,
+						possibleOptionsTo: payloadFrom
+					}
+				});
+			} else {
+				actionParamsDispatcher({
+					type: 'options',
+					payload: {
+						selectedOptionFrom: _selectedFrom,
+						selectedOptionTo: _selectedTo,
+						possibleOptionsFrom: payloadFrom,
+						possibleOptionsTo: payloadTo
+					}
+				});
+			}
 		});
 	});
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Fix withdraw doing an approve of yvToken spend by token

The problem appears to be the fact that when you reload the page the deep linking does not load the correct options as it believes you're trying to deposit even though you might be in the withdraw tab

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Fix the bug

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, reloading the page in with the withdraw param in the url loads the withdraw content 

