### PR TITLE
fix: Disable Portals.fi solver for Optimism

### DIFF
--- a/apps/vaults/hooks/useSolverPortals.ts
+++ b/apps/vaults/hooks/useSolverPortals.ts
@@ -97,6 +97,13 @@ export function useSolverPortals(): TSolverContext {
 		}
 
 		/******************************************************************************************
+		** Then, we check if the we are on optimist. If we are, we return 0.
+		******************************************************************************************/
+		if (safeChainID === 10) {
+			return toNormalizedBN(0);
+		}
+
+		/******************************************************************************************
 		** Then, we check if the solver can be used for this specific sellToken. If it can't, we
 		** return 0.
 		** This solveVia array is set via the yDaemon tokenList process. If a solve is not set for


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Disable the [portals.fi](https://portals.fi/) solver if we are on the Optimism network

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/yearn.fi/issues/274

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

[Portals.fi](https://portals.fi/) does not support Optimism chain

> "Network=optimism are not supported."

See below the full response:

```json
{
    "statusCode": 404,
    "message": "The requested token or its underlying addresses=optimism:0x93d6d0ab2b2aa25580cb77e8c5f9d5a0cc5e08fe,optimism:0xda10009cbd5d07dd0cecc66161fc93d7c9000da1 Network=optimism are not supported. Please report this issue to our team.",
    "timestamp": "2023-07-19T06:08:17.357Z",
    "path": "/v1/portal/optimism/estimate?sellToken=0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1&sellAmount=335492822692405&buyToken=0x93d6D0AB2b2aA25580cb77e8C5f9D5a0cc5E08Fe&slippagePercentage=0.01"
}
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and did not see the error
