### PR TITLE
Fix stale chunk errors during deployments by auto-reloading

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,6 +10,35 @@ if (import.meta.env.DEV) {
   void disableServiceWorkerDev()
 }
 
+// Handle stale chunk errors during deployments
+// When a new deployment happens, chunk hashes change and old chunks return 404 or HTML instead of JS
+// This catches those errors and reloads the page to get fresh chunks
+window.addEventListener('vite:preloadError', (event) => {
+  const RELOAD_KEY = 'vite-preload-error-reload-attempt'
+  const MAX_RETRIES = 1
+  const RETRY_WINDOW_MS = 10000 // Reset counter after 10 seconds
+
+  const now = Date.now()
+  const stored = sessionStorage.getItem(RELOAD_KEY)
+  const data = stored ? JSON.parse(stored) : { count: 0, timestamp: now }
+
+  // Reset counter if enough time has passed
+  if (now - data.timestamp > RETRY_WINDOW_MS) {
+    data.count = 0
+    data.timestamp = now
+  }
+
+  if (data.count < MAX_RETRIES) {
+    console.warn('Vite preload error detected, reloading page...', event)
+    data.count++
+    sessionStorage.setItem(RELOAD_KEY, JSON.stringify(data))
+    window.location.reload()
+  } else {
+    console.error('Vite preload error: Max reload attempts reached. Please manually refresh the page.', event)
+    sessionStorage.removeItem(RELOAD_KEY)
+  }
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>


### PR DESCRIPTION
Adds error handling for vite:preloadError events that occur when users navigate after a deployment. When chunk hashes change between deployments, old HTML references non-existent chunks causing "Failed to load module" errors. This fix automatically reloads the page once to fetch fresh chunks, with safeguards to prevent infinite reload loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Root cause
During build we currently split code between the app's major routes. Each split becomes a compiled chunk of code and given a name based on a hash of the code. When a user loads the site, their browser downloads the initial HTML which contains references to each chunk file (e.g., `index-DNRNQ5Le.js`).

When we deploy a new version of the site:
1. Vite rebuilds and generates new chunk hashes if the underlying code split has changed (e.g., `index-XYZ123.js`)
2. The old chunks (`index-DNRNQ5Le.js`) are deleted/no longer exist
3. A user with the old HTML still open in their browser will continue to reference the old chunk names
4. If such a user navigates to a new route, their browser attempts to dynamically import old chunks referenced by the outdated HTML file
5. The old chunk returns a 404, which our catch-all rewrite rule handles by serving `index.html`
6. The browser receives HTML (`text/html`) when it expects JavaScript, causing the error: `"Expected a JavaScript or Wasm module script but the server responded with a MIME type of 'text/html'"`

## The fix
Per the vite documentation, this PR adds a `vite:preloadError` event listener in the app's entry point that automatically reloads the page when the app fails to load a chunk. To prevent infinite reload loops, the handler uses sessionStorage to track reload attempts, allowing only one automatic retry within a 10-second window. If the error persists after one reload, it logs an error to the console and requires manual intervention. This ensures users seamlessly get fresh chunks after deployments while gracefully handling edge cases where legitimate errors occur.

See https://vite.dev/guide/build#load-error-handling

Another working fix to this problem was PRd here, https://github.com/yearn/yearn.fi/pull/792

Recommending the solution in this PR because:
Vite-native - uses vite's official error event, designed for this exact use case
Tech debt - wrapping the lazy route imports is unconventional and presents a challenge if we decide to split code differently
Self-healing - retry counter resets after 10 seconds, handles transient issues better
Cleaner reload behavior - using `vite:preloadError` catches bad chunks before react loads so the reload feels instant and seemless. Whereas the lazy route solution isn't engaged until after react and the page header have loaded, so it takes a bit longer and there's an obvious flash of content.

## How this was tested
To reproduce the bad chunk issue (aka a skew bug)
- PR a new branch with a trivial change to README.md
- Wait for the vercel preview to be ready and loaded the preview in a browser
- Only load the landing page, don't navigate anywhere
- Push a new commit to the same branch with a trivial change to `pages/v3/index.tsx`
- Wait for the new vercel preview to be ready
- Back in the browser, click on a link that changes route to pages/v3/index.tsx (eg Explore Vaults)
- The skew bug is reproduced

To verify the fixes, rebase the test branch on the fix branch, rerun the same test steps, the skew bug is fixed, the page reloads automatically. For example, https://github.com/yearn/yearn.fi/pull/822

