### PR TITLE
fix: yCRV Page crash if not mainnet

### DIFF
--- a/apps/ycrv/components/QuickActions.tsx
+++ b/apps/ycrv/components/QuickActions.tsx
@@ -55,7 +55,7 @@ function QASelect(props: TQASelect): ReactElement {
 		<div className={'relative z-10 w-full space-y-2'}>
 			<div className={'flex flex-row items-baseline justify-between'}>
 				<label className={'text-base text-neutral-600'}>{label}</label>
-				<legend className={'font-number inline text-xs text-neutral-600 md:hidden'}>
+				<legend className={'font-number inline text-xs text-neutral-600 md:hidden'} suppressHydrationWarning>
 					{legend}
 				</legend>
 			</div>
@@ -74,7 +74,7 @@ function QASelect(props: TQASelect): ReactElement {
 					</div>
 				</div>
 			</Renderable>
-			<legend className={'font-number hidden text-xs text-neutral-600 md:inline'}>
+			<legend className={'font-number hidden text-xs text-neutral-600 md:inline'} suppressHydrationWarning>
 				{legend}
 			</legend>
 		</div>

--- a/apps/ycrv/hooks/useVLyCRV.ts
+++ b/apps/ycrv/hooks/useVLyCRV.ts
@@ -85,8 +85,10 @@ export function useVLyCRV(): TUseVLyCRV {
 
 	const {data, mutate} = useSWR<TUseVLyCRV['initialData']>(isActive && provider ? 'vLyCRV' : null, fetcher);
 
+	const initialData = (data && !isEmpty(data)) ? data : DEFAULT_VLYCRV;
+
 	return {
-		initialData: data ?? DEFAULT_VLYCRV,
+		initialData,
 		mutateData: mutate,
 		deposit: vLyCRVDeposit,
 		withdraw: vLyCRVWithdraw,
@@ -96,4 +98,12 @@ export function useVLyCRV(): TUseVLyCRV {
 			approveERC20(provider, YCRV_TOKEN_ADDRESS, VLYCRV_TOKEN_ADDRESS, amount)
 		)
 	};
+}
+
+function isEmpty(data?: TUseVLyCRV['initialData']): boolean {
+	if (!data) {
+		return true;
+	}
+
+	return !data.nextPeriod || !data.userInfo || !data.getVotesUnpacked;
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Check if there's any `data` when in another network, we still get the same object but will all values (`nextPeriod`, `userInfo` and `getVotesUnpacked`) as `null`

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/yearn.fi/issues/159

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

yCRV vote page crashes when not in mainnet

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, changed to another network than Ethereum, observed the page loading

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot_2023-05-11_at_10_08_25" src="https://github.com/yearn/yearn.fi/assets/78794805/e17af3b9-96f9-4220-9756-1dcdc2e9ec48">

