### PR TITLE
fix: nav popover bug

### DIFF
--- a/packages/legacy/apps/lib/components/LogoPopover.tsx
+++ b/packages/legacy/apps/lib/components/LogoPopover.tsx
@@ -139,13 +139,12 @@ export function LogoPopover(): ReactElement {
           leaveTo={'opacity-0 translate-y-1'}
           className={'relative z-9999999'}
         >
-          <PopoverPanel className={'absolute left-0 top-10 z-20 w-[345px] scale-[115%] bg-transparent px-4 sm:px-0'}>
-            <div className={cl('overflow-hidden shadow-xl', isVaultPage ? 'pt-4' : 'pt-0')}>
+          <PopoverPanel className={'absolute left-0 top-6 z-20 w-[345px] scale-[115%] bg-transparent px-4 sm:px-0'}>
+            <div className={cl('overflow-hidden shadow-xl rounded-lg pt-4')}>
               <div
                 className={cl(
-                  'relative gap-2 border p-4 rounded-md',
-                  'border-transparent ',
-                  // 'bg-white',
+                  'relative gap-2 p-4  ',
+                  'border border-neutral-100',
                   isV3 ? 'border-[#151C40] bg-[#000520]' : 'dark:border-[#010A3B] dark:bg-neutral-300 bg-white'
                 )}
               >


### PR DESCRIPTION
## Description

fixes the popover so it doesn't get hidden if the mouse moved between the logo and popover element

## Related Issue

none

## Motivation and Context

reported bug

## How Has This Been Tested?

locally

## Screenshots (if appropriate):
