### PR TITLE
Fix/portals solver gaslimit

### DIFF
--- a/apps/vaults/hooks/useSolverPortals.ts
+++ b/apps/vaults/hooks/useSolverPortals.ts
@@ -158,7 +158,7 @@ export function useSolverPortals(): TSolverContext {
 			const signer = provider.getSigner();
 			const transactionResponse = await signer.sendTransaction({
 				value: BigNumber.from(value?.hex ?? 0),
-				gasLimit: BigNumber.from(gasLimit?.hex ?? 0),
+				gasLimit: gasLimit?.hex ? BigNumber.from(gasLimit.hex) : undefined,
 				...rest
 			});
 			const transactionReceipt = await transactionResponse.wait();

--- a/apps/vaults/hooks/useSolverPortals.ts
+++ b/apps/vaults/hooks/useSolverPortals.ts
@@ -145,7 +145,7 @@ export function useSolverPortals(): TSolverContext {
 					sellAmount: formatBN(request.current.inputAmount || 0).toString(),
 					buyToken: toAddress(request.current.outputToken.value),
 					slippagePercentage: String(zapSlippage / 100),
-					validate: false
+					validate: true
 				}
 			});
 


### PR DESCRIPTION
## Description

Currently the gaslimit is set to zero because there is not gaslimit returned by the API when `validate` param is set to false. This turns on validation and also handles the missing gaslimit in case `validate` is false.
