### PR TITLE
fix: AUSD tooltip text

### DIFF
--- a/apps/vaults-v3/components/table/KatanaApyTooltip.tsx
+++ b/apps/vaults-v3/components/table/KatanaApyTooltip.tsx
@@ -19,6 +19,14 @@ export function KatanaApyTooltip(props: {
   const positionClass = position === 'bottom' ? 'bottom-full' : 'top-full '
   const maxWidth = props.maxWidth || 'min-w-[360px] w-max'
 
+  // Check if this is the T-Bill vault
+  const isTBillVault =
+    props.currentVault.address.toLowerCase() === '0x93fec6639717b6215a48e5a72a162c50dcc40d68'.toLowerCase()
+  const extrinsicYieldLabel = isTBillVault ? 'T-Bill Yield' : 'Extrinsic Yield'
+  const extrinsicYieldDescription = isTBillVault
+    ? 'Interest from U.S. treasury bills'
+    : 'Yield Earned from underlying bridged assets'
+
   return (
     <span className={`tooltipLight ${positionClass}`}>
       <div
@@ -40,19 +48,21 @@ export function KatanaApyTooltip(props: {
           >
             <div className={'flex flex-row items-center space-x-2'}>
               <ImageWithFallback
-                src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${props.currentVault.chainID}/${props.currentVault.token.address.toLowerCase()}/logo-32.png`}
+                src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${
+                  props.currentVault.chainID
+                }/${props.currentVault.token.address.toLowerCase()}/logo-32.png`}
                 alt={''}
                 width={16}
                 height={16}
               />
-              <p>{'Extrinsic Yield '}</p>
+              <p>{extrinsicYieldLabel} </p>
             </div>
             <span className={'font-number'}>
               <RenderAmount shouldHideTooltip value={props.extrinsicYield} symbol={'percent'} decimals={6} />
             </span>
           </div>
           <p className={'-mt-1 mb-2 w-full text-left text-xs text-neutral-500 break-words'}>
-            {'Yield Earned from underlying bridged assets'}
+            {extrinsicYieldDescription}
           </p>
           <div
             className={
@@ -61,7 +71,9 @@ export function KatanaApyTooltip(props: {
           >
             <div className={'flex flex-row items-center space-x-2'}>
               <ImageWithFallback
-                src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${props.currentVault.chainID}/${props.currentVault.token.address.toLowerCase()}/logo-32.png`}
+                src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${
+                  props.currentVault.chainID
+                }/${props.currentVault.token.address.toLowerCase()}/logo-32.png`}
                 alt={''}
                 width={16}
                 height={16}


### PR DESCRIPTION
## Description

Fixes tooltip text to match Katana site when viewing AUSD.

## Related Issue

none

## Motivation and Context

request from katana/polygon team

## How Has This Been Tested?

locally

## Screenshots (if appropriate):
<img width="966" height="729" alt="image" src="https://github.com/user-attachments/assets/e03bd403-9012-4710-b225-0cbaff6000bd" />
