### PR TITLE
chore: Reduce Sentry's tracesSampleRate to 10%

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
 	dsn: process.env.SENTRY_DSN,
 
 	// Adjust this value in production, or use tracesSampler for greater control
-	tracesSampleRate: 0.2,
+	tracesSampleRate: 0.1,
 
 	// Setting this option to true will print useful information to the console while you're setting up Sentry.
 	debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
 	dsn: process.env.SENTRY_DSN,
 
 	// Adjust this value in production, or use tracesSampler for greater control
-	tracesSampleRate: 0.2,
+	tracesSampleRate: 0.1,
 
 	// Setting this option to true will print useful information to the console while you're setting up Sentry.
 	debug: false


### PR DESCRIPTION
We've exceeded our Sentry's allowance, reducing `tracesSampleRate` to 10%

## Screenshots (if appropriate):

![Screenshot 2023-07-27 at 14 10 50](https://github.com/yearn/yearn.fi/assets/78794805/1867d64b-d531-4b0a-875b-e3b836cfc896)
