### PR TITLE
Feat/Update OPT zap contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@popperjs/core": "^2.11.7",
     "@react-hookz/deep-equal": "^1.0.4",
     "@sentry/nextjs": "^7.52.1",
-    "@yearn-finance/web-lib": "^0.18.62",
+    "@yearn-finance/web-lib": "^0.18.75",
     "axios": "^1.2.2",
     "dayjs": "^1.11.7",
     "ethcall": "^4.8.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3060,10 +3060,10 @@
     "@web3-react/types" "^8.2.0"
     eventemitter3 "^4.0.7"
 
-"@yearn-finance/web-lib@^0.18.62":
-  version "0.18.62"
-  resolved "https://registry.yarnpkg.com/@yearn-finance/web-lib/-/web-lib-0.18.62.tgz#0900e5dd3a9271a9da458c09e8b7837c71d7527c"
-  integrity sha512-qamQ2U8xV7IUPcxiwccj50v5wB+lpjUYV/qAVebqAD1kCyApdbGpw/FOAUmbvp+E00YToCDCB6VwtXwHqbfC4g==
+"@yearn-finance/web-lib@^0.18.75":
+  version "0.18.75"
+  resolved "https://registry.yarnpkg.com/@yearn-finance/web-lib/-/web-lib-0.18.75.tgz#50c09725ae0e4b85fb0a44b24125b8c6ad69c295"
+  integrity sha512-ceavU87dxhMQ79hu0sUE9jxcd20nyOBo64w+VsXBMLymmSndqY4c6n8ZjsHVzBbeqAU4KVtDv4tsSjRd7pybHA==
   dependencies:
     "@coinbase/wallet-sdk" "^3.6.6"
     "@ethersproject/experimental" "^5.7.0"


### PR DESCRIPTION
Bump the webLib to upgrade the Optimism Zap contract
```
constant: STAKING_REWARDS_ZAP_ADDRESS
Previous: 0xd155F5bF8a475007Fa369e6314C3673e4Bb1e292
New: 0x498d9dCBB1708e135bdc76Ef007f08CBa4477BE2
```

[Weblib push](https://github.com/yearn/web-lib/commit/6dad92fa72d9a971aab1383689cfe7b70b479006) | [Weblib bump](https://github.com/yearn/web-lib/commit/a9eb6ec2446dcbdc15918aa82e14bff9f72470b0) | [Activation tx](https://app.safe.global/oeth:0xF5d9D6133b698cE29567a90Ab35CfB874204B3A7/transactions/queue)