### PR TITLE
fix: deposit and stake

### DIFF
--- a/apps/vaults-v2/contexts/useSolver.tsx
+++ b/apps/vaults-v2/contexts/useSolver.tsx
@@ -81,7 +81,9 @@ export function WithSolverContextApp({ children }: { children: React.ReactElemen
       if (currentNonce !== executionNonce.current) {
         return
       }
-      const requestHash = await hash(serialize({ ...request, solver, expectedOut: toBigInt(quote.value?.raw) }))
+      const requestHash = await hash(
+        `${request.chainID}-${request.from}-${request.inputToken?.value}-${request.outputToken?.value}-${request.inputAmount}-${solver}-${toBigInt(quote.value?.raw)}`
+      )
       setCurrentSolverState({
         ...ctx,
         quote: quote.value,
@@ -118,6 +120,10 @@ export function WithSolverContextApp({ children }: { children: React.ReactElemen
           currentVault.staking.available &&
           (currentVault.staking.source === 'VeYFI' || currentVault.staking.source === 'Juiced')
             ? toAddress(currentVault.staking.address)
+            : undefined,
+        vaultTokenAddress:
+          currentVault.staking.available && currentVault.staking.source === 'VeYFI'
+            ? toAddress(currentVault.address)
             : undefined
       }
 
@@ -347,7 +353,8 @@ export function WithSolverContextApp({ children }: { children: React.ReactElemen
       v3StakingBooster,
       partnerContract,
       internalMigration,
-      v3Router
+      v3Router,
+      currentVault.address
     ]
   )
 

--- a/apps/vaults-v2/hooks/useVaultStakingData.ts
+++ b/apps/vaults-v2/hooks/useVaultStakingData.ts
@@ -394,7 +394,7 @@ export function useVaultStakingData(props: { currentVault: TYDaemonVault }): {
       decimalsResult = await readContracts(retrieveConfig(), {
         contracts: [
           {
-            address: stakingToken,
+            address: toAddress(stakingAddress),
             abi: erc20Abi,
             chainId: props.currentVault.chainID,
             functionName: 'decimals'
@@ -413,7 +413,7 @@ export function useVaultStakingData(props: { currentVault: TYDaemonVault }): {
             functionName: 'decimals'
           },
           {
-            address: stakingToken,
+            address: toAddress(stakingAddress),
             abi: erc20Abi,
             chainId: props.currentVault.chainID,
             functionName: 'decimals'

--- a/apps/vaults-v2/types/solvers.ts
+++ b/apps/vaults-v2/types/solvers.ts
@@ -49,6 +49,7 @@ export type TInitSolverArgs = {
   isDepositing: boolean
   migrator?: TAddress
   stakingPoolAddress?: TAddress //Address of the staking pool, for veYFI zap in
+  vaultTokenAddress?: TAddress //Address of the vault token, for veYFI zap in
   asset?: `0x${string}`
 }
 


### PR DESCRIPTION
## Description

Few bugs:
1. Wrong decimals in Unstake section
2. Wrong `selectedOptionTo` token when `Deposit and Stake` is on (GaugeStakingBooster). Previously it was just vault token with correct symbol rendered, now it's staking token.
