### PR TITLE
refactor: Use number input fields

### DIFF
--- a/apps/vaults/components/details/actions/QuickActionsFrom.tsx
+++ b/apps/vaults/components/details/actions/QuickActionsFrom.tsx
@@ -78,7 +78,7 @@ function	VaultDetailsQuickActionsFrom(): ReactElement {
 						<input
 							id={'fromAmount'}
 							className={`w-full overflow-x-scroll border-none bg-transparent py-4 px-0 font-bold outline-none scrollbar-none ${isActive ? '' : 'cursor-not-allowed'}`}
-							type={'text'}
+							type={'number'}
 							disabled={!isActive}
 							value={actionParams?.amount.normalized}
 							onChange={(e: ChangeEvent<HTMLInputElement>): void => onChangeAmount(

--- a/apps/vaults/components/details/actions/QuickActionsTo.tsx
+++ b/apps/vaults/components/details/actions/QuickActionsTo.tsx
@@ -75,7 +75,7 @@ function	VaultDetailsQuickActionsTo(): ReactElement {
 							<input
 								id={'toAmount'}
 								className={'w-full cursor-default overflow-x-scroll border-none bg-transparent py-4 px-0 font-bold outline-none scrollbar-none'}
-								type={'text'}
+								type={'number'}
 								disabled
 								value={expectedOut?.normalized || 0} />
 						}


### PR DESCRIPTION
Follow up on https://github.com/yearn/web-lib/pull/245, related to https://github.com/yearn/yearn.fi/issues/181

## Description

<!--- Describe your changes -->

The input fields that take numbers should be of type `number`

## Related Issue

<!--- Please link to the issue here -->

Kind of related to https://github.com/yearn/yearn.fi/issues/181

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Prevent users from type non-digit characters.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and was unable to input non-digit characters