### PR TITLE
feat: migrate dynamic ogs to new service

### DIFF
--- a/packages/legacy/pages/_app.tsx
+++ b/packages/legacy/pages/_app.tsx
@@ -110,30 +110,18 @@ function MyApp(props: AppProps): ReactElement {
   let ogUrl = manifest.og || 'https://yearn.fi/og.png'
   let pageUri = manifest.uri || 'https://yearn.fi'
 
-  // Determine base URL for dynamic OG API based on environment
-  let baseUrl = 'https://yearn.fi' // Default to production
-  if (process.env.VERCEL_ENV === 'production') {
-    baseUrl = 'https://yearn.fi'
-  } else if (process.env.VERCEL_URL) {
-    // Vercel preview/development builds
-    baseUrl = `https://${process.env.VERCEL_URL}`
-  } else if (typeof window !== 'undefined') {
-    // Local development fallback
-    baseUrl = window.location.origin
-  } else {
-    // Server-side fallback for localhost
-    baseUrl = 'http://localhost:3000'
-  }
+  const ogBaseUrl = 'https://og.yearn.fi' // Default to production
+
   // Use dynamic OG API for V3 vault pages: /v3/[chainID]/[address]
   if (asPath.startsWith('/v3/') && asPath.split('/').length === 4) {
     const [, , chainID, address] = asPath.split('/')
-    ogUrl = `${baseUrl}/api/og/${chainID}/${address}`
+    ogUrl = `${ogBaseUrl}/api/og/yearn/vault/${chainID}/${address}`
     pageUri = `https://yearn.fi${asPath}`
   }
   // Use dynamic OG API for v2 vault pages: /vaults/[chainID]/[address]
   if (asPath.startsWith('/vaults/') && asPath.split('/').length === 4) {
     const [, , chainID, address] = asPath.split('/')
-    ogUrl = `${baseUrl}/api/og/${chainID}/${address}`
+    ogUrl = `${ogBaseUrl}/api/og/yearn/vault/${chainID}/${address}`
     pageUri = `https://yearn.fi${asPath}`
   }
 


### PR DESCRIPTION
## Description

Offloads OG generation from built in API route to external OG service at og.yearn.fi

## Related Issue

builds on https://github.com/yearn/yearn.fi/pull/727

## Motivation and Context

Make the site easier to maintain and allow re-use of OGs with other sites

## How Has This Been Tested?

TBD

## Screenshots (if appropriate):
