### PR TITLE
feat: Add yETH to the header popover

### DIFF
--- a/apps/common/components/AppHeader.tsx
+++ b/apps/common/components/AppHeader.tsx
@@ -68,7 +68,7 @@ function LogoPopover(): ReactElement {
 				leaveTo={'opacity-0 translate-y-1'}>
 				<Popover.Panel className={'absolute left-1/2 z-10 mt-6 w-80 -translate-x-1/2 px-4 pt-4 sm:px-0 md:w-96'}>
 					<div className={'overflow-hidden border border-neutral-200 shadow-lg'}>
-						<div className={'relative grid grid-cols-2 bg-neutral-0 md:grid-cols-4'}>
+						<div className={'relative grid grid-cols-2 bg-neutral-0 md:grid-cols-3'}>
 							{
 								Object.values(APPS)
 									.filter(({isDisabled}): boolean => !isDisabled)

--- a/apps/common/components/Apps.tsx
+++ b/apps/common/components/Apps.tsx
@@ -22,14 +22,15 @@ export enum AppName {
 	YCRV = 'yCRV',
 	YBAL = 'yBal',
 	VEYFI = 'veYFI',
-	YBRIBE = 'yBribe'
+	YBRIBE = 'yBribe',
+	YETH = 'yETH'
 }
 
 type TApp = {
 	name: AppName;
 	href: string;
 	menu: TMenu[];
-	manifest: TMetaFile;
+	manifest?: TMetaFile;
 	icon: ReactElement;
 	isDisabled?: boolean;
 }
@@ -95,5 +96,18 @@ export const APPS: { [key in AppName]: TApp } = {
 			className={'h-8 w-8'}
 			back={'text-neutral-900'}
 			front={'text-neutral-0'} />
+	},
+	yETH: {
+		name: AppName.YETH,
+		href: 'https://yeth.yearn.finance',
+		menu: [],
+		icon: <ImageWithFallback
+			alt={'yETH'}
+			className={'h-8 w-8'}
+			width={100}
+			height={100}
+			src={`${process.env.BASE_YEARN_ASSETS_URI}/1/0x1BED97CBC3c24A4fb5C069C6E311a967386131f7/logo-128.png`}
+			loading={'eager'}
+			priority />
 	}
 };


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Add the yETH icon to the header popover

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/312

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

A logo link to yETH should be available on all pages for easy navigation.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Locally, screenshot below

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot_2023-08-04_at_8_48_37" src="https://github.com/yearn/yearn.fi/assets/78794805/e13c02cf-a933-46dd-b5c3-f7de71b543cd">
