### PR TITLE
feat: turn cowswap back on

### DIFF
--- a/apps/vaults-v2/contexts/useSolver.tsx
+++ b/apps/vaults-v2/contexts/useSolver.tsx
@@ -28,7 +28,7 @@ export const isSolverDisabled = (key: TSolver): boolean => {
     [Solver.enum.GaugeStakingBooster]: false,
     [Solver.enum.JuicedStakingBooster]: false,
     [Solver.enum.V3StakingBooster]: false,
-    [Solver.enum.Cowswap]: true,
+    [Solver.enum.Cowswap]: false,
     [Solver.enum.Portals]: false,
     [Solver.enum.None]: false
   }


### PR DESCRIPTION
## Description

Sets the flag that turns the cowswap solver back on.

## Related Issue

cant wait: https://github.com/yearn/yearn.fi/pull/767

## Motivation and Context

User requests to get cowswap zaps back. Seasolver enabled low value zaps to vaults. Lets keep it simple.

## How Has This Been Tested?

locally

## Screenshots (if appropriate):
