### PR TITLE
fix: Remove duplicate base network config added to supported chains

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -209,7 +209,6 @@ function MyApp(props: AppProps): ReactElement {
 					fantom,
 					base,
 					arbitrum,
-					base,
 					localhost
 				]}
 				options={{


### PR DESCRIPTION
## Description

Base network config was accidentally added twice during merging of separate commits to main. 

Commit that adds base network config a second time: 
* https://github.com/yearn/yearn.fi/commit/3f20a06b234cf9e4c9ca40b80e52bdce17ca7714#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029
