### PR TITLE
refactor: USDC -> USDC.e

### DIFF
--- a/apps/common/utils/externalZapOutTokenList.json
+++ b/apps/common/utils/externalZapOutTokenList.json
@@ -59,7 +59,7 @@
 		"chainID": 1,
 		"address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
 		"name": "USD Coin",
-		"symbol": "USDC",
+		"symbol": "USDC.e",
 		"logoURI": "https://tokens.1inch.io/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.png",
 		"decimals": 6,
 		"balance": "0",


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Change the name of USDC to USDC.e

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/yearn.fi/issues/340

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The USDC vaults should be the USDC.e vault. The name changed, there's a native USDC version now.
