### PR TITLE
Fix: st-yCRV Total Assets

### DIFF
--- a/pages/ycrv/holdings.tsx
+++ b/pages/ycrv/holdings.tsx
@@ -188,7 +188,7 @@ function	Holdings(): ReactElement {
 								className={'font-number text-base text-neutral-900'}>
 								{holdings?.styCRVSupply ? formatCounterValue(
 									formatToNormalizedValue(holdings.styCRVSupply, 18),
-									stycrvPrice
+									ycrvPrice
 								) : formatAmount(0)}
 							</p>
 						</div>


### PR DESCRIPTION
$ amount displayed on the ycrv holdings page is incorrect. Use ycrvPrice instead of stycrvPrice.

## Description

<!--- Describe your changes -->

## Related Issue

<!--- Please link to the issue here -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

st-yCRV total assets displaying as $43.7m on the ycrv holdings page when it should be $36.2m (as it is on the standard vaults pages).

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/97782872/235980179-3f0fcb86-528f-48c1-be69-eae7d1f29de2.png)
![image](https://user-images.githubusercontent.com/97782872/235980279-dde844a6-1521-47da-8766-c8ec3108774c.png)
