### PR TITLE
Remove Sonic from v3 vaults UI

### DIFF
--- a/apps/lib/hooks/useFetchYearnVaults.ts
+++ b/apps/lib/hooks/useFetchYearnVaults.ts
@@ -38,7 +38,7 @@ function useFetchYearnVaults(chainIDs?: number[] | undefined): {
       strategiesDetails: 'withDetails',
       strategiesCondition: 'inQueue',
 
-      chainIDs: chainIDs ? chainIDs.join(',') : [1, 10, 137, 146, 250, 8453, 42161, 747474].join(','),
+      chainIDs: chainIDs ? chainIDs.join(',') : [1, 10, 137, 250, 8453, 42161, 747474].join(','),
       limit: '2500'
     })}`,
     schema: yDaemonVaultsSchema,
@@ -50,7 +50,7 @@ function useFetchYearnVaults(chainIDs?: number[] | undefined): {
   // const vaultsMigrations: TYDaemonVaults = useMemo(() => [], []);
   const { data: vaultsMigrations } = useFetch<TYDaemonVaults>({
     endpoint: `${yDaemonBaseUriWithoutChain}/vaults?${new URLSearchParams({
-      chainIDs: chainIDs ? chainIDs.join(',') : [1, 10, 137, 146, 250, 8453, 42161, 747474].join(','),
+      chainIDs: chainIDs ? chainIDs.join(',') : [1, 10, 137, 250, 8453, 42161, 747474].join(','),
       migratable: 'nodust',
       limit: '2500'
     })}`,

--- a/apps/lib/utils/constants.tsx
+++ b/apps/lib/utils/constants.tsx
@@ -6,11 +6,11 @@ import { IconYearn } from '@lib/icons/IconYearn'
 import { IconYearnXApps } from '@lib/icons/IconYearnXApps'
 import type { TAddress, TNDict, TToken } from '@lib/types'
 import type { TApp } from '@lib/types/mixed'
-import { arbitrum, base, fantom, mainnet, optimism, polygon, sonic } from 'viem/chains'
+import { arbitrum, base, fantom, mainnet, optimism, polygon } from 'viem/chains'
 import { toAddress } from './tools.address'
 import { katana } from './wagmi'
 
-export const SUPPORTED_NETWORKS = [mainnet, optimism, polygon, fantom, base, arbitrum, sonic, katana]
+export const SUPPORTED_NETWORKS = [mainnet, optimism, polygon, fantom, base, arbitrum, katana]
 
 export const MULTICALL3_ADDRESS = toAddress('0xcA11bde05977b3631167028862bE2a173976CA11')
 

--- a/apps/vaults-v3/components/Filters.tsx
+++ b/apps/vaults-v3/components/Filters.tsx
@@ -39,7 +39,6 @@ export function Filters({
       option.value === 137 ||
       option.value === 42161 ||
       option.value === 8453 ||
-      option.value === 146 ||
       option.value === 747474
   )
   const typeOptions = useMemo((): TMultiSelectOptionProps[] => {

--- a/apps/vaults-v3/components/VaultChainTag.tsx
+++ b/apps/vaults-v3/components/VaultChainTag.tsx
@@ -9,13 +9,11 @@ const ChainColors: { [key: number]: string } = {
   250: '#1969FF',
   8453: '#1C55F5',
   42161: '#2F3749',
-  747474: '#f6ff0d',
-  146: '#ffffff'
+  747474: '#f6ff0d'
 }
 
 const ChainTextColors: { [key: number]: string } = {
-  747474: '#000000',
-  146: '#000000'
+  747474: '#000000'
 }
 
 const ChainNames: { [key: number]: string } = {
@@ -25,8 +23,7 @@ const ChainNames: { [key: number]: string } = {
   250: 'Fantom',
   8453: 'Base',
   42161: 'Arbitrum',
-  747474: 'Katana',
-  146: 'Sonic'
+  747474: 'Katana'
 }
 
 export const VaultChainTag: FC<{


### PR DESCRIPTION
## Description

Previously, there was one USDC vault on Sonic... with $400 TVL. This edit removes Sonic from showing on the v3 UI.

<img width="1476" height="1007" alt="image" src="https://github.com/user-attachments/assets/e1154e54-a6fe-4a77-ba0a-546da636f61b" />

## Related Issue

N/A

## Motivation and Context

Remove low priority vaults from UI.

## How Has This Been Tested?

Local testing

## Screenshots (if appropriate):
