### PR TITLE
fix: Cannot read properties of `undefined` (reading 'length')

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
 	preset: 'ts-jest',
-	testEnvironment: 'node'
+	testEnvironment: 'node',
+	moduleNameMapper: {
+		'@vaults/(.*)': ['<rootDir>/apps/vaults/$1']
+	}
 };

--- a/pages/api/getBatchBalances.test.ts
+++ b/pages/api/getBatchBalances.test.ts
@@ -1,0 +1,41 @@
+import {isArrayOfUseBalancesTokens} from './getBatchBalances';
+
+import type {TUseBalancesTokens} from '@common/hooks/useBalances';
+
+describe('isArrayOfUseBalancesTokens', (): void => {
+	it('should return true for valid TUseBalancesTokens array', (): void => {
+		const validData: TUseBalancesTokens[] = [
+			{token: 'token1'},
+			{token: 'token2', for: 'for2'},
+			{token: 'token3', for: 'for3'}
+		];
+		expect(isArrayOfUseBalancesTokens(validData)).toBe(true);
+	});
+
+	it('should return false for an array including an item without a token', (): void => {
+		const invalidData: (TUseBalancesTokens | object)[] = [
+			{token: 'token1'},
+			{},
+			{token: 'token2', for: 'for2'}
+		];
+		expect(isArrayOfUseBalancesTokens(invalidData)).toBe(false);
+	});
+
+	it('should return false for an array including an item where token is not a string', (): void => {
+		const invalidData: unknown[] = [
+			{token: 'token1'},
+			{token: 123},
+			{token: 'token2', for: 'for2'}
+		];
+		expect(isArrayOfUseBalancesTokens(invalidData)).toBe(false);
+	});
+
+	it('should return false for non-array input', (): void => {
+		const nonArrayInput: unknown = 'not an array';
+		expect(isArrayOfUseBalancesTokens(nonArrayInput)).toBe(false);
+	});
+
+	it('should return false for undefined input', (): void => {
+		expect(isArrayOfUseBalancesTokens(undefined)).toBe(false);
+	});
+});

--- a/pages/api/getBatchBalances.tsx
+++ b/pages/api/getBatchBalances.tsx
@@ -93,11 +93,15 @@ async function getBatchBalances({
 	return data;
 }
 
+export function isArrayOfUseBalancesTokens(value: unknown): value is TUseBalancesTokens[] {
+	return Array.isArray(value) && value.every(({token}): boolean => token && typeof token === 'string');
+}
+
 export type TGetBatchBalancesResp = {balances: TDict<TBalanceData>, chainID: number};
 export default async function handler(req: NextApiRequest, res: NextApiResponse<TGetBatchBalancesResp>): Promise<void> {
 	const chainID = Number(req.body.chainID);
 	const address = String(req.body.address);
-	const tokens = req.body.tokens as unknown as TUseBalancesTokens[];
+	const tokens = isArrayOfUseBalancesTokens(req.body.tokens) ? req.body.tokens : [];
 
 	try {		
 		const balances = await getBatchBalances({chainID, address, tokens});

--- a/pages/api/getBatchBalances.tsx
+++ b/pages/api/getBatchBalances.tsx
@@ -94,7 +94,7 @@ async function getBatchBalances({
 }
 
 export function isArrayOfUseBalancesTokens(value: unknown): value is TUseBalancesTokens[] {
-	return Array.isArray(value) && value.every(({token}): boolean => token && typeof token === 'string');
+	return Array.isArray(value) && value.every(({token}): boolean => !!token && typeof token === 'string');
 }
 
 export type TGetBatchBalancesResp = {balances: TDict<TBalanceData>, chainID: number};


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

We're casting the `req.body.tokens` to `TUseBalancesTokens[]` but sometimes it's `undefined`

Add the type guard `isArrayOfUseBalancesTokens` to guarantee that the values are `TUseBalancesTokens[]`

## Related Issue

<!--- Please link to the issue here -->

Fix https://xopowo-team.sentry.io/issues/4187898965/events/15293aeae3ae4cb0b3a6ee8d902a6750/

<img width="899" alt="Screenshot 2023-05-22 at 9 10 08" src="https://github.com/yearn/yearn.fi/assets/78794805/56b763cb-b2b1-42a4-b3f3-13f71373d1ed">

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Avoid exception

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Tests in `pages/api/getBatchBalances.test.ts`
