### PR TITLE
fix: Add enpoint as tag

### DIFF
--- a/apps/common/hooks/useFetch.ts
+++ b/apps/common/hooks/useFetch.ts
@@ -20,7 +20,7 @@ export function	useFetch<T>({endpoint, schema, config}: TUseZodProps<T>): SWRRes
 
 	if (result.error) {
 		console.error(endpoint, result.error);
-		Sentry.captureException(result.error, {extra: {endpoint}});
+		Sentry.captureException(result.error, {tags: {endpoint}});
 		return {...result, isSuccess: false};
 	}
 
@@ -28,7 +28,7 @@ export function	useFetch<T>({endpoint, schema, config}: TUseZodProps<T>): SWRRes
 	
 	if (!parsedData.success) {
 		console.error(endpoint, parsedData.error);
-		Sentry.captureException(parsedData.error, {extra: {endpoint}});
+		Sentry.captureException(parsedData.error, {tags: {endpoint}});
 		return {...result, isSuccess: false};
 	}
 


### PR DESCRIPTION
It appears that `extra` was not working for sending the `endpoint`, using `tag` instead.

<img width="1259" alt="Error___karelianpie_-_xopowo-team_-_yearn-fi" src="https://github.com/yearn/yearn.fi/assets/78794805/332d970d-1487-4fd7-ac18-be1a8abc7aba">
