### PR TITLE
feat: Capture getBatchBalances error to Sentry

### DIFF
--- a/pages/api/getBatchBalances.tsx
+++ b/pages/api/getBatchBalances.tsx
@@ -32,6 +32,8 @@ async function getBatchBalances({
 		currentProvider = getProvider(chainID);
 	}
 
+	await currentProvider.ready;
+
 	const	ethcallProvider = await newEthCallProvider(currentProvider);
 	const	data: TDict<TBalanceData> = {};
 	const	chunks = [];


### PR DESCRIPTION
Capture getBatchBalances error to Sentry

> Error POST /api/getBatchBalances
> 
> could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.7.2)