### PR TITLE
feat: enhance portfolio page 

### DIFF
--- a/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
+++ b/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
@@ -40,14 +40,16 @@ type ExpandedTabId = (typeof EXPANDED_TABS)[number]['id']
 
 export function VaultsV3ListRow({
   currentVault,
-  flags
+  flags,
+  hrefOverride
 }: {
   currentVault: TYDaemonVault
   flags?: TVaultRowFlags
+  hrefOverride?: string
 }): ReactElement {
   const navigate = useNavigate()
   // const availableToDeposit = useAvailableToDeposit(currentVault)
-  const href = `/vaults-beta/${currentVault.chainID}/${toAddress(currentVault.address)}`
+  const href = hrefOverride ?? `/vaults-beta/${currentVault.chainID}/${toAddress(currentVault.address)}`
   const [isApyOpen, setIsApyOpen] = useState(false)
   const [isRiskOpen, setIsRiskOpen] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)

--- a/pages/portfolio/index.tsx
+++ b/pages/portfolio/index.tsx
@@ -2,9 +2,12 @@ import Link from '@components/Link'
 import { Button } from '@lib/components/Button'
 import { useWallet } from '@lib/contexts/useWallet'
 import { useWeb3 } from '@lib/contexts/useWeb3'
+import { useYearn } from '@lib/contexts/useYearn'
+import { useV2VaultFilter } from '@lib/hooks/useV2VaultFilter'
 import { useV3VaultFilter } from '@lib/hooks/useV3VaultFilter'
+import { IconSpinner } from '@lib/icons/IconSpinner'
 import type { TSortDirection } from '@lib/types'
-import { cl, toAddress } from '@lib/utils'
+import { isZero, toAddress } from '@lib/utils'
 import type { TPossibleSortBy } from '@vaults-v2/hooks/useSortVaults'
 import { useSortVaults } from '@vaults-v2/hooks/useSortVaults'
 import { VaultsV3ListHead } from '@vaults-v3/components/list/VaultsV3ListHead'
@@ -13,11 +16,14 @@ import { SuggestedVaultCard } from '@vaults-v3/components/SuggestedVaultCard'
 import type { ReactElement } from 'react'
 import { useMemo, useState } from 'react'
 
-const TIMEFRAMES = ['1H', '1D', '1W', '1M', '1Y', 'ALL'] as const
-
 const currencyFormatter = new Intl.NumberFormat('en-US', {
   style: 'currency',
   currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2
+})
+
+const percentFormatter = new Intl.NumberFormat('en-US', {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2
 })
