### PR TITLE
fix: Check if type is eip2930

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3777,12 +3777,20 @@ b4a@^1.6.4:
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.4.tgz#ef1c1422cae5ce6535ec191baeed7567443f36c9"
   integrity sha512-fpWrvyVHEKyeEvbKZTVOeZF3VSKKWtJxFIxX/jaVPf+cLbGUSitjb49pHLqPV2BUNNZ0LcoeEGfE/YCpyDYHIw==
 
-babel-loader@9.1.0, babel-loader@^8.2.5, babel-loader@^9.1.3:
+babel-loader@9.1.0, babel-loader@^8.2.5:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.1.0.tgz#839e9ae88aea930864ef9ec0f356dfca96ecf238"
   integrity sha512-Antt61KJPinUMwHwIIz9T5zfMgevnfZkEVWYDWlG888fgdvRRGD0JTuf/fFozQnfT+uq64sk1bmdHDy/mOEWnA==
   dependencies:
     find-cache-dir "^3.3.2"
+    schema-utils "^4.0.0"
+
+babel-loader@^9.1.3:
+  version "9.1.3"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.1.3.tgz#3d0e01b4e69760cc694ee306fe16d358aa1c6f9a"
+  integrity sha512-xG3ST4DglodGf8qSwv0MdeWLhrDsw/32QMdTO5T1ZIp9gQur0HkCyFs7Awskr10JKXFXwpAhiCuYX5oGXnRGbw==
+  dependencies:
+    find-cache-dir "^4.0.0"
     schema-utils "^4.0.0"
 
 babel-plugin-polyfill-corejs2@^0.4.4:


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

There seems to be a mismatch between the return of `prepareSendTransaction` and what `wagmiProvider.walletClient.sendTransaction` expects, namely:

* `type` expects a `"eip2930" | undefined`;
* `maxFeePerGas` just expects `undefined`;
* `maxPriorityFeePerGas` just expects `undefined`;
* `gasPrice` just expects `undefined`.

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/315

## Motivation and Context

Add type safety