### PR TITLE
Fix: Yearn Treasury veCRV figure

### DIFF
--- a/apps/ycrv/contexts/useHoldingsHook.tsx
+++ b/apps/ycrv/contexts/useHoldingsHook.tsx
@@ -74,7 +74,7 @@ export function useHoldings(): TCRVHoldings {
 		const crvYCRVPeg = decodeAsBigInt(data[7]);
 		return ({
 			legacy: yveCRVTotalSupply - yveCRVInYCRV,
-			treasury: veCRVBalance - ((yveCRVTotalSupply - yveCRVInYCRV) - yCRVTotalSupply),
+			treasury: veCRVBalance - ((yveCRVTotalSupply - yveCRVInYCRV) + yCRVTotalSupply),
 			yCRVSupply: yCRVTotalSupply,
 			styCRVSupply: styCRVTotalSupply,
 			lpyCRVSupply: lpyCRVTotalSupply,


### PR DESCRIPTION
## Description

Change a minus to a plus to correct the Yearn Treasury number on the new yCRV UI

## Related Issue

<!--- Please link to the issue here -->

## Motivation and Context

Yearn Treasury veCRV displaying as 109,498,717 on the new ycrv page when it should be ~10,000,000 because it is adding the totalSupply of yCRV instead of subtracting it.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Screenshots (if appropriate):

![image](https://github.com/yearn/yearn.fi/assets/97782872/32a6cc52-8454-4789-b01b-51076f704725)

