### PR TITLE
feat: Let users search for both the vault name and symbol

### DIFF
--- a/pages/vaults/index.tsx
+++ b/pages/vaults/index.tsx
@@ -216,14 +216,13 @@ function Index(): ReactElement {
 	**	implemented as a simple string.includes() on the vault name.
 	**********************************************************************************************/
 	const searchedVaultsToDisplay = useMemo((): TYDaemonVault[] => {
-		const vaultsToUse = [...vaultsToDisplay];
-
 		if (searchValue === '') {
-			return vaultsToUse;
+			return vaultsToDisplay;
 		}
-		return vaultsToUse.filter((vault): boolean => {
-			const searchString = getVaultName(vault);
-			return searchString.toLowerCase().includes(searchValue.toLowerCase());
+		return vaultsToDisplay.filter((vault: TYDaemonVault): boolean => {
+			const vaultName = getVaultName(vault).toLowerCase();
+			const vaultSymbol = vault.symbol.toLowerCase();
+			return [vaultName, vaultSymbol].some((attribute): boolean => attribute.includes(searchValue.toLowerCase()));
 		});
 	}, [vaultsToDisplay, searchValue]);
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Add the vault symbol to compare against the `searchValue`

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/291

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Let users search for both the vault name and symbol so they are more likely to find the vault they are looking for.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Tried locally, refer to the screenshot below

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot 2023-07-21 at 17 07 03" src="https://github.com/yearn/yearn.fi/assets/78794805/ce158f70-54f8-46d9-a029-bebafdeccc61">
