### PR TITLE
Update vault list row columns, charts, and styling

### DIFF
--- a/apps/vaults-v3/components/list/VaultsV3AuxiliaryList.tsx
+++ b/apps/vaults-v3/components/list/VaultsV3AuxiliaryList.tsx
@@ -26,7 +26,6 @@ type TVaultsV3AuxiliaryListProps = {
   onToggleCategory?: (category: string) => void
   onToggleType?: (type: string) => void
   showStrategies?: boolean
-  layoutVariant?: 'default' | 'balanced'
 }
 
 // TODO: the contents of this component override the type filers. This should only happen for HOLDINGS and not AVAILABLE TO DEPOSIT
@@ -41,8 +40,7 @@ export function VaultsV3AuxiliaryList({
   onToggleChain,
   onToggleCategory,
   onToggleType,
-  showStrategies,
-  layoutVariant
+  showStrategies
 }: TVaultsV3AuxiliaryListProps): ReactElement | null {
   if (vaults.length === 0) {
     return null
@@ -69,7 +67,6 @@ export function VaultsV3AuxiliaryList({
               onToggleCategory={onToggleCategory}
               onToggleType={onToggleType}
               showStrategies={showStrategies}
-              layoutVariant={layoutVariant}
             />
           )
         })}

--- a/apps/vaults-v3/components/list/VaultsV3ListHead.tsx
+++ b/apps/vaults-v3/components/list/VaultsV3ListHead.tsx
@@ -35,7 +35,6 @@ export type TListHead = {
   activeToggleValues?: Iterable<string>
   wrapperClassName?: string
   containerClassName?: string
-  layoutVariant?: 'default' | 'balanced'
 }
 
 function isToggleItem(item: TListHeadItem): item is TToggleListHeadItem {
@@ -50,14 +49,12 @@ export function VaultsV3ListHead({
   onToggle,
   activeToggleValues,
   wrapperClassName,
-  containerClassName,
-  layoutVariant = 'default'
+  containerClassName
 }: TListHead): ReactElement {
   const activeToggles = useMemo(() => new Set(activeToggleValues || []), [activeToggleValues])
-  const isBalancedLayout = layoutVariant === 'balanced'
-  const leftColumnSpan = isBalancedLayout ? 'col-span-12' : 'col-span-9'
-  const rightColumnSpan = isBalancedLayout ? 'col-span-12' : 'col-span-15'
-  const rightGridColumns = isBalancedLayout ? 'md:grid-cols-12' : 'md:grid-cols-15'
+  const leftColumnSpan = 'col-span-12'
+  const rightColumnSpan = 'col-span-12'
+  const rightGridColumns = 'md:grid-cols-12'
 
   const toggleSortDirection = (newSortBy: string): TSortDirection => {
     if (sortBy === newSortBy) {

--- a/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
+++ b/apps/vaults-v3/components/list/VaultsV3ListRow.tsx
@@ -42,8 +42,6 @@ type TVaultRowFlags = {
   isRetired?: boolean
 }
 
-type TVaultsV3ListRowLayout = 'default' | 'balanced'
-
 export function VaultsV3ListRow({
   currentVault,
   flags,
@@ -56,8 +54,7 @@ export function VaultsV3ListRow({
   onToggleChain,
   onToggleCategory,
   onToggleType,
-  showStrategies = false,
-  layoutVariant = 'default'
+  showStrategies = false
 }: {
   currentVault: TYDaemonVault
   flags?: TVaultRowFlags
@@ -71,7 +68,6 @@ export function VaultsV3ListRow({
   onToggleCategory?: (category: string) => void
   onToggleType?: (type: string) => void
   showStrategies?: boolean
-  layoutVariant?: TVaultsV3ListRowLayout
 }): ReactElement {
   const navigate = useNavigate()
   const href = hrefOverride ?? `/vaults/${currentVault.chainID}/${toAddress(currentVault.address)}`
@@ -80,11 +76,10 @@ export function VaultsV3ListRow({
   const [isExpanded, setIsExpanded] = useState(false)
   const [expandedView, setExpandedView] = useState<TVaultsV3ExpandedView>('apy')
   const [expandedTimeframe, setExpandedTimeframe] = useState<TVaultChartTimeframe>('all')
-  const isBalancedLayout = layoutVariant === 'balanced'
-  const leftColumnSpan = isBalancedLayout ? 'col-span-12' : 'col-span-9'
-  const rightColumnSpan = isBalancedLayout ? 'col-span-12' : 'col-span-15'
-  const rightGridColumns = isBalancedLayout ? 'md:grid-cols-12' : 'md:grid-cols-15'
-  const metricsColumnSpan = isBalancedLayout ? 'col-span-4' : 'col-span-5'
+  const leftColumnSpan = 'col-span-12'
+  const rightColumnSpan = 'col-span-12'
+  const rightGridColumns = 'md:grid-cols-12'
+  const metricsColumnSpan = 'col-span-4'
   const kindLabel =
     currentVault.kind === 'Multi Strategy'
       ? 'Allocator Vault'

--- a/pages/portfolio/index.tsx
+++ b/pages/portfolio/index.tsx
@@ -360,7 +360,6 @@ function PortfolioPage(): ReactElement {
                   setSortBy(newSortBy as TPossibleSortBy)
                   setSortDirection(newDirection)
                 }}
-                layoutVariant={'balanced'}
                 wrapperClassName={'rounded-t-3xl bg-surface-secondary'}
                 containerClassName={'rounded-t-3xl bg-surface-secondary'}
                 items={[
@@ -414,7 +413,6 @@ function PortfolioPage(): ReactElement {
                         flags={vaultFlags[key]}
                         hrefOverride={hrefOverride}
                         showBoostDetails={false}
-                        layoutVariant={'balanced'}
                       />
                     )
                   })}

--- a/pages/vaults/index.tsx
+++ b/pages/vaults/index.tsx
@@ -661,7 +661,6 @@ function ListOfVaults({
             vaults={section.vaults}
             vaultFlags={vaultFlags}
             apyDisplayVariant={apyDisplayVariant}
-            layoutVariant={'balanced'}
             activeChains={activeChains}
             activeCategories={activeCategories}
             activeTypes={activeTypes}
@@ -681,7 +680,6 @@ function ListOfVaults({
                   currentVault={vault}
                   flags={vaultFlags[key]}
                   apyDisplayVariant={apyDisplayVariant}
-                  layoutVariant={'balanced'}
                   activeChains={activeChains}
                   activeCategories={activeCategories}
                   activeTypes={activeTypes}
@@ -757,7 +755,6 @@ function ListOfVaults({
           <VaultsV3ListHead
             containerClassName={'rounded-t-xl bg-surface shrink-0'}
             wrapperClassName={'relative z-10 border border-border rounded-t-xl bg-transparent'}
-            layoutVariant={'balanced'}
             sortBy={sortBy}
             sortDirection={sortDirection}
             onSort={(newSortBy: string, newSortDirection: TSortDirection): void => {


### PR DESCRIPTION
## Description

##  Summary

  - Remove 30d APY + APY sparkline columns from vault lists and rebalance the grid.
  - Default expanded vault view to APY, rename it to “30-Day APY”, and add a TVL view between Performance and Vault Info.
  - “Go to Vault” uses the primary blue styling.

##  Issues

  - Closes #914
  - Closes #915
  - Closes #905

## Changes

  - Add a balanced layout variant to VaultsV3ListHead, VaultsV3ListRow, and VaultsV3AuxiliaryList, and apply it on /vaults and /portfolio.
  - Remove 30d APY + sparkline headers and cells from vault lists.
  - Expanded row: default to APY, relabel as “30-Day APY”, add TVL option and route to TVL chart.

## Manual QA

  - /vaults: confirm 30d APY + sparkline columns are gone; spacing feels balanced.
  - /portfolio: same column removals and spacing.
  - Expand a v3 vault row: default view is “30-Day APY”; TVL tab sits between Performance and Vault Info; “Go to Vault” is blue.

## Screenshots (if appropriate):
<img width="1220" height="501" alt="image" src="https://github.com/user-attachments/assets/d97f5796-5181-4234-94a0-14bed7193271" />
<img width="1210" height="436" alt="image" src="https://github.com/user-attachments/assets/0461ba0c-4a61-402e-8f2f-02ea547d8aa0" />
<img width="1237" height="810" alt="image" src="https://github.com/user-attachments/assets/18432f43-4441-4de3-80aa-12aaeb436bce" />
