### PR TITLE
fix: Strategy reports is nullable

### DIFF
--- a/apps/vaults/components/details/tabs/findLatestApr.ts
+++ b/apps/vaults/components/details/tabs/findLatestApr.ts
@@ -9,5 +9,9 @@ export function findLatestApr(reports?: TYDaemonReports): number {
 		return prev.timestamp > curr.timestamp ? prev : curr;
 	});
 
-	return (latestReport?.results?.[0]?.APR || 0) * 100;
+	if (!latestReport.results || latestReport.results.length === 0) {
+		return 0;
+	}
+
+	return latestReport.results[0].APR * 100;
 }

--- a/apps/vaults/schemas/reportsSchema.ts
+++ b/apps/vaults/schemas/reportsSchema.ts
@@ -17,7 +17,7 @@ const yDaemonReportSchema = z.object({
 	totalLoss: z.string().optional(),
 	debtPaid: z.string().optional(),
 	timestamp: z.coerce.number(),
-	results: z.array(resultSchema)
+	results: z.array(resultSchema).nullable()
 });
 
 export const yDaemonReportsSchema = z.array(yDaemonReportSchema);


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

`results` in yDaemonReport can be `null`

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/169
