### PR TITLE
feat: Tooltip for earnings [PRO-119]

### DIFF
--- a/apps/common/components/InfoTooltip.tsx
+++ b/apps/common/components/InfoTooltip.tsx
@@ -1,0 +1,52 @@
+import {cl} from '@yearn-finance/web-lib/utils/cl';
+
+import type {ReactElement} from 'react';
+
+type TProps = {
+	text: string | number;
+	size: 'sm' | 'md';
+};
+
+const getStyle = (
+	size: TProps['size']
+): {
+	iStyle: string;
+	tooltipStyle: string;
+} => {
+	if (size === 'sm') {
+		return {
+			iStyle: 'md:text-xs text-xxs pl-1',
+			tooltipStyle: 'p-1 px-2 text-xs'
+		};
+	}
+
+	return {
+		iStyle: 'md:text-md text-sm pl-2',
+		tooltipStyle: 'p-2 px-4 text-sm'
+	};
+};
+
+export const InfoTooltip = ({text, size}: TProps): ReactElement => {
+	const {iStyle, tooltipStyle} = getStyle(size);
+
+	return (
+		<sup
+			className={cl(
+				'tooltip underline decoration-neutral-600/30 decoration-dotted underline-offset-4 transition-opacity hover:decoration-neutral-600 font-light',
+				iStyle
+			)}>
+			<span
+				suppressHydrationWarning
+				className={'tooltiptext bottom-full mb-1'}>
+				<div
+					className={cl(
+						'w-fit border border-neutral-300 bg-neutral-100 text-center text-neutral-900',
+						tooltipStyle
+					)}>
+					{text}
+				</div>
+			</span>
+			{'(i)'}
+		</sup>
+	);
+};

--- a/apps/common/components/InfoTooltip.tsx
+++ b/apps/common/components/InfoTooltip.tsx
@@ -1,4 +1,5 @@
 import {cl} from '@yearn-finance/web-lib/utils/cl';
+import {IconQuestion} from '@common/icons/IconQuestion';
 
 import type {ReactElement} from 'react';
 
