### PR TITLE
chore: updated katana tooltip info

### DIFF
--- a/apps/lib/utils/wagmi/config.ts
+++ b/apps/lib/utils/wagmi/config.ts
@@ -1,10 +1,10 @@
 import { getDefaultConfig } from '@rainbow-me/rainbowkit'
 import {
   baseAccount,
-  rabbyWallet,
   frameWallet,
   injectedWallet,
   ledgerWallet,
+  rabbyWallet,
   rainbowWallet,
   safeWallet,
   walletConnectWallet

--- a/apps/vaults-v3/components/table/KatanaApyTooltip.tsx
+++ b/apps/vaults-v3/components/table/KatanaApyTooltip.tsx
@@ -114,7 +114,7 @@ export function KatanaApyTooltip(props: {
                   width={16}
                   height={16}
                 />
-                <p>{'Base Rewards APR '}</p>
+                <p>{'Base Rewards APR* '}</p>
               </div>
               <span className={'font-number text-right'}>
                 <RenderAmount
@@ -127,6 +127,19 @@ export function KatanaApyTooltip(props: {
             </div>
             <p className={'-mt-1 mb-2 w-full text-left text-xs text-neutral-500 break-words'}>
               {'Limited time fixed KAT rewards'}
+            </p>
+            <p className={'-mt-1 mb-2 w-full text-left text-xs text-neutral-500 break-words'}>
+              {'* claimable after 28 days, subject to '}
+              <a
+                href={'https://x.com/katana/status/1961475531188126178'}
+                target={'_blank'}
+                rel={'noopener noreferrer'}
+                className={
+                  'font-bold underline sm:decoration-neutral-600/30 decoration-dotted underline-offset-4 transition-opacity hover:decoration-neutral-600'
+                }
+              >
+                {'haircut schedule.'}
+              </a>
             </p>
             <div
               className={


### PR DESCRIPTION
## Description

The Katana tooltip was missing information on the haircut schedule for the base fixed katana rewards. This PR adds the information to the tooltip to match what is shown on app.katana.network.

## Related Issue

none

## Motivation and Context

matching info between our app and katana's

## How Has This Been Tested?

locally

## Screenshots (if appropriate):

<img width="474" height="692" alt="image" src="https://github.com/user-attachments/assets/a18e4e35-f284-43da-a300-a238a63c2893" />
