### PR TITLE
fix: katana APR calcs

### DIFF
--- a/packages/legacy/apps/vaults-v3/components/details/VaultDetailsHeader.tsx
+++ b/packages/legacy/apps/vaults-v3/components/details/VaultDetailsHeader.tsx
@@ -82,6 +82,21 @@ function VaultAPY({
   const currentAPY = apr.forwardAPR.netAPR + extraAPY
   const isSourceVeYFI = source === 'VeYFI'
 
+  const katanaNetAPY = useMemo(() => {
+    if (!katanaExtras) return 0
+    // Exclude legacy katanaRewardsAPR and non-APR "steerPointsPerDollar" from totals
+    const {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      katanaRewardsAPR: _katanaRewardsAPR,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      steerPointsPerDollar: _points,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      katanaBonusAPY: _bonus,
+      ...relevantAprs
+    } = katanaExtras ?? {}
+    return Object.values(relevantAprs).reduce((sum, value) => sum + value, 0)
+  }, [katanaExtras])
+
   if (katanaExtras) {
     return (
       <VaultHeaderLineItem
@@ -107,7 +122,7 @@ function VaultAPY({
         }
       >
         <Renderable shouldRender={!apr?.type.includes('new')} fallback={'New'}>
-          <RenderAmount value={netAPY} symbol={'percent'} decimals={6} />
+          <RenderAmount value={katanaNetAPY} symbol={'percent'} decimals={6} />
         </Renderable>
       </VaultHeaderLineItem>
     )

--- a/packages/legacy/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
+++ b/packages/legacy/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
@@ -398,7 +398,12 @@ function VaultForwardAPY({ currentVault }: { currentVault: TYDaemonVault }): Rea
   const totalAPR = useMemo(() => {
     if (!katanaAprData) return 0
     // Exclude legacy katanaRewardsAPR to avoid double counting with katanaAppRewardsAPR
-    const { katanaRewardsAPR: _katanaRewardsAPR, steerPointsPerDollar: _points, ...relevantAprs } = katanaAprData
+    const {
+      katanaRewardsAPR: _katanaRewardsAPR,
+      katanaBonusAPY: _bonus,
+      steerPointsPerDollar: _points,
+      ...relevantAprs
+    } = katanaAprData
     return Object.values(relevantAprs).reduce((sum, value) => sum + value, 0)
   }, [katanaAprData])
 


### PR DESCRIPTION
## Description

- Updated the logic to calculate APRs for katana to remove the bonus that is now expired in both the vault row and in the vault page
- removed steer points from the combined APR calc in the vault pages.

## Related Issue

<!--- Please link to the issue here -->

## Motivation and Context

Fix incorrect calc

## How Has This Been Tested?

locally ran site.

## Screenshots (if appropriate):
