### PR TITLE
refactor: CoinGecko prices fetch

### DIFF
--- a/apps/common/schemas/coinGeckoSchemas.ts
+++ b/apps/common/schemas/coinGeckoSchemas.ts
@@ -1,0 +1,6 @@
+import {z} from 'zod';
+
+export const coinGeckoPricesSchema = z.record(z.string(), z.object({usd: z.number()}));
+
+export type TCoinGeckoPrices = z.infer<typeof coinGeckoPricesSchema>;
+


### PR DESCRIPTION
Validate with Zod data coming from CoinGecko's [get_simple_price](https://www.coingecko.com/api/documentations/v3#/simple/get_simple_price)