### PR TITLE
chore: add CTA showing link to bridge

### DIFF
--- a/packages/legacy/apps/vaults-v3/components/details/VaultActionsTabsWrapper.tsx
+++ b/packages/legacy/apps/vaults-v3/components/details/VaultActionsTabsWrapper.tsx
@@ -499,10 +499,18 @@ export function VaultActionsTabsWrapper({ currentVault }: { currentVault: TYDaem
       {currentVault?.chainID === 747474 && (
         <div aria-label={'Rewards Claim Notification'} className={'col-span-12 mt-10'}>
           <div className={'w-full rounded-3xl bg-neutral-900 p-6 text-neutral-0'}>
-            <b>{'KAT Rewards earned by Katana Vaults can be claimed at: '}</b>
-            <a className={'underline'} href={'https://katana.yearn.space'} target={'_blank'} rel={'noreferrer'}>
-              {'https://katana.yearn.space'}
-            </a>
+            <div>
+              <b>{'Bridge to Katana at: '}</b>
+              <a className={'underline'} href={'https://bridge.katana.network/'} target={'_blank'} rel={'noreferrer'}>
+                {'https://bridge.katana.network/'}
+              </a>
+            </div>
+            <div>
+              <b>{'KAT Rewards earned by Katana Vaults can be claimed at: '}</b>
+              <a className={'underline'} href={'https://katana.yearn.space'} target={'_blank'} rel={'noreferrer'}>
+                {'https://katana.yearn.space'}
+              </a>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Description

Adds an additional CTA to the katana vault pages to show a link to the bridge website.

## Related Issue

<!--- Please link to the issue here -->

## Motivation and Context

It is unclear how to bridge to Katana without this. We should probably improve this flow, but this is a bandaid.

## How Has This Been Tested?

locally

## Screenshots (if appropriate):
<img width="822" height="384" alt="image" src="https://github.com/user-attachments/assets/ecaf71c7-12bd-4b4a-ac79-d856e298ed1f" />
