### PR TITLE
fix: use parseMardown for uiNotice messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.3
+
+-   Fix: Use Markdown for uiNotice
+
 # 0.4.2
 
 -   Feat: Show Only label in combobox

--- a/apps/vaults-v3/components/details/VaultActionsTabsWrapper.tsx
+++ b/apps/vaults-v3/components/details/VaultActionsTabsWrapper.tsx
@@ -17,6 +17,7 @@ import {VaultDetailsQuickActionsTo} from '@vaults-v3/components/details/actions/
 import {RewardsTab} from '@vaults-v3/components/details/RewardsTab';
 import {SettingsPopover} from '@vaults-v3/components/SettingsPopover';
 import {readContracts} from '@wagmi/core';
+import {parseMarkdown} from '@yearn-finance/web-lib/utils/helpers';
 import {useYearn} from '@common/contexts/useYearn';
 import {IconChevron} from '@common/icons/IconChevron';
 
@@ -408,7 +409,10 @@ export function VaultActionsTabsWrapper({currentVault}: {currentVault: TYDaemonV
 					className={'col-span-12 mt-10'}>
 					<div className={'w-full rounded-3xl bg-neutral-900 p-6 text-neutral-0'}>
 						<b className={'text-lg'}>{'Oh look, an important message for you to read!'}</b>
-						<p className={'mt-2'}>{currentVault?.info.uiNotice}</p>
+						<p
+							className={'mt-2'}
+							dangerouslySetInnerHTML={{__html: parseMarkdown(currentVault?.info.uiNotice)}}
+						/>
 					</div>
 				</div>
 			)}

--- a/apps/vaults/components/details/VaultActionsTabsWrapper.tsx
+++ b/apps/vaults/components/details/VaultActionsTabsWrapper.tsx
@@ -24,6 +24,7 @@ import {
 	VaultDetailsTab
 } from '@vaults-v3/components/details/VaultActionsTabsWrapper';
 import {readContracts} from '@wagmi/core';
+import {parseMarkdown} from '@yearn-finance/web-lib/utils/helpers';
 import {IconChevron} from '@common/icons/IconChevron';
 
 import type {ReactElement} from 'react';
@@ -178,7 +179,10 @@ export function VaultActionsTabsWrapper({currentVault}: {currentVault: TYDaemonV
 					className={'col-span-12 mt-10'}>
 					<div className={'w-full rounded-3xl bg-neutral-900 p-6 text-neutral-0'}>
 						<b className={'text-lg'}>{'Oh look, an important message for you to read!'}</b>
-						<p className={'mt-2'}>{currentVault?.info.uiNotice}</p>
+						<p
+							className={'mt-2'}
+							dangerouslySetInnerHTML={{__html: parseMarkdown(currentVault?.info.uiNotice)}}
+						/>
 					</div>
 				</div>
 			)}


### PR DESCRIPTION
Use parseMardown on messages so that links work, see screencast.

[Screencast from 01-12-2024 02:26:26 PM.webm](https://github.com/yearn/yearn.fi/assets/26435/0368004a-b8e3-40aa-9bb6-2923e501d60e)
