### PR TITLE
Chore: migration and retirement announcement cleanup

### DIFF
--- a/apps/vaults-v3/components/details/VaultActionsTabsWrapper.tsx
+++ b/apps/vaults-v3/components/details/VaultActionsTabsWrapper.tsx
@@ -504,7 +504,7 @@ export function VaultActionsTabsWrapper({currentVault}: {currentVault: TYDaemonV
 						<b className={'text-lg'}>{'Looks like this is an old vault.'}</b>
 						<p className={'mt-2'}>
 							{
-								'This Vault is no longer earning yield, but good news, there’s a shiny up to date version just waiting for you to deposit your tokens into. Click migrate, and your tokens will be migrated to the current Vault, which will be mi-great!'
+								'This Vault has been retired, but there is a migration path to a new Vault that is ready to earn yield for you. Please migrate or withdraw your assets.'
 							}
 						</p>
 					</div>
@@ -529,12 +529,12 @@ export function VaultActionsTabsWrapper({currentVault}: {currentVault: TYDaemonV
 					</div>
 				)}
 
-			{currentVault?.info.uiNotice && (
+			{currentVault?.info.uiNotice && !currentVault?.migration.available && (
 				<div
 					aria-label={'Migration Warning'}
 					className={'col-span-12 mt-10'}>
 					<div className={'w-full rounded-3xl bg-neutral-900 p-6 text-neutral-0'}>
-						<b className={'text-lg'}>{'Oh look, an important message for you to read!'}</b>
+						<b className={'text-lg'}>{'Looks like this is an old vault.'}</b>
 						<p
 							className={'mt-2'}
 							dangerouslySetInnerHTML={{

--- a/apps/vaults/hooks/useFilteredVaults.ts
+++ b/apps/vaults/hooks/useFilteredVaults.ts
@@ -28,7 +28,6 @@ export function useVaultFilter(
 	migratableVaults: TYDaemonVault[];
 } {
 	const {vaults, vaultsMigrations, vaultsRetired} = useYearn();
-	console.log('useVaultFilter', {vaults, vaultsMigrations, vaultsRetired});
 	const {getBalance, getPrice} = useYearn();
 	const {shouldHideDust} = useAppSettings();
 
@@ -126,8 +125,6 @@ export function useVaultFilter(
 	);
 	const migratableVaults = useFilteredVaults(vaultsMigrations, v => filterMigrationCallback(v));
 	const retiredVaults = useFilteredVaults(vaultsRetired, v => filterMigrationCallback(v));
-	console.log('useVaultFilter - migratableVaults', migratableVaults);
-	console.log('useVaultFilter - retiredVaults', retiredVaults);
 
 	/* 🔵 - Yearn Finance **************************************************************************
 	 **	First, we need to determine in which category we are. The activeVaults function will

--- a/apps/vaults/hooks/useFilteredVaults.ts
+++ b/apps/vaults/hooks/useFilteredVaults.ts
@@ -28,6 +28,7 @@ export function useVaultFilter(
 	migratableVaults: TYDaemonVault[];
 } {
 	const {vaults, vaultsMigrations, vaultsRetired} = useYearn();
+	console.log('useVaultFilter', {vaults, vaultsMigrations, vaultsRetired});
 	const {getBalance, getPrice} = useYearn();
 	const {shouldHideDust} = useAppSettings();
 
@@ -92,7 +93,7 @@ export function useVaultFilter(
 	);
 
 	// Specific filter
-	const hightlightedVaults = useFilteredVaults(vaults, ({info}): boolean => info.isHighlighted);
+	const highlightedVaults = useFilteredVaults(vaults, ({info}): boolean => info.isHighlighted);
 	const holdingsVaults = useFilteredVaults(vaults, (vault): boolean => filterHoldingsCallback(vault, false, false));
 	const holdingsV3Vaults = useFilteredVaults(vaults, (vault): boolean => filterHoldingsCallback(vault, false, true));
 
@@ -125,6 +126,8 @@ export function useVaultFilter(
 	);
 	const migratableVaults = useFilteredVaults(vaultsMigrations, v => filterMigrationCallback(v));
 	const retiredVaults = useFilteredVaults(vaultsRetired, v => filterMigrationCallback(v));
+	console.log('useVaultFilter - migratableVaults', migratableVaults);
+	console.log('useVaultFilter - retiredVaults', retiredVaults);
 
 	/* 🔵 - Yearn Finance **************************************************************************
 	 **	First, we need to determine in which category we are. The activeVaults function will
@@ -135,7 +138,7 @@ export function useVaultFilter(
 		let _vaultList: TYDaemonVault[] = [];
 		if (v3) {
 			if (categories?.includes('highlight')) {
-				_vaultList = [..._vaultList, ...hightlightedVaults];
+				_vaultList = [..._vaultList, ...highlightedVaults];
 			}
 			if (categories?.includes('single')) {
 				_vaultList = [..._vaultList, ...singleVaults];
@@ -227,7 +230,7 @@ export function useVaultFilter(
 		categories,
 		holdingsVaults,
 		holdingsV3Vaults,
-		hightlightedVaults,
+		highlightedVaults,
 		singleVaults,
 		MultiVaults,
 		curveFactoryVaults,

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pages/v3/index.tsx
+++ b/pages/v3/index.tsx
@@ -160,7 +160,10 @@ function ListOfVaults(): ReactElement {
 		defaultCategories: ALL_VAULTSV3_CATEGORIES_KEYS,
 		defaultPathname: `/v3`
 	});
-	const {activeVaults} = useVaultFilter(types, chains, true);
+	const {activeVaults, retiredVaults, migratableVaults} = useVaultFilter(types, chains, true);
+	console.log('activeVaults', activeVaults);
+	console.log('retiredVaults', retiredVaults);
+	console.log('migratableVaults', migratableVaults);
 
 	/**********************************************************************************************
 	 **	Then, on the activeVaults list, we apply the search filter. The search filter is
@@ -172,11 +175,11 @@ function ListOfVaults(): ReactElement {
 		}
 		const filtered = activeVaults.filter((vault: TYDaemonVault): boolean => {
 			const lowercaseSearch = search.toLowerCase();
-			const splitted =
+			const searchableFields =
 				`${vault.name} ${vault.symbol} ${vault.token.name} ${vault.token.symbol} ${vault.address} ${vault.token.address}`
 					.toLowerCase()
 					.split(' ');
-			return splitted.some((word): boolean => word.includes(lowercaseSearch));
+			return searchableFields.some((word): boolean => word.includes(lowercaseSearch));
 		});
 		return filtered;
 	}, [activeVaults, search]);


### PR DESCRIPTION
## Description

- Vaults that have been retired or have a migration path now show up correctly for users who have deposits in those vaults.
- Vaults that have been retired or have a migration path now are correctly accounted for in the portfolio balance amount.
- alert message for retired and migration ready vaults updated.

## Related Issue

https://github.com/yearn/ydaemon/pull/462

## Motivation and Context

fix broken shit.

## How Has This Been Tested?

Impersonated Wallets with these assets in them. Ran locally, etc. 

## Screenshots (if appropriate):
