### PR TITLE
refactor: Use `formatBigNumberOver10K` and `formatNumberOver10K` from web-lib

### DIFF
--- a/apps/vaults/components/list/VaultListFactory.tsx
+++ b/apps/vaults/components/list/VaultListFactory.tsx
@@ -7,6 +7,7 @@ import {useFilteredVaults} from '@vaults/hooks/useFilteredVaults';
 import {useSortVaults} from '@vaults/hooks/useSortVaults';
 import {toAddress} from '@yearn-finance/web-lib/utils/address';
 import {toBigInt} from '@yearn-finance/web-lib/utils/format.bigNumber';
+import {isZero} from '@yearn-finance/web-lib/utils/isZero';
 import performBatchedUpdates from '@yearn-finance/web-lib/utils/performBatchedUpdates';
 import ListHead from '@common/components/ListHead';
 import ListHero from '@common/components/ListHero';
@@ -18,7 +19,6 @@ import type {ReactElement, ReactNode} from 'react';
 import type {TYDaemonVaults} from '@common/schemas/yDaemonVaultsSchemas';
 import type {TSortDirection} from '@common/types/types';
 import type {TPossibleSortBy} from '@vaults/hooks/useSortVaults';
-import { isZero } from '@yearn-finance/web-lib/utils/isZero';
 
 function VaultListFactory(): ReactElement {
 	const {balances} = useWallet();

--- a/pages/ybal/index.tsx
+++ b/pages/ybal/index.tsx
@@ -1,7 +1,7 @@
-import React, {Fragment, useCallback, useMemo} from 'react';
+import React, {Fragment, useMemo} from 'react';
 import {LPYBAL_TOKEN_ADDRESS, STYBAL_TOKEN_ADDRESS, YBAL_TOKEN_ADDRESS} from '@yearn-finance/web-lib/utils/constants';
-import {formatToNormalizedValue, toBigInt} from '@yearn-finance/web-lib/utils/format.bigNumber';
-import {formatAmount, formatPercent} from '@yearn-finance/web-lib/utils/format.number';
+import {formatBigNumberOver10K, formatToNormalizedValue} from '@yearn-finance/web-lib/utils/format.bigNumber';
+import {formatAmount, formatNumberOver10K, formatPercent} from '@yearn-finance/web-lib/utils/format.number';
 import {formatCounterValue, formatCounterValueRaw} from '@yearn-finance/web-lib/utils/format.value';
 import ValueAnimation from '@common/components/ValueAnimation';
 import {useWallet} from '@common/contexts/useWallet';
@@ -78,20 +78,6 @@ function Holdings(): ReactElement {
 	const lpyBalPrice = useTokenPrice(LPYBAL_TOKEN_ADDRESS);
 	const balanceOfStyBal = useBalance(STYBAL_TOKEN_ADDRESS);
 	const balanceOfLpyBal = useBalance(LPYBAL_TOKEN_ADDRESS);
-
-	const formatBigNumberOver10K = useCallback((v: bigint): string => {
-		if (toBigInt(v) > (toBigInt(10000) * toBigInt(1e18))) {
-			return formatAmount(formatToNormalizedValue(toBigInt(v), 18), 0, 0) ?? '';
-		}
-		return formatAmount(formatToNormalizedValue(toBigInt(v), 18)) ?? '';
-	}, []);
-
-	const formatNumberOver10K = useCallback((v: number): string => {
-		if (v >= 10000) {
-			return formatAmount(v, 0, 0) ?? '';
-		}
-		return formatAmount(v) ?? '';
-	}, []);
 
 	return (
 		<section className={'mt-4 grid w-full grid-cols-12 gap-y-10 pb-10 md:mt-20 md:gap-x-10 md:gap-y-20'}>

--- a/pages/ycrv/index.tsx
+++ b/pages/ycrv/index.tsx
@@ -1,7 +1,7 @@
-import React, {Fragment, useCallback, useMemo} from 'react';
+import React, {Fragment, useMemo} from 'react';
 import {LPYCRV_TOKEN_ADDRESS, STYCRV_TOKEN_ADDRESS, YCRV_TOKEN_ADDRESS} from '@yearn-finance/web-lib/utils/constants';
-import {formatToNormalizedValue, toBigInt} from '@yearn-finance/web-lib/utils/format.bigNumber';
-import {formatAmount, formatPercent} from '@yearn-finance/web-lib/utils/format.number';
+import {formatBigNumberOver10K, formatToNormalizedValue, toBigInt} from '@yearn-finance/web-lib/utils/format.bigNumber';
+import {formatAmount, formatNumberOver10K, formatPercent} from '@yearn-finance/web-lib/utils/format.number';
 import {formatCounterValue, formatCounterValueRaw} from '@yearn-finance/web-lib/utils/format.value';
 import ValueAnimation from '@common/components/ValueAnimation';
 import {useCurve} from '@common/contexts/useCurve';
@@ -82,20 +82,6 @@ function ZapAndStats(): ReactElement {
 	const lpycrvPrice = useTokenPrice(LPYCRV_TOKEN_ADDRESS);
 	const balanceOfStyCRV = useBalance(STYCRV_TOKEN_ADDRESS);
 	const balanceOfLpyCRV = useBalance(LPYCRV_TOKEN_ADDRESS);
-
-	const formatBigNumberOver10K = useCallback((v: bigint): string => {
-		if (toBigInt(v) > (toBigInt(10000) * toBigInt(1e18))) {
-			return formatAmount(formatToNormalizedValue(toBigInt(v), 18), 0, 0) ?? '';
-		}
-		return formatAmount(formatToNormalizedValue(toBigInt(v), 18)) ?? '';
-	}, []);
-
-	const formatNumberOver10K = useCallback((v: number): string => {
-		if (v >= 10000) {
-			return formatAmount(v, 0, 0) ?? '';
-		}
-		return formatAmount(v) ?? '';
-	}, []);
 
 	const latestCurveFeesValue = useMemo((): number => {
 		const {weeklyFeesTable} = curveWeeklyFees;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Use `formatBigNumberOver10K` and `formatNumberOver10K` from web-lib

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/238
