### PR TITLE
Redirect /_next/image requests to reduce edge usage

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,13 @@
   "installCommand": "bun install --frozen-lockfile",
   "buildCommand": "bun run build",
   "outputDirectory": "dist",
+  "redirects": [
+    {
+      "source": "/_next/image/:path*",
+      "destination": "https://localhost",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     {
       "source": "/proxy/plausible/:path*",


### PR DESCRIPTION
Adds permanent redirect for /_next/image/* paths to localhost to prevent bots from continuing to request these outdated URLs after migration to Vite. This addresses the same edge request optimization issue as f4045e86 and 8127c92c by causing bots to cache the 308 redirect and stop hitting our edge network entirely. 

To test, use the site as usual, should only effect bots.