### PR TITLE
refactor: Disable solvers in SettingsPopover dropdown

### DIFF
--- a/apps/vaults/components/SettingsPopover.tsx
+++ b/apps/vaults/components/SettingsPopover.tsx
@@ -46,22 +46,22 @@ export default function SettingsPopover({chainID}: TSettingPopover): ReactElemen
 										<select
 											id={'zapProvider'}
 											onChange={(e): void => set_zapProvider(e.target.value as TSolver)}
-											value={currentZapProvider}
+											value={!isSolverDisabled(chainID)[currentZapProvider] ? currentZapProvider : Solver.enum.Wido}
 											className={'mt-1 h-10 w-full overflow-x-scroll border-none bg-neutral-100 p-2 outline-none scrollbar-none'}>
 											{chainID === 1 ? (
 												<option
-													disabled={isSolverDisabled[Solver.enum.Cowswap]}
+													disabled={isSolverDisabled(chainID)[Solver.enum.Cowswap]}
 													value={Solver.enum.Cowswap}>
 													{Solver.enum.Cowswap}
 												</option>
 											): null}
 											<option
-												disabled={isSolverDisabled[Solver.enum.Wido]}
+												disabled={isSolverDisabled(chainID)[Solver.enum.Wido]}
 												value={Solver.enum.Wido}>
 												{Solver.enum.Wido}
 											</option>
 											<option
-												disabled={isSolverDisabled[Solver.enum.Portals]}
+												disabled={isSolverDisabled(chainID)[Solver.enum.Portals]}
 												value={Solver.enum.Portals}>
 												{Solver.enum.Portals}
 											</option>

--- a/apps/vaults/hooks/useSolverCowswap.ts
+++ b/apps/vaults/hooks/useSolverCowswap.ts
@@ -73,7 +73,7 @@ export function useSolverCowswap(): TSolverContext {
 	const request = useRef<TInitSolverArgs>();
 	const latestQuote = useRef<OrderQuoteResponse>();
 	const existingAllowances = useRef<TDict<TNormalizedBN>>({});
-	const isDisabled = isSolverDisabled[Solver.enum.Cowswap] || safeChainID !== 1;
+	const isDisabled = isSolverDisabled(safeChainID)[Solver.enum.Cowswap] || safeChainID !== 1;
 
 	/* 🔵 - Yearn Finance **************************************************************************
 	** A slippage of 1% per default is set to avoid the transaction to fail due to price
@@ -140,7 +140,7 @@ export function useSolverCowswap(): TSolverContext {
 		if (!data) {
 			type TCowRequestError = {body: {description: string}};
 			const err = error as unknown as TCowRequestError;
-			if (error && !shouldLogError) {
+			if (error && shouldLogError) {
 				if (err?.body?.description) {
 					toast({type: 'error', content: err?.body?.description});
 				} else {

--- a/apps/vaults/hooks/useSolverPortals.ts
+++ b/apps/vaults/hooks/useSolverPortals.ts
@@ -98,14 +98,7 @@ export function useSolverPortals(): TSolverContext {
 		/******************************************************************************************
 		** This first obvious check is to see if the solver is disabled. If it is, we return 0.
 		******************************************************************************************/
-		if (isSolverDisabled[Solver.enum.Portals]) {
-			return toNormalizedBN(0);
-		}
-
-		/******************************************************************************************
-		** Then, we check if the we are on optimist. If we are, we return 0.
-		******************************************************************************************/
-		if (safeChainID === 10) {
+		if (isSolverDisabled(safeChainID)[Solver.enum.Portals]) {
 			return toNormalizedBN(0);
 		}
 
@@ -142,7 +135,7 @@ export function useSolverPortals(): TSolverContext {
 		const {data, error} = await getQuote(_request, safeChainID, zapSlippage);
 		if (!data) {
 			console.error(error?.message);
-			if (error && !shouldLogError) {
+			if (error && shouldLogError) {
 				toast({type: 'error', content: `Portals.fi zap not possible: ${error?.message}`});
 			}
 			return toNormalizedBN(0);
@@ -161,7 +154,7 @@ export function useSolverPortals(): TSolverContext {
 	** not.
 	**********************************************************************************************/
 	const execute = useCallback(async (): Promise<TTxResponse> => {
-		if (isSolverDisabled[Solver.enum.Portals]) {
+		if (isSolverDisabled(safeChainID)[Solver.enum.Portals]) {
 			return ({isSuccessful: false});
 		}
 
@@ -230,18 +223,18 @@ export function useSolverPortals(): TSolverContext {
 	** process and displayed to the user.
 	**************************************************************************/
 	const expectedOut = useMemo((): TNormalizedBN => {
-		if (!latestQuote?.current?.minBuyAmount || isSolverDisabled[Solver.enum.Portals]) {
+		if (!latestQuote?.current?.minBuyAmount || isSolverDisabled(safeChainID)[Solver.enum.Portals]) {
 			return (toNormalizedBN(0));
 		}
 		return toNormalizedBN(latestQuote?.current?.minBuyAmount, request?.current?.outputToken?.decimals || 18);
-	}, [latestQuote, request]);
+	}, [latestQuote, request, safeChainID]);
 
 	/* 🔵 - Yearn Finance ******************************************************
 	** Retrieve the allowance for the token to be used by the solver. This will
 	** be used to determine if the user should approve the token or not.
 	**************************************************************************/
 	const onRetrieveAllowance = useCallback(async (shouldForceRefetch?: boolean): Promise<TNormalizedBN> => {
-		if (!latestQuote?.current || !request?.current || isSolverDisabled[Solver.enum.Portals]) {
+		if (!latestQuote?.current || !request?.current || isSolverDisabled(safeChainID)[Solver.enum.Portals]) {
 			return toNormalizedBN(0);
 		}
 
@@ -292,7 +285,7 @@ export function useSolverPortals(): TSolverContext {
 		txStatusSetter: React.Dispatch<React.SetStateAction<TTxStatus>>,
 		onSuccess: () => Promise<void>
 	): Promise<void> => {
-		if (isSolverDisabled[Solver.enum.Portals]) {
+		if (isSolverDisabled(safeChainID)[Solver.enum.Portals]) {
 			return;
 		}
 		assert(request.current, 'Request is not set');


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

* Disable solvers in SettingsPopover dropdown;
* Refactor the logic to display the toast;
* Refactor the `isSolverDisabled` to take the chain ID so we can have more complex logic regarding solver state;
* debounces the toast for wido, maybe worth to add this in the web-lib directly as an option perhaps.

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/yearn.fi/issues/323

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We're allowing disabled solvers to be selected, and the toast is showing too frequently when changing the amount and the zap is not supported

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Tested locally

## Screenshots (if appropriate):

<img width="1462" alt="Screenshot 2023-08-15 at 15 48 55" src="https://github.com/yearn/yearn.fi/assets/78794805/618e2c27-22f6-41ce-9aae-e2d80596298e">
