### PR TITLE
fix: retired vaults not showing up

### DIFF
--- a/apps/common/hooks/useFetchYearnVaults.ts
+++ b/apps/common/hooks/useFetchYearnVaults.ts
@@ -47,14 +47,17 @@ function useFetchYearnVaults(chainIDs?: number[] | undefined): {
 	const {data: vaultsMigrations} = useFetch<TYDaemonVaults>({
 		endpoint: `${yDaemonBaseUriWithoutChain}/vaults?${new URLSearchParams({
 			chainIDs: chainIDs ? chainIDs.join(',') : [1, 10, 137, 250, 8453, 42161].join(','),
-			migratable: 'nodust'
+			migratable: 'nodust',
+			limit: '2500'
 		})}`,
 		schema: yDaemonVaultsSchema
 	});
 
 	// const vaultsRetired: TYDaemonVaults = useMemo(() => [], []);
 	const {data: vaultsRetired} = useFetch<TYDaemonVaults>({
-		endpoint: `${yDaemonBaseUriWithoutChain}/vaults/retired`,
+		endpoint: `${yDaemonBaseUriWithoutChain}/vaults/retired?${new URLSearchParams({
+			limit: '2500'
+		})}`,
 		schema: yDaemonVaultsSchema
 	});
 

--- a/pages/v3/index.tsx
+++ b/pages/v3/index.tsx
@@ -209,20 +209,9 @@ function ListOfVaults(): ReactElement {
 		// Add migratable vaults to holdings (guaranteed to have balance)
 		for (const vault of migratableVaults) {
 			const key = `${vault.chainID}_${vault.address}`;
-			holdings.push(
-				<VaultsV3ListRow
-					key={key}
-					currentVault={vault}
-				/>
-			);
-			processedForHoldings.add(key);
-		}
-
-		// Add retired vaults to holdings (guaranteed to have balance)
-		for (const vault of retiredVaults) {
-			const key = `${vault.chainID}_${vault.address}`;
-			if (!processedForHoldings.has(key)) {
-				// Avoid duplicates
+			const hasBalance = getBalance({address: vault.address, chainID: vault.chainID}).raw > 0n;
+			const hasStakingBalance = getBalance({address: vault.staking.address, chainID: vault.chainID}).raw > 0n;
+			if (hasBalance || hasStakingBalance) {
 				holdings.push(
 					<VaultsV3ListRow
 						key={key}
@@ -230,6 +219,25 @@ function ListOfVaults(): ReactElement {
 					/>
 				);
 				processedForHoldings.add(key);
+			}
+		}
+
+		// Add retired vaults to holdings (guaranteed to have balance)
+		for (const vault of retiredVaults) {
+			const key = `${vault.chainID}_${vault.address}`;
+			if (!processedForHoldings.has(key)) {
+				// Avoid duplicates
+				const hasBalance = getBalance({address: vault.address, chainID: vault.chainID}).raw > 0n;
+				const hasStakingBalance = getBalance({address: vault.staking.address, chainID: vault.chainID}).raw > 0n;
+				if (hasBalance || hasStakingBalance) {
+					holdings.push(
+						<VaultsV3ListRow
+							key={key}
+							currentVault={vault}
+						/>
+					);
+					processedForHoldings.add(key);
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description

Some of the retired vaults were not showing up for users with balances. This was due to incorrectly limiting the returned data from yDaemon. By setting the query limit to 2500 the problem fixes itself.

## Related Issue

continuation of this merged PR: https://github.com/yearn/yearn.fi/pull/653

## Motivation and Context

It wasn't working

## How Has This Been Tested?

Impersonated vault and staked token holder.

## Screenshots (if appropriate):
