### PR TITLE
fix: Earned fetch

### DIFF
--- a/apps/common/contexts/useYearn.tsx
+++ b/apps/common/contexts/useYearn.tsx
@@ -98,7 +98,7 @@ export const YearnContextApp = memo(function YearnContextApp({children}: { child
 	});
 
 	const {data: earned} = useFetch<TYDaemonEarned>({
-		endpoint: `${YDAEMON_BASE_URI}/earned/${address}`,
+		endpoint: address ? `${YDAEMON_BASE_URI}/earned/${address}` : null,
 		schema: yDaemonEarnedSchema
 	});
 

--- a/apps/common/hooks/useFetch.ts
+++ b/apps/common/hooks/useFetch.ts
@@ -6,7 +6,7 @@ import type {SWRResponse} from 'swr';
 import type {z} from 'zod';
 
 type TUseZodProps<T> = {
-	endpoint: string;
+	endpoint: string | null;
 	schema: z.ZodSchema;
 	config?: Parameters<typeof useSWR<T>>[2];
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Previously we had

```typescript
const	{data: earned} = useSWR(
    address ? `${baseAPISettings.yDaemonBaseURI || process.env.YDAEMON_BASE_URI}/${safeChainID}/earned/${address}` : null,
    baseFetcher,
    {revalidateOnFocus: false}
) as SWRResponse;
```

So whenever there's no address we just pass `null` to the `useSWR` hook, bring that back to solve https://github.com/yearn/yearn.fi/issues/173

## Related Issue

<!--- Please link to the issue here -->

Fix https://github.com/yearn/yearn.fi/issues/173

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Avoid unnecessary fetches when there's no `address`

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, logged the `depositLimit`
