### PR TITLE
feat: Add keepVELO to strategy page fee for Velodrome vaults

### DIFF
--- a/apps/common/schemas/yDaemonVaultsSchemas.ts
+++ b/apps/common/schemas/yDaemonVaultsSchemas.ts
@@ -111,6 +111,7 @@ export const yDaemonVaultSchema = z.object({
 			withdrawal: z.number(),
 			management: z.number(),
 			keep_crv: z.number(),
+			keep_velo: z.number(),
 			cvx_keep_crv: z.number()
 		}),
 		points: z.object({

--- a/apps/vaults/components/details/tabs/VaultDetailsAbout.tsx
+++ b/apps/vaults/components/details/tabs/VaultDetailsAbout.tsx
@@ -1,6 +1,7 @@
 import {useIsMounted} from '@react-hookz/web';
 import {GraphForVaultEarnings} from '@vaults/components/graphs/GraphForVaultEarnings';
 import Renderable from '@yearn-finance/web-lib/components/Renderable';
+import {cl} from '@yearn-finance/web-lib/utils/cl';
 import {formatPercent} from '@yearn-finance/web-lib/utils/format.number';
 import {parseMarkdown} from '@yearn-finance/web-lib/utils/helpers';
 import {isZero} from '@yearn-finance/web-lib/utils/isZero';
@@ -19,6 +20,7 @@ type TAPYLineItemProps = {
 type TYearnFeesLineItem = {
 	children: ReactElement;
 	label: string;
+	tooltip?: string;
 };
 
 function APYLineItem({value, label, apyType}: TAPYLineItemProps): ReactElement {
@@ -41,11 +43,21 @@ function APYLineItem({value, label, apyType}: TAPYLineItemProps): ReactElement {
 	);
 }
 
-function YearnFeesLineItem({children, label}: TYearnFeesLineItem): ReactElement {
+function YearnFeesLineItem({children, label, tooltip}: TYearnFeesLineItem): ReactElement {
 	return (
 		<div className={'flex flex-col space-y-0 md:space-y-2'}>
 			<p className={'text-xxs text-neutral-600 md:text-xs'}>{label}</p>
-			{children}
+			<div
+				className={cl(tooltip ? 'tooltip underline decoration-neutral-600/30 decoration-dotted underline-offset-4 transition-opacity hover:decoration-neutral-600' : '')}>
+				{tooltip ? (
+					<span suppressHydrationWarning className={'tooltipFees bottom-full'}>
+						<div className={'font-number w-96 border border-neutral-300 bg-neutral-100 p-1 px-2 text-center text-xxs text-neutral-900'}>
+							{tooltip}
+						</div>
+					</span>
+				) : null}
+				{children}
+			</div>
 		</div>
 	);
 }
@@ -103,6 +115,16 @@ function VaultDetailsAbout({currentVault, harvestData}: { currentVault: TYDaemon
 								{formatPercent((details.performanceFee || 0) / 100, 0)}
 							</b>
 						</YearnFeesLineItem>
+						{currentVault.category === 'Velodrome' ? (
+							<YearnFeesLineItem
+								label={'keepVELO'}
+								tooltip={'Percentage of VELO locked in each harvest. This is used to boost Velodrome vault pools, and is offset via yvOP staking rewards.'}
+							>
+								<b className={'font-number text-xl text-neutral-500'}>
+									{formatPercent((currentVault.apy.fees.keep_velo) * 100, 0)}
+								</b>
+							</YearnFeesLineItem>
+						) : null}
 					</div>
 				</div>
 				<div>

--- a/style.css
+++ b/style.css
@@ -273,6 +273,9 @@ details {
 .tooltip .tooltipLight {
 	@apply invisible inset-x-0 absolute z-50 opacity-0 transition-opacity flex justify-center items-center;
 }
+.tooltip .tooltipFees {
+	@apply invisible right-0 absolute z-50 opacity-0 transition-opacity;
+}
 .tooltip .tooltiptext {
 	@apply text-xs text-center invisible bg-neutral-0 text-neutral-900 absolute z-50 right-1 opacity-0 transition-opacity p-2;
 	width: 15rem;
@@ -283,7 +286,7 @@ details {
 .tooltip:hover .tooltiptext {
 	@apply visible opacity-100;
 }
-.tooltip:hover .tooltipLight {
+.tooltip:hover .tooltipFees {
 	@apply visible opacity-100;
 }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

* Adds a style specific to yearn fees list, the `tooltipLight` was overflowing to the right;
* Augments the `yDaemonVaultSchema` schema to include `keep_velo`;
* Adds the new field when the vault category is 'Velodrome'

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/310

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Although we already include keepVELO in our overall APR calc, it's nice that users can know exactly how much VELO is being kept by a vault. And the tooltip lets them know what it is, why we do it, and tells them they are getting more than enough to cover it in yvOP.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally, tested with vault `0x88B429359665B8685b7431f5A0f6e8C719Bf49` which as `keep_velo` of 0.5

## Screenshots (if appropriate):

### Web

#### No hover

<img width="1582" alt="without-hover" src="https://github.com/yearn/yearn.fi/assets/78794805/5dda351f-f2b5-445a-9be1-881b7588362a">

#### On hover

<img width="1582" alt="on-hover" src="https://github.com/yearn/yearn.fi/assets/78794805/e9737236-c990-492c-8e75-8e04cad7e7f6">

### Mobile

| No hover               | On hover               |
| ---------------------- | ---------------------- |
| <img width="612" alt="mobile-no-hover" src="https://github.com/yearn/yearn.fi/assets/78794805/90d00269-0ae9-4d7d-80d8-fb95cd2a5218"> | <img width="612" alt="mobile-hover" src="https://github.com/yearn/yearn.fi/assets/78794805/8e588f47-8dae-45f7-8274-2b27702e05ea"> |