@@ -29,10 +35,10 @@ function HoldingsEmptyState({ isActive, onConnect }: { isActive: boolean; onConn
         {isActive ? 'No vault positions yet' : 'Connect a wallet to get started'}
       </p>
       <p className={'max-w-md text-sm text-text-secondary'}>
-        {isActive ? 'Deposit into a Yearn v3 vault to see it here.' : 'Link a wallet to load your Yearn balances.'}
+        {isActive ? 'Deposit into a Yearn vault to see it here.' : 'Link a wallet to load your Yearn balances.'}
       </p>
       {isActive ? (
-        <Link to="/v3" className={'yearn--button'} data-variant={'filled'}>
+        <Link to="/vaults-beta" className={'yearn--button'} data-variant={'filled'}>
           {'Browse vaults'}
         </Link>
       ) : (
@@ -45,15 +51,51 @@ function HoldingsEmptyState({ isActive, onConnect }: { isActive: boolean; onConn
 }
 
 function PortfolioPage(): ReactElement {
-  const { cumulatedValueInV3Vaults } = useWallet()
-  const { isActive, openLoginModal } = useWeb3()
-  const { holdingsVaults, filteredVaults, vaultFlags, isLoading } = useV3VaultFilter(null, null, '', null)
-  const [selectedRange, setSelectedRange] = useState<(typeof TIMEFRAMES)[number]>('1W')
+  const { cumulatedValueInV2Vaults, cumulatedValueInV3Vaults, isLoading: isWalletLoading, getBalance } = useWallet()
+  const { isActive, openLoginModal, isUserConnecting, isIdentityLoading } = useWeb3()
+  const { getPrice, katanaAprs } = useYearn()
+  const {
+    holdingsVaults: v3HoldingsVaults,
+    filteredVaults: v3FilteredVaults,
+    vaultFlags: v3VaultFlags,
+    isLoading: isV3Loading
+  } = useV3VaultFilter(null, null, '', null)
+  const {
+    holdingsVaults: v2HoldingsVaults,
+    vaultFlags: v2VaultFlags,
+    isLoading: isV2Loading
+  } = useV2VaultFilter(null, null, '')
   const [sortBy, setSortBy] = useState<TPossibleSortBy>('deposited')
   const [sortDirection, setSortDirection] = useState<TSortDirection>('desc')
 
+  const holdingsVaults = useMemo(() => {
+    const combined = [...v3HoldingsVaults, ...v2HoldingsVaults]
+    const seen = new Set<string>()
+    return combined.filter((vault) => {
+      const key = `${vault.chainID}_${toAddress(vault.address)}`
+      if (seen.has(key)) {
+        return false
+      }
+      seen.add(key)
+      return true
+    })
+  }, [v3HoldingsVaults, v2HoldingsVaults])
+
+  const vaultFlags = useMemo(() => {
+    const merged: typeof v3VaultFlags = { ...v2VaultFlags }
+    Object.entries(v3VaultFlags).forEach(([key, value]) => {
+      merged[key] = { ...merged[key], ...value }
+    })
+    return merged
+  }, [v2VaultFlags, v3VaultFlags])
+
+  const isSearchingBalances =
+    (isActive || isUserConnecting) && (isWalletLoading || isUserConnecting || isIdentityLoading)
+  const isLoading = isV3Loading || isV2Loading
+  const isHoldingsLoading = (isLoading && isActive) || isSearchingBalances
+
   const sortedHoldings = useSortVaults(holdingsVaults, sortBy, sortDirection)
-  const sortedCandidates = useSortVaults(filteredVaults, 'featuringScore', 'desc')
+  const sortedCandidates = useSortVaults(v3FilteredVaults, 'featuringScore', 'desc')
 
   const holdingsKeySet = useMemo(
     () => new Set(sortedHoldings.map((vault) => `${vault.chainID}_${toAddress(vault.address)}`)),
@@ -69,10 +111,132 @@ function PortfolioPage(): ReactElement {
   )
 
   const hasHoldings = sortedHoldings.length > 0
+  const totalPortfolioValue = (cumulatedValueInV2Vaults || 0) + (cumulatedValueInV3Vaults || 0)
+
+  const getVaultEstimatedAPY = useMemo(
+    () =>
+      (vault: (typeof holdingsVaults)[number]): number | null => {
+        if (vault.chainID === 747474) {
+          const katanaAprData = katanaAprs?.[toAddress(vault.address)]?.apr?.extra
+          if (katanaAprData) {
+            return (
+              (katanaAprData.extrinsicYield || 0) +
+              (katanaAprData.katanaNativeYield || 0) +
+              (katanaAprData.FixedRateKatanaRewards || 0) +
+              (katanaAprData.katanaAppRewardsAPR || 0) +
+              (katanaAprData.katanaBonusAPY || 0) +
+              (katanaAprData.steerPointsPerDollar || 0)
+            )
+          }
+        }
+
+        if (vault.apr?.forwardAPR?.type === '') {
+          return (vault.apr?.extra?.stakingRewardsAPR || 0) + (vault.apr?.netAPR || 0)
+        }
+
+        if (
+          vault.chainID === 1 &&
+          vault.apr?.forwardAPR?.composite?.boost > 0 &&
+          !vault.apr?.extra?.stakingRewardsAPR
+        ) {
+          return vault.apr?.forwardAPR?.netAPR || 0
+        }
+
+        const sumOfRewardsAPY = (vault.apr?.extra?.stakingRewardsAPR || 0) + (vault.apr?.extra?.gammaRewardAPR || 0)
+        const hasCurrentAPY = !isZero(vault?.apr?.forwardAPR?.netAPR || 0)
+        if (sumOfRewardsAPY > 0) {
+          return sumOfRewardsAPY + (vault.apr?.forwardAPR?.netAPR || 0)
+        }
+        if (hasCurrentAPY) {
+          return vault.apr?.forwardAPR?.netAPR || 0
+        }
+        return vault.apr?.netAPR ?? null
+      },
+    [katanaAprs]
+  )
+
+  const getVaultHistoricalAPY = useMemo(
+    () =>
+      (vault: (typeof holdingsVaults)[number]): number | null => {
+        const monthlyAPY = vault.apr?.points?.monthAgo
+        const weeklyAPY = vault.apr?.points?.weekAgo
+        const chosenAPY = !isZero(monthlyAPY || 0) ? monthlyAPY : weeklyAPY
+        return typeof chosenAPY === 'number' ? chosenAPY : null
+      },
+    []
+  )
+
+  const getVaultValue = useMemo(
+    () =>
+      (vault: (typeof holdingsVaults)[number]): number => {
+        const shareBalance = getBalance({
+          address: vault.address,
+          chainID: vault.chainID
+        })
+        const price = getPrice({
+          address: vault.address,
+          chainID: vault.chainID
+        })
+        const baseValue = shareBalance.normalized * price.normalized
+
+        let stakingValue = 0
+        if (vault.staking?.available && vault.staking.address) {
+          const stakingBalance = getBalance({
+            address: vault.staking.address,
+            chainID: vault.chainID
+          })
+          stakingValue = stakingBalance.normalized * price.normalized
+        }
+
+        return baseValue + stakingValue
+      },
+    [getBalance, getPrice]
+  )
+
+  const blendedMetrics = useMemo(() => {
+    let totalValue = 0
+    let weightedCurrent = 0
+    let weightedHistorical = 0
+    let hasCurrent = false
+    let hasHistorical = false
+
+    holdingsVaults.forEach((vault) => {
+      const value = getVaultValue(vault)
+      if (!Number.isFinite(value) || value <= 0) {
+        return
+      }
+
+      const estimatedAPY = getVaultEstimatedAPY(vault)
+      if (typeof estimatedAPY === 'number' && Number.isFinite(estimatedAPY)) {
+        weightedCurrent += value * estimatedAPY
+        hasCurrent = true
+      }
+
+      const historicalAPY = getVaultHistoricalAPY(vault)
+      if (typeof historicalAPY === 'number' && Number.isFinite(historicalAPY)) {
+        weightedHistorical += value * historicalAPY
+        hasHistorical = true
+      }
+
+      totalValue += value
+    })
+
+    const blendedCurrentAPY = totalValue > 0 && hasCurrent ? weightedCurrent / totalValue : null
+    const blendedHistoricalAPY = totalValue > 0 && hasHistorical ? weightedHistorical / totalValue : null
+    const blendedCurrentAPYPercent = blendedCurrentAPY !== null ? blendedCurrentAPY * 100 : null
+    const blendedHistoricalAPYPercent = blendedHistoricalAPY !== null ? blendedHistoricalAPY * 100 : null
+    const estimatedAnnualReturn = blendedCurrentAPY !== null ? totalPortfolioValue * blendedCurrentAPY : null
+
+    return {
+      blendedCurrentAPY: blendedCurrentAPYPercent,
+      blendedHistoricalAPY: blendedHistoricalAPYPercent,
+      estimatedAnnualReturn
+    }
+  }, [getVaultEstimatedAPY, getVaultHistoricalAPY, getVaultValue, holdingsVaults, totalPortfolioValue])
 
   return (
     <div className={'min-h-[calc(100vh-var(--header-height))] w-full bg-app pb-8'}>
-      <div className={'mx-auto flex w-full max-w-[1232px] flex-col gap-10 px-4 pb-16'}>
+      <div className={'mx-auto flex w-full max-w-[1232px] flex-col gap-5 px-4 pb-16'}>
         <section className={'flex flex-col gap-4'}>
           <div className={'flex items-center gap-2 mt-2 text-sm text-text-secondary'}>
             <Link to={'/'} className={'transition-colors hover:text-text-primary'}>
@@ -87,49 +251,85 @@ function PortfolioPage(): ReactElement {
               {'Monitor your balances, returns, and discover new vaults.'}
             </p>
           </div>
-          <div className={'grid grid-cols-1 gap-4 md:grid-cols-3'}>
-            <div className={'rounded-3xl border border-border bg-surface p-6 md:col-span-2'}>
-              <div className={'flex flex-wrap items-center justify-between gap-4'}>
-                <div>
-                  <p className={'text-sm font-semibold uppercase tracking-wide text-text-secondary'}>
-                    {'Total balance'}
-                  </p>
-                  <p className={'mt-1 text-3xl font-black text-text-primary'}>
-                    {currencyFormatter.format(cumulatedValueInV3Vaults || 0)}
-                  </p>
-                </div>
-                <div className={'flex flex-wrap gap-2'}>
-                  {TIMEFRAMES.map((range) => (
-                    <button
-                      key={range}
-                      type={'button'}
-                      onClick={(): void => setSelectedRange(range)}
-                      className={cl(
-                        'rounded-full px-3 py-1 text-xs font-semibold transition-colors',
-                        selectedRange === range
-                          ? 'bg-text-primary text-surface'
-                          : 'bg-surface-secondary text-text-secondary hover:text-text-primary'
-                      )}
-                    >
-                      {range}
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div className={'mt-6 relative flex h-48 w-full items-center justify-center rounded-2xl overflow-hidden'}>
-                <div
-                  className={
-                    'absolute inset-0 bg-gradient-to-r from-[#DCE6FF] via-[#F2EBFF] to-[#FFE7F3] [html[data-theme=dark]_&]:opacity-15 [html[data-theme=soft-dark]_&]:opacity-15'
-                  }
-                />
-                <span className={'relative z-10 text-sm text-text-secondary'}>{'Performance chart coming soon'}</span>
-              </div>
-            </div>
+          <div className={'grid grid-cols-1 gap-4 md:grid-cols-4'}>
             <div className={'rounded-3xl border border-border bg-surface p-6'}>
-              <p className={'text-sm font-semibold uppercase tracking-wide text-text-secondary'}>{'Total return'}</p>
-              <p className={'mt-3 text-3xl font-black text-text-primary'}>{'—'}</p>
+              <p className={'text-sm font-semibold uppercase tracking-wide text-text-secondary'}>{'Total balance'}</p>
+              <p className={'mt-3 text-3xl font-black text-text-primary'}>
+                {isSearchingBalances ? (
+                  <span
+                    className={
+                      'inline-flex h-9 w-40 items-center justify-center rounded-xl bg-surface-secondary animate-pulse'
+                    }
+                  >
+                    <IconSpinner className={'h-4 w-4 text-text-secondary'} />
+                  </span>
+                ) : (
+                  currencyFormatter.format(totalPortfolioValue)
+                )}
+              </p>
+            </div>
+
+            <div className={'rounded-3xl border border-border bg-surface p-6'}>
+              <p className={'text-sm font-semibold uppercase tracking-wide text-text-secondary'}>
+                {'Blended Current APY'}
+              </p>
+              <p className={'mt-3 text-3xl font-black text-text-primary'}>
+                {isHoldingsLoading ? (
+                  <span className={'inline-flex h-9 w-20 items-center justify-center animate-spin'}>
+                    <IconSpinner className={'h-5 w-5 text-text-secondary'} />
+                  </span>
+                ) : blendedMetrics.blendedCurrentAPY !== null ? (
+                  `${percentFormatter.format(blendedMetrics.blendedCurrentAPY)}%`
+                ) : (
+                  '—'
+                )}
+              </p>
               <p className={'mt-2 text-sm text-text-secondary'}>
-                {'Return insights will appear here once this data becomes available.'}
+                {'Weighted by your total deposits across all Yearn vaults.'}
+              </p>
+            </div>
+
+            <div className={'rounded-3xl border border-border bg-surface p-6'}>
+              <p className={'text-sm font-semibold uppercase tracking-wide text-text-secondary'}>
+                {'Blended 30-day APY'}
+              </p>
+              <p className={'mt-3 text-3xl font-black text-text-primary'}>
+                {isHoldingsLoading ? (
+                  <span className={'inline-flex h-9 w-20 items-center justify-center animate-spin'}>
+                    <IconSpinner className={'h-5 w-5 text-text-secondary'} />
+                  </span>
+                ) : blendedMetrics.blendedHistoricalAPY !== null ? (
+                  `${percentFormatter.format(blendedMetrics.blendedHistoricalAPY)}%`
+                ) : (
+                  '—'
+                )}
+              </p>
+              <p className={'mt-2 text-sm text-text-secondary'}>
+                {'Blended 30-day performance using your current positions.'}
+              </p>
+            </div>
+
+            <div className={'rounded-3xl border border-border bg-surface p-6'}>
+              <p className={'text-sm font-semibold uppercase tracking-wide text-text-secondary'}>
+                {'Estimated Annual Return'}
+              </p>
+              <p className={'mt-3 text-3xl font-black text-text-primary'}>
+                {isHoldingsLoading ? (
+                  <span
+                    className={
+                      'inline-flex h-9 w-40 items-center justify-center rounded-xl bg-surface-secondary animate-pulse'
+                    }
+                  >
+                    <IconSpinner className={'h-4 w-4 text-text-secondary'} />
+                  </span>
+                ) : blendedMetrics.estimatedAnnualReturn !== null ? (
+                  currencyFormatter.format(blendedMetrics.estimatedAnnualReturn)
+                ) : (
+                  '—'
+                )}
+              </p>
+              <p className={'mt-2 text-sm text-text-secondary'}>
+                {'Projects potential returns based on your blended current APY.'}
               </p>
             </div>
           </div>
@@ -139,10 +339,10 @@ function PortfolioPage(): ReactElement {
           <div className={'flex flex-wrap items-center justify-between gap-4'}>
             <div>
               <h2 className={'text-2xl font-semibold text-text-primary'}>{'Your vaults'}</h2>
-              <p className={'text-sm text-text-secondary'}>{'Track every v3 position you currently hold.'}</p>
+              <p className={'text-sm text-text-secondary'}>{'Track every Yearn position you currently hold.'}</p>
             </div>
             {hasHoldings ? (
-              <Link to="/v3" className={'yearn--button text-sm'} data-variant={'light'}>
+              <Link to="/vaults-beta" className={'yearn--button text-sm'} data-variant={'light'}>
                 {'Browse more vaults'}
               </Link>
             ) : null}
@@ -203,15 +403,27 @@ function PortfolioPage(): ReactElement {
                   }
                 ]}
               />
-              {isLoading ? (
-                <div className={'flex items-center justify-center px-6 py-16 text-sm text-text-secondary'}>
-                  {'Loading your vaults...'}
+              {isHoldingsLoading ? (
+                <div
+                  className={'flex flex-col items-center justify-center gap-3 px-6 py-16 text-sm text-text-secondary'}
+                >
+                  <IconSpinner className={'h-6 w-6 text-text-secondary'} />
+                  <span>{'Searching for Yearn balances...'}</span>
                 </div>
               ) : hasHoldings ? (
                 <div className={'flex flex-col gap-px'}>
                   {sortedHoldings.map((vault) => {
                     const key = `${vault.chainID}_${toAddress(vault.address)}`
-                    return <VaultsV3ListRow key={key} currentVault={vault} flags={vaultFlags[key]} />
+                    const isV3 = vault.version?.startsWith('3') || vault.version?.startsWith('~3')
+                    const hrefOverride = isV3 ? undefined : `/vaults/${vault.chainID}/${toAddress(vault.address)}`
+                    return (
+                      <VaultsV3ListRow
+                        key={key}
+                        currentVault={vault}
+                        flags={vaultFlags[key]}
+                        hrefOverride={hrefOverride}
+                      />
+                    )
                   })}
                 </div>
               ) : (

--- a/pages/v3/home.tsx
+++ b/pages/v3/home.tsx
@@ -1,7 +1,5 @@
 import { useV3VaultFilter } from '@lib/hooks/useV3VaultFilter'
 import { cl } from '@lib/utils'
-import type { CSSProperties, ReactElement } from 'react'
-import { useRef, useState } from 'react'
 import { DiscoverCard } from '@new-landing/components/DiscoverCard'
 import { FAQs } from '@new-landing/components/FAQs'
 import { HeroCard } from '@new-landing/components/HeroCard'
@@ -11,6 +9,8 @@ import { PortfolioCard } from '@new-landing/components/PortfolioCard'
 import { Security } from '@new-landing/components/Security'
 import { ExploreOurVaults } from '@new-landing/components/V3SecondaryCard'
 import { VaultInfo } from '@new-landing/components/VaultInfo'
+import type { CSSProperties, ReactElement } from 'react'
+import { useRef, useState } from 'react'
 
 const LEARN_MORE_SECTIONS = [
   { key: 'vaultInfo', Component: VaultInfo, rowSpan: 6 },


### PR DESCRIPTION
## Description

- Adds v2 vaults to portfolio page
- Removes placeholder chart
- Adds blended APYs and estimated returns on vaults with blended APY and deposit amounts

## Related Issue

https://linear.app/yearn-webops/issue/FE-88/consolidated-portfolio-of-v2-and-v3-vaults-on-portfolio-page

## Motivation and Context

Make the Page better. Need to see all positions

## How Has This Been Tested?

locally.

## Screenshots (if appropriate):
<img width="1116" height="899" alt="image" src="https://github.com/user-attachments/assets/8745ddb2-6e24-4ca2-aa49-5be65ade8f33" />
