### PR TITLE
fix: Fix compiler warning

### DIFF
--- a/apps/common/components/Meta.tsx
+++ b/apps/common/components/Meta.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Head from 'next/head';
+import Script from 'next/script';
 import {DefaultSeo} from 'next-seo';
 
 import type {ReactElement} from 'react';
@@ -97,14 +98,14 @@ function Meta({meta}: {meta: TMetaFile}): ReactElement {
 					rel={'apple-touch-icon'}
 					sizes={'167x167'}
 					href={'/favicons/apple-icon-167x167.png'} />
-				<script
-					defer
-					data-domain={'yearn.finance'}
-					src={'/js/script.js'} />
-				<meta name={'robots'} content={'index,nofollow'} />
-				<meta name={'googlebot'} content={'index,nofollow'} />
-				<meta charSet={'utf-8'} />
 			</Head>
+			<Script
+				defer
+				data-domain={'yearn.finance'}
+				src={'/js/script.js'} />
+			<meta name={'robots'} content={'index,nofollow'} />
+			<meta name={'googlebot'} content={'index,nofollow'} />
+			<meta charSet={'utf-8'} />
 			<DefaultSeo
 				title={meta.name}
 				defaultTitle={meta.name}


### PR DESCRIPTION
## Description

The purpose to this PR is to fix a warning in the repo.
After executing `yarn dev`, this warning is being terminal logged:

`Do not add <script> tags using next/head (see <script> tag with src="/js/script.js"). Use next/script instead.
See more info here: https://nextjs.org/docs/messages/no-script-tags-in-head-component`

Steps to resolve this warning:

- Imported `Script` from `next/script`.
- Replaced existing <script/> tag by new `<Script>` tag.
- Moved the `<Script />` component outside of `<Head>` instead.

## Related Issue

N/A

## Motivation and Context

The intention to apply this change is fix current warning in the terminal.
Reference: 
https://nextjs.org/docs/messages/no-script-tags-in-head-component
https://nextjs.org/docs/messages/no-script-component-in-head

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that no console logs regarding the above stated warnings.

## Screenshots (if appropriate):
N/A