@@ -10,31 +11,28 @@ type TProps = {
 const getStyle = (
 	size: TProps['size']
 ): {
-	iStyle: string;
+	iconStyle: string;
 	tooltipStyle: string;
 } => {
 	if (size === 'sm') {
 		return {
-			iStyle: 'md:text-xs text-xxs pl-1',
+			iconStyle: 'md:h-3 md:w-3 md:top-0',
 			tooltipStyle: 'p-1 px-2 text-xs'
 		};
 	}
 
 	return {
-		iStyle: 'md:text-md text-sm pl-2',
+		iconStyle: 'md:h-4 md:w-4 md:top-1',
 		tooltipStyle: 'p-2 px-4 text-sm'
 	};
 };
 
 export const InfoTooltip = ({text, size}: TProps): ReactElement => {
-	const {iStyle, tooltipStyle} = getStyle(size);
+	const {iconStyle, tooltipStyle} = getStyle(size);
 
 	return (
-		<sup
-			className={cl(
-				'tooltip underline decoration-neutral-600/30 decoration-dotted underline-offset-4 transition-opacity hover:decoration-neutral-600 font-light',
-				iStyle
-			)}>
+		<sup className={'tooltip font-light transition-opacity'}>
+			<IconQuestion className={cl('absolute h-3 w-3 md:-right-4 -right-3 top-0', iconStyle)} />
 			<span
 				suppressHydrationWarning
 				className={'tooltiptext bottom-full mb-1'}>
@@ -46,7 +44,6 @@ export const InfoTooltip = ({text, size}: TProps): ReactElement => {
 					{text}
 				</div>
 			</span>
-			{'(i)'}
 		</sup>
 	);
 };

--- a/pages/vaults-v3/index.tsx
+++ b/pages/vaults-v3/index.tsx
@@ -14,6 +14,7 @@ import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import {cl} from '@yearn-finance/web-lib/utils/cl';
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 import {isZero} from '@yearn-finance/web-lib/utils/isZero';
+import {InfoTooltip} from '@common/components/InfoTooltip';
 import {useWallet} from '@common/contexts/useWallet';
 import {useYearn} from '@common/contexts/useYearn';
 
@@ -161,7 +162,15 @@ function PortfolioCard(): ReactElement {
 					</b>
 				</div>
 				<div>
-					<p className={'pb-0 text-[#757CA6] md:pb-2'}>{'Earnings'}</p>
+					<p className={'pb-0 text-[#757CA6] md:pb-2'}>
+						{'Earnings'}
+						<InfoTooltip
+							text={
+								'Your earning are estimated based on available onchain data and some nerdy maths stuff.'
+							}
+							size={'sm'}
+						/>
+					</p>
 					<b className={'font-number text-xl text-neutral-900 md:text-3xl'}>
 						<Counter value={Number(formatedYouEarned)} />
 					</b>

--- a/pages/vaults-v3/index.tsx
+++ b/pages/vaults-v3/index.tsx
@@ -166,7 +166,7 @@ function PortfolioCard(): ReactElement {
 						{'Earnings'}
 						<InfoTooltip
 							text={
-								'Your earning are estimated based on available onchain data and some nerdy maths stuff.'
+								'Your earnings are estimated based on available onchain data and some nerdy maths stuff.'
 							}
 							size={'sm'}
 						/>

--- a/pages/vaults/index.tsx
+++ b/pages/vaults/index.tsx
@@ -86,7 +86,7 @@ function HeaderUserPosition(): ReactElement {
 				<p className={'pb-2 text-lg text-neutral-900 md:pb-6 md:text-3xl '}>
 					{'Earnings'}
 					<InfoTooltip
-						text={'Your earning are estimated based on available onchain data and some nerdy maths stuff.'}
+						text={'Your earnings are estimated based on available onchain data and some nerdy maths stuff.'}
 						size={'md'}
 					/>
 				</p>

--- a/pages/vaults/index.tsx
+++ b/pages/vaults/index.tsx
@@ -17,6 +17,7 @@ import {useWeb3} from '@yearn-finance/web-lib/contexts/useWeb3';
 import {IconChain} from '@yearn-finance/web-lib/icons/IconChain';
 import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 import {isZero} from '@yearn-finance/web-lib/utils/isZero';
+import {InfoTooltip} from '@common/components/InfoTooltip';
 import {ListHead} from '@common/components/ListHead';
 import {Pagination} from '@common/components/Pagination';
 import {useWallet} from '@common/contexts/useWallet';
@@ -82,7 +83,13 @@ function HeaderUserPosition(): ReactElement {
 				</b>
 			</div>
 			<div className={'col-span-12 w-full md:col-span-4'}>
-				<p className={'pb-2 text-lg text-neutral-900 md:pb-6 md:text-3xl'}>{'Earnings'}</p>
+				<p className={'pb-2 text-lg text-neutral-900 md:pb-6 md:text-3xl '}>
+					{'Earnings'}
+					<InfoTooltip
+						text={'Your earning are estimated based on available onchain data and some nerdy maths stuff.'}
+						size={'md'}
+					/>
+				</p>
 				<b className={'font-number text-3xl text-neutral-900 md:text-7xl'}>
 					<Counter value={Number(formatedYouEarned)} />
 				</b>

--- a/style.css
+++ b/style.css
@@ -293,9 +293,9 @@
 		@apply invisible right-0 absolute z-50 opacity-0 transition-opacity;
 	}
 	.tooltip .tooltiptext {
-		@apply text-xs text-center invisible bg-neutral-0 text-neutral-900 absolute z-50 right-1 opacity-0 transition-opacity p-2;
+		@apply text-xs text-center invisible bg-neutral-0 text-neutral-900 absolute z-50 -right-7 opacity-0 transition-opacity;
 		width: 15rem;
-		top: 110%;
+		top: 130%;
 		margin-right: calc(-122px + 50%);
 		box-shadow: 0px 4px 16px rgba(0, 0, 0, 0.16);
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7390,13 +7390,6 @@ next-pwa@^5.6.0:
     workbox-webpack-plugin "^6.5.4"
     workbox-window "^6.5.4"
 
-next-query-params@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/next-query-params/-/next-query-params-4.3.0.tgz#62cf9297005a66ebc5b0823c3c66d77971ec87b5"
-  integrity sha512-8w8AXfPJ8vnYvSFBCByT5ZR8ItNSJ6lAbVer8aRZZRUpADZAR6hQ4dh7fLDs/6383DU0Ve7WvNHqswMR8S98zg==
-  dependencies:
-    tslib "^2.0.3"
-
 next-seo@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-6.4.0.tgz#05a75b8acae881f856eb690b1f66b5e8741aa16e"
@@ -8709,11 +8702,6 @@ serialize-javascript@^6.0.1:
   dependencies:
     randombytes "^2.1.0"
 
-serialize-query-params@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-query-params/-/serialize-query-params-2.0.2.tgz#598a3fb9e13f4ea1c1992fbd20231aa16b31db81"
-  integrity sha512-1chMo1dST4pFA9RDXAtF0Rbjaut4is7bzFbI1Z26IuMub68pNCILku85aYmeFhvnY//BXUPUhoRMjYcsT93J/Q==
-
 set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -9583,7 +9571,7 @@ tslib@1.14.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -9812,13 +9800,6 @@ use-callback-ref@^1.3.0:
   integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
   dependencies:
     tslib "^2.0.0"
-
-use-query-params@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/use-query-params/-/use-query-params-2.2.1.tgz#c558ab70706f319112fbccabf6867b9f904e947d"
-  integrity sha512-i6alcyLB8w9i3ZK3caNftdb+UnbfBRNPDnc89CNQWkGRmDrm/gfydHvMBfVsQJRq3NoHOM2dt/ceBWG2397v1Q==
-  dependencies:
-    serialize-query-params "^2.0.2"
 
 use-sidecar@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

* Implement `InfoTooltip` component
* Add InfoTooltip to earnings header

## Related Issue

<!--- Please link to the issue here -->

https://linear.app/fancy-xopowo/issue/PRO-119/tooltip-for-earnings

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The earnings heading section can be confusing (where does this come from, why, how, blabla) and adding a little copy to explain where this is coming from in a tooltip can be good.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Locally

## Screenshots (if appropriate):

### v2

#### web
<img width="1202" alt="PRO-119-tooltip-for-earnings-1" src="https://github.com/yearn/yearn.fi/assets/78794805/2da325ee-5ff8-4a4b-9c6a-140df022b705">

<img width="1258" alt="PRO-119-tooltip-for-earnings-2" src="https://github.com/yearn/yearn.fi/assets/78794805/dd38806a-3a8a-40bd-8a7f-4d5174122971">

#### mobile

<img width="1013" alt="PRO-119-tooltip-for-earnings-3" src="https://github.com/yearn/yearn.fi/assets/78794805/f66ab0b2-a961-49e5-be2d-464f3a745d77">

### v3

#### web

<img width="738" alt="PRO-119-tooltip-for-earnings-v3-1" src="https://github.com/yearn/yearn.fi/assets/78794805/4e5d577d-d1bd-46ab-adeb-fd789a97853c">

<img width="748" alt="PRO-119-tooltip-for-earnings-v3-2" src="https://github.com/yearn/yearn.fi/assets/78794805/94fa4047-09e8-47e9-8b82-9576ebc2693c">

#### mobile

<img width="978" alt="PRO-119-tooltip-for-earnings-v3-3" src="https://github.com/yearn/yearn.fi/assets/78794805/73a0eb9f-bc0c-47f7-937a-c89bd2564048">
