### PR TITLE
fix/wido native coin tx

### DIFF
--- a/apps/vaults/hooks/useSolverWido.tsx
+++ b/apps/vaults/hooks/useSolverWido.tsx
@@ -125,8 +125,8 @@ export function useSolverWido(): TSolverContext {
 
 		const signer = provider.getSigner();
 		try {
-			const {data, to} = latestQuote.current;
-			const transaction = await signer.sendTransaction({data, to});
+			const {data, to, value} = latestQuote.current;
+			const transaction = await signer.sendTransaction({data, to, value});
 			const transactionReceipt = await transaction.wait();
 			if (transactionReceipt.status === 0) {
 				console.error('Fail to perform transaction');


### PR DESCRIPTION
## Description

Added the `value` argument required to be sent on the `sendTransaction`.

## Related Issue


## Motivation and Context

When the input asset is a native coin, the value is required to be specified so the wallet send those coins to the contract.

## How Has This Been Tested?


## Screenshots (if appropriate):
