### PR TITLE
refactor: Support very small numbers

### DIFF
--- a/apps/common/components/BalanceReminderPopover.tsx
+++ b/apps/common/components/BalanceReminderPopover.tsx
@@ -65,7 +65,7 @@ function TokenItem({element}: {element: TBalanceReminderElement}): ReactElement 
 					<span className={'ml-2'}>{element.symbol}</span>
 				</span>
 				<span className={'font-number flex flex-row items-center justify-center text-neutral-900'}>
-					{formatAmount(balance.normalized, 2, 4)}
+					{formatAmount({amount: balance.normalized, fractionDigits: {min: 2, max: 4}})}
 					<IconAddToMetamask
 						onClick={(e): void => {
 							e.preventDefault();

--- a/apps/common/components/TokenDropdown.tsx
+++ b/apps/common/components/TokenDropdown.tsx
@@ -27,7 +27,7 @@ function DropdownItem({option, balanceSource}: TDropdownItemProps): ReactElement
 							{option.symbol}
 						</p>
 						<p className={`${option.icon ? 'pl-2' : 'pl-0'} text-xxs font-normal text-neutral-600`}>
-							{`${formatAmount(balance.normalized)} ${option.symbol}`}
+							{`${formatAmount({amount: balance.normalized})} ${option.symbol}`}
 						</p>
 					</div>
 				</div>

--- a/apps/common/components/ValueAnimation.tsx
+++ b/apps/common/components/ValueAnimation.tsx
@@ -93,7 +93,7 @@ function ValueAnimation({
 	});
 
 	useEffect((): void => {
-		if (value && value !== formatAmount(0) && !hasBeenTriggerd.current) {
+		if (value && value !== formatAmount({amount: 0}) && !hasBeenTriggerd.current) {
 			onStartAnimation();
 		}
 	}, [value, onStartAnimation]);

--- a/apps/vaults/components/details/actions/QuickActionsFrom.tsx
+++ b/apps/vaults/components/details/actions/QuickActionsFrom.tsx
@@ -55,7 +55,7 @@ function VaultDetailsQuickActionsFrom(): ReactElement {
 						{isDepositing ? 'From wallet' : 'From vault'}
 					</label>
 					<legend className={'font-number inline text-xs text-neutral-600 md:hidden'} suppressHydrationWarning>
-						{`You have ${formatAmount(selectedFromBalance.normalized)} ${actionParams?.selectedOptionFrom?.symbol || 'tokens'}`}
+						{`You have ${formatAmount({amount: selectedFromBalance.normalized})} ${actionParams?.selectedOptionFrom?.symbol || 'tokens'}`}
 					</legend>
 				</div>
 				<Renderable
@@ -74,7 +74,7 @@ function VaultDetailsQuickActionsFrom(): ReactElement {
 				</Renderable>
 
 				<legend className={'font-number hidden text-xs text-neutral-600 md:inline'} suppressHydrationWarning>
-					{`You have ${formatAmount(selectedFromBalance.normalized)} ${actionParams?.selectedOptionFrom?.symbol || 'tokens'}`}
+					{`You have ${formatAmount({amount: selectedFromBalance.normalized})} ${actionParams?.selectedOptionFrom?.symbol || 'tokens'}`}
 				</legend>
 			</div>
 			<div className={'w-full space-y-2'}>

--- a/apps/vaults/components/details/tabs/VaultDetailsStrategies.tsx
+++ b/apps/vaults/components/details/tabs/VaultDetailsStrategies.tsx
@@ -105,17 +105,23 @@ function VaultDetailsStrategy({currentVault, strategy}: TProps): ReactElement {
 									{'Capital Allocation'}
 								</p>
 								<b className={'font-number text-lg text-neutral-900'}>
-									{`${formatAmount(formatToNormalizedValue(toBigInt(strategy.details?.totalDebt), currentVault?.decimals), 0, 0)} ${currentVault.token.symbol}`}
+									{`${formatAmount({
+										amount: formatToNormalizedValue(toBigInt(strategy.details?.totalDebt), currentVault?.decimals),
+										fractionDigits: {min: 0, max: 0}
+									})} ${currentVault.token.symbol}`}
 								</b>
 							</div>
 
 							<div className={'col-span-2 flex flex-col space-y-2 bg-neutral-200 p-2 md:p-4'}>
 								<p className={'text-base text-neutral-600'}>{'Total Gain'}</p>
 								<b className={'font-number text-lg text-neutral-900'}>
-									{`${formatAmount(formatToNormalizedValue(
-										toBigInt(strategy.details?.totalGain) - toBigInt(strategy.details?.totalLoss),
-										currentVault?.decimals
-									), 0, 0)} ${currentVault.token.symbol}`}
+									{`${formatAmount({
+										amount: formatToNormalizedValue(
+											toBigInt(strategy.details?.totalGain) - toBigInt(strategy.details?.totalLoss),
+											currentVault?.decimals
+										),
+										fractionDigits: {min: 0, max: 0}
+									})} ${currentVault.token.symbol}`}
 								</b>
 							</div>
 						</div>

--- a/apps/vaults/components/graphs/GraphForStrategyReports.tsx
+++ b/apps/vaults/components/graphs/GraphForStrategyReports.tsx
@@ -108,7 +108,7 @@ function GraphForStrategyReports({strategy, vaultDecimals, vaultTicker, height =
 									<div className={'flex flex-row items-center justify-between'}>
 										<p className={'text-xs text-neutral-600'}>{normalizedDiff > 0 ? 'Gain' : 'Loss'}</p>
 										<b className={'font-number text-xs font-bold text-neutral-900'}>
-											{`${formatAmount(normalizedDiff)} ${vaultTicker}`}
+											{`${formatAmount({amount: normalizedDiff})} ${vaultTicker}`}
 										</b>
 									</div>
 								</div>

--- a/apps/vaults/components/graphs/GraphForVaultEarnings.tsx
+++ b/apps/vaults/components/graphs/GraphForVaultEarnings.tsx
@@ -87,7 +87,7 @@ function GraphForVaultEarnings({currentVault, harvestData, height = 312, isCumul
 									<div className={'flex flex-row items-center justify-between'}>
 										<p className={'text-xs text-neutral-600'}>{'Earnings'}</p>
 										<b className={'font-number text-xs font-bold text-neutral-900'}>
-											{`${formatAmount(Number(value))} ${currentVault.token.symbol}`}
+											{`${formatAmount({amount: Number(value)})} ${currentVault.token.symbol}`}
 										</b>
 									</div>
 								</div>

--- a/apps/vaults/components/graphs/GraphForVaultPPSGrowth.tsx
+++ b/apps/vaults/components/graphs/GraphForVaultPPSGrowth.tsx
@@ -48,7 +48,7 @@ function GraphForVaultPPSGrowth({messariData, height = 312}: TGraphForVaultPPSGr
 						delete e.verticalAnchor;
 						delete e.visibleTicksCount;
 						delete e.tickFormatter;
-						const formatedValue = formatAmount(value, 3, 3);
+						const formatedValue = formatAmount({amount: value, fractionDigits: {min: 3, max: 3}});
 						return <text {...e}>{formatedValue}</text>;
 					}} />
 				<Tooltip

--- a/apps/vaults/components/graphs/GraphForVaultTVL.tsx
+++ b/apps/vaults/components/graphs/GraphForVaultTVL.tsx
@@ -68,7 +68,7 @@ function GraphForVaultTVL({messariData, height = 312}: TGraphForVaultTVLProps): 
 									<div className={'flex flex-row items-center justify-between'}>
 										<p className={'text-xs text-neutral-600'}>{'TVL'}</p>
 										<b className={'font-number text-xs font-bold text-neutral-900'}>
-											{`${formatAmount(Number(value))} $`}
+											{`${formatAmount({amount: Number(value)})} $`}
 										</b>
 									</div>
 								</div>

--- a/apps/vaults/components/list/VaultsListInternalMigrationRow.tsx
+++ b/apps/vaults/components/list/VaultsListInternalMigrationRow.tsx
@@ -30,7 +30,7 @@ function VaultsListInternalMigrationRow({currentVault}: {currentVault: TYDaemonV
 						</div>
 						<div className={'text-left'}>
 							<p>{vaultName}</p>
-							<p className={'font-number text-xs'}>{`${formatAmount(balanceToMigrate.normalized)} ${currentVault.token.symbol}`}</p>
+							<p className={'font-number text-xs'}>{`${formatAmount({amount: balanceToMigrate.normalized})} ${currentVault.token.symbol}`}</p>
 						</div>
 					</div>
 				</div>

--- a/apps/vaults/components/list/VaultsListRetired.tsx
+++ b/apps/vaults/components/list/VaultsListRetired.tsx
@@ -30,7 +30,7 @@ function VaultsListRetired({currentVault}: {currentVault: TYDaemonVault}): React
 						</div>
 						<div className={'text-left'}>
 							<p>{vaultName}</p>
-							<p className={'font-number text-xs'}>{`${formatAmount(balanceToMigrate.normalized)} ${currentVault.token.symbol}`}</p>
+							<p className={'font-number text-xs'}>{`${formatAmount({amount: balanceToMigrate.normalized})} ${currentVault.token.symbol}`}</p>
 						</div>
 					</div>
 				</div>

--- a/apps/vaults/components/list/VaultsListRow.tsx
+++ b/apps/vaults/components/list/VaultsListRow.tsx
@@ -38,34 +38,6 @@ function VaultsListRow({currentVault}: {currentVault: TYDaemonVault}): ReactElem
 		return balanceOfWant.normalized;
 	}, [balanceOfCoin.normalized, balanceOfCoin.raw, balanceOfWant.normalized, balanceOfWrappedCoin.normalized, currentVault.token.address]);
 
-	//TODO: EXPORT THIS AS EXTERNAL FUNCTION
-	function renderAvailableToDeposit(): string {
-		if (isZero(availableToDeposit)) {
-			return formatAmount(0);
-		}
-		if (availableToDeposit < 0.01) {
-			if (availableToDeposit > 0.00000001) {
-				return formatAmount(availableToDeposit, 8, 8);
-			}
-			return formatAmount(availableToDeposit, currentVault.token.decimals, currentVault.token.decimals);
-		}
-		return formatAmount(availableToDeposit);
-	}
-
-	//TODO: EXPORT THIS AS EXTERNAL FUNCTION
-	function renderDepositedAndStaked(): string {
-		if (isZero(depositedAndStaked)) {
-			return formatAmount(0);
-		}
-		if (depositedAndStaked < 0.01) {
-			if (depositedAndStaked > 0.00000001) {
-				return formatAmount(depositedAndStaked, 8, 8);
-			}
-			return formatAmount(depositedAndStaked, currentVault.token.decimals, currentVault.token.decimals);
-		}
-		return formatAmount(depositedAndStaked);
-	}
-
 	return (
 		<Link key={`${currentVault.address}`} href={`/vaults/${safeChainID}/${toAddress(currentVault.address)}`}>
 			<div className={'yearn--table-wrapper cursor-pointer transition-colors hover:bg-neutral-300'}>
@@ -93,7 +65,7 @@ function VaultsListRow({currentVault}: {currentVault: TYDaemonVault}): ReactElem
 								)}
 							</b>
 							<small className={'text-xs text-neutral-900'}>
-								{isEthMainnet && currentVault.apy?.composite?.boost && !currentVault.apy?.staking_rewards_apr ? `BOOST ${formatAmount(currentVault.apy?.composite?.boost, 2, 2)}x` : null}
+								{isEthMainnet && currentVault.apy?.composite?.boost && !currentVault.apy?.staking_rewards_apr ? `BOOST ${formatAmount({amount: currentVault.apy?.composite?.boost})}x` : null}
 							</small>
 							<small className={'text-xs text-neutral-900'}>
 								{currentVault.apy?.staking_rewards_apr ? `REWARD ${formatPercent((currentVault.apy?.staking_rewards_apr || 0) * 100, 2, 2, 500)}` : null}
@@ -104,14 +76,14 @@ function VaultsListRow({currentVault}: {currentVault: TYDaemonVault}): ReactElem
 					<div className={'yearn--table-data-section-item md:col-span-2'} datatype={'number'}>
 						<label className={'yearn--table-data-section-item-label !font-aeonik'}>{'Available'}</label>
 						<p className={`yearn--table-data-section-item-value ${isZero(availableToDeposit) ? 'text-neutral-400' : 'text-neutral-900'}`}>
-							{renderAvailableToDeposit()}
+							{formatAmount({amount: availableToDeposit})}
 						</p>
 					</div>
 
 					<div className={'yearn--table-data-section-item md:col-span-2'} datatype={'number'}>
 						<label className={'yearn--table-data-section-item-label !font-aeonik'}>{'Deposited'}</label>
 						<p className={`yearn--table-data-section-item-value ${isZero(depositedAndStaked) ? 'text-neutral-400' : 'text-neutral-900'}`}>
-							{renderDepositedAndStaked()}
+							{formatAmount({amount: depositedAndStaked})}
 						</p>
 					</div>
 

--- a/apps/ybribe/components/bribe/GaugeListRow.tsx
+++ b/apps/ybribe/components/bribe/GaugeListRow.tsx
@@ -31,7 +31,7 @@ function GaugeRowItemWithExtraData({address, value}: {address: TAddress, value: 
 				{formatUSD(bribeValue, 5, 5)}
 			</p>
 			<p className={'font-number inline-flex items-baseline text-right text-xs text-neutral-400'}>
-				{formatAmount(bribeAmount, 5, 5)}
+				{formatAmount({amount: bribeAmount, fractionDigits: {min: 5, max: 5}})}
 				&nbsp;
 				<span>{`${symbol}`}</span>
 			</p>

--- a/apps/ybribe/components/claim/GaugeListRow.tsx
+++ b/apps/ybribe/components/claim/GaugeListRow.tsx
@@ -38,7 +38,7 @@ function GaugeRowItemWithExtraData({
 				{formatUSD(bribeValue, minDecimals, minDecimals)}
 			</div>
 			<p className={'font-number inline-flex items-baseline text-right text-xs text-neutral-400'}>
-				{formatAmount(bribeAmount, minDecimals, minDecimals)}
+				{formatAmount({amount: bribeAmount, fractionDigits: {min: minDecimals, max: minDecimals}})}
 				&nbsp;
 				<span>{`${symbol}`}</span>
 			</p>

--- a/apps/ybribe/components/rewardFeed/RewardFeedTableRow.tsx
+++ b/apps/ybribe/components/rewardFeed/RewardFeedTableRow.tsx
@@ -31,7 +31,7 @@ function RewardFeedRowItemWithExtraData({
 				{formatUSD(bribeValue)}
 			</div>
 			<p className={'font-number inline-flex items-baseline text-right text-xs text-neutral-400'}>
-				{formatAmount(bribeAmount)}
+				{formatAmount({amount: bribeAmount})}
 				&nbsp;
 				<span>{`${symbol}`}</span>
 			</p>

--- a/apps/ycrv/components/HarvestsListRow.tsx
+++ b/apps/ycrv/components/HarvestsListRow.tsx
@@ -33,7 +33,7 @@ function HarvestListRow({harvest}: {harvest: TYDaemonVaultHarvest}): ReactElemen
 				<div className={'yearn--table-data-section-item md:col-span-1'} datatype={'number'}>
 					<p className={'yearn--table-data-section-item-label'}>{'Gain'}</p>
 					<b className={'yearn--table-data-section-item-value'}>
-						{formatAmount(formatToNormalizedValue(toBigInt(harvest.profit) - toBigInt(harvest.loss), 18))}
+						{formatAmount({amount: formatToNormalizedValue(toBigInt(harvest.profit) - toBigInt(harvest.loss), 18)})}
 					</b>
 				</div>
 

--- a/pages/vaults/factory.tsx
+++ b/pages/vaults/factory.tsx
@@ -315,7 +315,7 @@ function Factory(): ReactElement {
 					</div>
 					<div>
 						<p className={'font-number text-xs'}>
-							{`Est. gas ${formatAmount(Number(estimate), 0, 0)}`}
+							{`Est. gas ${formatAmount({amount: Number(estimate), fractionDigits: {min: 0, max: 0}})}`}
 						</p>
 					</div>
 				</div>

--- a/pages/vaults/index.tsx
+++ b/pages/vaults/index.tsx
@@ -39,11 +39,11 @@ function HeaderUserPosition(): ReactElement {
 
 	const formatedYouEarned = useMemo((): string => {
 		const amount = (earned?.totalUnrealizedGainsUSD || 0) > 0 ? earned?.totalUnrealizedGainsUSD || 0 : 0;
-		return formatAmount(amount) ?? '';
+		return formatAmount({amount: amount}) ?? '';
 	}, [earned?.totalUnrealizedGainsUSD]);
 
 	const formatedYouHave = useMemo((): string => {
-		return formatAmount(cumulatedValueInVaults || 0) ?? '';
+		return formatAmount({amount: cumulatedValueInVaults || 0}) ?? '';
 	}, [cumulatedValueInVaults]);
 
 	if (!isActive) {

--- a/pages/veyfi/index.tsx
+++ b/pages/veyfi/index.tsx
@@ -38,11 +38,11 @@ function Index(): ReactElement {
 					items={[
 						{
 							label: 'Total Locked YFI',
-							content: formatAmount(totalLockedYFI, 4) ?? '-'
+							content: formatAmount({amount: totalLockedYFI, fractionDigits: {min:4}}) ?? '-'
 						},
 						{
 							label: 'Your Locked YFI',
-							content: formatAmount(yourLockedYFI, 4) ?? '-'
+							content: formatAmount({amount: yourLockedYFI, fractionDigits: {min:4}}) ?? '-'
 						},
 						{
 							label: 'Expiration for the lock',

--- a/pages/ybal/index.tsx
+++ b/pages/ybal/index.tsx
@@ -26,7 +26,7 @@ function HeaderPosition(): ReactElement {
 
 	const formatedYearnHas = useMemo((): string => (
 		holdings?.veBalBalance ?
-			formatAmount(formatToNormalizedValue(holdings.veBalBalance, 18), 0, 0)
+			formatAmount({amount: formatToNormalizedValue(holdings.veBalBalance, 18), fractionDigits: {min: 0, max: 0}})
 			: ''
 	), [holdings?.veBalBalance]);
 
@@ -50,7 +50,7 @@ function HeaderPosition(): ReactElement {
 						identifier={'veBalTreasury'}
 						value={formatedYearnHas}
 						suffix={'veBal'}
-						defaultValue={formatAmount(0, 2, 2)} />
+						defaultValue={formatAmount({amount: 0})} />
 				</b>
 			</div>
 			<div className={'col-span-12 w-full md:col-span-4'}>
@@ -60,7 +60,7 @@ function HeaderPosition(): ReactElement {
 						identifier={'youHave'}
 						value={formatedYouHave}
 						prefix={'$'}
-						defaultValue={formatAmount(0, 2, 2)} />
+						defaultValue={formatAmount({amount: 0})} />
 				</b>
 			</div>
 		</Fragment>
@@ -147,7 +147,7 @@ function Holdings(): ReactElement {
 								{holdings?.styBalSupply ? formatCounterValue(
 									formatToNormalizedValue(holdings.styBalSupply, 18),
 									yBalPrice
-								) : formatAmount(0)}
+								) : formatAmount({amount: 0})}
 							</p>
 						</div>
 						<div className={'flex flex-row items-center justify-between pb-1'}>
@@ -210,7 +210,7 @@ function Holdings(): ReactElement {
 								{holdings?.lpyBalSupply ? formatCounterValue(
 									formatToNormalizedValue(holdings.lpyBalSupply, 18),
 									lpyBalPrice
-								) : formatAmount(0)}
+								) : formatAmount({amount: 0})}
 							</p>
 						</div>
 						<div className={'flex flex-row items-center justify-between pb-1'}>

--- a/pages/ycrv/index.tsx
+++ b/pages/ycrv/index.tsx
@@ -27,7 +27,7 @@ function HeaderPosition(): ReactElement {
 
 	const formatedYearnHas = useMemo((): string => (
 		holdings?.veCRVBalance ?
-			formatAmount(formatToNormalizedValue(holdings.veCRVBalance, 18), 0, 0)
+			formatAmount({amount: formatToNormalizedValue(holdings.veCRVBalance, 18), fractionDigits: {min: 0, max: 0}})
 			: ''
 	), [holdings?.veCRVBalance]);
 
@@ -122,7 +122,7 @@ function ZapAndStats(): ReactElement {
 						<p
 							suppressHydrationWarning
 							className={'font-number text-sm text-neutral-900'}>
-							{`Price = $${(formatAmount(ycrvPrice || 0))} | Peg = ${(
+							{`Price = $${(formatAmount({amount: ycrvPrice || 0}))} | Peg = ${(
 								holdings?.crvYCRVPeg ? (formatPercent(
 									(formatToNormalizedValue(holdings?.crvYCRVPeg, 18) + 0.0015) * 100)
 								): formatPercent(0)
@@ -205,12 +205,12 @@ function ZapAndStats(): ReactElement {
 									<p
 										suppressHydrationWarning
 										className={'font-number text-neutral-400 md:text-xxs'}>
-										{`∙ ${curveAdminFeePercent ? formatPercent(curveAdminFeePercent) : formatPercent(0)} Curve Admin Fees (${formatAmount(Number(holdings?.boostMultiplier) / 10000)}x boost)`}
+										{`∙ ${curveAdminFeePercent ? formatPercent(curveAdminFeePercent) : formatPercent(0)} Curve Admin Fees (${formatAmount({amount: Number(holdings?.boostMultiplier) / 10000})}x boost)`}
 									</p>
 									<p
 										suppressHydrationWarning
 										className={'font-number text-neutral-400 md:text-xxs'}>
-										{`∙ ${styCRVAPY && curveAdminFeePercent && styCRVMegaBoost ? formatAmount(styCRVAPY - (curveAdminFeePercent + (styCRVMegaBoost * 100)), 2, 2) : '0.00'}% Gauge Voting Bribes`}
+										{`∙ ${styCRVAPY && curveAdminFeePercent && styCRVMegaBoost ? formatAmount({amount: styCRVAPY - (curveAdminFeePercent + (styCRVMegaBoost * 100))}) : '0.00'}% Gauge Voting Bribes`}
 									</p>
 									<p
 										suppressHydrationWarning
@@ -231,7 +231,7 @@ function ZapAndStats(): ReactElement {
 							{holdings?.styCRVSupply ? formatCounterValue(
 								formatToNormalizedValue(holdings.styCRVSupply, 18),
 								ycrvPrice
-							) : formatAmount(0)}
+							) : formatAmount({amount: 0})}
 						</p>
 					</div>
 					<div className={'flex flex-row items-center justify-between pb-1'}>
@@ -296,7 +296,7 @@ function ZapAndStats(): ReactElement {
 							{holdings?.lpyCRVSupply ? formatCounterValue(
 								formatToNormalizedValue(holdings.lpyCRVSupply, 18),
 								lpycrvPrice
-							) : formatAmount(0)}
+							) : formatAmount({amount: 0})}
 						</p>
 					</div>
 					<div className={'flex flex-row items-center justify-between pb-1'}>


### PR DESCRIPTION
⚠️ Depends on https://github.com/yearn/web-lib/pull/281

## Description

<!--- Describe your changes -->

* Add support for very small numbers by increasing the number of decimals displayed and adding the full number on hover
* Refactor the use of the `formatAmount ` function to use named params

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/yearn.fi/issues/267

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Display more decimals for smaller values, so that values like 0.001 or 0.000001 still show some useful information, and display the whole number on hover

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Linked the web-lib https://github.com/yearn/web-lib/pull/281 and tested locally

## Screenshots (if appropriate):

https://github.com/yearn/yearn.fi/assets/78794805/356445e9-ec84-4afa-b744-4d7c5eb1dafd
