### PR TITLE
feat: Display "to vault" when migration available

### DIFF
--- a/apps/vaults/components/details/actions/QuickActionsTo.tsx
+++ b/apps/vaults/components/details/actions/QuickActionsTo.tsx
@@ -16,6 +16,8 @@ function VaultDetailsQuickActionsTo(): ReactElement {
 	const {expectedOut, isLoadingExpectedOut} = useSolver();
 	const selectedOptionToPricePerToken = useTokenPrice(toAddress(actionParams?.selectedOptionTo?.value));
 
+	const isMigrationAvailable = currentVault?.migration?.available;
+
 	function renderMultipleOptionsFallback(): ReactElement {
 		return (
 			<Dropdown
@@ -31,7 +33,7 @@ function VaultDetailsQuickActionsTo(): ReactElement {
 			<div className={'relative z-10 w-full space-y-2'}>
 				<div className={'flex flex-row items-baseline justify-between'}>
 					<label className={'text-base text-neutral-600'}>
-						{isDepositing ? 'To vault' : 'To wallet'}
+						{isDepositing || isMigrationAvailable ? 'To vault' : 'To wallet'}
 					</label>
 					<legend className={'font-number inline text-xs text-neutral-600 md:hidden'} suppressHydrationWarning>
 						{`APY ${formatPercent(((currentVault?.apy?.net_apy || 0) + (currentVault?.apy?.staking_rewards_apr || 0)) * 100, 2, 2, 500)}`}


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

When we have a vault that has migration available, the quick actions to label is "To vault" rather than "To wallet"

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/283

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Display what is happening more accurately

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

TBC

## Screenshots (if appropriate):

TBC