### PR TITLE
refactor: Coerce reports types

### DIFF
--- a/apps/vaults/components/details/tabs/VaultDetailsStrategies.tsx
+++ b/apps/vaults/components/details/tabs/VaultDetailsStrategies.tsx
@@ -62,14 +62,20 @@ function	VaultDetailsStrategy({currentVault, strategy}: {currentVault: TYearnVau
 		{revalidateOnFocus: false}
 	) as SWRResponse;
 
-	const result = yDaemonReportsSchema.safeParse(data);
+	let latestApr;
 
-	if (!result.success) {
-		// TODO Send to Sentry
-		console.error(result.error);
+	if (!data) {
+		latestApr = 0;
 	}
 
-	const latestApr = result.success ? findLatestApr(result.data) : 0;
+	const result = data ? yDaemonReportsSchema.safeParse(data) : null;
+
+	if (data && !result?.success) {
+		// TODO Send to Sentry
+		console.error(result?.error);
+	}
+
+	latestApr = result?.success ? findLatestApr(result.data) : 0;
 
 	return (
 		<details className={'p-0'}>

--- a/apps/vaults/components/details/tabs/findLatestApr.test.ts
+++ b/apps/vaults/components/details/tabs/findLatestApr.test.ts
@@ -1,51 +1,17 @@
 import {findLatestApr} from './findLatestApr';
 
 describe('findLatestApr', (): void => {
-	it('should return 0 when no reports are provided', (): void => {
-		expect(findLatestApr()).toBe(0);
-	});
-
 	it('should return 0 when an empty array is provided', (): void => {
 		expect(findLatestApr([])).toBe(0);
-	});
-
-	it('should return 0 if a result item has no APR', (): void => {
-		const reports = [
-			{
-				timestamp: '1000',
-				results: [
-					{
-						APR: ''
-					}
-				]
-			}
-		];
-
-		expect(findLatestApr(reports)).toBe(0);
-	});
-
-	it('should return 0 if a result item has an invalid APR', (): void => {
-		const reports = [
-			{
-				timestamp: '1000',
-				results: [
-					{
-						APR: 'foo'
-					}
-				]
-			}
-		];
-
-		expect(findLatestApr(reports)).toBe(0);
 	});
 
 	it('should return the correct APR for a single report', (): void => {
 		const reports = [
 			{
-				timestamp: '1000',
+				timestamp: 1000,
 				results: [
 					{
-						APR: '0.05'
+						APR: 0.05
 					}
 				]
 			}
@@ -57,26 +23,26 @@ describe('findLatestApr', (): void => {
 	it('should return the correct APR for multiple reports', (): void => {
 		const reports = [
 			{
-				timestamp: '1000',
+				timestamp: 1000,
 				results: [
 					{
-						APR: '0.05'
+						APR: 0.05
 					}
 				]
 			},
 			{
-				timestamp: '3000',
+				timestamp: 3000,
 				results: [
 					{
-						APR: '0.1'
+						APR: 0.1
 					}
 				]
 			},
 			{
-				timestamp: '2000',
+				timestamp: 2000,
 				results: [
 					{
-						APR: '0.07'
+						APR: 0.07
 					}
 				]
 			}

--- a/apps/vaults/components/details/tabs/findLatestApr.ts
+++ b/apps/vaults/components/details/tabs/findLatestApr.ts
@@ -1,17 +1,13 @@
 import type {TYDaemonReports} from '@vaults/schemas';
 
-export function findLatestApr(reports?: TYDaemonReports[]): number {
-	if (!reports?.length) {
+export function findLatestApr(reports: TYDaemonReports[]): number {
+	if (!reports.length) {
 		return 0;
 	}
 
 	const latestReport = reports.reduce((prev, curr): TYDaemonReports => {
-		return parseInt(prev.timestamp) > parseInt(curr.timestamp)
-			? prev
-			: curr;
+		return prev.timestamp > curr.timestamp ? prev : curr;
 	});
 
-	const apr = Number(latestReport.results[0]?.APR);
-
-	return isNaN(apr) ? 0 : apr * 100;
+	return latestReport.results[0].APR * 100;
 }

--- a/apps/vaults/schemas/reportsSchema.ts
+++ b/apps/vaults/schemas/reportsSchema.ts
@@ -1,9 +1,9 @@
 import {z} from 'zod';
 
 const resultSchema = z.object({
-	duration: z.string().optional(),
-	durationPR: z.string().optional(),
-	APR: z.string()
+	duration: z.coerce.number().optional(),
+	durationPR: z.coerce.number().optional(),
+	APR: z.coerce.number()
 });
 
 const reportSchema = z.object({
@@ -16,7 +16,7 @@ const reportSchema = z.object({
 	loss: z.string().optional(),
 	totalLoss: z.string().optional(),
 	debtPaid: z.string().optional(),
-	timestamp: z.string(),
+	timestamp: z.coerce.number(),
 	results: z.array(resultSchema)
 });
 


### PR DESCRIPTION
Follow up on yDaemon reports' props type changes

* `duration`: `string` to `number`
* `durationPR`: `string` to `number`
* `APR`: `string` to `number`
* `timestamp`: `string` to `number`