### PR TITLE
fix: Use want symbol for "Total deposited"

### DIFF
--- a/apps/vaults/components/details/VaultDetailsHeader.tsx
+++ b/apps/vaults/components/details/VaultDetailsHeader.tsx
@@ -79,7 +79,7 @@ function VaultDetailsHeader({vault}: { vault: TYDaemonVault }): ReactElement {
 				) : <p className={'text-xxs text-neutral-500 md:text-xs'}>&nbsp;</p>}
 			</div>
 			<div className={'grid grid-cols-2 gap-6 md:grid-cols-4 md:gap-12'}>
-				<VaultHeaderLineItem label={`Total deposited, ${symbol}`} legend={formatUSD(tvl.tvl)}>
+				<VaultHeaderLineItem label={`Total deposited, ${token.symbol}`} legend={formatUSD(tvl.tvl)}>
 					{formatAmount(formatToNormalizedValue(toBigInt(tvl.total_assets), decimals))}
 				</VaultHeaderLineItem>
 


### PR DESCRIPTION
## Description
On the vault page "Total deposited" uses the vault's token symbol but shows total assets denominated in the vault's want token. I changed the displayed symbol to the want token.

## Related Issue

## Motivation and Context

When I saw this I got confused. Maybe others same?

## How Has This Been Tested?

Tested in local dev

## Screenshots (if appropriate):
![image](https://github.com/yearn/yearn.fi/assets/89237203/f63fd56b-c781-43ac-850e-1d5c5faad683)
