### PR TITLE
Optimize edge function caching and reduce invocations

### DIFF
--- a/api/vault/meta.ts
+++ b/api/vault/meta.ts
@@ -56,14 +56,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     html = html.replace('</head>', `${metaTags}\n  </head>`)
 
     res.setHeader('Content-Type', 'text/html')
-    res.setHeader('Cache-Control', 's-maxage=3600, stale-while-revalidate=86400')
+    res.setHeader('Vercel-CDN-Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=604800')
+    res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
 
     return res.status(200).send(html)
   } catch (error) {
     console.error('Error generating meta tags:', error)
     // Fallback to regular SPA with cached HTML
     res.setHeader('Content-Type', 'text/html')
-    res.setHeader('Cache-Control', 's-maxage=3600, stale-while-revalidate=86400')
+    res.setHeader('Vercel-CDN-Cache-Control', 'public, s-maxage=86400, stale-while-revalidate=604800')
+    res.setHeader('Cache-Control', 'public, max-age=0, must-revalidate')
     return res.status(200).send(baseHtml)
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,14 @@
       "destination": "https://plausible.io/:path*"
     },
     {
+      "source": "/assets/:path*",
+      "destination": "/assets/:path*"
+    },
+    {
+      "source": "/:file*.(js|css|svg|png|jpg|jpeg|gif|ico|woff|woff2|ttf|eot)",
+      "destination": "/:file*.$1"
+    },
+    {
       "source": "/v3/:chainId/:address",
       "destination": "/api/vault/meta?chainId=$1&address=$2"
     },


### PR DESCRIPTION
- Add static asset exclusions in vercel.json to prevent edge function calls for JS/CSS/images
- Use Vercel-CDN-Cache-Control header with 24hr cache and 7-day revalidation
- Set proper browser Cache-Control headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### How to test
use an open graph tester like https://www.opengraph.xyz/ to verify the preview url produces correct OG images.
