### PR TITLE
refactor: Swap search and category filters

### DIFF
--- a/apps/common/components/ListHero.tsx
+++ b/apps/common/components/ListHero.tsx
@@ -21,7 +21,6 @@ type TSwitchProps = {
 export type TListHero<T> = {
 	headLabel: string;
 	switchProps?: TSwitchProps;
-	searchLabel: string;
 	searchPlaceholder: string;
 	categories: TListHeroCategory<T>[][];
 	onSelect: (category: T) => void;
@@ -41,8 +40,7 @@ function DesktopCategories<T>({categories, onSelect}: TListHeroDesktopCategories
 	}, []);
 
 	return (
-		<div>
-			<label className={'text-neutral-600'}>&nbsp;</label>
+		<div className={'w-full'}>
 			<div className={'mt-1 flex flex-row space-x-4'}>
 				{(categories || []).map((currentCategory, index: number): ReactElement => (
 					<div
@@ -95,7 +93,6 @@ function Switch(props: TSwitchProps): ReactElement {
 
 function ListHero<T extends string>({
 	headLabel,
-	searchLabel,
 	searchPlaceholder,
 	categories,
 	onSelect,
@@ -114,8 +111,11 @@ function ListHero<T extends string>({
 			</div>
 
 			<div className={'hidden w-full flex-row items-center justify-between space-x-4 md:flex'}>
+				<DesktopCategories
+					categories={categories}
+					onSelect={onSelect} />
+
 				<SearchBar
-					searchLabel={searchLabel}
 					searchPlaceholder={searchPlaceholder}
 					searchValue={searchValue}
 					set_searchValue={set_searchValue} />
@@ -126,10 +126,6 @@ function ListHero<T extends string>({
 						<Switch {...switchProps} />
 					</div>
 				)}
-
-				<DesktopCategories
-					categories={categories}
-					onSelect={onSelect} />
 			</div>
 
 			<div className={'flex w-full flex-row space-x-2 md:hidden md:w-2/3'}>

--- a/apps/common/components/SearchBar.tsx
+++ b/apps/common/components/SearchBar.tsx
@@ -1,21 +1,14 @@
 import type {ChangeEvent, ReactElement} from 'react';
 
 export type TSearchBar = {
-	searchLabel: string;
 	searchPlaceholder: string;
 	searchValue: string;
 	set_searchValue: (searchValue: string) => void;
 }
 
-export function SearchBar({searchLabel, searchPlaceholder, searchValue, set_searchValue}: TSearchBar): ReactElement {
+export function SearchBar({searchPlaceholder, searchValue, set_searchValue}: TSearchBar): ReactElement {
 	return (
-		<div className={'w-full'}>
-			<label
-				suppressHydrationWarning
-				htmlFor={'search'}
-				className={'text-neutral-600'}>
-				{searchLabel}
-			</label>
+		<>
 			<div className={'mt-1 flex h-10 w-full max-w-md items-center border border-neutral-0 bg-neutral-0 p-2 md:w-2/3'}>
 				<div className={'relative flex h-10 w-full flex-row items-center justify-between'}>
 					<input
@@ -46,6 +39,6 @@ export function SearchBar({searchLabel, searchPlaceholder, searchValue, set_sear
 
 				</div>
 			</div>
-		</div>
+		</>
 	);
 }

--- a/apps/vaults/components/list/VaultListFactory.tsx
+++ b/apps/vaults/components/list/VaultListFactory.tsx
@@ -130,8 +130,7 @@ function VaultListFactory(): ReactElement {
 			</div>
 			<ListHero
 				headLabel={category}
-				searchLabel={`Search ${category}`}
-				searchPlaceholder={'YFI Vault'}
+				searchPlaceholder={`Search ${category}`}
 				categories={[
 					[
 						{value: 'Curve Factory Vaults', label: 'Curve', isSelected: category === 'Curve Factory Vaults'},

--- a/apps/vaults/contexts/useAppSettings.tsx
+++ b/apps/vaults/contexts/useAppSettings.tsx
@@ -27,7 +27,7 @@ const defaultProps: TAppSettingsContext = {
 
 const AppSettingsContext = createContext<TAppSettingsContext>(defaultProps);
 export const AppSettingsContextApp = memo(function AppSettingsContextApp({children}: {children: ReactElement}): ReactElement {
-	const [category, set_category] = useSessionStorage('yearn.finance/vaults-category', 'Featured Vaults');
+	const [category, set_category] = useSessionStorage('yearn.finance/vaults-category', 'All Vaults');
 	const [searchValue, set_searchValue] = useSessionStorage('yearn.finance/vaults-search', '');
 	const [shouldHideDust, set_shouldHideDust] = useLocalStorage('yearn.finance/hide-dust', true);
 	const [shouldHideLowTVLVaults, set_shouldHideLowTVLVaults] = useLocalStorage('yearn.finance/hide-low-tvl', false);

--- a/pages/vaults/index.tsx
+++ b/pages/vaults/index.tsx
@@ -147,6 +147,7 @@ function Index(): ReactElement {
 
 	const categoriesToDisplay = useMemo((): TListHeroCategory<string>[] => {
 		const categories = [
+			{value: 'All Vaults', label: 'All', isSelected: category === 'All Vaults'},
 			{value: 'Featured Vaults', label: 'Featured', isSelected: category === 'Featured Vaults'},
 			{value: 'Crypto Vaults', label: 'Crypto', isSelected: category === 'Crypto Vaults'},
 			{value: 'Stables Vaults', label: 'Stables', isSelected: category === 'Stables Vaults'},
@@ -159,10 +160,7 @@ function Index(): ReactElement {
 		} else {
 			categories.push({value: 'Balancer Vaults', label: 'Balancer', isSelected: category === 'Balancer Vaults'});
 		}
-		return [
-			...categories,
-			{value: 'All Vaults', label: 'All', isSelected: category === 'All Vaults'}
-		];
+		return categories;
 	}, [category, safeChainID]);
 
 	/* 🔵 - Yearn Finance **************************************************************************
@@ -272,8 +270,7 @@ function Index(): ReactElement {
 				</div>
 				<ListHero
 					headLabel={category}
-					searchLabel={`Search ${category}`}
-					searchPlaceholder={'YFI Vault'}
+					searchPlaceholder={`Search ${category}`}
 					categories={[
 						categoriesToDisplay,
 						[

--- a/pages/ybribe/index.tsx
+++ b/pages/ybribe/index.tsx
@@ -133,8 +133,7 @@ function GaugeList(): ReactElement {
 			<div className={'col-span-12 flex w-full flex-col bg-neutral-100'}>
 				<ListHero
 					headLabel={'Claim Bribe'}
-					searchLabel={`Search ${category}`}
-					searchPlaceholder={'f-yfieth'}
+					searchPlaceholder={`Search ${category}`}
 					categories={[
 						[
 							{value: 'claimable', label: 'Claimable', isSelected: category === 'claimable'},

--- a/pages/ybribe/offer-bribe.tsx
+++ b/pages/ybribe/offer-bribe.tsx
@@ -120,8 +120,7 @@ function GaugeList(): ReactElement {
 			<div className={'col-span-12 flex w-full flex-col bg-neutral-100'}>
 				<ListHero
 					headLabel={'Offer Bribe'}
-					searchLabel={`Search ${category}`}
-					searchPlaceholder={'f-yfieth'}
+					searchPlaceholder={`Search ${category}`}
 					categories={[
 						[
 							{value: 'standard', label: 'Standard', isSelected: category === 'standard'},


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Swap search and category filters

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/272

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The Vaults page currently defaults to the Featured tab, with the search bar look-up solely in that category. Recent feedback received from users and partners indicates that this might be problematic, namely;

1- Users use the search bar from the default page, not finding the vault they are looking for (look-up only within 'Featured').

2- Users might not see the different filtering tabs.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Locally, screenshot below

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot 2023-07-17 at 8 59 57" src="https://github.com/yearn/yearn.fi/assets/78794805/e4c728c3-1e49-4ac1-ab22-3f6700091fce">
