### PR TITLE
fix: Solve dependency warning (@next/font)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@cowprotocol/cow-sdk": "^2.1.0",
     "@headlessui/react": "^1.7.15",
     "@next/bundle-analyzer": "^13.4.5",
-    "@next/font": "^13.4.5",
     "@popperjs/core": "^2.11.8",
     "@react-hookz/deep-equal": "^1.0.4",
     "@sentry/nextjs": "^7.54.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import React, {Fragment, memo} from 'react';
+import localFont from 'next/font/local';
 import {AnimatePresence, domAnimation, LazyMotion, motion} from 'framer-motion';
-import localFont from '@next/font/local';
 import {useLocalStorageValue} from '@react-hookz/web';
 import {WithYearn} from '@yearn-finance/web-lib/contexts/WithYearn';
 import {AppHeader} from '@common/components/AppHeader';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,11 +1766,6 @@
   dependencies:
     glob "7.1.7"
 
-"@next/font@^13.4.5":
-  version "13.4.5"
-  resolved "https://registry.yarnpkg.com/@next/font/-/font-13.4.5.tgz#c720fc2196557aa34330985de46a513688c9adcc"
-  integrity sha512-pjgtnnyamcFK9rv/WKr9WDmVBcd50VK4zZX9E846jowRm8FadjiumDOV80elXUtYW9GXSpAiqWqNMw/kVXNuQQ==
-
 "@next/swc-darwin-arm64@13.4.5":
   version "13.4.5"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.5.tgz#54eb1fb2521a18e1682214c416cc44f3721dd9c8"


### PR DESCRIPTION
## Description
The purpose to this pull request is to solve a warning present in the terminal.

After executing `yarn dev` you can observe the following warning in the terminal:

⚠️ warn Your project has `@next/font` installed as a dependency, please use the built-in `next/font` instead. The `@next/font` package will be removed in Next.js 14. You can migrate by running `npx @next/codemod@latest built-in-next-font`. Read more: https://nextjs.org/docs/messages/built-in-next-font

## Related Issue
N/A

## Motivation and Context

To solve this warning, I removed the @next/font package since it is now built into next.js itself. 

## How Has This Been Tested?

I confirmed that the warning was no longer present after making the change.

## Resources (if appropriate):

N/A
