### PR TITLE
feat: Throw when yDaemon url is missing

### DIFF
--- a/apps/common/utils/getYDaemonBaseURI.ts
+++ b/apps/common/utils/getYDaemonBaseURI.ts
@@ -10,7 +10,11 @@ export function useYDaemonBaseURI({chainID}: TProps): {
 	// eslint-disable-next-line @typescript-eslint/naming-convention
 	const {settings} = useSettings();
 
-	const baseUri = settings.yDaemonBaseURI || String(process.env.YDAEMON_BASE_URI);
+	const baseUri = settings.yDaemonBaseURI || process.env.YDAEMON_BASE_URI;
+
+	if (!baseUri) {
+		throw new Error('YDAEMON_BASE_URI is not defined');
+	}
 
 	return {yDaemonBaseUri: `${baseUri}/${chainID}`};
 }


### PR DESCRIPTION
## Description

Throw when the yDaemon url is missing

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Improve discoverability when the yDaemon url is missing

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Locally

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot 2023-09-10 at 22 15 31" src="https://github.com/yearn/yearn.fi/assets/78794805/8a665c8a-5ee9-47bb-a692-acfc6816f312">
