### PR TITLE
fix: display full list

### DIFF
--- a/packages/legacy/pages/v3/index.tsx
+++ b/packages/legacy/pages/v3/index.tsx
@@ -152,7 +152,7 @@ function ListOfVaults(): ReactElement {
     onChangeSortBy,
     onReset
   } = useQueryArguments({
-    defaultTypes: [ALL_VAULTSV3_KINDS_KEYS[0]],
+    defaultTypes: ALL_VAULTSV3_KINDS_KEYS,
     defaultCategories: ALL_VAULTSV3_CATEGORIES_KEYS,
     defaultPathname: '/v3'
   })


### PR DESCRIPTION
## Description

Only fancy vaults are currently displayed by default. Probably makes sense to display all of them

## Screenshots (if appropriate):
before:
<img width="715" height="484" alt="image" src="https://github.com/user-attachments/assets/a6bf9f73-2884-441a-b48e-68c85c23cb03" />
after: 
<img width="724" height="491" alt="image" src="https://github.com/user-attachments/assets/92046c62-524d-4937-99c8-d63c1a917c5b" />
