### PR TITLE
fix: Depositing state when no param

### DIFF
--- a/apps/vaults/contexts/useActionFlow.tsx
+++ b/apps/vaults/contexts/useActionFlow.tsx
@@ -82,7 +82,8 @@ function useContextualIs({selectedTo, currentVault}: TUseContextualIs): [boolean
 	const router = useRouter();
 
 	const isDepositing = useMemo((): boolean => (
-		router.query.action === 'deposit' && (!selectedTo?.value || toAddress(selectedTo?.value) === toAddress(currentVault.address))
+		(!router.query.action || router.query.action === 'deposit') &&
+			(!selectedTo?.value || toAddress(selectedTo?.value) === toAddress(currentVault.address))
 	), [selectedTo?.value, currentVault.address, router.query.action]);
 
 	const isPartnerAddressValid = useMemo((): boolean => (


### PR DESCRIPTION
## Description

When there is no action param, we should by default send the user to the Deposit tab

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Have the user go to the Deposit tab when there's no deep linking

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, when open the vault without any action params the initial tab is Deposit
