### PR TITLE
fix: Operator '<' cannot be applied to types 'Timestamp' and 'number'

### DIFF
--- a/apps/vaults/hooks/useSolverCowswap.tsx
+++ b/apps/vaults/hooks/useSolverCowswap.tsx
@@ -211,7 +211,7 @@ export function useSolverCowswap(): TSolverContext {
 			if (order?.status === 'cancelled' || order?.status === 'expired') {
 				return ({isSuccessful: false, error: new Error('TX fail because the order was not fulfilled')});
 			}
-			if (validTo < (new Date().valueOf() / 1000)) {
+			if (validTo.valueOf() < (new Date().valueOf() / 1000)) {
 				return ({isSuccessful: false, error: new Error('TX fail because the order expired')});
 			}
 			// Sleep for 3 seconds before checking the status again


### PR DESCRIPTION
The latest TypeScript https://github.com/yearn/yearn.fi/pull/152 picked up an issue with comparing `Timestamp` and `number`

<img width="678" alt="Screenshot 2023-05-10 at 9 31 53" src="https://github.com/yearn/yearn.fi/assets/78794805/f39dc8b4-659a-4f5c-9d5c-60e98fd4dadb">
