### PR TITLE
fix: Internal Server Error when invalid vaults

### DIFF
--- a/apps/common/schemas/custom/addressSchema.ts
+++ b/apps/common/schemas/custom/addressSchema.ts
@@ -2,7 +2,7 @@ import {z} from 'zod';
 
 import type {TAddress} from '@yearn-finance/web-lib/types';
 
-const ADDRESS_REGEX = new RegExp(/^0x[0-9a-f]{40}$/i);
+export const ADDRESS_REGEX = new RegExp(/^0x[0-9a-f]{40}$/i);
 
 // TODO Change in web-lib the address type to have the regex /^0x[0-9a-f]{40}$/i
 export const addressSchema = z.custom<TAddress>((val): boolean => {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yearnfi",
   "version": "0.1.23",
   "scripts": {
-    "dev": "next",
+    "dev": "NODE_OPTIONS='--inspect' next",
     "dev:ts": "tsc --watch",
     "start": "tsc && next build && next start",
     "build": "tsc && next build",


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

When [Googlebot](https://developers.google.com/search/docs/crawling-indexing/googlebot), or a user goes to an invalid `/vaults` route -- be it an invalid chainID or an invalid vault address the app crashes with a 500 Internal Server Error, i.e. https://yearn.finance/vaults/invest/0xA74d4B67b3368E83797a35382AFB776bAAE4F5C8

The way to solve this is to validate both dynamic routes, `chainID` and `address` and only allow through the valid routes. The ones that do not have a valid `chainID` nor `address` should return 404 so that Google's crawler stops crawling them.

## Related Issue

<!--- Please link to the issue here -->

Fix https://github.com/yearn/yearn.fi/issues/194

<img width="1256" alt="FetchError__invalid_json_response_body_at_https___ydaemon_yearn_finance_invest_vaults_0xA74d4B67b3368E83797a35382AFB776bAAE4F5C8_hideAlways_true_orderBy_apy_net_apy_orderDirection_desc_strategiesDetails_withDetails_strategiesRisk_withRisk_s" src="https://github.com/yearn/yearn.fi/assets/78794805/74c4a632-ae03-4c9a-8a75-a40dba1aa878">

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Prevent 500 Internal Server Error and gracefully return 404 for invalid routes

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, went to invalid routes and observed 404 and valid routes working as expected

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot 2023-05-23 at 9 50 56" src="https://github.com/yearn/yearn.fi/assets/78794805/f2d4c82b-249a-41ec-a3f5-205af40c9d2c">
