### PR TITLE
YOLO: lazy expanded content

### DIFF
--- a/apps/vaults/components/list/VaultsListRow.tsx
+++ b/apps/vaults/components/list/VaultsListRow.tsx
@@ -1,15 +1,6 @@
-import {
-  AllocationChart,
-  DARK_MODE_COLORS,
-  LIGHT_MODE_COLORS,
-  type TAllocationChartData,
-  useDarkMode
-} from '@lib/components/AllocationChart'
 import { RenderAmount } from '@lib/components/RenderAmount'
 import { TokenLogo } from '@lib/components/TokenLogo'
 import { Tooltip } from '@lib/components/Tooltip'
-import { useYearn } from '@lib/contexts/useYearn'
-import { useYearnTokenPrice } from '@lib/hooks/useYearnTokenPrice'
 import { IconChevron } from '@lib/icons/IconChevron'
 import { IconCircle } from '@lib/icons/IconCircle'
 import { IconCirclePile } from '@lib/icons/IconCirclePile'
@@ -18,15 +9,10 @@ import { IconRewind } from '@lib/icons/IconRewind'
 import { IconStablecoin } from '@lib/icons/IconStablecoin'
 import { IconStack } from '@lib/icons/IconStack'
 import { IconVolatile } from '@lib/icons/IconVolatile'
-import { cl, formatCounterValue, toAddress, toNormalizedBN } from '@lib/utils'
-import type { TYDaemonVault, TYDaemonVaultStrategy } from '@lib/utils/schemas/yDaemonVaultsSchemas'
+import { cl, toAddress, toNormalizedBN } from '@lib/utils'
+import type { TYDaemonVault } from '@lib/utils/schemas/yDaemonVaultsSchemas'
 import { getNetwork } from '@lib/utils/wagmi'
