### PR TITLE
fix: Cannot read property getNetwork of `undefined`

### DIFF
--- a/apps/common/hooks/useBalances.tsx
+++ b/apps/common/hooks/useBalances.tsx
@@ -102,20 +102,23 @@ async function performCall(
 }
 
 async function getBalances(
-	provider: ethers.providers.JsonRpcProvider,
+	provider: ethers.providers.JsonRpcProvider | undefined,
 	fallBackProvider: ethers.providers.JsonRpcProvider,
 	ownerAddress: TAddress,
 	tokens: TUseBalancesTokens[],
 	prices?: TYDaemonPrices
 ): Promise<[TDict<TBalanceData>, Error | undefined]> {
+	if (!provider) {
+		return [{}, new Error('Provider not found')];
+	}
+
 	const	result: TDict<TBalanceData> = {};
-	const	currentProvider = provider;
 	const	calls = [];
-	const	ethcallProvider = await newEthCallProvider(currentProvider);
+	const	ethcallProvider = await newEthCallProvider(provider);
 
 	for (const {token} of tokens) {
 		if (toAddress(token) === ETH_TOKEN_ADDRESS) {
-			const	tokenContract = new Contract(getNativeTokenWrapperContract(currentProvider.network.chainId), ERC20_ABI);
+			const	tokenContract = new Contract(getNativeTokenWrapperContract(provider.network.chainId), ERC20_ABI);
 			calls.push(
 				ethcallProvider.getEthBalance(ownerAddress),
 				tokenContract.decimals(),


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Provider can be `undefined` when wallet is disconnected.

Check if there's a provider before calling `getNetwork()` on it

## Related Issue

<!--- Please link to the issue here -->

Fix https://github.com/yearn/yearn.fi/issues/175

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Fix the bug

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Tried locally and the error was gone