### PR TITLE
refactor: Remove outdated and unused redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -48,32 +48,6 @@ module.exports = withBundleAnalyzer(withPWA({
 				has: [{type: 'host', value: 'vote.yearn.finance'}],
 				destination: 'https://yearn.finance/veyfi/:path*',
 				permanent: true
-			},
-			//
-			{
-				source: '/twitter',
-				destination: 'https://twitter.com/iearnfinance',
-				permanent: true
-			},
-			{
-				source: '/telegram',
-				destination: 'https://t.me/yearnfinance/',
-				permanent: true
-			},
-			{
-				source: '/medium',
-				destination: 'https://medium.com/iearn',
-				permanent: true
-			},
-			{
-				source: '/governance',
-				destination: 'https://gov.yearn.finance/',
-				permanent: true
-			},
-			{
-				source: '/snapshot',
-				destination: 'https://snapshot.org/#/ybaby.eth',
-				permanent: true
 			}
 		];
 	},


### PR DESCRIPTION
## Description

The redirects point to out outdated urls. Since there have been no complains I assume no one uses them and we can remove them. 

## Motivation and Context

Keep code tidy. Remove likely unused code providing limited utility. 
