### PR TITLE
feat: vercel best practises

### DIFF
--- a/apps/lib/components/AccountDropdown.tsx
+++ b/apps/lib/components/AccountDropdown.tsx
@@ -42,7 +42,7 @@ function AccountView({ onSettingsClick, onClose }: { onSettingsClick: () => void
   }, [address, ens, clusters])
 
   const recentActivity = useMemo(() => {
-    return cachedEntries.sort((a, b) => (b.timeFinished ?? 0) - (a.timeFinished ?? 0)).slice(0, 3)
+    return cachedEntries.toSorted((a, b) => (b.timeFinished ?? 0) - (a.timeFinished ?? 0)).slice(0, 3)
   }, [cachedEntries])
 
   const handleViewPortfolio = useCallback(() => {

--- a/apps/lib/hooks/useFilteredVaults.ts
+++ b/apps/lib/hooks/useFilteredVaults.ts
@@ -177,10 +177,9 @@ export function useVaultFilter(
     }
 
     if (categories?.includes('featured')) {
-      _vaultList.sort(
-        (a, b): number => (b.tvl.tvl || 0) * (b?.apr?.netAPR || 0) - (a.tvl.tvl || 0) * (a?.apr?.netAPR || 0)
-      )
-      _vaultList = _vaultList.slice(0, 10)
+      _vaultList = _vaultList
+        .toSorted((a, b): number => (b.tvl.tvl || 0) * (b?.apr?.netAPR || 0) - (a.tvl.tvl || 0) * (a?.apr?.netAPR || 0))
+        .slice(0, 10)
     }
     if (categories?.includes('curveF')) {
       _vaultList = [..._vaultList, ...curveFactoryVaults]

--- a/apps/vaults/components/detail/VaultChartsSection.tsx
+++ b/apps/vaults/components/detail/VaultChartsSection.tsx
@@ -2,14 +2,15 @@ import { cl } from '@lib/utils'
 import { useVaultChartTimeseries } from '@vaults/hooks/useVaultChartTimeseries'
 import { transformVaultChartData } from '@vaults/utils/charts'
 import type { ReactElement } from 'react'
-import { useMemo, useState } from 'react'
-import { APYChart } from './charts/APYChart'
+import { lazy, Suspense, useMemo, useState } from 'react'
 import { ChartErrorBoundary } from './charts/ChartErrorBoundary'
 import ChartSkeleton from './charts/ChartSkeleton'
 import ChartsLoader from './charts/ChartsLoader'
 import { FixedHeightChartContainer } from './charts/FixedHeightChartContainer'
-import { PPSChart } from './charts/PPSChart'
-import { TVLChart } from './charts/TVLChart'
+
+const APYChart = lazy(() => import('./charts/APYChart').then((m) => ({ default: m.APYChart })))
+const PPSChart = lazy(() => import('./charts/PPSChart').then((m) => ({ default: m.PPSChart })))
+const TVLChart = lazy(() => import('./charts/TVLChart').then((m) => ({ default: m.TVLChart })))
 
 type VaultChartsSectionProps = {
   chainId: number
@@ -131,15 +132,17 @@ export function VaultChartsSection({
       ) : (
         <FixedHeightChartContainer heightPx={chartHeightPx} heightMdPx={chartHeightMdPx}>
           <ChartErrorBoundary>
-            {activeTab === 'historical-pps' && transformed.ppsData ? (
-              <PPSChart chartData={transformed.ppsData} timeframe={activeTimeframe} />
-            ) : null}
-            {activeTab === 'historical-apy' && transformed.aprApyData ? (
-              <APYChart chartData={transformed.aprApyData} timeframe={activeTimeframe} />
-            ) : null}
-            {activeTab === 'historical-tvl' && transformed.tvlData ? (
-              <TVLChart chartData={transformed.tvlData} timeframe={activeTimeframe} />
-            ) : null}
+            <Suspense fallback={<ChartSkeleton />}>
+              {activeTab === 'historical-pps' && transformed.ppsData ? (
+                <PPSChart chartData={transformed.ppsData} timeframe={activeTimeframe} />
+              ) : null}
+              {activeTab === 'historical-apy' && transformed.aprApyData ? (
+                <APYChart chartData={transformed.aprApyData} timeframe={activeTimeframe} />
+              ) : null}
+              {activeTab === 'historical-tvl' && transformed.tvlData ? (
+                <TVLChart chartData={transformed.tvlData} timeframe={activeTimeframe} />
+              ) : null}
+            </Suspense>
           </ChartErrorBoundary>
         </FixedHeightChartContainer>
       )}

--- a/apps/vaults/components/detail/VaultStrategiesSection.tsx
+++ b/apps/vaults/components/detail/VaultStrategiesSection.tsx
@@ -1,5 +1,5 @@
 import type { TAllocationChartData } from '@lib/components/AllocationChart'
-import { AllocationChart, DARK_MODE_COLORS, LIGHT_MODE_COLORS, useDarkMode } from '@lib/components/AllocationChart'
+import { DARK_MODE_COLORS, LIGHT_MODE_COLORS, useDarkMode } from '@lib/components/AllocationChart'
 import { useYearn } from '@lib/contexts/useYearn'
 import { useYearnTokenPrice } from '@lib/hooks/useYearnTokenPrice'
 import type { TSortDirection } from '@lib/types'
@@ -10,9 +10,13 @@ import type { TPossibleSortBy } from '@vaults/shared/hooks/useSortVaults'
 import { useSortVaults } from '@vaults/shared/hooks/useSortVaults'
 import { useQueryArguments } from '@vaults/shared/hooks/useVaultsQueryArgs'
 import type { ReactElement } from 'react'
-import { useMemo } from 'react'
+import { lazy, Suspense, useMemo } from 'react'
 import { VaultsListHead } from './VaultsListHead'
 import { VaultsListStrategy } from './VaultsListStrategy'
+
+const AllocationChart = lazy(() =>
+  import('@lib/components/AllocationChart').then((m) => ({ default: m.AllocationChart }))
+)
 
 export function VaultStrategiesSection({ currentVault }: { currentVault: TYDaemonVault }): ReactElement {
   const { vaults } = useYearn()
@@ -126,7 +130,9 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TYDaemo
             {allocationChartData.length > 0 ? (
               <div className={'flex flex-col gap-4'}>
                 <div className={'flex flex-row items-center gap-8'}>
-                  <AllocationChart allocationChartData={allocationChartData} />
+                  <Suspense fallback={<div className={'h-32 w-32 animate-pulse rounded-full bg-surface-secondary'} />}>
+                    <AllocationChart allocationChartData={allocationChartData} />
+                  </Suspense>
                   <div className={'flex flex-col gap-2'}>
                     {activeStrategyData.map((item, index) => {
                       const colors = isDark ? DARK_MODE_COLORS : LIGHT_MODE_COLORS

--- a/apps/vaults/components/notifications/Notification.tsx
+++ b/apps/vaults/components/notifications/Notification.tsx
@@ -13,6 +13,11 @@ import type { ReactElement } from 'react'
 import { memo, useCallback, useMemo, useState } from 'react'
 import Link from '/src/components/Link'
 
+const NETWORK_BY_CHAIN_ID = new Map(SUPPORTED_NETWORKS.map((network) => [network.id, network] as const)) as ReadonlyMap<
+  number,
+  (typeof SUPPORTED_NETWORKS)[number]
+>
+
 const STATUS: { [key: string]: [string, string, ReactElement] } = {
   success: ['Success', 'text-white bg-[#00796D]', <IconCheck className={'size-4'} key={'success'} />],
   submitted: ['Submitted', 'text-white bg-[#2563EB]', <IconCheck className={'size-4'} key={'submitted'} />],
@@ -48,14 +53,14 @@ function NotificationContent({
   fromVault?: TYDaemonVault
   toVault?: TYDaemonVault
 }): ReactElement {
-  const fromChainName = SUPPORTED_NETWORKS.find((network) => network.id === notification.chainId)?.name || 'Unknown'
+  const fromChainName = NETWORK_BY_CHAIN_ID.get(notification.chainId)?.name || 'Unknown'
   const toChainName = notification.toChainId
-    ? SUPPORTED_NETWORKS.find((network) => network.id === notification.toChainId)?.name || 'Unknown'
+    ? NETWORK_BY_CHAIN_ID.get(notification.toChainId)?.name || 'Unknown'
     : undefined
   const isCrossChain = !!notification.toChainId && notification.toChainId !== notification.chainId
 
   const explorerBaseURI = useMemo(() => {
-    const chain = SUPPORTED_NETWORKS.find((network) => network.id === notification.chainId)
+    const chain = NETWORK_BY_CHAIN_ID.get(notification.chainId)
     return chain?.blockExplorers?.default?.url || 'https://etherscan.io'
   }, [notification.chainId])
 
@@ -248,7 +253,7 @@ export const Notification = memo(function Notification({
       return null
     }
 
-    const chain = SUPPORTED_NETWORKS.find((network) => network.id === notification.chainId)
+    const chain = NETWORK_BY_CHAIN_ID.get(notification.chainId)
     const explorerBaseURI = chain?.blockExplorers?.default?.url || 'https://etherscan.io'
     return `${explorerBaseURI}/tx/${notification.txHash}`
   }, [notification.chainId, notification.txHash])

--- a/apps/vaults/components/widget/TokenSelector.tsx
+++ b/apps/vaults/components/widget/TokenSelector.tsx
@@ -152,7 +152,7 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
     }
 
     // Sort by balance (highest first)
-    return filtered.sort((a, b) => {
+    return filtered.toSorted((a, b) => {
       const aBalance = a.balance?.raw || 0n
       const bBalance = b.balance?.raw || 0n
       return bBalance > aBalance ? 1 : -1

--- a/apps/vaults/shared/components/VaultsFilters.tsx
+++ b/apps/vaults/shared/components/VaultsFilters.tsx
@@ -173,7 +173,7 @@ export function VaultsFilters({
   }, [chainDisplayOrder])
 
   const chainModalOptions = useMemo(() => {
-    return [...chainOptions].sort((a, b) => {
+    return [...chainOptions].toSorted((a, b) => {
       const rankA = chainOrderMap.get(Number(a.value)) ?? Number.MAX_SAFE_INTEGER
       const rankB = chainOrderMap.get(Number(b.value)) ?? Number.MAX_SAFE_INTEGER
       if (rankA === rankB) {

--- a/apps/vaults/utils/charts.ts
+++ b/apps/vaults/utils/charts.ts
@@ -178,7 +178,7 @@ function normalizeSeries(series?: TChartTimeseriesResponse[keyof TChartTimeserie
       }
     })
     .filter((point): point is TTimeseriesPoint => Boolean(point))
-    .sort((a, b) => a.time - b.time)
+    .toSorted((a, b) => a.time - b.time)
 }
 
 function findTimestampBounds(series: TTimeseriesPoint[][]): { earliest: number; latest: number } | null {

--- a/pages/vaults/index.tsx
+++ b/pages/vaults/index.tsx
@@ -279,7 +279,7 @@ function ListOfVaults({
         if (!value || value.length === 0) {
           return []
         }
-        return [...new Set(value)].sort((left, right) => String(left).localeCompare(String(right)))
+        return [...new Set(value)].toSorted((left, right) => String(left).localeCompare(String(right)))
       }
       const normalizedA = normalize(a)
       const normalizedB = normalize(b)


### PR DESCRIPTION
  - Lazy load charts: now dynamically imported, reducing initial bundle size                                                                                                               
  - Immutable sorting: Replaced .sort() calls with .toSorted() to prevent array mutation bugs                                                                                                                                          
  - O(1) lookups: Created NETWORK_BY_CHAIN_ID Map to replace repeated .find() calls    