### PR TITLE
feat: Show toast when yDaemon is down

### DIFF
--- a/apps/common/contexts/useYearn.tsx
+++ b/apps/common/contexts/useYearn.tsx
@@ -1,11 +1,13 @@
-import {createContext, memo, useContext, useMemo} from 'react';
+import {createContext, memo, useContext, useEffect, useMemo} from 'react';
 import {STACKING_TO_VAULT} from '@vaults/constants/optRewards';
+import {toast} from '@yearn-finance/web-lib/components/yToast';
 import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import {useChainID} from '@yearn-finance/web-lib/hooks/useChainID';
 import {useLocalStorage} from '@yearn-finance/web-lib/hooks/useLocalStorage';
 import {toAddress} from '@yearn-finance/web-lib/utils/address';
 import {yDaemonPricesSchema} from '@yearn-finance/web-lib/utils/schemas/yDaemonPricesSchema';
 import {useFetch} from '@common/hooks/useFetch';
+import {useYDaemonStatus} from '@common/hooks/useYDaemonStatus';
 import {yDaemonEarnedSchema} from '@common/schemas/yDaemonEarnedSchema';
 import {Solver} from '@common/schemas/yDaemonTokenListBalances';
 import {yDaemonTokensSchema} from '@common/schemas/yDaemonTokensSchema';
@@ -61,9 +63,16 @@ const YearnContext = createContext<TYearnContext>({
 export const YearnContextApp = memo(function YearnContextApp({children}: { children: ReactElement }): ReactElement {
 	const {safeChainID} = useChainID();
 	const {yDaemonBaseUri} = useYDaemonBaseURI({chainID: safeChainID});
+	const result = useYDaemonStatus({chainID: safeChainID});
 	const {address, currentPartner} = useWeb3();
 	const [zapSlippage, set_zapSlippage] = useLocalStorage<number>('yearn.finance/zap-slippage', DEFAULT_SLIPPAGE);
 	const [zapProvider, set_zapProvider] = useLocalStorage<TSolver>('yearn.finance/zap-provider', Solver.enum.Cowswap);
+
+	useEffect((): void => {
+		if (result?.error?.code === 'ERR_NETWORK') {
+			toast({type: 'error', content: 'AxiosError: Network Error'});
+		}
+	}, [result?.error?.code]);
 
 	const {data: prices} = useFetch<TYDaemonPrices>({
 		endpoint: `${yDaemonBaseUri}/prices/all`,

--- a/apps/common/hooks/useYDaemonStatus.ts
+++ b/apps/common/hooks/useYDaemonStatus.ts
@@ -1,0 +1,20 @@
+import useSWR from 'swr';
+import {baseFetcher} from '@yearn-finance/web-lib/utils/fetchers';
+import {useYDaemonBaseURI} from '@common/utils/getYDaemonBaseURI';
+
+import type {SWRResponse} from 'swr';
+
+type TProps = {
+	chainID: number | string;
+};
+
+export function useYDaemonStatus<T>({chainID}: TProps): SWRResponse<T> | null {
+	const {yDaemonBaseUri} = useYDaemonBaseURI({chainID});
+	const result = useSWR<T>(`${yDaemonBaseUri}/status`, baseFetcher, {revalidateOnFocus: false});
+
+	if (!result.data || result.isLoading || result.isValidating) {
+		return result;
+	}
+
+	return result;
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Add a toast when yDaemon is not ok

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/yearn.fi/issues/326

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

When yDaemon is down, no warning is shown on the website. But vaults still wouldn't load

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Changed the yDaemon endpoint to something random, then opened the app

## Screenshots (if appropriate):

![photo_2023-08-18 11 13 54](https://github.com/yearn/yearn.fi/assets/78794805/a1eead0e-d7be-4d1f-9440-8cfa62532ed2)