-import { VaultAboutSection } from '@vaults/components/detail/VaultAboutSection'
-import {
-  type TVaultChartTab,
-  type TVaultChartTimeframe,
-  VaultChartsSection
-} from '@vaults/components/detail/VaultChartsSection'
+import type { TVaultChartTimeframe } from '@vaults/components/detail/VaultChartsSection'
 import {
   type TVaultForwardAPYVariant,
   VaultForwardAPY
@@ -35,10 +21,22 @@ import {
 import { VaultHoldingsAmount } from '@vaults/components/table/VaultHoldingsAmount'
 import { deriveListKind } from '@vaults/shared/utils/vaultListFacets'
 import type { ReactElement } from 'react'
-import { useEffect, useMemo, useState } from 'react'
+import { lazy, Suspense, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
-import { type TVaultsExpandedView, VaultsExpandedSelector } from './VaultsExpandedSelector'
+import type { TVaultsExpandedView } from './VaultsExpandedSelector'
 import { VaultsListChip } from './VaultsListChip'
+
+const VaultsListRowExpandedContent = lazy(() => import('./VaultsListRowExpandedContent'))
+
+const ExpandedRowFallback = (): ReactElement => (
+  <div className={'hidden md:block bg-surface'}>
+    <div className={'px-6 pb-6 pt-3'}>
+      <div className={'flex min-h-[240px] items-center justify-center'}>
+        <span className={'loader'} />
+      </div>
+    </div>
+  </div>
+)
 
 type TVaultRowFlags = {
   hasHoldings?: boolean
@@ -379,204 +377,17 @@ export function VaultsListRow({
       </div>
 
       {isExpanded ? (
-        <div className={'hidden md:block bg-surface'}>
-          <div className={'px-6 pb-6 pt-3'}>
-            <div className={' bg-surface'}>
-              <VaultsExpandedSelector
-                className={'p-3'}
-                activeView={expandedView}
-                onViewChange={setExpandedView}
-                timeframe={expandedTimeframe}
-                onTimeframeChange={setExpandedTimeframe}
-                rightElement={
-                  <button
-                    type={'button'}
-                    onClick={(event): void => {
-                      event.stopPropagation()
-                      navigate(href)
-                    }}
-                    className={
-                      'rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400'
-                    }
-                  >
-                    {'Go to Vault'}
-                  </button>
-                }
-              />
-
-              {expandedView === 'apy' || expandedView === 'performance' || expandedView === 'tvl' ? (
-                <div className={'px-3 pb-4'}>
-                  <VaultChartsSection
-                    chainId={currentVault.chainID}
-                    vaultAddress={currentVault.address}
-                    shouldRenderSelectors={false}
-                    chartTab={
-                      (expandedView === 'apy'
-                        ? 'historical-apy'
-                        : expandedView === 'performance'
-                          ? 'historical-pps'
-                          : 'historical-tvl') satisfies TVaultChartTab
-                    }
-                    timeframe={expandedTimeframe}
-                    chartHeightPx={200}
-                    chartHeightMdPx={200}
-                  />
-                </div>
-              ) : null}
-
-              {expandedView === 'info' ? (
-                <div className={'grid md:grid-cols-2 divide-y divide-border md:divide-y-0 md:divide-x'}>
-                  <div className={'p-4 md:p-6'}>
-                    <VaultStrategyAllocationPreview currentVault={currentVault} />
-                  </div>
-                  <div className={'p-4 md:p-6'}>
-                    <VaultAboutSection currentVault={currentVault} className={'p-0'} />
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          </div>
-        </div>
+        <Suspense fallback={<ExpandedRowFallback />}>
+          <VaultsListRowExpandedContent
+            currentVault={currentVault}
+            expandedView={expandedView}
+            expandedTimeframe={expandedTimeframe}
+            onExpandedViewChange={setExpandedView}
+            onExpandedTimeframeChange={setExpandedTimeframe}
+            onNavigateToVault={() => navigate(href)}
+          />
+        </Suspense>
       ) : null}
-    </div>
-  )
-}
-
-function VaultStrategyAllocationPreview({ currentVault }: { currentVault: TYDaemonVault }): ReactElement {
-  const { vaults } = useYearn()
-  const tokenPrice = useYearnTokenPrice({
-    address: currentVault.token.address,
-    chainID: currentVault.chainID
-  })
-  const isDark = useDarkMode()
-
-  const vaultList = useMemo(() => {
-    const list: (TYDaemonVault & {
-      details: TYDaemonVaultStrategy['details']
-      status: TYDaemonVaultStrategy['status']
-    })[] = []
-
-    for (const strategy of currentVault?.strategies || []) {
-      const linkedVault = vaults[strategy.address]
-      if (linkedVault?.address) {
-        list.push({
-          ...linkedVault,
-          details: strategy.details,
-          status: strategy.status
-        })
-      }
-    }
-
-    return list
-  }, [currentVault?.strategies, vaults])
-
-  const strategyList = useMemo(() => {
-    const list: TYDaemonVaultStrategy[] = []
-
-    for (const strategy of currentVault?.strategies || []) {
-      if (!vaults[strategy.address]) {
-        list.push(strategy)
-      }
-    }
-
-    return list
-  }, [currentVault?.strategies, vaults])
-
-  const mergedList = useMemo(
-    () =>
-      [...vaultList, ...strategyList] as (TYDaemonVault & {
-        details: TYDaemonVaultStrategy['details']
-        status: TYDaemonVaultStrategy['status']
-      })[],
-    [vaultList, strategyList]
-  )
-
-  const filteredVaultList = useMemo(
-    () => mergedList.filter((strategy) => strategy.status !== 'not_active'),
-    [mergedList]
-  )
-
-  const activeStrategyData = useMemo(
-    () =>
-      filteredVaultList
-        .filter((strategy) => {
-          const hasAllocation =
-            strategy.details?.totalDebt && strategy.details.totalDebt !== '0' && strategy.details?.debtRatio
-          return hasAllocation
-        })
-        .map(
-          (strategy): TAllocationChartData => ({
-            id: strategy.address,
-            name: strategy.name,
-            value: (strategy.details?.debtRatio || 0) / 100,
-            amount: formatCounterValue(
-              toNormalizedBN(strategy.details?.totalDebt || 0, currentVault.token.decimals).display,
-              tokenPrice
-            )
-          })
-        ),
-    [filteredVaultList, currentVault.token.decimals, tokenPrice]
-  )
-
-  const unallocatedPercentage =
-    100 * 100 - mergedList.reduce((acc, strategy) => acc + (strategy.details?.debtRatio || 0), 0)
-  const unallocatedValue =
-    Number(currentVault.tvl?.totalAssets || 0) -
-    mergedList.reduce((acc, strategy) => acc + Number(strategy.details?.totalDebt || 0), 0)
-
-  const unallocatedData = useMemo(() => {
-    if (unallocatedValue > 0 && unallocatedPercentage > 0) {
-      return {
-        id: 'unallocated',
-        name: 'Unallocated',
-        value: unallocatedPercentage / 100,
-        amount: formatCounterValue(toNormalizedBN(unallocatedValue, currentVault.token.decimals).display, tokenPrice)
-      }
-    }
-    return null
-  }, [currentVault.token.decimals, tokenPrice, unallocatedPercentage, unallocatedValue])
-
-  const allocationChartData = useMemo(
-    () => [...activeStrategyData, unallocatedData].filter(Boolean) as TAllocationChartData[],
-    [activeStrategyData, unallocatedData]
-  )
-
-  const legendColors = useMemo(() => (isDark ? DARK_MODE_COLORS : LIGHT_MODE_COLORS), [isDark])
-
-  if (allocationChartData.length === 0) {
-    return <div className={'text-sm text-text-secondary'}>{'No strategy allocation data available.'}</div>
-  }
-
-  return (
-    <div className={'flex flex-col gap-6'}>
-      <div className={'flex flex-col gap-6 lg:flex-row lg:items-center'}>
-        <AllocationChart allocationChartData={allocationChartData} />
-        <div className={'flex flex-col gap-3'}>
-          {activeStrategyData.map((item, index) => (
-            <div key={item.id} className={'flex flex-row items-center gap-3'}>
-              <div
-                className={'h-3 w-3 rounded-sm'}
-                style={{
-                  backgroundColor: legendColors[index % legendColors.length]
-                }}
-              />
-              <div className={'flex flex-col'}>
-                <span className={'text-sm text-text-primary'}>{item.name}</span>
-                <span className={'text-xs text-text-secondary'}>{item.amount}</span>
-              </div>
-            </div>
-          ))}
-          {unallocatedData ? (
-            <div className={'flex flex-row items-center gap-3'}>
-              <div className={'h-3 w-3 rounded-sm bg-surface-tertiary'} />
-              <div className={'flex flex-col'}>
-                <span className={'text-sm text-text-secondary'}>{'Unallocated'}</span>
-                <span className={'text-xs text-text-secondary'}>{unallocatedData.amount}</span>
-              </div>
-            </div>
-          ) : null}
-        </div>
-      </div>
     </div>
   )
 }

--- a/apps/vaults/components/list/VaultsListRowExpandedContent.tsx
+++ b/apps/vaults/components/list/VaultsListRowExpandedContent.tsx
@@ -1,0 +1,238 @@
+import {
+  AllocationChart,
+  DARK_MODE_COLORS,
+  LIGHT_MODE_COLORS,
+  type TAllocationChartData,
+  useDarkMode
+} from '@lib/components/AllocationChart'
+import { useYearn } from '@lib/contexts/useYearn'
+import { useYearnTokenPrice } from '@lib/hooks/useYearnTokenPrice'
+import { formatCounterValue, toNormalizedBN } from '@lib/utils'
+import type { TYDaemonVault, TYDaemonVaultStrategy } from '@lib/utils/schemas/yDaemonVaultsSchemas'
+import { VaultAboutSection } from '@vaults/components/detail/VaultAboutSection'
+import {
+  type TVaultChartTab,
+  type TVaultChartTimeframe,
+  VaultChartsSection
+} from '@vaults/components/detail/VaultChartsSection'
+import type { ReactElement } from 'react'
+import { useMemo } from 'react'
+import { type TVaultsExpandedView, VaultsExpandedSelector } from './VaultsExpandedSelector'
+
+type TVaultsListRowExpandedContentProps = {
+  currentVault: TYDaemonVault
+  expandedView: TVaultsExpandedView
+  expandedTimeframe: TVaultChartTimeframe
+  onExpandedViewChange: (nextView: TVaultsExpandedView) => void
+  onExpandedTimeframeChange: (nextTimeframe: TVaultChartTimeframe) => void
+  onNavigateToVault: () => void
+}
+
+export default function VaultsListRowExpandedContent({
+  currentVault,
+  expandedView,
+  expandedTimeframe,
+  onExpandedViewChange,
+  onExpandedTimeframeChange,
+  onNavigateToVault
+}: TVaultsListRowExpandedContentProps): ReactElement {
+  return (
+    <div className={'hidden md:block bg-surface'}>
+      <div className={'px-6 pb-6 pt-3'}>
+        <div className={' bg-surface'}>
+          <VaultsExpandedSelector
+            className={'p-3'}
+            activeView={expandedView}
+            onViewChange={onExpandedViewChange}
+            timeframe={expandedTimeframe}
+            onTimeframeChange={onExpandedTimeframeChange}
+            rightElement={
+              <button
+                type={'button'}
+                onClick={(event): void => {
+                  event.stopPropagation()
+                  onNavigateToVault()
+                }}
+                className={
+                  'rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400'
+                }
+              >
+                {'Go to Vault'}
+              </button>
+            }
+          />
+
+          {expandedView === 'apy' || expandedView === 'performance' || expandedView === 'tvl' ? (
+            <div className={'px-3 pb-4'}>
+              <VaultChartsSection
+                chainId={currentVault.chainID}
+                vaultAddress={currentVault.address}
+                shouldRenderSelectors={false}
+                chartTab={
+                  (expandedView === 'apy'
+                    ? 'historical-apy'
+                    : expandedView === 'performance'
+                      ? 'historical-pps'
+                      : 'historical-tvl') satisfies TVaultChartTab
+                }
+                timeframe={expandedTimeframe}
+                chartHeightPx={200}
+                chartHeightMdPx={200}
+              />
+            </div>
+          ) : null}
+
+          {expandedView === 'info' ? (
+            <div className={'grid md:grid-cols-2 divide-y divide-border md:divide-y-0 md:divide-x'}>
+              <div className={'p-4 md:p-6'}>
+                <VaultStrategyAllocationPreview currentVault={currentVault} />
+              </div>
+              <div className={'p-4 md:p-6'}>
+                <VaultAboutSection currentVault={currentVault} className={'p-0'} />
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function VaultStrategyAllocationPreview({ currentVault }: { currentVault: TYDaemonVault }): ReactElement {
+  const { vaults } = useYearn()
+  const tokenPrice = useYearnTokenPrice({
+    address: currentVault.token.address,
+    chainID: currentVault.chainID
+  })
+  const isDark = useDarkMode()
+
+  const vaultList = useMemo(() => {
+    const list: (TYDaemonVault & {
+      details: TYDaemonVaultStrategy['details']
+      status: TYDaemonVaultStrategy['status']
+    })[] = []
+
+    for (const strategy of currentVault?.strategies || []) {
+      const linkedVault = vaults[strategy.address]
+      if (linkedVault?.address) {
+        list.push({
+          ...linkedVault,
+          details: strategy.details,
+          status: strategy.status
+        })
+      }
+    }
+
+    return list
+  }, [currentVault?.strategies, vaults])
+
+  const strategyList = useMemo(() => {
+    const list: TYDaemonVaultStrategy[] = []
+
+    for (const strategy of currentVault?.strategies || []) {
+      if (!vaults[strategy.address]) {
+        list.push(strategy)
+      }
+    }
+
+    return list
+  }, [currentVault?.strategies, vaults])
+
+  const mergedList = useMemo(
+    () =>
+      [...vaultList, ...strategyList] as (TYDaemonVault & {
+        details: TYDaemonVaultStrategy['details']
+        status: TYDaemonVaultStrategy['status']
+      })[],
+    [vaultList, strategyList]
+  )
+
+  const filteredVaultList = useMemo(
+    () => mergedList.filter((strategy) => strategy.status !== 'not_active'),
+    [mergedList]
+  )
+
+  const activeStrategyData = useMemo(
+    () =>
+      filteredVaultList
+        .filter((strategy) => {
+          const hasAllocation =
+            strategy.details?.totalDebt && strategy.details.totalDebt !== '0' && strategy.details?.debtRatio
+          return hasAllocation
+        })
+        .map(
+          (strategy): TAllocationChartData => ({
+            id: strategy.address,
+            name: strategy.name,
+            value: (strategy.details?.debtRatio || 0) / 100,
+            amount: formatCounterValue(
+              toNormalizedBN(strategy.details?.totalDebt || 0, currentVault.token.decimals).display,
+              tokenPrice
+            )
+          })
+        ),
+    [filteredVaultList, currentVault.token.decimals, tokenPrice]
+  )
+
+  const unallocatedPercentage =
+    100 * 100 - mergedList.reduce((acc, strategy) => acc + (strategy.details?.debtRatio || 0), 0)
+  const unallocatedValue =
+    Number(currentVault.tvl?.totalAssets || 0) -
+    mergedList.reduce((acc, strategy) => acc + Number(strategy.details?.totalDebt || 0), 0)
+
+  const unallocatedData = useMemo(() => {
+    if (unallocatedValue > 0 && unallocatedPercentage > 0) {
+      return {
+        id: 'unallocated',
+        name: 'Unallocated',
+        value: unallocatedPercentage / 100,
+        amount: formatCounterValue(toNormalizedBN(unallocatedValue, currentVault.token.decimals).display, tokenPrice)
+      }
+    }
+    return null
+  }, [currentVault.token.decimals, tokenPrice, unallocatedPercentage, unallocatedValue])
+
+  const allocationChartData = useMemo(
+    () => [...activeStrategyData, unallocatedData].filter(Boolean) as TAllocationChartData[],
+    [activeStrategyData, unallocatedData]
+  )
+
+  const legendColors = useMemo(() => (isDark ? DARK_MODE_COLORS : LIGHT_MODE_COLORS), [isDark])
+
+  if (allocationChartData.length === 0) {
+    return <div className={'text-sm text-text-secondary'}>{'No strategy allocation data available.'}</div>
+  }
+
+  return (
+    <div className={'flex flex-col gap-6'}>
+      <div className={'flex flex-col gap-6 lg:flex-row lg:items-center'}>
+        <AllocationChart allocationChartData={allocationChartData} />
+        <div className={'flex flex-col gap-3'}>
+          {activeStrategyData.map((item, index) => (
+            <div key={item.id} className={'flex flex-row items-center gap-3'}>
+              <div
+                className={'h-3 w-3 rounded-sm'}
+                style={{
+                  backgroundColor: legendColors[index % legendColors.length]
+                }}
+              />
+              <div className={'flex flex-col'}>
+                <span className={'text-sm text-text-primary'}>{item.name}</span>
+                <span className={'text-xs text-text-secondary'}>{item.amount}</span>
+              </div>
+            </div>
+          ))}
+          {unallocatedData ? (
+            <div className={'flex flex-row items-center gap-3'}>
+              <div className={'h-3 w-3 rounded-sm bg-surface-tertiary'} />
+              <div className={'flex flex-col'}>
+                <span className={'text-sm text-text-secondary'}>{'Unallocated'}</span>
+                <span className={'text-xs text-text-secondary'}>{unallocatedData.amount}</span>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Lazy-load vault list expanded content to reduce initial list render cost.

## Changes
- `apps/vaults/components/list/VaultsListRow.tsx`: move expanded content into a lazy component.
- `apps/vaults/components/list/VaultsListRowExpandedContent.tsx`: new lazy-loaded component.

## Testing
- Expand a vault row and confirm charts/details render correctly.
- Collapse/expand repeatedly to ensure no errors.

## References 
Performance Improvements Report #934
- §4 P0.4: Lazy-load expanded row content to keep Recharts out of list chunks.
