### PR TITLE
Feat/improve mobile and vaults page clean

### DIFF
--- a/apps/lib/components/Header.tsx
+++ b/apps/lib/components/Header.tsx
@@ -22,9 +22,11 @@ function Navbar({ nav, currentPathName }: TNavbar): ReactElement {
   return (
     <nav className={'yearn--nav'}>
       {nav.map(
-        (option): ReactElement => (
+        (option, index): ReactElement => (
           <Link key={option.path} target={option.target} href={option.path}>
-            <p className={`yearn--header-nav-item ${currentPathName.startsWith(option.path) ? 'active' : ''}`}>
+            <p
+              className={`yearn--header-nav-item ${currentPathName.startsWith(option.path) ? 'active' : ''} ${index > 0 ? 'hidden md:block' : ''}`}
+            >
               {option?.label || 'Unknown'}
             </p>
           </Link>
@@ -157,12 +159,12 @@ function AppHeader(props: { supportedNetworks: Chain[] }): ReactElement {
           </div>
           <div className={'flex w-1/3 items-center justify-end'}>
             <button
-              className={'yearn--header-nav-item relative rounded-full p-2 transition-colors'}
+              className={'yearn--header-nav-item relative rounded-full p-4 transition-colors'}
               onClick={(): void => setShouldOpenCurtain(true)}
             >
               <IconBell className={'size-4 font-bold transition-colors'} />
 
-              <div className={cl('absolute right-1 top-1 size-2 rounded-full', notificationDotColor)} />
+              <div className={cl('absolute right-4 top-4 size-2 rounded-full', notificationDotColor)} />
             </button>
             <WalletSelector />
             <div className={'flex md:hidden pl-4 text-neutral-500'}>

--- a/apps/lib/components/ModalMobileMenu.tsx
+++ b/apps/lib/components/ModalMobileMenu.tsx
@@ -91,7 +91,7 @@ export function ModalMobileMenu(props: TModalMobileMenu): ReactElement {
 
   return (
     <Transition show={isOpen} as={'div'}>
-      <Dialog as={'div'} className={'fixed inset-0 overflow-y-auto'} style={{ zIndex: 88 }} onClose={onClose}>
+      <Dialog as={'div'} className={'fixed w-screen inset-0 overflow-y-auto'} style={{ zIndex: 88 }} onClose={onClose}>
         <div className={'relative flex h-screen w-screen items-stretch justify-start px-0 pb-0 text-center'}>
           <TransitionChild
             as={'div'}

--- a/apps/vaults-v3/components/Filters.tsx
+++ b/apps/vaults-v3/components/Filters.tsx
@@ -3,11 +3,13 @@ import { MultiSelectDropdown } from '@lib/components/MultiSelectDropdown'
 import { SearchBar } from '@lib/components/SearchBar'
 import { useChainOptions } from '@lib/hooks/useChains'
 import { IconChevron } from '@lib/icons/IconChevron'
-import { cl } from '@lib/utils'
+import { cl, formatAmount } from '@lib/utils'
 import { ALL_VAULTSV3_CATEGORIES, ALL_VAULTSV3_KINDS } from '@vaults-v3/constants'
 
 import type { ReactElement } from 'react'
 import { useMemo, useState } from 'react'
+import useWallet from '@lib/contexts/useWallet'
+import { useWeb3 } from '@lib/contexts/useWeb3'
 
 type TListHero = {
   types: string[] | null
@@ -19,6 +21,55 @@ type TListHero = {
   onChangeChains: (chains: number[] | null) => void
   onChangeCategories: (categories: string[] | null) => void
   onSearch: (searchValue: string) => void
+}
+
+function PortfolioCard(): ReactElement {
+  const { cumulatedValueInV3Vaults, isLoading } = useWallet()
+  const { isActive, address, openLoginModal, onSwitchChain } = useWeb3()
+
+  if (!isActive) {
+    return (
+      <div className={'flex flex-row items-center mb-4 gap-4 h-18'}>
+        <button
+          className={cl('rounded-lg overflow-hidden flex', 'px-[42px] py-2', 'relative group', 'border-none')}
+          onClick={(): void => {
+            if (!isActive && address) {
+              onSwitchChain(1)
+            } else {
+              openLoginModal()
+            }
+          }}
+        >
+          <div
+            className={cl(
+              'absolute inset-0',
+              'opacity-80 transition-opacity group-hover:opacity-100 pointer-events-none',
+              'bg-[linear-gradient(80deg,#D21162,#2C3DA6)]'
+            )}
+          />
+          <p className={'z-10 text-neutral-900'}>{'Connect Wallet'}</p>
+        </button>
+        <p className={'text-[#757CA6] p-2'}>{'It looks like you need to connect your wallet.'}</p>
+      </div>
+    )
+  }
+  return (
+    <div className={'flex flex-row justify-between mb-4'}>
+      <div className={'flex flex-row gap-4 md:flex-row md:gap-32'}>
+        <div>
+          <p className={'pb-0 text-[#757CA6] md:pb-2'}>{'Amount Deposited'}</p>
+          {isLoading ? (
+            <div className={'h-[36.5px] w-32 animate-pulse rounded-sm bg-[#757CA6]'} />
+          ) : (
+            <b className={'font-number text-xl text-neutral-900 md:text-3xl'}>
+              {'$'}
+              <span suppressHydrationWarning>{formatAmount(cumulatedValueInV3Vaults.toFixed(2), 2, 2)}</span>
+            </b>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export function Filters({
@@ -66,9 +117,7 @@ export function Filters({
 
   return (
     <div className={'relative col-span-12 w-full rounded-3xl bg-neutral-100 p-6 md:col-span-8'}>
-      <strong className={'block pb-2 text-3xl font-black text-neutral-900 md:pb-4 md:text-4xl md:leading-[48px]'}>
-        {'Filters'}
-      </strong>
+      <PortfolioCard />
 
       <div className={'absolute right-10 top-10 block md:hidden'}>
         <button onClick={(): void => setShouldExpandFilters((prev): boolean => !prev)}>

--- a/apps/vaults-v3/components/Filters.tsx
+++ b/apps/vaults-v3/components/Filters.tsx
@@ -2,9 +2,10 @@ import type { TMultiSelectOptionProps } from '@lib/components/MultiSelectDropdow
 import { MultiSelectDropdown } from '@lib/components/MultiSelectDropdown'
 import { SearchBar } from '@lib/components/SearchBar'
 import { useChainOptions } from '@lib/hooks/useChains'
-import { IconChevron } from '@lib/icons/IconChevron'
+import { IconCross } from '@lib/icons/IconCross'
 import { cl, formatAmount } from '@lib/utils'
 import { ALL_VAULTSV3_CATEGORIES, ALL_VAULTSV3_KINDS } from '@vaults-v3/constants'
+import { Drawer } from 'vaul'
 
 import type { ReactElement } from 'react'
 import { useMemo, useState } from 'react'
@@ -83,7 +84,7 @@ export function Filters({
   shouldDebounce,
   onChangeChains
 }: TListHero): ReactElement {
-  const [shouldExpandFilters, setShouldExpandFilters] = useState(false)
+  const [isMobileFiltersOpen, setIsMobileFiltersOpen] = useState(false)
   const chainOptions = useChainOptions(chains).filter(
     (option): boolean =>
       option.value === 1 ||
@@ -130,67 +131,125 @@ export function Filters({
           shouldDebounce={shouldDebounce || false}
         />
       </div>
-      <button
-        onClick={(): void => setShouldExpandFilters((prev): boolean => !prev)}
-        className={
-          'w-full py-2 cursor-pointer rounded-[4px] bg-neutral-800/20 text-sm text-neutral-900 transition-colors hover:bg-neutral-800/50 sm:hidden'
-        }
-      >
-        {'Filter Vaults'}
-      </button>
-      <div
-        className={cl(
-          'grid grid-cols-1 gap-6 md:grid-cols-3',
-          shouldExpandFilters ? 'h-auto' : 'h-0 overflow-hidden md:h-auto md:overflow-visible'
-        )}
-      >
-        <div className={'w-full'}>
-          <p className={'pb-2 text-[#757CA6]'}>{'Select Blockchain'}</p>
-          <MultiSelectDropdown
-            buttonClassName={'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'}
-            comboboxOptionsClassName={'bg-neutral-300 rounded-lg'}
-            options={chainOptions}
-            placeholder={'Select chain'}
-            onSelect={(options): void => {
-              const selectedChains = options
-                .filter((o): boolean => o.isSelected)
-                .map((option): number => Number(option.value))
-              onChangeChains(selectedChains)
-            }}
-          />
-        </div>
+      <div className={'md:hidden'}>
+        <Drawer.Root open={isMobileFiltersOpen} onOpenChange={setIsMobileFiltersOpen} direction={'bottom'}>
+          <Drawer.Trigger asChild>
+            <button
+              className={
+                'w-full cursor-pointer rounded-[4px] bg-neutral-800/20 py-2 text-sm text-neutral-900 transition-colors hover:bg-neutral-800/50'
+              }
+            >
+              {'Filter Vaults'}
+            </button>
+          </Drawer.Trigger>
+          <Drawer.Portal>
+            <Drawer.Overlay className={'fixed inset-0 z-99998 bg-black/40 backdrop-blur-xs transition-opacity'} />
+            <Drawer.Content className={'fixed inset-x-0 bottom-0 z-99999 flex justify-center outline-hidden'}>
+              <div
+                className={
+                  'w-full max-w-[520px] rounded-t-3xl bg-neutral-100 p-6 shadow-[0_-16px_60px_rgba(15,23,42,0.35)]'
+                }
+                style={{ height: '85vh', overflowY: 'auto' }}
+              >
+                <div className={'mb-4 flex items-center justify-between'}>
+                  <p className={'text-base font-medium text-neutral-900'}>{'Filter Vaults'}</p>
+                  <Drawer.Close
+                    className={'rounded-full p-2 text-neutral-900 transition-colors hover:text-neutral-600'}
+                  >
+                    <IconCross className={'size-4'} />
+                  </Drawer.Close>
+                </div>
+                <FilterControls
+                  chainOptions={chainOptions}
+                  onChangeChains={onChangeChains}
+                  categoryOptions={categoryOptions}
+                  onChangeCategories={onChangeCategories}
+                  typeOptions={typeOptions}
+                  onChangeTypes={onChangeTypes}
+                />
+              </div>
+            </Drawer.Content>
+          </Drawer.Portal>
+        </Drawer.Root>
+      </div>
 
-        <div className={'w-full'}>
-          <p className={'pb-2 text-[#757CA6]'}>{'Select Category'}</p>
-          <MultiSelectDropdown
-            buttonClassName={'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'}
-            comboboxOptionsClassName={'bg-neutral-300 rounded-lg'}
-            options={categoryOptions}
-            placeholder={'Filter categories'}
-            onSelect={(options): void => {
-              const selectedCategories = options
-                .filter((o): boolean => o.isSelected)
-                .map((option): string => String(option.value))
-              onChangeCategories(selectedCategories)
-            }}
-          />
-        </div>
+      <div className={'hidden md:block'}>
+        <FilterControls
+          chainOptions={chainOptions}
+          onChangeChains={onChangeChains}
+          categoryOptions={categoryOptions}
+          onChangeCategories={onChangeCategories}
+          typeOptions={typeOptions}
+          onChangeTypes={onChangeTypes}
+        />
+      </div>
+    </div>
+  )
+}
 
-        <div className={'w-full'}>
-          <p className={'pb-2 text-[#757CA6]'}>{'Select Type'}</p>
-          <MultiSelectDropdown
-            buttonClassName={'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'}
-            comboboxOptionsClassName={'bg-neutral-300 rounded-lg'}
-            options={typeOptions}
-            placeholder={'Filter list'}
-            onSelect={(options): void => {
-              const selectedTypes = options
-                .filter((o): boolean => o.isSelected)
-                .map((option): string => String(option.value))
-              onChangeTypes(selectedTypes)
-            }}
-          />
-        </div>
+function FilterControls({
+  chainOptions,
+  onChangeChains,
+  categoryOptions,
+  onChangeCategories,
+  typeOptions,
+  onChangeTypes
+}: {
+  chainOptions: TMultiSelectOptionProps[]
+  onChangeChains: (chains: number[] | null) => void
+  categoryOptions: TMultiSelectOptionProps[]
+  onChangeCategories: (categories: string[] | null) => void
+  typeOptions: TMultiSelectOptionProps[]
+  onChangeTypes: (types: string[] | null) => void
+}): ReactElement {
+  return (
+    <div className={'grid grid-cols-1 gap-6 md:grid-cols-3'}>
+      <div className={'w-full'}>
+        <p className={'pb-2 text-[#757CA6]'}>{'Select Blockchain'}</p>
+        <MultiSelectDropdown
+          buttonClassName={'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'}
+          comboboxOptionsClassName={'bg-neutral-300 rounded-lg'}
+          options={chainOptions}
+          placeholder={'Select chain'}
+          onSelect={(options): void => {
+            const selectedChains = options
+              .filter((o): boolean => o.isSelected)
+              .map((option): number => Number(option.value))
+            onChangeChains(selectedChains)
+          }}
+        />
+      </div>
+
+      <div className={'w-full'}>
+        <p className={'pb-2 text-[#757CA6]'}>{'Select Category'}</p>
+        <MultiSelectDropdown
+          buttonClassName={'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'}
+          comboboxOptionsClassName={'bg-neutral-300 rounded-lg'}
+          options={categoryOptions}
+          placeholder={'Filter categories'}
+          onSelect={(options): void => {
+            const selectedCategories = options
+              .filter((o): boolean => o.isSelected)
+              .map((option): string => String(option.value))
+            onChangeCategories(selectedCategories)
+          }}
+        />
+      </div>
+
+      <div className={'w-full'}>
+        <p className={'pb-2 text-[#757CA6]'}>{'Select Type'}</p>
+        <MultiSelectDropdown
+          buttonClassName={'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'}
+          comboboxOptionsClassName={'bg-neutral-300 rounded-lg'}
+          options={typeOptions}
+          placeholder={'Filter list'}
+          onSelect={(options): void => {
+            const selectedTypes = options
+              .filter((o): boolean => o.isSelected)
+              .map((option): string => String(option.value))
+            onChangeTypes(selectedTypes)
+          }}
+        />
       </div>
     </div>
   )

--- a/apps/vaults-v3/components/Filters.tsx
+++ b/apps/vaults-v3/components/Filters.tsx
@@ -4,7 +4,10 @@ import { SearchBar } from '@lib/components/SearchBar'
 import { useChainOptions } from '@lib/hooks/useChains'
 import { IconCross } from '@lib/icons/IconCross'
 import { cl, formatAmount } from '@lib/utils'
-import { ALL_VAULTSV3_CATEGORIES, ALL_VAULTSV3_KINDS } from '@vaults-v3/constants'
+import {
+  ALL_VAULTSV3_CATEGORIES,
+  ALL_VAULTSV3_KINDS,
+} from '@vaults-v3/constants'
 import { Drawer } from 'vaul'
 
 import type { ReactElement } from 'react'
@@ -32,7 +35,12 @@ function PortfolioCard(): ReactElement {
     return (
       <div className={'flex flex-row items-center mb-4 gap-4 h-18'}>
         <button
-          className={cl('rounded-lg overflow-hidden flex', 'px-[42px] py-2', 'relative group', 'border-none')}
+          className={cl(
+            'rounded-lg overflow-hidden flex',
+            'px-[42px] py-2',
+            'relative group',
+            'border-none'
+          )}
           onClick={(): void => {
             if (!isActive && address) {
               onSwitchChain(1)
@@ -50,7 +58,9 @@ function PortfolioCard(): ReactElement {
           />
           <p className={'z-10 text-neutral-900'}>{'Connect Wallet'}</p>
         </button>
-        <p className={'text-[#757CA6] p-2'}>{'It looks like you need to connect your wallet.'}</p>
+        <p className={'text-[#757CA6] p-2'}>
+          {'It looks like you need to connect your wallet.'}
+        </p>
       </div>
     )
   }
@@ -60,11 +70,17 @@ function PortfolioCard(): ReactElement {
         <div>
           <p className={'pb-0 text-[#757CA6] md:pb-2'}>{'Amount Deposited'}</p>
           {isLoading ? (
-            <div className={'h-[36.5px] w-32 animate-pulse rounded-sm bg-[#757CA6]'} />
+            <div
+              className={
+                'h-[36.5px] w-32 animate-pulse rounded-sm bg-[#757CA6]'
+              }
+            />
           ) : (
             <b className={'font-number text-xl text-neutral-900 md:text-3xl'}>
               {'$'}
-              <span suppressHydrationWarning>{formatAmount(cumulatedValueInV3Vaults.toFixed(2), 2, 2)}</span>
+              <span suppressHydrationWarning>
+                {formatAmount(cumulatedValueInV3Vaults.toFixed(2), 2, 2)}
+              </span>
             </b>
           )}
         </div>
@@ -82,7 +98,7 @@ export function Filters({
   chains,
   onSearch,
   shouldDebounce,
-  onChangeChains
+  onChangeChains,
 }: TListHero): ReactElement {
   const [isMobileFiltersOpen, setIsMobileFiltersOpen] = useState(false)
   const chainOptions = useChainOptions(chains).filter(
@@ -95,35 +111,45 @@ export function Filters({
       option.value === 747474
   )
   const typeOptions = useMemo((): TMultiSelectOptionProps[] => {
-    const options: TMultiSelectOptionProps[] = Object.entries(ALL_VAULTSV3_KINDS).map(
+    const options: TMultiSelectOptionProps[] = Object.entries(
+      ALL_VAULTSV3_KINDS
+    ).map(
       ([key, value]): TMultiSelectOptionProps => ({
         value: key,
         label: value.replaceAll(' Vaults', ''),
-        isSelected: types?.includes(key) || false
+        isSelected: types?.includes(key) || false,
       })
     )
     return options
   }, [types])
 
   const categoryOptions = useMemo((): TMultiSelectOptionProps[] => {
-    const options: TMultiSelectOptionProps[] = Object.values(ALL_VAULTSV3_CATEGORIES).map(
+    const options: TMultiSelectOptionProps[] = Object.values(
+      ALL_VAULTSV3_CATEGORIES
+    ).map(
       (value): TMultiSelectOptionProps => ({
         value: value,
         label: value,
-        isSelected: categories?.includes(value) || false
+        isSelected: categories?.includes(value) || false,
       })
     )
     return options
   }, [categories])
 
   return (
-    <div className={'relative col-span-12 w-full rounded-3xl bg-neutral-100 p-6 md:col-span-8'}>
+    <div
+      className={
+        'relative col-span-12 w-full rounded-3xl bg-neutral-100 p-6 md:col-span-8'
+      }
+    >
       <PortfolioCard />
 
       <div className={'mb-5 w-full'}>
         <p className={'pb-2 text-[#757CA6]'}>{'Search'}</p>
         <SearchBar
-          className={'max-w-none rounded-lg border-none bg-neutral-300 text-neutral-900 md:w-full'}
+          className={
+            'max-w-none rounded-lg border-none bg-neutral-300 text-neutral-900 md:w-full'
+          }
           iconClassName={'text-neutral-900'}
           searchPlaceholder={'YFI Vault'}
           searchValue={searchValue}
@@ -132,7 +158,11 @@ export function Filters({
         />
       </div>
       <div className={'md:hidden'}>
-        <Drawer.Root open={isMobileFiltersOpen} onOpenChange={setIsMobileFiltersOpen} direction={'bottom'}>
+        <Drawer.Root
+          open={isMobileFiltersOpen}
+          onOpenChange={setIsMobileFiltersOpen}
+          direction={'bottom'}
+        >
           <Drawer.Trigger asChild>
             <button
               className={
@@ -143,18 +173,30 @@ export function Filters({
             </button>
           </Drawer.Trigger>
           <Drawer.Portal>
-            <Drawer.Overlay className={'fixed inset-0 z-99998 bg-black/40 backdrop-blur-xs transition-opacity'} />
-            <Drawer.Content className={'fixed inset-x-0 bottom-0 z-99999 flex justify-center outline-hidden'}>
+            <Drawer.Overlay
+              className={
+                'fixed inset-0 z-99998 bg-black/40 backdrop-blur-xs transition-opacity'
+              }
+            />
+            <Drawer.Content
+              className={
+                'fixed inset-x-0 bottom-0 z-99999 flex justify-center outline-hidden'
+              }
+            >
               <div
                 className={
                   'w-full max-w-[520px] rounded-t-3xl bg-neutral-100 p-6 shadow-[0_-16px_60px_rgba(15,23,42,0.35)]'
                 }
-                style={{ height: '70vh', overflowY: 'auto' }}
+                style={{ height: '75vh', overflowY: 'auto' }}
               >
                 <div className={'mb-4 flex items-center justify-between'}>
-                  <p className={'text-base font-medium text-neutral-900'}>{'Filter Vaults'}</p>
+                  <p className={'text-base font-medium text-neutral-900'}>
+                    {'Filter Vaults'}
+                  </p>
                   <Drawer.Close
-                    className={'rounded-full p-2 text-neutral-900 transition-colors hover:text-neutral-600'}
+                    className={
+                      'rounded-full p-2 text-neutral-900 transition-colors hover:text-neutral-600'
+                    }
                   >
                     <IconCross className={'size-4'} />
                   </Drawer.Close>
@@ -193,7 +235,7 @@ function FilterControls({
   categoryOptions,
   onChangeCategories,
   typeOptions,
-  onChangeTypes
+  onChangeTypes,
 }: {
   chainOptions: TMultiSelectOptionProps[]
   onChangeChains: (chains: number[] | null) => void
@@ -207,7 +249,9 @@ function FilterControls({
       <div className={'w-full'}>
         <p className={'pb-2 text-[#757CA6]'}>{'Select Blockchain'}</p>
         <MultiSelectDropdown
-          buttonClassName={'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'}
+          buttonClassName={
+            'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'
+          }
           comboboxOptionsClassName={'bg-neutral-300 rounded-lg'}
           options={chainOptions}
           placeholder={'Select chain'}
@@ -223,7 +267,9 @@ function FilterControls({
       <div className={'w-full'}>
         <p className={'pb-2 text-[#757CA6]'}>{'Select Category'}</p>
         <MultiSelectDropdown
-          buttonClassName={'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'}
+          buttonClassName={
+            'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'
+          }
           comboboxOptionsClassName={'bg-neutral-300 rounded-lg'}
           options={categoryOptions}
           placeholder={'Filter categories'}
@@ -239,7 +285,9 @@ function FilterControls({
       <div className={'w-full'}>
         <p className={'pb-2 text-[#757CA6]'}>{'Select Type'}</p>
         <MultiSelectDropdown
-          buttonClassName={'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'}
+          buttonClassName={
+            'max-w-none rounded-lg bg-neutral-300 text-neutral-900 md:w-full'
+          }
           comboboxOptionsClassName={'bg-neutral-300 rounded-lg'}
           options={typeOptions}
           placeholder={'Filter list'}

--- a/apps/vaults-v3/components/Filters.tsx
+++ b/apps/vaults-v3/components/Filters.tsx
@@ -119,17 +119,6 @@ export function Filters({
     <div className={'relative col-span-12 w-full rounded-3xl bg-neutral-100 p-6 md:col-span-8'}>
       <PortfolioCard />
 
-      <div className={'absolute right-10 top-10 block md:hidden'}>
-        <button onClick={(): void => setShouldExpandFilters((prev): boolean => !prev)}>
-          <IconChevron
-            className={cl(
-              'size-4 text-neutral-400 transition-all hover:text-neutral-900',
-              !shouldExpandFilters ? '-rotate-90' : 'rotate-0'
-            )}
-          />
-        </button>
-      </div>
-
       <div className={'mb-5 w-full'}>
         <p className={'pb-2 text-[#757CA6]'}>{'Search'}</p>
         <SearchBar
@@ -141,6 +130,14 @@ export function Filters({
           shouldDebounce={shouldDebounce || false}
         />
       </div>
+      <button
+        onClick={(): void => setShouldExpandFilters((prev): boolean => !prev)}
+        className={
+          'w-full py-2 cursor-pointer rounded-[4px] bg-neutral-800/20 text-sm text-neutral-900 transition-colors hover:bg-neutral-800/50 sm:hidden'
+        }
+      >
+        {'Filter Vaults'}
+      </button>
       <div
         className={cl(
           'grid grid-cols-1 gap-6 md:grid-cols-3',

--- a/apps/vaults-v3/components/Filters.tsx
+++ b/apps/vaults-v3/components/Filters.tsx
@@ -149,7 +149,7 @@ export function Filters({
                 className={
                   'w-full max-w-[520px] rounded-t-3xl bg-neutral-100 p-6 shadow-[0_-16px_60px_rgba(15,23,42,0.35)]'
                 }
-                style={{ height: '85vh', overflowY: 'auto' }}
+                style={{ height: '70vh', overflowY: 'auto' }}
               >
                 <div className={'mb-4 flex items-center justify-between'}>
                   <p className={'text-base font-medium text-neutral-900'}>{'Filter Vaults'}</p>

--- a/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
+++ b/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
@@ -11,6 +11,7 @@ import type { ReactElement } from 'react'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { VaultChainTag } from '../VaultChainTag'
+import { getNetwork } from '../../../lib/utils/wagmi'
 
 export function VaultsV3ListRow({
   currentVault,
@@ -47,7 +48,7 @@ export function VaultsV3ListRow({
       onKeyDown={handleKeyDown}
       className={cl(
         'grid w-full grid-cols-1 md:grid-cols-12 rounded-3xl',
-        'p-6 pt-2 md:pr-10',
+        'p-6 sm:py-4 md:pr-10',
         'cursor-pointer relative group'
       )}
     >
@@ -59,13 +60,15 @@ export function VaultsV3ListRow({
         )}
       />
 
-      <div className={cl('col-span-4 z-10', 'flex flex-row items-center justify-between')}>
-        <div className={'flex flex-row gap-6 overflow-hidden pr-10'}>
-          <div className={'mt-2.5 size-8 min-h-8 min-w-8 rounded-full md:flex'}>
-            {/* TODO:add env for asset address */}
+      {/* TODO:on hover add list head categories */}
+      <div className={cl('col-span-4 z-10', 'flex flex-row items-center justify-between sm:pt-0')}>
+        <div
+          className={'flex flex-row-reverse sm:flex-row w-full justify-between sm:justify-normal gap-4 overflow-hidden'}
+        >
+          <div className={'flex items-center justify-center self-center size-8 min-h-8 min-w-8 rounded-full'}>
             <ImageWithFallback
-              src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${currentVault.chainID}/${currentVault.token.address.toLowerCase()}/logo-32.png`}
-              alt={''}
+              src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${currentVault.chainID}/${currentVault.token.address.toLowerCase()}/logo-128.png`}
+              alt={currentVault.token.symbol || ''}
               width={32}
               height={32}
             />
@@ -73,18 +76,23 @@ export function VaultsV3ListRow({
           <div className={'truncate'}>
             <strong
               title={currentVault.name}
-              className={'block truncate font-black text-neutral-800 md:-mb-0.5 md:text-lg'}
+              className={'block truncate font-black text-neutral-800 md:-mb-0.5 text-lg'}
             >
               {currentVault.name}
             </strong>
-            <p className={'mb-0 block text-sm text-neutral-800/60 md:mb-2'}>{currentVault.token.name}</p>
-            {/* Chain tag under name on mobile */}
-            <div className={'flex flex-row items-center gap-2 pt-1 md:hidden'}>
-              <VaultChainTag chainID={currentVault.chainID} />
+            {/* <p className={'mb-0 block text-sm text-neutral-800/60 md:mb-2'}>{currentVault.token.name}</p> */}
+            <div className={'flex flex-row items-center gap-1'}>
+              <ImageWithFallback
+                src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/chains/${currentVault.chainID}/logo-32.png`}
+                alt={`Chain ${currentVault.chainID}`}
+                width={14}
+                height={14}
+              />
+              <p className={'block text-sm text-neutral-800/60'}>{getNetwork(currentVault.chainID).name}</p>
             </div>
-            <div className={'hidden flex-row items-center md:flex'}>
-              <VaultChainTag chainID={currentVault.chainID} />
-            </div>
+            <p
+              className={'mb-0 block text-sm text-neutral-800/60 md:mb-2'}
+            >{`${currentVault.kind} - ${currentVault.category}`}</p>
           </div>
         </div>
       </div>
@@ -158,11 +166,23 @@ export function VaultsV3ListRow({
       </div>
 
       {/* Mobile metrics grid; conditionally show Deposited if user has holdings */}
-      <div className={cl('col-span-8 z-10', 'grid grid-cols-2 gap-4 md:hidden', 'mt-4 md:mt-0')}>
+      <div
+        className={cl(
+          'col-span-8 z-10',
+          'grid grid-cols-2 gap-4 md:hidden',
+          'pt-2 mt-2 md:mt-0 md:pt-0 border-t border-neutral-800/20'
+        )}
+      >
+        {isHoldings ? (
+          <div className={'yearn--table-data-section-item col-span-2 flex-row items-center'} datatype={'number'}>
+            <p className={'inline text-start text-dm text-neutral-800'}>{'Your Deposit'}</p>
+            <VaultStakedAmount currentVault={currentVault} />
+          </div>
+        ) : null}
         <div className={'yearn--table-data-section-item col-span-2'} datatype={'number'}>
           <div className={'w-full flex flex-col items-start'} onClick={(e): void => e.stopPropagation()}>
             <div className={'flex w-full flex-row items-center justify-between'}>
-              <p className={'inline text-start text-xs text-neutral-800/60'}>{'Estimated APY'}</p>
+              <p className={'inline text-start text-dm text-neutral-800'}>{'Estimated APY'}</p>
               <VaultForwardAPY currentVault={currentVault} onMobileToggle={(): void => setIsApyOpen((v) => !v)} />
             </div>
             {isApyOpen ? (
@@ -173,17 +193,11 @@ export function VaultsV3ListRow({
           </div>
         </div>
         <div className={'yearn--table-data-section-item col-span-2 flex-row items-center'} datatype={'number'}>
-          <p className={'inline text-start text-xs text-neutral-800/60'}>{'Historical APY'}</p>
+          <p className={'inline text-start text-dm text-neutral-800'}>{'Historical APY'}</p>
           <VaultHistoricalAPY currentVault={currentVault} />
         </div>
-        {isHoldings ? (
-          <div className={'yearn--table-data-section-item col-span-2 flex-row items-center'} datatype={'number'}>
-            <p className={'inline text-start text-xs text-neutral-800/60'}>{'Deposited'}</p>
-            <VaultStakedAmount currentVault={currentVault} />
-          </div>
-        ) : null}
         <div className={'yearn--table-data-section-item col-span-2 flex-row items-center'} datatype={'number'}>
-          <p className={'inline text-start text-xs text-neutral-800/60'}>{'TVL'}</p>
+          <p className={'inline text-start text-dm text-neutral-800'}>{'TVL'}</p>
           <div className={'flex flex-col pt-0 text-right'}>
             <p className={'yearn--table-data-section-item-value'}>
               <RenderAmount

--- a/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
+++ b/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
@@ -2,9 +2,15 @@ import { ImageWithFallback } from '@lib/components/ImageWithFallback'
 import { RenderAmount } from '@lib/components/RenderAmount'
 import { cl, isZero, toAddress, toNormalizedBN } from '@lib/utils'
 import type { TYDaemonVault } from '@lib/utils/schemas/yDaemonVaultsSchemas'
-import { VaultForwardAPY, VaultForwardAPYInlineDetails } from '@vaults-v3/components/table/VaultForwardAPY'
+import {
+  VaultForwardAPY,
+  VaultForwardAPYInlineDetails,
+} from '@vaults-v3/components/table/VaultForwardAPY'
 import { VaultHistoricalAPY } from '@vaults-v3/components/table/VaultHistoricalAPY'
-import { RiskScoreInlineDetails, VaultRiskScoreTag } from '@vaults-v3/components/table/VaultRiskScoreTag'
+import {
+  RiskScoreInlineDetails,
+  VaultRiskScoreTag,
+} from '@vaults-v3/components/table/VaultRiskScoreTag'
 import { VaultStakedAmount } from '@vaults-v3/components/table/VaultStakedAmount'
 import { useAvailableToDeposit } from '@vaults-v3/utils/useAvailableToDeposit'
 import type { ReactElement } from 'react'
@@ -14,7 +20,7 @@ import { getNetwork } from '../../../lib/utils/wagmi'
 
 export function VaultsV3ListRow({
   currentVault,
-  isHoldings = false
+  isHoldings = false,
 }: {
   currentVault: TYDaemonVault
   isHoldings?: boolean
@@ -58,13 +64,26 @@ export function VaultsV3ListRow({
       />
 
       {/* TODO:on hover add list head categories */}
-      <div className={cl('col-span-4 z-10', 'flex flex-row items-center justify-between sm:pt-0')}>
+      <div
+        className={cl(
+          'col-span-4 z-10',
+          'flex flex-row items-center justify-between sm:pt-0'
+        )}
+      >
         <div
-          className={'flex flex-row-reverse sm:flex-row w-full justify-between sm:justify-normal gap-4 overflow-hidden'}
+          className={
+            'flex flex-row-reverse sm:flex-row w-full justify-between sm:justify-normal gap-4 overflow-hidden'
+          }
         >
-          <div className={'flex items-center justify-center self-center size-8 min-h-8 min-w-8 rounded-full'}>
+          <div
+            className={
+              'flex items-center justify-center self-center size-8 min-h-8 min-w-8 rounded-full'
+            }
+          >
             <ImageWithFallback
-              src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${currentVault.chainID}/${currentVault.token.address.toLowerCase()}/logo-128.png`}
+              src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${
+                currentVault.chainID
+              }/${currentVault.token.address.toLowerCase()}/logo-128.png`}
               alt={currentVault.token.symbol || ''}
               width={32}
               height={32}
@@ -73,18 +92,24 @@ export function VaultsV3ListRow({
           <div className={'truncate'}>
             <strong
               title={currentVault.name}
-              className={'block truncate font-black text-neutral-800 md:-mb-0.5 text-lg'}
+              className={
+                'block truncate font-black text-neutral-800 md:-mb-0.5 text-lg'
+              }
             >
               {currentVault.name}
             </strong>
             <div className={'flex flex-row items-center gap-1'}>
               <ImageWithFallback
-                src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/chains/${currentVault.chainID}/logo-32.png`}
+                src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/chains/${
+                  currentVault.chainID
+                }/logo-32.png`}
                 alt={`Chain ${currentVault.chainID}`}
                 width={14}
                 height={14}
               />
-              <p className={'block text-sm text-neutral-800/60'}>{getNetwork(currentVault.chainID).name}</p>
+              <p className={'block text-sm text-neutral-800/60'}>
+                {getNetwork(currentVault.chainID).name}
+              </p>
             </div>
             <p
               className={'mb-0 block text-sm text-neutral-800/60 md:mb-2'}
@@ -94,42 +119,117 @@ export function VaultsV3ListRow({
       </div>
 
       {/* Desktop metrics grid */}
-      <div className={cl('col-span-8 z-10', 'hidden md:grid md:grid-cols-12 gap-4', 'mt-4 md:mt-0')}>
-        <div className={'yearn--table-data-section-item col-span-2 flex-row md:flex-col'} datatype={'number'}>
-          <p className={'inline text-start text-xs text-neutral-800/60 md:hidden'}>{'Estimated APY'}</p>
+      <div
+        className={cl(
+          'col-span-8 z-10',
+          'hidden md:grid md:grid-cols-12 gap-4',
+          'mt-4 md:mt-0'
+        )}
+      >
+        <div
+          className={
+            'yearn--table-data-section-item col-span-2 flex-row md:flex-col'
+          }
+          datatype={'number'}
+        >
+          <p
+            className={
+              'inline text-start text-xs text-neutral-800/60 md:hidden'
+            }
+          >
+            {'Estimated APY'}
+          </p>
           <VaultForwardAPY currentVault={currentVault} />
         </div>
-        <div className={'yearn--table-data-section-item col-span-2 flex-row md:flex-col'} datatype={'number'}>
-          <p className={'inline text-start text-xs text-neutral-800/60 md:hidden'}>{'Historical APY'}</p>
+        <div
+          className={
+            'yearn--table-data-section-item col-span-2 flex-row md:flex-col'
+          }
+          datatype={'number'}
+        >
+          <p
+            className={
+              'inline text-start text-xs text-neutral-800/60 md:hidden'
+            }
+          >
+            {'Historical APY'}
+          </p>
           <VaultHistoricalAPY currentVault={currentVault} />
         </div>
         <div className={'col-span-2'}>
           <VaultRiskScoreTag riskLevel={currentVault.info.riskLevel} />
         </div>
-        <div className={'yearn--table-data-section-item col-span-2 flex-row md:flex-col'} datatype={'number'}>
-          <p className={'inline text-start text-xs text-neutral-800/60 md:hidden'}>{'Available'}</p>
+        <div
+          className={
+            'yearn--table-data-section-item col-span-2 flex-row md:flex-col'
+          }
+          datatype={'number'}
+        >
           <p
-            className={`yearn--table-data-section-item-value ${isZero(availableToDeposit) ? 'text-neutral-400' : 'text-neutral-900'}`}
+            className={
+              'inline text-start text-xs text-neutral-800/60 md:hidden'
+            }
+          >
+            {'Available'}
+          </p>
+          <p
+            className={`yearn--table-data-section-item-value ${
+              isZero(availableToDeposit)
+                ? 'text-neutral-400'
+                : 'text-neutral-900'
+            }`}
           >
             <RenderAmount
-              value={Number(toNormalizedBN(availableToDeposit, currentVault.token.decimals).normalized)}
+              value={Number(
+                toNormalizedBN(availableToDeposit, currentVault.token.decimals)
+                  .normalized
+              )}
               symbol={currentVault.token.symbol}
               decimals={currentVault.token.decimals}
               shouldFormatDust
               options={{
                 shouldDisplaySymbol: false,
                 maximumFractionDigits:
-                  Number(toNormalizedBN(availableToDeposit, currentVault.token.decimals).normalized) > 1000 ? 2 : 4
+                  Number(
+                    toNormalizedBN(
+                      availableToDeposit,
+                      currentVault.token.decimals
+                    ).normalized
+                  ) > 1000
+                    ? 2
+                    : 4,
               }}
             />
           </p>
         </div>
-        <div className={'yearn--table-data-section-item col-span-2 flex-row md:flex-col'} datatype={'number'}>
-          <p className={'inline text-start text-xs text-neutral-800/60 md:hidden'}>{'Deposited'}</p>
+        <div
+          className={
+            'yearn--table-data-section-item col-span-2 flex-row md:flex-col'
+          }
+          datatype={'number'}
+        >
+          <p
+            className={
+              'inline text-start text-xs text-neutral-800/60 md:hidden'
+            }
+          >
+            {'Deposited'}
+          </p>
           <VaultStakedAmount currentVault={currentVault} />
         </div>
-        <div className={'yearn--table-data-section-item col-span-2 flex-row md:flex-col'} datatype={'number'}>
-          <p className={'inline text-start text-xs text-neutral-800/60 md:hidden'}>{'TVL'}</p>
+        <div
+          className={
+            'yearn--table-data-section-item col-span-2 flex-row md:flex-col'
+          }
+          datatype={'number'}
+        >
+          <p
+            className={
+              'inline text-start text-xs text-neutral-800/60 md:hidden'
+            }
+          >
+            {'TVL'}
+          </p>
           <div className={'flex flex-col pt-0 text-right'}>
             <p className={'yearn--table-data-section-item-value'}>
               <RenderAmount
@@ -139,20 +239,25 @@ export function VaultsV3ListRow({
                 options={{
                   shouldCompactValue: true,
                   maximumFractionDigits: 2,
-                  minimumFractionDigits: 0
+                  minimumFractionDigits: 0,
                 }}
               />
             </p>
             <small className={'text-xs flex flex-row text-neutral-900/40'}>
               <RenderAmount
-                value={Number(toNormalizedBN(currentVault.tvl.totalAssets, currentVault.token.decimals).normalized)}
+                value={Number(
+                  toNormalizedBN(
+                    currentVault.tvl.totalAssets,
+                    currentVault.token.decimals
+                  ).normalized
+                )}
                 symbol={''}
                 decimals={6}
                 shouldFormatDust
                 options={{
                   shouldCompactValue: true,
                   maximumFractionDigits: 2,
-                  minimumFractionDigits: 2
+                  minimumFractionDigits: 2,
                 }}
               />
               <p className="pl-1">{currentVault.token.symbol}</p>
@@ -170,16 +275,33 @@ export function VaultsV3ListRow({
         )}
       >
         {isHoldings ? (
-          <div className={'yearn--table-data-section-item col-span-2 flex-row items-center'} datatype={'number'}>
-            <p className={'inline text-start text-dm text-neutral-800'}>{'Your Deposit'}</p>
+          <div
+            className={
+              'yearn--table-data-section-item col-span-2 flex-row items-center'
+            }
+            datatype={'number'}
+          >
+            <p className={'inline text-start text-dm text-neutral-800'}>
+              {'Your Deposit'}
+            </p>
             <VaultStakedAmount currentVault={currentVault} />
           </div>
         ) : null}
-        <div className={'yearn--table-data-section-item col-span-2'} datatype={'number'}>
-          <div className={'w-full flex flex-col items-start'} onClick={(e): void => e.stopPropagation()}>
-            <div className={'flex w-full flex-row items-center justify-between'}>
-              <p className={'inline text-start text-dm text-neutral-800'}>{'Estimated APY'}</p>
-              <VaultForwardAPY currentVault={currentVault} onMobileToggle={(): void => setIsApyOpen((v) => !v)} />
+        <div
+          className={'yearn--table-data-section-item col-span-2'}
+          datatype={'number'}
+        >
+          <div className={'w-full flex flex-col items-start'}>
+            <div
+              className={'flex w-full flex-row items-center justify-between'}
+            >
+              <p className={'inline text-start text-dm text-neutral-800'}>
+                {'Estimated APY'}
+              </p>
+              <VaultForwardAPY
+                currentVault={currentVault}
+                onMobileToggle={(): void => setIsApyOpen((v) => !v)}
+              />
             </div>
             {isApyOpen ? (
               <div className={'mt-2 w-full'}>
@@ -188,12 +310,26 @@ export function VaultsV3ListRow({
             ) : null}
           </div>
         </div>
-        <div className={'yearn--table-data-section-item col-span-2 flex-row items-center'} datatype={'number'}>
-          <p className={'inline text-start text-dm text-neutral-800'}>{'Historical APY'}</p>
+        <div
+          className={
+            'yearn--table-data-section-item col-span-2 flex-row items-center'
+          }
+          datatype={'number'}
+        >
+          <p className={'inline text-start text-dm text-neutral-800'}>
+            {'Historical APY'}
+          </p>
           <VaultHistoricalAPY currentVault={currentVault} />
         </div>
-        <div className={'yearn--table-data-section-item col-span-2 flex-row items-center'} datatype={'number'}>
-          <p className={'inline text-start text-dm text-neutral-800'}>{'TVL'}</p>
+        <div
+          className={
+            'yearn--table-data-section-item col-span-2 flex-row items-center'
+          }
+          datatype={'number'}
+        >
+          <p className={'inline text-start text-dm text-neutral-800'}>
+            {'TVL'}
+          </p>
           <div className={'flex flex-col pt-0 text-right'}>
             <p className={'yearn--table-data-section-item-value'}>
               <RenderAmount
@@ -203,35 +339,48 @@ export function VaultsV3ListRow({
                 options={{
                   shouldCompactValue: true,
                   maximumFractionDigits: 2,
-                  minimumFractionDigits: 0
+                  minimumFractionDigits: 0,
                 }}
               />
             </p>
             <small className={'text-xs flex flex-row text-neutral-900/40'}>
               <RenderAmount
-                value={Number(toNormalizedBN(currentVault.tvl.totalAssets, currentVault.token.decimals).normalized)}
+                value={Number(
+                  toNormalizedBN(
+                    currentVault.tvl.totalAssets,
+                    currentVault.token.decimals
+                  ).normalized
+                )}
                 symbol={''}
                 decimals={6}
                 shouldFormatDust
                 options={{
                   shouldCompactValue: true,
                   maximumFractionDigits: 2,
-                  minimumFractionDigits: 2
+                  minimumFractionDigits: 2,
                 }}
               />
               <p className="pl-1">{currentVault.token.symbol}</p>
             </small>
           </div>
         </div>
-        <div className={'yearn--table-data-section-item col-span-2'} datatype={'number'}>
-          <div className={'w-full flex flex-col items-start'} onClick={(e): void => e.stopPropagation()}>
+        <div
+          className={'yearn--table-data-section-item col-span-2'}
+          datatype={'number'}
+        >
+          <div
+            className={'w-full flex flex-col items-start'}
+            onClick={(e): void => e.stopPropagation()}
+          >
             <VaultRiskScoreTag
               riskLevel={currentVault.info.riskLevel}
               onMobileToggle={(): void => setIsRiskOpen((v) => !v)}
             />
             {isRiskOpen ? (
               <div className={'mt-2 w-full'}>
-                <RiskScoreInlineDetails riskLevel={currentVault.info.riskLevel} />
+                <RiskScoreInlineDetails
+                  riskLevel={currentVault.info.riskLevel}
+                />
               </div>
             ) : null}
           </div>

--- a/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
+++ b/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
@@ -10,7 +10,6 @@ import { useAvailableToDeposit } from '@vaults-v3/utils/useAvailableToDeposit'
 import type { ReactElement } from 'react'
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { VaultChainTag } from '../VaultChainTag'
 import { getNetwork } from '../../../lib/utils/wagmi'
 
 export function VaultsV3ListRow({
@@ -36,8 +35,6 @@ export function VaultsV3ListRow({
       navigate(href)
     }
   }
-
-  // Separate mobile and desktop layouts
 
   return (
     // biome-ignore lint/a11y/useSemanticElements: Using a div with link-like behavior for row navigation
@@ -80,7 +77,6 @@ export function VaultsV3ListRow({
             >
               {currentVault.name}
             </strong>
-            {/* <p className={'mb-0 block text-sm text-neutral-800/60 md:mb-2'}>{currentVault.token.name}</p> */}
             <div className={'flex flex-row items-center gap-1'}>
               <ImageWithFallback
                 src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/chains/${currentVault.chainID}/logo-32.png`}

--- a/apps/vaults-v3/components/notifications/Notification.tsx
+++ b/apps/vaults-v3/components/notifications/Notification.tsx
@@ -107,18 +107,24 @@ function NotificationContent({
   return (
     <div className={'flex gap-4'}>
       <div className={'flex flex-col items-center gap-3'}>
-        <div className={'relative'}>
+        <div className={'relative flex size-10 items-center justify-center'}>
           <ImageWithFallback
             alt={notification.fromTokenName || 'Token'}
             unoptimized
+            className={'size-8 rounded-full border border-neutral-300 bg-neutral-200/40 object-cover'}
             src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${notification.chainId}/${notification.fromAddress ? notification.fromAddress.toLowerCase() : '0x0'}/logo-32.png`}
             altSrc={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${notification.chainId}/${notification.fromAddress ? notification.fromAddress.toLowerCase() : '0x0'}/logo-32.png`}
             quality={90}
             width={32}
             height={32}
           />
-          <div className={'absolute bottom-5 left-5 flex size-4 items-center justify-center rounded-full bg-white'}>
+          <div
+            className={
+              'absolute -bottom-1 -right-1 flex size-4 items-center justify-center rounded-full bg-white shadow-sm'
+            }
+          >
             <Image
+              className={'object-contain'}
               width={14}
               height={14}
               alt={'chain'}
@@ -130,18 +136,24 @@ function NotificationContent({
         {notification.toTokenName && <IconArrow className={'size-4 rotate-135'} />}
 
         {notification.toTokenName && notification.toAddress && (
-          <div className={'relative'}>
+          <div className={'relative flex size-10 items-center justify-center'}>
             <ImageWithFallback
               alt={notification.toTokenName || 'Token'}
               unoptimized
-              src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${notification.chainId}/${notification.toAddress}/logo-128.png`}
-              altSrc={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${notification.chainId}/${notification.toAddress}/logo-128.png`}
+              className={'size-8 rounded-full border border-neutral-300 bg-neutral-200/40 object-cover'}
+              src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${notification.chainId}/${notification.toAddress.toLowerCase()}/logo-128.png`}
+              altSrc={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${notification.chainId}/${notification.toAddress.toLowerCase()}/logo-128.png`}
               quality={90}
               width={32}
               height={32}
             />
-            <div className={'absolute bottom-5 left-5 flex size-4 items-center justify-center rounded-full bg-white'}>
+            <div
+              className={
+                'absolute -bottom-1 -right-1 flex size-4 items-center justify-center rounded-full bg-white shadow-sm'
+              }
+            >
               <Image
+                className={'object-contain'}
                 width={14}
                 height={14}
                 alt={'chain'}

--- a/apps/vaults-v3/components/table/VaultRiskScoreTag.tsx
+++ b/apps/vaults-v3/components/table/VaultRiskScoreTag.tsx
@@ -23,7 +23,7 @@ export function VaultRiskScoreTag({
   return (
     <div className={'col-span-2 w-full md:pt-4'}>
       <div className={'flex flex-row items-end justify-between md:flex-col'}>
-        <p className={'inline whitespace-nowrap text-start text-xs text-neutral-800/60 md:hidden'}>{'Risk Score'}</p>
+        <p className={'inline whitespace-nowrap text-start text-md text-neutral-800 md:hidden'}>{'Risk Score'}</p>
         <div
           className={cl('flex w-fit items-center justify-end gap-4 md:justify-center', 'tooltip relative z-50 h-6')}
           onClick={handleToggle}

--- a/apps/vaults-v3/components/table/VaultRiskScoreTag.tsx
+++ b/apps/vaults-v3/components/table/VaultRiskScoreTag.tsx
@@ -4,14 +4,21 @@ import { useState } from 'react'
 
 export function VaultRiskScoreTag({
   riskLevel,
-  onMobileToggle
+  onMobileToggle,
 }: {
   riskLevel: number
   onMobileToggle?: (e: React.MouseEvent) => void
 }): ReactElement {
   const [mobileOpen, setMobileOpen] = useState(false)
   const level = riskLevel < 0 ? 0 : riskLevel > 5 ? 5 : riskLevel
-  const riskColor = ['transparent', '#63C532', '#F8A908', '#F8A908', '#C73203', '#C73203']
+  const riskColor = [
+    'transparent',
+    '#63C532',
+    '#F8A908',
+    '#F8A908',
+    '#C73203',
+    '#C73203',
+  ]
   const handleToggle = (e: React.MouseEvent): void => {
     e.stopPropagation()
     if (onMobileToggle) {
@@ -21,19 +28,32 @@ export function VaultRiskScoreTag({
     setMobileOpen((v) => !v)
   }
   return (
-    <div className={'col-span-2 w-full md:pt-4'}>
+    <div className={'col-span-2 w-full md:pt-4'} onClick={handleToggle}>
       <div className={'flex flex-row items-end justify-between md:flex-col'}>
-        <p className={'inline whitespace-nowrap text-start text-md text-neutral-800 md:hidden'}>{'Risk Score'}</p>
-        <div
-          className={cl('flex w-fit items-center justify-end gap-4 md:justify-center', 'tooltip relative z-50 h-6')}
-          onClick={handleToggle}
+        <p
+          className={
+            'inline whitespace-nowrap text-start text-md text-neutral-800 md:hidden'
+          }
         >
-          <div className={'h-3 w-10 min-w-10 rounded-xs border-2 border-neutral-400 p-[2px]'}>
+          {'Risk Score'}
+        </p>
+        <div
+          className={cl(
+            'flex w-fit items-center justify-end gap-4 md:justify-center',
+            'tooltip relative z-50 h-6'
+          )}
+        >
+          <div
+            className={
+              'h-3 w-10 min-w-10 rounded-xs border-2 border-neutral-400 p-[2px]'
+            }
+          >
             <div
               className={'h-1 rounded-[1px]'}
               style={{
-                backgroundColor: riskColor.length > level ? riskColor[level] : riskColor[0],
-                width: `${(level / 5) * 100}%`
+                backgroundColor:
+                  riskColor.length > level ? riskColor[level] : riskColor[0],
+                width: `${(level / 5) * 100}%`,
               }}
             />
           </div>
@@ -57,16 +77,24 @@ export function VaultRiskScoreTag({
           </span>
         </div>
       </div>
-      {onMobileToggle ? null : mobileOpen ? <RiskScoreInlineDetails riskLevel={riskLevel} /> : null}
+      {onMobileToggle ? null : mobileOpen ? (
+        <RiskScoreInlineDetails riskLevel={riskLevel} />
+      ) : null}
     </div>
   )
 }
 
-export function RiskScoreInlineDetails({ riskLevel }: { riskLevel: number }): ReactElement {
+export function RiskScoreInlineDetails({
+  riskLevel,
+}: {
+  riskLevel: number
+}): ReactElement {
   const level = riskLevel < 0 ? 0 : riskLevel > 5 ? 5 : riskLevel
   return (
     <div
-      className={'md:hidden mt-2 w-full rounded-xl border border-neutral-300 bg-neutral-100 p-3 text-neutral-900'}
+      className={
+        'md:hidden mt-2 w-full rounded-xl border border-neutral-300 bg-neutral-100 p-3 text-neutral-900'
+      }
       onClick={(e): void => e.stopPropagation()}
     >
       <div className={'flex flex-col gap-2'}>

--- a/apps/vaults-v3/components/table/VaultStakedAmount.tsx
+++ b/apps/vaults-v3/components/table/VaultStakedAmount.tsx
@@ -34,7 +34,7 @@ export function VaultStakedAmount({ currentVault }: { currentVault: TYDaemonVaul
   return (
     <div className={'flex flex-col pt-0 text-right'}>
       <p
-        className={`yearn--table-data-section-item-value ${isZero(staked.raw) ? 'text-neutral-400' : 'text-neutral-900'}`}
+        className={`yearn--table-data-section-item-value ${isZero(staked.raw) ? 'text-neutral-400' : 'text-neutral-900 font-bold'}`}
       >
         <RenderAmount
           value={staked.normalized * tokenPrice.normalized}

--- a/pages/v3/index.tsx
+++ b/pages/v3/index.tsx
@@ -1,9 +1,8 @@
 import { useWallet } from '@lib/contexts/useWallet'
-import { useWeb3 } from '@lib/contexts/useWeb3'
 import { useYearn } from '@lib/contexts/useYearn'
 import { useVaultFilter } from '@lib/hooks/useFilteredVaults'
 import type { TSortDirection } from '@lib/types'
-import { cl, formatAmount, isZero, toNormalizedBN } from '@lib/utils'
+import { cl, isZero, toNormalizedBN } from '@lib/utils'
 import type { TYDaemonVault } from '@lib/utils/schemas/yDaemonVaultsSchemas'
 import { VaultsListEmpty } from '@vaults-v2/components/list/VaultsListEmpty'
 import type { TPossibleSortBy } from '@vaults-v2/hooks/useSortVaults'
@@ -15,40 +14,8 @@ import { VaultsV3ListRow } from '@vaults-v3/components/list/VaultsV3ListRow'
 import { ALL_VAULTSV3_CATEGORIES_KEYS, ALL_VAULTSV3_KINDS_KEYS } from '@vaults-v3/constants'
 import { V3Mask } from '@vaults-v3/Mark'
 import type { ReactElement, ReactNode } from 'react'
-import { Children, Fragment, useMemo, useState } from 'react'
+import { Children, Fragment, useMemo } from 'react'
 
-function Background(): ReactElement {
-  return (
-    <div className={cl('absolute inset-0', 'pointer-events-none', 'bg-gradient-to-r from-[#D21162] to-[#2C3DA6]')} />
-  )
-}
-function BrandNewVaultCard(): ReactElement {
-  return (
-    <div
-      className={cl(
-        'h-full rounded-3xl relative overflow-hidden',
-        'pr-2 pl-4 pb-4 pt-6 md:p-10',
-        'col-span-75 md:col-span-60'
-      )}
-    >
-      <div className={'relative z-10'}>
-        <h1
-          className={cl(
-            'mb-2 md:mb-4 font-black text-neutral-900',
-            'text-[48px] lg:text-[56px] lg:leading-[64px] leading-[48px]',
-            'whitespace-break-spaces uppercase'
-          )}
-        >
-          {'Yearn Automated Vaults'}
-        </h1>
-        {/* <p className={'mb-4 whitespace-break-spaces text-base text-[#F2B7D0] md:text-lg'}>
-          {'Yearn v3 is a new yield paradigm offering better automation,\ncomposability and flexibility. Enjoy!'}
-        </p> */}
-      </div>
-      <Background />
-    </div>
-  )
-}
 function V3Card(): ReactElement {
   return (
     <div className={'col-span-12 w-full rounded-3xl bg-neutral-100 p-2 hidden md:block md:col-span-4'}>
@@ -337,69 +304,14 @@ function ListOfVaults(): ReactElement {
 }
 
 function Index(): ReactElement {
-  const [isCollapsed, setIsCollapsed] = useState(true)
-
-  function onClick(): void {
-    setIsCollapsed(!isCollapsed)
-  }
-
   return (
-    <div className={'z-50 w-full bg-neutral-100 pt-20'}>
-      <div className={'relative mx-auto w-full max-w-[1232px]'}>
-        <div className={'absolute inset-x-0 top-0 w-full px-4 pt-6 md:pt-16'}>
-          {/* <div className={'grid grid-cols-75'}>
-            <V3Card />
-            <BrandNewVaultCard />
-          </div> */}
-        </div>
-      </div>
-
-      <div className={cl('relative pb-8 bg-neutral-0 z-50')}>
-        <div className={'mx-auto w-full max-w-[1232px] px-4'}>
-          {/* <div
-            onClick={onClick}
-            className={'absolute inset-x-0 top-0 flex w-full cursor-pointer items-center justify-center'}
-          >
-            <div className={'relative -mt-8 flex justify-center rounded-t-3xl'}>
-              <svg
-                xmlns={'http://www.w3.org/2000/svg'}
-                width={'113'}
-                height={'32'}
-                viewBox={'0 0 113 32'}
-                fill={'none'}
-              >
-                <path d={'M0 32C37.9861 32 20.9837 0 56 0C91.0057 0 74.388 32 113 32H0Z'} fill={'#000520'} />
-              </svg>
-              <div
-                className={`absolute mt-2 flex justify-center transition-transform ${isCollapsed ? '' : '-rotate-180'}`}
-              >
-                <svg
-                  xmlns={'http://www.w3.org/2000/svg'}
-                  width={'24'}
-                  height={'24'}
-                  viewBox={'0 0 24 24'}
-                  fill={'none'}
-                >
-                  <path
-                    fillRule={'evenodd'}
-                    clipRule={'evenodd'}
-                    d={
-                      'M4.34151 16.7526C3.92587 16.3889 3.88375 15.7571 4.24744 15.3415L11.2474 7.34148C11.4373 7.12447 11.7117 6.99999 12 6.99999C12.2884 6.99999 12.5627 7.12447 12.7526 7.34148L19.7526 15.3415C20.1163 15.7571 20.0742 16.3889 19.6585 16.7526C19.2429 17.1162 18.6111 17.0741 18.2474 16.6585L12 9.51858L5.75259 16.6585C5.38891 17.0741 4.75715 17.1162 4.34151 16.7526Z'
-                    }
-                    fill={'white'}
-                  />
-                </svg>
-              </div>
-            </div>
-          </div> */}
-
-          <div className={'grid grid-cols-12 gap-4 pt-6 md:gap-6'}>
-            <V3Card />
-
-            <ListOfVaults />
-          </div>
-        </div>
-      </div>
+    <div
+      className={
+        'relative mx-auto z-50 w-full max-w-[1232px] grid grid-cols-12 gap-4 md:gap-6 bg-neutral-0 pt-20 px-4 pb-8'
+      }
+    >
+      <V3Card />
+      <ListOfVaults />
     </div>
   )
 }

--- a/pages/v3/index.tsx
+++ b/pages/v3/index.tsx
@@ -28,22 +28,22 @@ function BrandNewVaultCard(): ReactElement {
       className={cl(
         'h-full rounded-3xl relative overflow-hidden',
         'pr-2 pl-4 pb-4 pt-6 md:p-10',
-        'col-span-75 md:col-span-46'
+        'col-span-75 md:col-span-60'
       )}
     >
       <div className={'relative z-10'}>
         <h1
           className={cl(
-            'mb-2 md:mb-4 lg:mb-10 font-black text-neutral-900',
+            'mb-2 md:mb-4 font-black text-neutral-900',
             'text-[48px] lg:text-[56px] lg:leading-[64px] leading-[48px]',
             'whitespace-break-spaces uppercase'
           )}
         >
-          {'A brave new\nworld for Yield'}
+          {'Yearn Automated Vaults'}
         </h1>
-        <p className={'mb-4 whitespace-break-spaces text-base text-[#F2B7D0] md:text-lg'}>
+        {/* <p className={'mb-4 whitespace-break-spaces text-base text-[#F2B7D0] md:text-lg'}>
           {'Yearn v3 is a new yield paradigm offering better automation,\ncomposability and flexibility. Enjoy!'}
-        </p>
+        </p> */}
       </div>
       <Background />
     </div>
@@ -51,7 +51,7 @@ function BrandNewVaultCard(): ReactElement {
 }
 function V3Card(): ReactElement {
   return (
-    <div className={'col-span-75 mb-4 mr-0 hidden md:col-span-29 md:mb-0 md:mr-6 md:block'}>
+    <div className={'col-span-12 w-full rounded-3xl bg-neutral-100 p-2 hidden md:block md:col-span-4'}>
       <div
         className={cl(
           'flex h-full w-full flex-col items-center justify-center',
@@ -64,66 +64,6 @@ function V3Card(): ReactElement {
   )
 }
 
-function PortfolioCard(): ReactElement {
-  const { cumulatedValueInV3Vaults, isLoading } = useWallet()
-  const { isActive, address, openLoginModal, onSwitchChain } = useWeb3()
-
-  if (!isActive) {
-    return (
-      <div className={'col-span-12 w-full rounded-3xl bg-neutral-100 p-6 md:col-span-4'}>
-        <strong className={'block pb-2 text-3xl font-black text-neutral-900 md:pb-4 md:text-4xl md:leading-[48px]'}>
-          {'Portfolio'}
-        </strong>
-        <div className={'flex'}>
-          <div>
-            <p className={'pb-0 text-[#757CA6] md:pb-2'}>
-              {'Looks like you need to connect your wallet. And call your mum. Always important.'}
-            </p>
-            <button
-              className={cl('rounded-lg overflow-hidden flex', 'px-[42px] py-2 mt-16', 'relative group', 'border-none')}
-              onClick={(): void => {
-                if (!isActive && address) {
-                  onSwitchChain(1)
-                } else {
-                  openLoginModal()
-                }
-              }}
-            >
-              <div
-                className={cl(
-                  'absolute inset-0',
-                  'opacity-80 transition-opacity group-hover:opacity-100 pointer-events-none',
-                  'bg-[linear-gradient(80deg,#D21162,#2C3DA6)]'
-                )}
-              />
-              <p className={'z-10 text-neutral-900'}>{'Connect Wallet'}</p>
-            </button>
-          </div>
-        </div>
-      </div>
-    )
-  }
-  return (
-    <div className={'col-span-12 w-full rounded-3xl bg-neutral-100 p-6 md:col-span-4'}>
-      <strong className={'block pb-2 text-3xl font-black text-neutral-900 md:pb-4 md:text-4xl md:leading-[48px]'}>
-        {'Portfolio'}
-      </strong>
-      <div className={'flex flex-col gap-4 md:flex-row md:gap-32'}>
-        <div>
-          <p className={'pb-0 text-[#757CA6] md:pb-2'}>{'Deposited'}</p>
-          {isLoading ? (
-            <div className={'h-[36.5px] w-32 animate-pulse rounded-sm bg-[#757CA6]'} />
-          ) : (
-            <b className={'font-number text-xl text-neutral-900 md:text-3xl'}>
-              {'$'}
-              <span suppressHydrationWarning>{formatAmount(cumulatedValueInV3Vaults.toFixed(2), 2, 2)}</span>
-            </b>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}
 function ListOfVaults(): ReactElement {
   const { getBalance } = useWallet()
   const { getPrice, isLoadingVaultList } = useYearn()
@@ -390,7 +330,7 @@ function ListOfVaults(): ReactElement {
             { label: 'Deposits', value: 'tvl', sortable: true, className: 'col-span-2 justify-end' }
           ]}
         />
-        <div className={'grid gap-4'}>{renderVaultList()}</div>
+        <div className={'grid gap-3'}>{renderVaultList()}</div>
       </div>
     </Fragment>
   )
@@ -407,23 +347,16 @@ function Index(): ReactElement {
     <div className={'z-50 w-full bg-neutral-100 pt-20'}>
       <div className={'relative mx-auto w-full max-w-[1232px]'}>
         <div className={'absolute inset-x-0 top-0 w-full px-4 pt-6 md:pt-16'}>
-          <div className={'grid grid-cols-75'}>
+          {/* <div className={'grid grid-cols-75'}>
             <V3Card />
             <BrandNewVaultCard />
-          </div>
+          </div> */}
         </div>
       </div>
 
-      <div
-        className={cl(
-          'relative pb-8 bg-neutral-0 z-50',
-          'min-h-screen',
-          'transition-transform duration-300',
-          isCollapsed ? 'translate-y-[354px] md:translate-y-[464px]' : 'translate-y-[24px] md:translate-y-[40px]'
-        )}
-      >
+      <div className={cl('relative pb-8 bg-neutral-0 z-50')}>
         <div className={'mx-auto w-full max-w-[1232px] px-4'}>
-          <div
+          {/* <div
             onClick={onClick}
             className={'absolute inset-x-0 top-0 flex w-full cursor-pointer items-center justify-center'}
           >
@@ -458,10 +391,11 @@ function Index(): ReactElement {
                 </svg>
               </div>
             </div>
-          </div>
+          </div> */}
 
           <div className={'grid grid-cols-12 gap-4 pt-6 md:gap-6'}>
-            <PortfolioCard />
+            <V3Card />
+
             <ListOfVaults />
           </div>
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -143,6 +143,7 @@ function App(): ReactElement {
               }
             }}
             position={'bottom-right'}
+            containerStyle={{ maxWidth: 'calc(100vw - 32px)', width: '100%' }}
           />
         </main>
       </WithFonts>

--- a/style.css
+++ b/style.css
@@ -1,16 +1,18 @@
 /* External Dependencies */
 /** biome-ignore-all lint/complexity/noImportantStyles: overriding some library styles */
-@import "@rainbow-me/rainbowkit/styles.css";
+@import '@rainbow-me/rainbowkit/styles.css';
 /* Tailwind CSS */
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @theme {
   /* Font families */
-  --font-family-aeonik: Aeonik, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --font-family-aeonik-fono:
-    "Aeonik Fono", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --font-family-aeonik-mono: "Aeonik Mono", Consolas, "Courier New", monospace;
-  --font-family-source-code-pro: "Source Code Pro", "Aeonik Mono", Consolas, "Courier New", monospace;
+  --font-family-aeonik: Aeonik, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
+  --font-family-aeonik-fono: 'Aeonik Fono', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-family-aeonik-mono: 'Aeonik Mono', Consolas, 'Courier New', monospace;
+  --font-family-source-code-pro: 'Source Code Pro', 'Aeonik Mono', Consolas,
+    'Courier New', monospace;
 
   --color-black: hsl(0 0% 0%);
   --color-white: hsl(0 0% 100%);
@@ -129,7 +131,8 @@ html {
 
 body {
   color: var(--color-neutral-900);
-  font-family: aeonik, "aeonik Fallback", "Source Code Pro", "Source Code Pro Fallback", sans-serif;
+  font-family: aeonik, 'aeonik Fallback', 'Source Code Pro',
+    'Source Code Pro Fallback', sans-serif;
 }
 
 #main {
@@ -138,8 +141,8 @@ body {
 
 @layer utilities {
   .font-number {
-    font-family:
-      "Aeonik Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-family: 'Aeonik Mono', ui-monospace, SFMono-Regular, Menlo, Monaco,
+      Consolas, 'Liberation Mono', 'Courier New', monospace;
   }
 
   .scrollbar-none {
@@ -152,7 +155,7 @@ body {
 }
 
 @layer components {
-  [role="button"],
+  [role='button'],
   button {
     @apply cursor-pointer;
   }
@@ -165,7 +168,7 @@ body {
   @apply inset-x-0 top-0 z-50 flex h-20 w-full max-w-[1200px] flex-row items-center justify-between p-4 text-xs sm:text-sm md:inset-x-auto md:mb-0 md:px-0 md:text-base;
 }
 .yearn--nav {
-  @apply hidden flex-row items-center space-x-3 md:flex md:space-x-6;
+  @apply flex flex-row items-center space-x-3 md:space-x-6;
 }
 .yearn--header-nav-item {
   @apply relative cursor-pointer transition-colors text-neutral-500 hover:text-neutral-900 font-normal text-sm;
@@ -215,7 +218,7 @@ body {
 }
 
 .tooltip .tooltiptext::after {
-  content: "";
+  content: '';
   position: absolute;
   bottom: 98%;
   right: 50%;
@@ -244,7 +247,7 @@ body {
 }
 .yearn--table-head-label-wrapper {
   @apply flex flex-row items-center justify-start space-x-1;
-  &[datatype="number"] {
+  &[datatype='number'] {
     justify-content: flex-end;
     & > .yearn--table-head-label {
       text-align: right;
@@ -275,7 +278,7 @@ body {
 }
 .yearn--table-data-section-item {
   @apply flex h-min flex-row md:items-start justify-between pt-0 px-0 md:min-h-14 md:pt-4;
-  &[datatype="number"] {
+  &[datatype='number'] {
     @apply md:text-right md:justify-end;
     & > .yearn--table-data-section-item-value {
       font-variant-numeric: tabular-nums;
@@ -289,13 +292,13 @@ body {
 
 .yearn--next-switch {
   @apply relative flex h-[18px] w-8 border-neutral-500 rounded-full cursor-pointer transition-colors ease-in-out duration-200 p-0 items-center border-2;
-  &[aria-checked="true"] {
+  &[aria-checked='true'] {
     @apply bg-neutral-400 border-neutral-900;
     & > div {
       @apply bg-neutral-900;
     }
   }
-  &[aria-checked="false"] {
+  &[aria-checked='false'] {
     @apply bg-transparent border-neutral-600;
     & > div {
       @apply bg-neutral-600;
@@ -322,7 +325,7 @@ body {
   @apply rounded-lg;
 
   /* Global state styles */
-  &[aria-busy="true"] {
+  &[aria-busy='true'] {
     @apply cursor-wait;
     color: transparent !important;
   }
@@ -332,62 +335,62 @@ body {
   }
 
   /* Variant: Filled (Primary) */
-  &[data-variant="filled"] {
+  &[data-variant='filled'] {
     @apply text-neutral-0 bg-neutral-900;
 
     &:disabled {
       @apply bg-neutral-700;
     }
 
-    &:not(:disabled):not([aria-busy="true"]):hover {
+    &:not(:disabled):not([aria-busy='true']):hover {
       @apply bg-neutral-800;
     }
   }
 
   /* Variant: Light */
-  &[data-variant="light"] {
+  &[data-variant='light'] {
     @apply text-neutral-900 bg-neutral-100;
 
-    &:not(:disabled):not([aria-busy="true"]):hover {
+    &:not(:disabled):not([aria-busy='true']):hover {
       @apply bg-neutral-200;
     }
   }
 
   /* Variant: Outlined */
-  &[data-variant="outlined"] {
+  &[data-variant='outlined'] {
     @apply text-neutral-900 bg-transparent border-neutral-900;
 
-    &:not(:disabled):not([aria-busy="true"]):hover {
+    &:not(:disabled):not([aria-busy='true']):hover {
       @apply bg-neutral-900 text-neutral-0;
     }
   }
 
   /* Variant: Reverted */
-  &[data-variant="reverted"] {
+  &[data-variant='reverted'] {
     @apply text-neutral-900 bg-neutral-0;
 
     &:disabled {
       @apply bg-neutral-200;
     }
 
-    &:not(:disabled):not([aria-busy="true"]):hover {
+    &:not(:disabled):not([aria-busy='true']):hover {
       @apply bg-neutral-200;
     }
 
-    &[aria-busy="true"] svg {
+    &[aria-busy='true'] svg {
       @apply text-neutral-900;
     }
   }
 
   /* Variant: V3 (Special variant) */
-  &[data-variant="v3"] {
+  &[data-variant='v3'] {
     @apply text-neutral-900 bg-pink-600;
 
     &:disabled {
       @apply bg-pink-600;
     }
 
-    &:not(:disabled):not([aria-busy="true"]):hover {
+    &:not(:disabled):not([aria-busy='true']):hover {
       @apply bg-pink-600/80;
     }
   }
@@ -400,11 +403,11 @@ body {
   &:disabled {
     @apply bg-neutral-200 opacity-40;
   }
-  &:not(:disabled):not([aria-busy="true"]):hover {
+  &:not(:disabled):not([aria-busy='true']):hover {
     @apply bg-neutral-200;
   }
 
-  &[aria-busy="true"] svg {
+  &[aria-busy='true'] svg {
     @apply text-neutral-900;
   }
 }
@@ -421,7 +424,7 @@ body {
 .yearn--dropdown-menu-item {
   @apply w-full flex flex-row items-center cursor-pointer py-2 pr-4 pl-3 transition-colors;
 
-  &[data-active="true"] {
+  &[data-active='true'] {
     @apply bg-neutral-0/40;
   }
 
@@ -435,7 +438,7 @@ body {
 }
 .yearn--listbox-menu-item {
   @apply w-full flex flex-row items-center cursor-pointer py-2 pr-4 pl-3 transition-colors;
-  &[data-active="true"] {
+  &[data-active='true'] {
     @apply bg-neutral-0/40;
   }
 }
@@ -445,7 +448,7 @@ body {
  *************************************************************************************************/
 .tab {
   @apply font-normal text-neutral-600 transition-colors hover:text-neutral-900 cursor-pointer border-b-2 border-transparent pb-4 z-20;
-  &[aria-selected="true"] {
+  &[aria-selected='true'] {
     @apply font-bold text-neutral-900 border-neutral-900;
   }
 }
@@ -480,7 +483,7 @@ body {
 /* 🔵 - Yearn Finance ******************************************************
 ** Overwriting the defaults to match our needs
 **************************************************************************/
-input[type="number"] {
+input[type='number'] {
   /* Firefox: Remove increment/decrement buttons */
   -moz-appearance: textfield;
 
@@ -495,8 +498,8 @@ input[type="number"] {
 :focus {
   outline: none;
 }
-[type="checkbox"],
-[type="checkbox"]:focus {
+[type='checkbox'],
+[type='checkbox']:focus {
   @apply outline-none focus:border-0 focus:outline-none focus:ring-0 active:border-0 active:ring-0;
   box-shadow: none !important;
 }


### PR DESCRIPTION
## Description

- update V3 vaults page to move filters into spot where the title CTA was to save space. portfolio shown in same place
- Update desktop v3 list row to show chain differently
- Update desktop v3 list row to show vault type and asset type
- Update mobile v3 list row to be laid out better
- Updated mobile notifications drawer to come up from bottom to match other drawers
- mobile filters moved to drawer with button.
- updated header to improve spacing and show page title in mobile.

## Related Issue

<!--- Please link to the issue here -->

## Motivation and Context

Improve usability and delight

## How Has This Been Tested?

locally

## Screenshots (if appropriate):

<img width="385" height="819" alt="image" src="https://github.com/user-attachments/assets/7751e60f-c6a5-4443-ba7f-5ba9ddf1b0bd" />
<img width="1292" height="952" alt="Screenshot 2025-09-29 102734" src="https://github.com/user-attachments/assets/7a30d0f2-3a52-481b-8afa-6eb4b28d76d6" />

