### PR TITLE
add chip tooltips and improve vault info section

### DIFF
--- a/apps/lib/components/MultiSelectDropdown.tsx
+++ b/apps/lib/components/MultiSelectDropdown.tsx
@@ -59,10 +59,7 @@ function Option(option: TMultiSelectOptionProps): ReactElement {
               {option.icon}
             </div>
           ) : null}
-          <p className={`${option.icon ? 'pl-2' : 'pl-0'} font-normal text-neutral-900`}>
-            {option.label}{' '}
-            <span className={'pl-1 text-xs text-neutral-900 transition-opacity hover:opacity-100'}>{'(only)'}</span>
-          </p>
+          <p className={`${option.icon ? 'pl-2' : 'pl-0'} font-normal text-neutral-900`}>{option.label}</p>
         </div>
         <input
           type={'checkbox'}
@@ -227,8 +224,8 @@ export function MultiSelectDropdown({
           <ComboboxButton
             onClick={(): void => setIsOpen(!isOpen)}
             className={cl(
-              props.buttonClassName,
-              'flex h-10 w-full items-center justify-between bg-neutral-0 p-2 text-base text-neutral-900 md:px-3'
+              'flex h-10 w-full items-center justify-between bg-neutral-0 p-2 text-base text-neutral-900 md:px-3',
+              props.buttonClassName
             )}
           >
             {customMultipleRender && options.filter((o) => o.isSelected).length > 1 && !areAllSelected ? (
@@ -265,8 +262,8 @@ export function MultiSelectDropdown({
         >
           <ComboboxOptions
             className={cl(
-              props.comboboxOptionsClassName,
-              'absolute top-12 z-50 flex w-full min-w-[256px] cursor-pointer flex-col overflow-y-auto bg-neutral-0 px-2 py-3 scrollbar-none origin-top will-change-[opacity,transform] transform-gpu'
+              'absolute top-12 z-50 flex w-full min-w-[256px] cursor-pointer flex-col overflow-y-auto bg-neutral-0 px-2 py-3 scrollbar-none origin-top will-change-[opacity,transform] transform-gpu',
+              props.comboboxOptionsClassName
             )}
           >
             <SelectAllOption

--- a/apps/lib/components/Tooltip.tsx
+++ b/apps/lib/components/Tooltip.tsx
@@ -12,7 +12,8 @@ export const Tooltip: FC<{
   tooltip: string | ReactElement
   openDelayMs?: number
   toggleOnClick?: boolean
-}> = ({ children, tooltip, className, openDelayMs = 0, toggleOnClick = false }) => {
+  align?: 'center' | 'start'
+}> = ({ children, tooltip, className, openDelayMs = 0, toggleOnClick = false, align = 'center' }) => {
   const [isTooltipVisible, setIsTooltipVisible] = useState(false)
   const [tooltipPosition, setTooltipPosition] = useState({ x: 0, y: 0 })
   const triggerRef = useRef<HTMLDivElement>(null)
@@ -77,13 +78,14 @@ export const Tooltip: FC<{
   const showTooltip = useCallback((): void => {
     if (triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect()
+      const x = align === 'start' ? rect.left : rect.left + rect.width / 2
       setTooltipPosition({
-        x: rect.left + rect.width / 2,
+        x,
         y: rect.bottom
       })
       setIsTooltipVisible(true)
     }
-  }, [])
+  }, [align])
 
   const scheduleOpen = useCallback((): void => {
     cancelScheduledClose()
@@ -188,7 +190,7 @@ export const Tooltip: FC<{
               left: tooltipPosition.x,
               top: tooltipPosition.y,
               paddingTop: 8,
-              transform: 'translateX(-50%)',
+              transform: align === 'start' ? 'translateX(0)' : 'translateX(-50%)',
               zIndex: 9999,
               pointerEvents: 'auto'
             }}

--- a/apps/lib/icons/IconPercent.tsx
+++ b/apps/lib/icons/IconPercent.tsx
@@ -1,0 +1,12 @@
+import type React from 'react'
+import type { ReactElement } from 'react'
+
+export function IconPercent(props: React.SVGProps<SVGSVGElement>): ReactElement {
+  return (
+    <svg width={24} height={24} viewBox={'0 0 24 24'} fill={'none'} xmlns={'http://www.w3.org/2000/svg'} {...props}>
+      <line x1={19} y1={5} x2={5} y2={19} stroke={'currentColor'} strokeWidth={2} strokeLinecap={'round'} />
+      <circle cx={6.5} cy={6.5} r={2.5} stroke={'currentColor'} strokeWidth={2} />
+      <circle cx={17.5} cy={17.5} r={2.5} stroke={'currentColor'} strokeWidth={2} />
+    </svg>
+  )
+}

--- a/apps/lib/icons/IconScissors.tsx
+++ b/apps/lib/icons/IconScissors.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement } from 'react'
+
+export function IconScissors(props: React.SVGProps<SVGSVGElement>): ReactElement {
+  return (
+    <svg {...props} width={'24'} height={'24'} viewBox={'0 0 24 24'} fill={'none'} xmlns={'http://www.w3.org/2000/svg'}>
+      <circle cx={'6'} cy={'6'} r={'3'} stroke={'currentColor'} strokeWidth={'2'} />
+      <path
+        d={'M8.12 8.12 12 12'}
+        stroke={'currentColor'}
+        strokeWidth={'2'}
+        strokeLinecap={'round'}
+        strokeLinejoin={'round'}
+      />
+      <path
+        d={'M20 4 8.12 15.88'}
+        stroke={'currentColor'}
+        strokeWidth={'2'}
+        strokeLinecap={'round'}
+        strokeLinejoin={'round'}
+      />
+      <circle cx={'6'} cy={'18'} r={'3'} stroke={'currentColor'} strokeWidth={'2'} />
+      <path
+        d={'M14.8 14.8 20 20'}
+        stroke={'currentColor'}
+        strokeWidth={'2'}
+        strokeLinecap={'round'}
+        strokeLinejoin={'round'}
+      />
+    </svg>
+  )
+}

--- a/apps/vaults/components/SuggestedVaultCard.tsx
+++ b/apps/vaults/components/SuggestedVaultCard.tsx
@@ -1,11 +1,17 @@
 import Link from '@components/Link'
 import { RenderAmount } from '@lib/components/RenderAmount'
 import { TokenLogo } from '@lib/components/TokenLogo'
+import { IconRewind } from '@lib/icons/IconRewind'
+import { IconStablecoin } from '@lib/icons/IconStablecoin'
+import { IconVolatile } from '@lib/icons/IconVolatile'
 import { toAddress } from '@lib/utils'
 import { formatPercent } from '@lib/utils/format'
 import type { TYDaemonVault } from '@lib/utils/schemas/yDaemonVaultsSchemas'
 import { getNetwork } from '@lib/utils/wagmi'
+import { VaultsListChip } from '@vaults/components/list/VaultsListChip'
 import { useVaultApyData } from '@vaults/hooks/useVaultApyData'
+import { deriveListKind } from '@vaults/utils/vaultListFacets'
+import { getCategoryDescription, getChainDescription, getProductTypeDescription } from '@vaults/utils/vaultTagCopy'
 import type { ReactElement } from 'react'
 import { useMemo } from 'react'
 
@@ -33,13 +39,28 @@ export function SuggestedVaultCard({ vault }: { vault: TYDaemonVault }): ReactEl
       return { type: 'value', label: '30D APY', value: apyData.netApr }
     }
     if (apyData.mode === 'katana' && apyData.katanaTotalApr !== undefined) {
-      return { type: 'value', label: 'Est. APY', prefix: '⚔️', value: apyData.katanaTotalApr }
+      return {
+        type: 'value',
+        label: 'Est. APY',
+        prefix: '',
+        value: apyData.katanaTotalApr
+      }
     }
     if (apyData.mode === 'rewards') {
       if (isVeYfi && apyData.estAprRange) {
-        return { type: 'range', label: 'Est. APY', prefix: '⚡️', range: apyData.estAprRange }
+        return {
+          type: 'range',
+          label: 'Est. APY',
+          prefix: '⚡️',
+          range: apyData.estAprRange
+        }
       }
-      return { type: 'value', label: 'Est. APY', prefix: '⚡️', value: boostedApr }
+      return {
+        type: 'value',
+        label: 'Est. APY',
+        prefix: '⚡️',
+        value: boostedApr
+      }
     }
     if (apyData.mode === 'boosted' && apyData.isBoosted) {
       return {
@@ -56,6 +77,27 @@ export function SuggestedVaultCard({ vault }: { vault: TYDaemonVault }): ReactEl
   const tokenIcon = `${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${vault.chainID}/${toAddress(
     vault.token.address
   ).toLowerCase()}/logo-128.png`
+  const chainLogoSrc = `${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/chains/${vault.chainID}/logo-32.png`
+  const listKind = deriveListKind(vault)
+  const isAllocatorVault = listKind === 'allocator' || listKind === 'strategy'
+  const isLegacyVault = listKind === 'legacy'
+  const productTypeLabel = isAllocatorVault ? 'Single Asset Vault' : isLegacyVault ? 'Legacy' : 'LP Token Vault'
+  const productTypeIcon = isAllocatorVault ? (
+    <span className={'text-sm leading-none'}>{'⚙️'}</span>
+  ) : isLegacyVault ? (
+    <IconRewind className={'size-3.5'} />
+  ) : (
+    <span className={'text-sm leading-none'}>{'🏭'}</span>
+  )
+  const categoryIcon: ReactElement | null =
+    vault.category === 'Stablecoin' ? (
+      <IconStablecoin className={'size-3.5'} />
+    ) : vault.category === 'Volatile' ? (
+      <IconVolatile className={'size-3.5'} />
+    ) : null
+  const chainDescription = getChainDescription(vault.chainID)
+  const categoryDescription = getCategoryDescription(vault.category)
+  const productTypeDescription = getProductTypeDescription(listKind)
 
   const renderAprValue = (): string => {
     if (aprDisplay.type === 'range') {
@@ -68,7 +110,7 @@ export function SuggestedVaultCard({ vault }: { vault: TYDaemonVault }): ReactEl
     <Link
       to={`/vaults/${vault.chainID}/${toAddress(vault.address)}`}
       className={
-        'group flex h-full flex-col rounded-md border border-border bg-surface p-4 shadow-[0_12px_32px_rgba(4,8,32,0.05)] transition-all hover:-translate-y-0.5 hover:shadow-[0_18px_36px_rgba(4,8,32,0.12)]'
+        'group flex h-full flex-col rounded-md border border-border bg-surface px-4 pt-3 pb-2 shadow-[0_12px_32px_rgba(4,8,32,0.05)] transition-all hover:-translate-y-0.5 hover:shadow-[0_18px_36px_rgba(4,8,32,0.12)]'
       }
     >
       <div className={'flex items-center gap-3'}>
@@ -77,12 +119,30 @@ export function SuggestedVaultCard({ vault }: { vault: TYDaemonVault }): ReactEl
         </div>
         <div className={'flex min-w-0 flex-col'}>
           <p className={'truncate text-base font-semibold text-text-primary'}>{vault.name}</p>
-          <p className={'text-xs text-text-secondary'}>
-            {chain.name} • {vault.category}
-          </p>
         </div>
       </div>
-      <div className={'mt-4 flex items-end justify-between gap-4'}>
+      <div className={'mt-0 flex flex-wrap items-center gap-1'}>
+        <VaultsListChip
+          label={chain.name}
+          icon={<TokenLogo src={chainLogoSrc} tokenSymbol={chain.name} width={14} height={14} />}
+          tooltipDescription={chainDescription}
+        />
+        {vault.category ? (
+          <VaultsListChip
+            label={vault.category}
+            icon={categoryIcon || undefined}
+            tooltipDescription={categoryDescription || undefined}
+          />
+        ) : null}
+        <VaultsListChip
+          label={productTypeLabel}
+          icon={productTypeIcon}
+          tooltipDescription={productTypeDescription}
+          isCollapsed
+          showCollapsedTooltip
+        />
+      </div>
+      <div className={'mt-1 flex items-end justify-between gap-4'}>
         <div>
           <p className={'text-xs font-semibold uppercase tracking-wide text-text-secondary'}>{aprDisplay.label}</p>
           <p className={'mt-1 text-2xl font-bold text-text-primary'}>
@@ -97,7 +157,11 @@ export function SuggestedVaultCard({ vault }: { vault: TYDaemonVault }): ReactEl
               value={vault.tvl?.tvl || 0}
               symbol={'USD'}
               decimals={0}
-              options={{ shouldCompactValue: true, maximumFractionDigits: 2, minimumFractionDigits: 0 }}
+              options={{
+                shouldCompactValue: true,
+                maximumFractionDigits: 2,
+                minimumFractionDigits: 0
+              }}
             />
           </p>
         </div>

--- a/apps/vaults/components/detail/VaultAboutSection.tsx
+++ b/apps/vaults/components/detail/VaultAboutSection.tsx
@@ -1,50 +1,133 @@
-import { cl, formatAmount, formatPercent } from '@lib/utils'
+import { TokenLogo } from '@lib/components/TokenLogo'
+import { IconChevron } from '@lib/icons/IconChevron'
+import { IconLinkOut } from '@lib/icons/IconLinkOut'
+import { IconRewind } from '@lib/icons/IconRewind'
+import { IconScissors } from '@lib/icons/IconScissors'
+import { IconStablecoin } from '@lib/icons/IconStablecoin'
+import { IconVolatile } from '@lib/icons/IconVolatile'
+import { cl, formatPercent } from '@lib/utils'
 import { parseMarkdown } from '@lib/utils/helpers'
 import type { TYDaemonVault } from '@lib/utils/schemas/yDaemonVaultsSchemas'
-import type { ReactElement } from 'react'
+import { getNetwork } from '@lib/utils/wagmi/utils'
+import { deriveListKind } from '@vaults/utils/vaultListFacets'
+import {
+  getCategoryDescription,
+  getChainDescription,
+  getChainWebsite,
+  getKindDescription,
+  getProductTypeDescription
+} from '@vaults/utils/vaultTagCopy'
+import { type ReactElement, type ReactNode, useState } from 'react'
 
-type TVaultFeesLineItem = {
-  children: ReactElement
+type TInlineHeading = {
   label: string
-  tooltip?: string
+  value: ReactNode
+  icon?: ReactNode
+  suffix?: ReactNode
 }
 
-export function VaultFeesLineItem({ children, label, tooltip }: TVaultFeesLineItem): ReactElement {
+function InlineHeading({ label, value, icon, suffix }: TInlineHeading): ReactElement {
   return (
-    <div className={'flex flex-col space-y-0 md:space-y-0'}>
-      <p className={'text-xxs text-text-secondary md:text-xs'}>{label}</p>
-      <div
-        className={cl(
-          tooltip
-            ? 'tooltip underline decoration-neutral-600/30 decoration-dotted underline-offset-4 transition-opacity hover:decoration-neutral-600'
-            : ''
-        )}
-      >
-        {tooltip ? (
-          <span suppressHydrationWarning className={'tooltipFees bottom-full'}>
-            <div
-              className={
-                'w-96 rounded-xl border border-border bg-surface-secondary p-4 text-center text-xxs text-text-primary'
-              }
-            >
-              {tooltip}
-            </div>
-          </span>
-        ) : null}
-        {children}
-      </div>
+    <div className={'flex flex-wrap items-center gap-2 text-sm'}>
+      <span className={'sr-only'}>{`${label}:`}</span>
+      <span className={'flex items-center gap-1 font-normal text-text-primary'}>
+        {icon ? <span className={'flex size-4 items-center justify-center'}>{icon}</span> : null}
+        <span>{value}</span>
+        {suffix ? <span className={'flex size-3 items-center justify-center'}>{suffix}</span> : null}
+      </span>
     </div>
+  )
+}
+
+type TExpandableInfoItem = {
+  label: string
+  value: ReactNode
+  children: ReactNode
+  className?: string
+  icon?: ReactNode
+}
+
+function ExpandableInfoItem({ label, value, children, className, icon }: TExpandableInfoItem): ReactElement {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <details
+      className={cl('py-1', className)}
+      onToggle={(event): void => {
+        setIsOpen(event.currentTarget.open)
+      }}
+    >
+      <summary className={'cursor-pointer list-none [&::-webkit-details-marker]:hidden'}>
+        <InlineHeading
+          label={label}
+          value={value}
+          icon={icon}
+          suffix={
+            <IconChevron
+              className={'text-text-secondary transition-transform duration-200'}
+              size={12}
+              direction={isOpen ? 'up' : 'down'}
+            />
+          }
+        />
+      </summary>
+      <div className={'mt-1 pl-5 text-sm text-text-secondary'}>{children}</div>
+    </details>
   )
 }
 
 export function VaultAboutSection({
   currentVault,
-  className
+  className,
+  showKindTag = true
 }: {
   currentVault: TYDaemonVault
   className?: string
+  showKindTag?: boolean
+  showHiddenTag?: boolean
+  isHidden?: boolean
 }): ReactElement {
   const { token, apr } = currentVault
+  const chainName = getNetwork(currentVault.chainID).name
+  const chainLogoSrc = `${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/chains/${currentVault.chainID}/logo-32.png`
+  const listKind = deriveListKind(currentVault)
+  const isAllocatorVault = listKind === 'allocator' || listKind === 'strategy'
+  const isLegacyVault = listKind === 'legacy'
+  const productTypeLabel = isAllocatorVault ? 'Single Asset Vault' : isLegacyVault ? 'Legacy' : 'LP Token Vault'
+  const baseKindType: 'multi' | 'single' | undefined =
+    currentVault.kind === 'Multi Strategy' ? 'multi' : currentVault.kind === 'Single Strategy' ? 'single' : undefined
+  const fallbackKindType: 'multi' | 'single' | undefined =
+    listKind === 'allocator' ? 'multi' : listKind === 'strategy' ? 'single' : undefined
+  const kindType = baseKindType ?? fallbackKindType
+  const kindLabel: string | undefined =
+    kindType === 'multi' ? 'Allocator' : kindType === 'single' ? 'Strategy' : currentVault.kind
+  const shouldShowKind = showKindTag && Boolean(kindLabel)
+  const vaultTypeLabel = [productTypeLabel, shouldShowKind ? kindLabel : null].filter(Boolean).join(' | ')
+  const chainDescription = getChainDescription(currentVault.chainID)
+  const chainWebsite = getChainWebsite(currentVault.chainID) ?? ''
+  const hasChainWebsite = Boolean(chainWebsite)
+  const assetTypeLabel = currentVault.category ?? 'Not specified'
+  const assetTypeDescription = getCategoryDescription(currentVault.category) ?? 'No asset category provided.'
+  const productTypeDescription = getProductTypeDescription(listKind)
+  const vaultKindDescription = shouldShowKind ? getKindDescription(kindType, kindLabel) : null
+  const managementFee = formatPercent((apr.fees.management || 0) * 100, 0, 2)
+  const performanceFee = formatPercent((apr.fees.performance || 0) * 100, 0, 2)
+  const feesSummary = `${managementFee} Management | ${performanceFee} Performance`
+  const categoryIcon =
+    currentVault.category === 'Stablecoin' ? (
+      <IconStablecoin className={'size-4 text-text-secondary'} />
+    ) : currentVault.category === 'Volatile' ? (
+      <IconVolatile className={'size-4 text-text-secondary'} />
+    ) : null
+  const productTypeIcon = isAllocatorVault ? (
+    <span className={'text-sm leading-none'}>{'⚙️'}</span>
+  ) : isLegacyVault ? (
+    <IconRewind className={'size-4 text-text-secondary'} />
+  ) : (
+    <span className={'text-sm leading-none'}>{'🏭'}</span>
+  )
+  const chainIcon = <TokenLogo src={chainLogoSrc} tokenSymbol={chainName} width={16} height={16} />
+  const feesIcon = <IconScissors className={'size-4 text-text-secondary'} />
 
   function getVaultDescription(): string | ReactElement {
     if (currentVault.description) {
@@ -88,42 +171,67 @@ export function VaultAboutSection({
     )
   }
 
+  const vaultDescription = getVaultDescription()
+  const isDescriptionString = typeof vaultDescription === 'string'
+
   return (
-    <div className={cl('space-y-4 p-8 pt-0', className)}>
-      <div className={'w-full'}>
-        <div className={'text-sm text-text-secondary'}>
-          {typeof getVaultDescription() === 'string' ? (
-            <p
+    <div className={cl('p-8 pt-0', className)}>
+      <div className={'flex flex-col gap-4'}>
+        <div className={'px-4 text-sm text-text-secondary'}>
+          {isDescriptionString ? (
+            <div
               // biome-ignore lint/security/noDangerouslySetInnerHtml: Controlled description content
               dangerouslySetInnerHTML={{
-                __html: getVaultDescription() as string
+                __html: vaultDescription as string
               }}
             />
           ) : (
-            <p>{getVaultDescription()}</p>
+            <div>{vaultDescription}</div>
           )}
         </div>
-      </div>
 
-      <div className={'w-full'}>
-        <b className={'text-semibold text-text-primary'}>{'Fees'}</b>
-        <div className={'mt-2 grid grid-cols-4 gap-8'}>
-          <VaultFeesLineItem label={'Management'}>
-            <p className={'text-xl text-text-primary'}>{formatPercent((apr.fees.management || 0) * 100, 0)}</p>
-          </VaultFeesLineItem>
-          <VaultFeesLineItem label={'Performance'}>
-            <p className={'text-xl text-text-primary'}>{formatPercent((apr.fees.performance || 0) * 100, 0)}</p>
-          </VaultFeesLineItem>
-          {(currentVault.apr.forwardAPR.composite?.keepVELO || 0) > 0 ? (
-            <VaultFeesLineItem
-              label={'keepVELO'}
-              tooltip={`Percentage of VELO locked in each harvest. This is used to boost ${currentVault.category} vault pools, and is offset via yvOP staking rewards.`}
-            >
-              <b className={'text-xl text-text-secondary'}>
-                {`${formatAmount((currentVault.apr.forwardAPR.composite?.keepVELO || 0) * 100, 0, 2)} %`}
-              </b>
-            </VaultFeesLineItem>
-          ) : null}
+        <div className={'flex flex-col gap-1.5 px-4'}>
+          <ExpandableInfoItem label={'Chain'} value={chainName} icon={chainIcon}>
+            <p>
+              {chainDescription}
+              {hasChainWebsite ? (
+                <>
+                  {' Learn more about '} {chainName} {' at '}
+                  <a
+                    href={chainWebsite}
+                    target={'_blank'}
+                    rel={'noopener noreferrer'}
+                    className={'inline-flex items-center gap-1 text-text-primary underline'}
+                  >
+                    {chainWebsite}
+                    <IconLinkOut className={'inline-block size-3'} />
+                  </a>
+                </>
+              ) : null}
+            </p>
+          </ExpandableInfoItem>
+
+          <ExpandableInfoItem label={'Asset Type'} value={assetTypeLabel} icon={categoryIcon}>
+            <p>{assetTypeDescription}</p>
+          </ExpandableInfoItem>
+
+          <ExpandableInfoItem label={'Vault Type'} value={vaultTypeLabel || productTypeLabel} icon={productTypeIcon}>
+            <div className={'space-y-1'}>
+              <p>{productTypeDescription}</p>
+              {vaultKindDescription ? <p>{vaultKindDescription}</p> : null}
+            </div>
+          </ExpandableInfoItem>
+
+          <ExpandableInfoItem label={'Fees'} value={feesSummary} icon={feesIcon}>
+            <div className={'space-y-3'}>
+              <p>
+                {
+                  'Management fees are claimed from earned yield, pro-rated and up to the stated percentage of principal.'
+                }
+              </p>
+              <p>{'Performance fees are claimed from earned yield, up to the stated percentage of yield earned.'}</p>
+            </div>
+          </ExpandableInfoItem>
         </div>
       </div>
     </div>

--- a/apps/vaults/components/detail/VaultDetailsHeader.tsx
+++ b/apps/vaults/components/detail/VaultDetailsHeader.tsx
@@ -22,6 +22,14 @@ import { VaultHistoricalAPY } from '@vaults/components/table/VaultHistoricalAPY'
 import { useHeaderCompression } from '@vaults/hooks/useHeaderCompression'
 import { useVaultUserData } from '@vaults/hooks/useVaultUserData'
 import { deriveListKind } from '@vaults/utils/vaultListFacets'
+import {
+  getCategoryDescription,
+  getChainDescription,
+  getKindDescription,
+  getProductTypeDescription,
+  MIGRATABLE_TAG_DESCRIPTION,
+  RETIRED_TAG_DESCRIPTION
+} from '@vaults/utils/vaultTagCopy'
 import type { ReactElement } from 'react'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router'
@@ -381,6 +389,10 @@ export function VaultDetailsHeader({
     ) : kindType === 'single' ? (
       <IconStack className={'size-3.5'} />
     ) : null
+  const chainDescription = getChainDescription(currentVault.chainID)
+  const categoryDescription = getCategoryDescription(currentVault.category)
+  const productTypeDescription = getProductTypeDescription(listKind)
+  const kindDescription = getKindDescription(kindType, kindLabel)
   const isMigratable = Boolean(currentVault.migration?.available)
   const isRetired = Boolean(currentVault.info?.isRetired)
   const migratableIcon = <IconMigratable className={'size-3.5'} />
@@ -503,6 +515,7 @@ export function VaultDetailsHeader({
                 icon={<TokenLogo src={chainLogoSrc} tokenSymbol={chainName} width={14} height={14} priority />}
                 isCollapsed={isCompressed}
                 showCollapsedTooltip={isCompressed}
+                tooltipDescription={chainDescription}
               />
             ) : null}
             {showCategoryChip ? (
@@ -511,6 +524,7 @@ export function VaultDetailsHeader({
                 icon={categoryIcon}
                 isCollapsed={isCompressed}
                 showCollapsedTooltip={isCompressed}
+                tooltipDescription={categoryDescription || undefined}
               />
             ) : null}
             <VaultsListChip
@@ -518,6 +532,7 @@ export function VaultDetailsHeader({
               icon={productTypeIcon}
               isCollapsed={isCompressed}
               showCollapsedTooltip={isCompressed}
+              tooltipDescription={productTypeDescription}
             />
             {showKindChip ? (
               <VaultsListChip
@@ -525,6 +540,7 @@ export function VaultDetailsHeader({
                 icon={kindIcon}
                 isCollapsed={isCompressed}
                 showCollapsedTooltip={isCompressed}
+                tooltipDescription={kindDescription}
               />
             ) : null}
             {isRetired ? (
@@ -533,6 +549,7 @@ export function VaultDetailsHeader({
                 icon={retiredIcon}
                 isCollapsed={isCompressed}
                 showCollapsedTooltip={isCompressed}
+                tooltipDescription={RETIRED_TAG_DESCRIPTION}
               />
             ) : null}
             {isMigratable ? (
@@ -541,6 +558,7 @@ export function VaultDetailsHeader({
                 icon={migratableIcon}
                 isCollapsed={isCompressed}
                 showCollapsedTooltip={isCompressed}
+                tooltipDescription={MIGRATABLE_TAG_DESCRIPTION}
               />
             ) : null}
             {isCompressed && explorerHref ? (

--- a/apps/vaults/components/detail/charts/APYChart.tsx
+++ b/apps/vaults/components/detail/charts/APYChart.tsx
@@ -12,6 +12,12 @@ import { useId, useMemo } from 'react'
 import { Area, CartesianGrid, ComposedChart, Line, LineChart, XAxis, YAxis } from 'recharts'
 import type { ChartConfig } from './ChartPrimitives'
 import { ChartContainer, ChartTooltip } from './ChartPrimitives'
+import {
+  CHART_WITH_AXES_MARGIN,
+  CHART_Y_AXIS_TICK_MARGIN,
+  CHART_Y_AXIS_TICK_STYLE,
+  CHART_Y_AXIS_WIDTH
+} from './chartLayout'
 
 type SeriesKey = 'derivedApy' | 'sevenDayApy' | 'thirtyDayApy'
 
@@ -55,7 +61,7 @@ export function APYChart({ chartData, timeframe, hideTooltip }: APYChartProps) {
   }, [chartData, timeframe])
   const isShortTimeframe = timeframe === '30d' || timeframe === '90d'
   const ticks = useMemo(
-    () => (isShortTimeframe ? getChartWeeklyTicks(filteredData, true) : getChartMonthlyTicks(filteredData, true)),
+    () => (isShortTimeframe ? getChartWeeklyTicks(filteredData) : getChartMonthlyTicks(filteredData)),
     [filteredData, isShortTimeframe]
   )
   const tickFormatter = isShortTimeframe ? formatChartWeekLabel : formatChartMonthYearLabel
@@ -76,15 +82,7 @@ export function APYChart({ chartData, timeframe, hideTooltip }: APYChartProps) {
     return (
       <div className={'relative h-full'}>
         <ChartContainer config={chartConfig} style={{ height: 'inherit' }}>
-          <LineChart
-            data={filteredData}
-            margin={{
-              top: 20,
-              right: 30,
-              left: 10,
-              bottom: 20
-            }}
-          >
+          <LineChart data={filteredData} margin={CHART_WITH_AXES_MARGIN}>
             <CartesianGrid vertical={false} />
             <XAxis
               dataKey={'date'}
@@ -97,7 +95,10 @@ export function APYChart({ chartData, timeframe, hideTooltip }: APYChartProps) {
             <YAxis
               domain={[0, 'auto']}
               tickFormatter={formatPercentTick}
-              tick={{ fill: 'var(--chart-axis)' }}
+              mirror
+              width={CHART_Y_AXIS_WIDTH}
+              tickMargin={CHART_Y_AXIS_TICK_MARGIN}
+              tick={CHART_Y_AXIS_TICK_STYLE}
               axisLine={{ stroke: 'var(--chart-axis)' }}
               tickLine={{ stroke: 'var(--chart-axis)' }}
             />
@@ -149,15 +150,7 @@ export function APYChart({ chartData, timeframe, hideTooltip }: APYChartProps) {
     return (
       <div className={'relative h-full'}>
         <ChartContainer config={chartConfig} style={{ height: 'inherit' }}>
-          <ComposedChart
-            data={filteredData}
-            margin={{
-              top: 20,
-              right: 30,
-              left: 10,
-              bottom: 20
-            }}
-          >
+          <ComposedChart data={filteredData} margin={CHART_WITH_AXES_MARGIN}>
             <CartesianGrid vertical={false} />
             <defs>
               <linearGradient id={`${gradientId}-apy`} x1="0" x2="0" y1="0" y2="1">
@@ -176,7 +169,10 @@ export function APYChart({ chartData, timeframe, hideTooltip }: APYChartProps) {
             <YAxis
               domain={[0, 'auto']}
               tickFormatter={formatPercentTick}
-              tick={{ fill: 'var(--chart-axis)' }}
+              mirror
+              width={CHART_Y_AXIS_WIDTH}
+              tickMargin={CHART_Y_AXIS_TICK_MARGIN}
+              tick={CHART_Y_AXIS_TICK_STYLE}
               axisLine={{ stroke: 'var(--chart-axis)' }}
               tickLine={{ stroke: 'var(--chart-axis)' }}
             />

--- a/apps/vaults/components/detail/charts/PPSChart.tsx
+++ b/apps/vaults/components/detail/charts/PPSChart.tsx
@@ -12,6 +12,12 @@ import { useId, useMemo } from 'react'
 import { Area, CartesianGrid, ComposedChart, Line, LineChart, XAxis, YAxis } from 'recharts'
 import type { ChartConfig } from './ChartPrimitives'
 import { ChartContainer, ChartTooltip } from './ChartPrimitives'
+import {
+  CHART_WITH_AXES_MARGIN,
+  CHART_Y_AXIS_TICK_MARGIN,
+  CHART_Y_AXIS_TICK_STYLE,
+  CHART_Y_AXIS_WIDTH
+} from './chartLayout'
 
 type PercentSeriesKey = 'derivedApr'
 
@@ -33,6 +39,30 @@ const shouldOmitZeroTick = (value: number | string) => Number(value) === 0
 const formatPercentTick = (value: number | string) => (shouldOmitZeroTick(value) ? '' : `${value}%`)
 const formatPpsTick = (value: number | string) => (shouldOmitZeroTick(value) ? '' : Number(value).toFixed(3))
 
+type YAxisTickProps = {
+  x?: number
+  y?: number
+  payload?: { value?: number | string }
+  index?: number
+}
+
+const renderPpsTick = ({ x = 0, y = 0, payload, index }: YAxisTickProps) => {
+  const formattedValue = index === 0 ? '' : formatPpsTick(payload?.value ?? '')
+
+  return (
+    <text
+      x={x}
+      y={y}
+      dx={CHART_Y_AXIS_TICK_STYLE.dx}
+      dy={4}
+      fill={CHART_Y_AXIS_TICK_STYLE.fill}
+      textAnchor={CHART_Y_AXIS_TICK_STYLE.textAnchor}
+    >
+      {formattedValue}
+    </text>
+  )
+}
+
 export function PPSChart({ chartData, timeframe, hideTooltip, dataKey = 'PPS' }: PPSChartProps) {
   const gradientId = useId().replace(/:/g, '')
   const { chartStyle } = useChartStyle()
@@ -47,12 +77,13 @@ export function PPSChart({ chartData, timeframe, hideTooltip, dataKey = 'PPS' }:
   }, [chartData, timeframe])
   const isShortTimeframe = timeframe === '30d' || timeframe === '90d'
   const ticks = useMemo(
-    () => (isShortTimeframe ? getChartWeeklyTicks(filteredData, true) : getChartMonthlyTicks(filteredData, true)),
+    () => (isShortTimeframe ? getChartWeeklyTicks(filteredData) : getChartMonthlyTicks(filteredData)),
     [filteredData, isShortTimeframe]
   )
   const tickFormatter = isShortTimeframe ? formatChartWeekLabel : formatChartMonthYearLabel
 
   const isPercentSeries = dataKey !== 'PPS'
+  const shouldHideFirstPpsTick = dataKey === 'PPS'
   const seriesColor = isPercentSeries ? `var(--color-${dataKey})` : 'var(--color-pps)'
   const chartConfig = useMemo<ChartConfig>(() => {
     const config: ChartConfig = {}
@@ -74,15 +105,7 @@ export function PPSChart({ chartData, timeframe, hideTooltip, dataKey = 'PPS' }:
   if (isPowerglove) {
     return (
       <ChartContainer config={chartConfig} style={{ height: 'inherit' }}>
-        <LineChart
-          data={filteredData}
-          margin={{
-            top: 20,
-            right: 30,
-            left: 10,
-            bottom: 20
-          }}
-        >
+        <LineChart data={filteredData} margin={CHART_WITH_AXES_MARGIN}>
           <CartesianGrid vertical={false} />
           <XAxis
             dataKey={'date'}
@@ -94,8 +117,11 @@ export function PPSChart({ chartData, timeframe, hideTooltip, dataKey = 'PPS' }:
           />
           <YAxis
             domain={isPercentSeries ? [0, 'auto'] : ['auto', 'auto']}
-            tickFormatter={(value) => (isPercentSeries ? formatPercentTick(value) : formatPpsTick(value))}
-            tick={{ fill: 'var(--chart-axis)' }}
+            tickFormatter={isPercentSeries ? formatPercentTick : undefined}
+            mirror
+            width={CHART_Y_AXIS_WIDTH}
+            tickMargin={CHART_Y_AXIS_TICK_MARGIN}
+            tick={shouldHideFirstPpsTick ? renderPpsTick : CHART_Y_AXIS_TICK_STYLE}
             axisLine={{ stroke: 'var(--chart-axis)' }}
             tickLine={{ stroke: 'var(--chart-axis)' }}
           />
@@ -131,15 +157,7 @@ export function PPSChart({ chartData, timeframe, hideTooltip, dataKey = 'PPS' }:
   if (isBlended) {
     return (
       <ChartContainer config={chartConfig} style={{ height: 'inherit' }}>
-        <ComposedChart
-          data={filteredData}
-          margin={{
-            top: 20,
-            right: 30,
-            left: 10,
-            bottom: 20
-          }}
-        >
+        <ComposedChart data={filteredData} margin={CHART_WITH_AXES_MARGIN}>
           <CartesianGrid vertical={false} />
           <defs>
             <linearGradient id={`${gradientId}-pps`} x1="0" x2="0" y1="0" y2="1">
@@ -157,8 +175,11 @@ export function PPSChart({ chartData, timeframe, hideTooltip, dataKey = 'PPS' }:
           />
           <YAxis
             domain={isPercentSeries ? [0, 'auto'] : ['auto', 'auto']}
-            tickFormatter={(value) => (isPercentSeries ? formatPercentTick(value) : formatPpsTick(value))}
-            tick={{ fill: 'var(--chart-axis)' }}
+            tickFormatter={isPercentSeries ? formatPercentTick : undefined}
+            mirror
+            width={CHART_Y_AXIS_WIDTH}
+            tickMargin={CHART_Y_AXIS_TICK_MARGIN}
+            tick={shouldHideFirstPpsTick ? renderPpsTick : CHART_Y_AXIS_TICK_STYLE}
             axisLine={{ stroke: 'var(--chart-axis)' }}
             tickLine={{ stroke: 'var(--chart-axis)' }}
           />

--- a/apps/vaults/components/detail/charts/TVLChart.tsx
+++ b/apps/vaults/components/detail/charts/TVLChart.tsx
@@ -12,6 +12,12 @@ import { useId, useMemo } from 'react'
 import { Area, Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from 'recharts'
 import type { ChartConfig } from './ChartPrimitives'
 import { ChartContainer, ChartTooltip } from './ChartPrimitives'
+import {
+  CHART_WITH_AXES_MARGIN,
+  CHART_Y_AXIS_TICK_MARGIN,
+  CHART_Y_AXIS_TICK_STYLE,
+  CHART_Y_AXIS_WIDTH
+} from './chartLayout'
 
 type TVLChartProps = {
   chartData: TTvlChartData
@@ -41,7 +47,7 @@ export function TVLChart({ chartData, timeframe, hideTooltip }: TVLChartProps) {
   }, [chartData, timeframe])
   const isShortTimeframe = timeframe === '30d' || timeframe === '90d'
   const ticks = useMemo(
-    () => (isShortTimeframe ? getChartWeeklyTicks(filteredData, true) : getChartMonthlyTicks(filteredData, true)),
+    () => (isShortTimeframe ? getChartWeeklyTicks(filteredData) : getChartMonthlyTicks(filteredData)),
     [filteredData, isShortTimeframe]
   )
   const tickFormatter = isShortTimeframe ? formatChartWeekLabel : formatChartMonthYearLabel
@@ -58,15 +64,7 @@ export function TVLChart({ chartData, timeframe, hideTooltip }: TVLChartProps) {
   if (isPowerglove) {
     return (
       <ChartContainer config={chartConfig} style={{ height: 'inherit' }}>
-        <ComposedChart
-          data={filteredData}
-          margin={{
-            top: 20,
-            right: 30,
-            left: 10,
-            bottom: 20
-          }}
-        >
+        <ComposedChart data={filteredData} margin={CHART_WITH_AXES_MARGIN}>
           <CartesianGrid vertical={false} />
           <XAxis
             dataKey={'date'}
@@ -79,7 +77,10 @@ export function TVLChart({ chartData, timeframe, hideTooltip }: TVLChartProps) {
           <YAxis
             domain={[0, 'auto']}
             tickFormatter={formatTvlTick}
-            tick={{ fill: 'var(--chart-axis)' }}
+            mirror
+            width={CHART_Y_AXIS_WIDTH}
+            tickMargin={CHART_Y_AXIS_TICK_MARGIN}
+            tick={CHART_Y_AXIS_TICK_STYLE}
             axisLine={{ stroke: 'var(--chart-axis)' }}
             tickLine={{ stroke: 'var(--chart-axis)' }}
           />
@@ -116,15 +117,7 @@ export function TVLChart({ chartData, timeframe, hideTooltip }: TVLChartProps) {
   if (isBlended) {
     return (
       <ChartContainer config={chartConfig} style={{ height: 'inherit' }}>
-        <ComposedChart
-          data={filteredData}
-          margin={{
-            top: 20,
-            right: 30,
-            left: 10,
-            bottom: 20
-          }}
-        >
+        <ComposedChart data={filteredData} margin={CHART_WITH_AXES_MARGIN}>
           <CartesianGrid vertical={false} />
           <defs>
             <linearGradient id={`${gradientId}-tvl`} x1="0" x2="0" y1="0" y2="1">
@@ -143,7 +136,10 @@ export function TVLChart({ chartData, timeframe, hideTooltip }: TVLChartProps) {
           <YAxis
             domain={[0, 'auto']}
             tickFormatter={formatTvlTick}
-            tick={{ fill: 'var(--chart-axis)' }}
+            mirror
+            width={CHART_Y_AXIS_WIDTH}
+            tickMargin={CHART_Y_AXIS_TICK_MARGIN}
+            tick={CHART_Y_AXIS_TICK_STYLE}
             axisLine={{ stroke: 'var(--chart-axis)' }}
             tickLine={{ stroke: 'var(--chart-axis)' }}
           />

--- a/apps/vaults/components/detail/charts/chartLayout.ts
+++ b/apps/vaults/components/detail/charts/chartLayout.ts
@@ -1,0 +1,15 @@
+export const CHART_RIGHT_GUTTER = 0
+export const CHART_WITH_AXES_MARGIN = {
+  top: 20,
+  right: CHART_RIGHT_GUTTER,
+  left: 0,
+  bottom: 20
+}
+
+export const CHART_Y_AXIS_TICK_MARGIN = 0
+export const CHART_Y_AXIS_WIDTH = 12
+export const CHART_Y_AXIS_TICK_STYLE = {
+  fill: 'var(--chart-axis)',
+  textAnchor: 'start' as const,
+  dx: 6
+}

--- a/apps/vaults/components/filters/VaultVersionToggle.tsx
+++ b/apps/vaults/components/filters/VaultVersionToggle.tsx
@@ -1,6 +1,8 @@
+import { Tooltip } from '@lib/components/Tooltip'
 import { cl } from '@lib/utils'
+import { TOOLTIP_DELAY_MS } from '@vaults/utils/vaultTagCopy'
 import type { TVaultType } from '@vaults/utils/vaultTypeCopy'
-import { getVaultTypeEmoji, getVaultTypeLabel } from '@vaults/utils/vaultTypeCopy'
+import { getVaultTypeDescription, getVaultTypeEmoji, getVaultTypeLabel } from '@vaults/utils/vaultTypeCopy'
 import {
   getSupportedChainsForVaultType,
   normalizeVaultTypeParam,
@@ -75,7 +77,8 @@ export function VaultVersionToggle({
     >
       {BUTTON_CONFIGS.map((config) => {
         const active = isActive(config.type)
-        return (
+        const description = getVaultTypeDescription(config.type)
+        const button = (
           <button
             key={config.type}
             type={'button'}
@@ -97,6 +100,33 @@ export function VaultVersionToggle({
             </span>
             <span className={'whitespace-nowrap'}>{getVaultTypeLabel(config.type)}</span>
           </button>
+        )
+
+        if (!description) {
+          return button
+        }
+
+        return (
+          <Tooltip
+            key={config.type}
+            className={cl('h-full', stretch ? 'flex-1 w-full' : '')}
+            openDelayMs={TOOLTIP_DELAY_MS}
+            tooltip={
+              <div
+                className={
+                  'max-w-[220px] rounded-lg border border-border bg-surface-secondary px-3 py-2 text-xs text-text-primary shadow-md'
+                }
+              >
+                <div className={'flex items-center gap-1 font-semibold'}>
+                  <span aria-hidden={true}>{getVaultTypeEmoji(config.type)}</span>
+                  <span>{getVaultTypeLabel(config.type)}</span>
+                </div>
+                <p className={'text-text-secondary'}>{description}</p>
+              </div>
+            }
+          >
+            {button}
+          </Tooltip>
         )
       })}
     </div>

--- a/apps/vaults/components/filters/VaultsAssetFilter.tsx
+++ b/apps/vaults/components/filters/VaultsAssetFilter.tsx
@@ -1,0 +1,189 @@
+import type { TMultiSelectOptionProps } from '@lib/components/MultiSelectDropdown'
+import { IconChevron } from '@lib/icons/IconChevron'
+import { IconCross } from '@lib/icons/IconCross'
+import { IconSearch } from '@lib/icons/IconSearch'
+import { cl } from '@lib/utils'
+import type { ReactElement } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+
+type TVaultsAssetFilterProps = {
+  options: TMultiSelectOptionProps[]
+  onSelect: (options: TMultiSelectOptionProps[]) => void
+  buttonLabel?: string
+}
+
+export function VaultsAssetFilter({
+  options,
+  onSelect,
+  buttonLabel = 'Filter by assets'
+}: TVaultsAssetFilterProps): ReactElement {
+  const [isOpen, setIsOpen] = useState(false)
+  const [query, setQuery] = useState('')
+
+  const selectedOptions = useMemo(() => options.filter((option) => option.isSelected), [options])
+  const selectedCount = selectedOptions.length
+  const buttonTitle = selectedCount > 0 ? `${buttonLabel} (${selectedCount})` : buttonLabel
+
+  const filteredOptions = useMemo((): TMultiSelectOptionProps[] => {
+    if (query.trim() === '') {
+      return options
+    }
+    const loweredQuery = query.toLowerCase()
+    return options.filter((option) => option.label.toLowerCase().includes(loweredQuery))
+  }, [options, query])
+
+  const handleClose = useCallback((): void => {
+    setIsOpen(false)
+    setQuery('')
+  }, [])
+
+  const handleSelectSingle = useCallback(
+    (option: TMultiSelectOptionProps): void => {
+      const nextState = options.map((current) =>
+        current.value === option.value ? { ...current, isSelected: true } : { ...current, isSelected: false }
+      )
+      onSelect(nextState)
+    },
+    [onSelect, options]
+  )
+
+  const handleToggleOption = useCallback(
+    (option: TMultiSelectOptionProps): void => {
+      const nextState = options.map((current) =>
+        current.value === option.value ? { ...current, isSelected: !current.isSelected } : current
+      )
+      onSelect(nextState)
+    },
+    [onSelect, options]
+  )
+
+  const handleClear = useCallback((): void => {
+    const nextState = options.map((option) => ({ ...option, isSelected: false }))
+    onSelect(nextState)
+  }, [onSelect, options])
+
+  const hasSelection = selectedOptions.length > 0
+
+  return (
+    <div className={'w-full'}>
+      <button
+        type={'button'}
+        onClick={(): void => setIsOpen(true)}
+        className={
+          'flex w-full items-center justify-between gap-3 rounded-lg border border-border bg-surface px-3 py-2 text-left'
+        }
+      >
+        <p className={'truncate text-sm font-medium text-text-primary'}>{buttonTitle}</p>
+        <IconChevron
+          aria-hidden={'true'}
+          className={`size-4 text-text-secondary transition-transform ${isOpen ? '-rotate-180' : 'rotate-0'}`}
+        />
+      </button>
+
+      {isOpen ? (
+        <div
+          className={'absolute inset-0 z-30 flex flex-col rounded-2xl border border-border bg-surface p-4 shadow-lg'}
+        >
+          <div className={'flex items-center justify-between gap-3'}>
+            <div>
+              <p className={'text-base font-semibold text-text-primary'}>{'Filter by assets'}</p>
+              <p className={'text-xs text-text-secondary'}>{'Pick one or more assets to include.'}</p>
+            </div>
+            <div className={'flex items-center gap-2'}>
+              <button
+                type={'button'}
+                onClick={handleClear}
+                disabled={!hasSelection}
+                className={cl(
+                  'rounded-full border border-border px-3 py-1 text-xs font-medium text-text-primary transition-colors',
+                  hasSelection ? 'hover:border-border-hover' : 'cursor-not-allowed opacity-50'
+                )}
+              >
+                {'Clear'}
+              </button>
+              <button
+                type={'button'}
+                onClick={handleClose}
+                className={
+                  'inline-flex size-8 items-center justify-center rounded-full border border-transparent text-text-secondary hover:border-border hover:text-text-primary'
+                }
+                aria-label={'Close asset filter'}
+              >
+                <IconCross className={'size-4'} />
+              </button>
+            </div>
+          </div>
+
+          <div className={'mt-4'}>
+            <div className={'flex items-center gap-2 rounded-lg border border-border bg-surface px-3 py-2'}>
+              <IconSearch className={'size-4 text-text-secondary'} />
+              <input
+                type={'search'}
+                value={query}
+                onChange={(event): void => setQuery(event.target.value)}
+                placeholder={'Search assets'}
+                className={'w-full bg-transparent text-sm text-text-primary outline-hidden'}
+                aria-label={'Search assets'}
+              />
+              {query ? (
+                <button
+                  type={'button'}
+                  onClick={(): void => setQuery('')}
+                  className={'text-xs text-text-secondary hover:text-text-primary'}
+                >
+                  {'Clear'}
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className={'mt-4 flex min-h-0 flex-1 flex-col gap-2 overflow-hidden'}>
+            <div className={'flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto pr-1'}>
+              {filteredOptions.length === 0 ? (
+                <div className={'rounded-lg border border-dashed border-border px-3 py-6 text-center'}>
+                  <p className={'text-sm text-text-secondary'}>{'No assets found.'}</p>
+                </div>
+              ) : null}
+              {filteredOptions.map((option) => (
+                <div
+                  key={option.value}
+                  className={cl(
+                    'flex items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors',
+                    option.isSelected
+                      ? 'border-border bg-surface-tertiary/80'
+                      : 'border-border hover:bg-surface-tertiary/40'
+                  )}
+                >
+                  <button
+                    type={'button'}
+                    className={'flex min-w-0 flex-1 items-center gap-2 text-left'}
+                    onClick={(): void => handleSelectSingle(option)}
+                  >
+                    {option.icon ? (
+                      <div
+                        className={cl(
+                          'size-8 overflow-hidden rounded-full',
+                          option.label === 'Sonic' ? 'bg-white' : ''
+                        )}
+                      >
+                        {option.icon}
+                      </div>
+                    ) : null}
+                    <span className={'truncate text-sm font-medium text-text-primary'}>{option.label}</span>
+                  </button>
+                  <input
+                    type={'checkbox'}
+                    className={'checkbox accent-blue-500'}
+                    checked={option.isSelected}
+                    onChange={(): void => handleToggleOption(option)}
+                    readOnly
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/vaults/components/filters/VaultsChainSelector.tsx
+++ b/apps/vaults/components/filters/VaultsChainSelector.tsx
@@ -1,13 +1,16 @@
+import { Tooltip } from '@lib/components/Tooltip'
 import { IconChevron } from '@lib/icons/IconChevron'
 import { LogoYearn } from '@lib/icons/LogoYearn'
 import { cl } from '@lib/utils'
-import type { ReactElement } from 'react'
+import { TOOLTIP_DELAY_MS } from '@vaults/utils/vaultTagCopy'
+import type { ReactElement, RefObject } from 'react'
 
 type TVaultsChainButton = {
   id: number
   label: string
   icon?: ReactElement
   isSelected: boolean
+  description?: string
 }
 
 type TVaultsChainSelectorProps = {
@@ -15,10 +18,13 @@ type TVaultsChainSelectorProps = {
   areAllChainsSelected: boolean
   allChainsLabel: string
   showMoreChainsButton?: boolean
+  isMinimal?: boolean
+  enableResponsiveLayout?: boolean
   isStacked?: boolean
   onSelectAllChains: () => void
   onSelectChain: (chainId: number) => void
   onOpenChainModal: () => void
+  selectorRef?: RefObject<HTMLDivElement | null>
 }
 
 export function VaultsChainSelector({
@@ -26,16 +32,23 @@ export function VaultsChainSelector({
   areAllChainsSelected,
   allChainsLabel,
   showMoreChainsButton = true,
+  isMinimal = true,
+  enableResponsiveLayout = false,
   isStacked = false,
   onSelectAllChains,
   onSelectChain,
-  onOpenChainModal
+  onOpenChainModal,
+  selectorRef
 }: TVaultsChainSelectorProps): ReactElement {
+  const shouldStretchChainButtons = !enableResponsiveLayout && !isStacked
+  const tooltipWrapperClass = cl('h-full', shouldStretchChainButtons ? 'flex-1 w-full' : '')
+
   return (
     <div
+      ref={selectorRef}
       className={cl(
         'flex h-10 items-stretch overflow-x-auto scrollbar-themed rounded-xl border border-border bg-surface-secondary text-sm text-text-primary divide-x divide-border',
-        isStacked ? 'min-w-0 shrink-0' : 'min-w-0'
+        isStacked ? 'min-w-0 shrink-0' : enableResponsiveLayout ? 'min-w-0' : 'w-full'
       )}
     >
       <button
@@ -43,7 +56,8 @@ export function VaultsChainSelector({
         className={cl(
           'flex h-full items-center justify-center gap-1 px-2 font-medium transition-colors',
           'data-[active=false]:text-text-secondary data-[active=false]:hover:bg-surface/30 data-[active=false]:hover:text-text-primary',
-          'data-[active=true]:bg-surface data-[active=true]:text-text-primary'
+          'data-[active=true]:bg-surface data-[active=true]:text-text-primary',
+          !enableResponsiveLayout && !isStacked ? 'flex-1' : ''
         )}
         data-active={areAllChainsSelected}
         onClick={onSelectAllChains}
@@ -54,26 +68,60 @@ export function VaultsChainSelector({
         </span>
         <span className={'whitespace-nowrap'}>{allChainsLabel}</span>
       </button>
-      {chainButtons.map((chain) => (
-        <button
-          key={chain.id}
-          type={'button'}
-          className={cl(
-            'flex h-full items-center justify-center gap-1 px-2 font-medium transition-colors',
-            'data-[active=false]:text-text-secondary data-[active=false]:hover:bg-surface/30 data-[active=false]:hover:text-text-primary',
-            'data-[active=true]:bg-surface data-[active=true]:text-text-primary'
-          )}
-          data-active={chain.isSelected}
-          onClick={(): void => onSelectChain(chain.id)}
-          aria-pressed={chain.isSelected}
-          aria-label={chain.label}
-        >
-          {chain.icon ? (
-            <span className={'size-5 overflow-hidden rounded-full bg-surface/80'}>{chain.icon}</span>
-          ) : null}
-          <span className={cl('whitespace-nowrap', chain.isSelected ? '' : 'hidden')}>{chain.label}</span>
-        </button>
-      ))}
+      {chainButtons.map((chain) => {
+        const showChainLabel = !isMinimal || chain.isSelected
+        const button = (
+          <button
+            key={chain.id}
+            type={'button'}
+            className={cl(
+              'flex h-full items-center justify-center gap-1 px-2 font-medium transition-colors',
+              'data-[active=false]:text-text-secondary data-[active=false]:hover:bg-surface/30 data-[active=false]:hover:text-text-primary',
+              'data-[active=true]:bg-surface data-[active=true]:text-text-primary',
+              !enableResponsiveLayout && !isStacked ? 'flex-1' : ''
+            )}
+            data-active={chain.isSelected}
+            onClick={(): void => onSelectChain(chain.id)}
+            aria-pressed={chain.isSelected}
+            aria-label={showChainLabel ? undefined : chain.label}
+          >
+            {chain.icon ? (
+              <span className={'size-5 overflow-hidden rounded-full bg-surface/80'}>{chain.icon}</span>
+            ) : null}
+            {showChainLabel ? <span className={'whitespace-nowrap'}>{chain.label}</span> : null}
+          </button>
+        )
+
+        if (!chain.description) {
+          return button
+        }
+
+        return (
+          <Tooltip
+            key={chain.id}
+            className={tooltipWrapperClass}
+            openDelayMs={TOOLTIP_DELAY_MS}
+            align={'start'}
+            tooltip={
+              <div
+                className={
+                  'max-w-[220px] rounded-lg border border-border bg-surface-secondary px-3 py-2 text-xs text-text-primary shadow-md'
+                }
+              >
+                <div className={'flex items-center gap-1 font-semibold'}>
+                  {chain.icon ? (
+                    <span className={'size-4 overflow-hidden rounded-full bg-surface/80'}>{chain.icon}</span>
+                  ) : null}
+                  <span>{chain.label}</span>
+                </div>
+                <p className={'text-text-secondary'}>{chain.description}</p>
+              </div>
+            }
+          >
+            {button}
+          </Tooltip>
+        )
+      })}
 
       {showMoreChainsButton ? (
         <button

--- a/apps/vaults/components/filters/VaultsFiltersBar.tsx
+++ b/apps/vaults/components/filters/VaultsFiltersBar.tsx
@@ -5,6 +5,7 @@ import { useChainOptions } from '@lib/hooks/useChains'
 import { IconCross } from '@lib/icons/IconCross'
 import { IconSearch } from '@lib/icons/IconSearch'
 import { cl } from '@lib/utils'
+import { DEFAULT_MIN_TVL } from '@vaults/utils/constants'
 import type { ReactElement, ReactNode, RefObject } from 'react'
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { Drawer } from 'vaul'
@@ -484,6 +485,8 @@ function FilterControls({
 const EMPTY_FILTERS_STATE: TPendingFiltersState = {
   categories: [],
   aggressiveness: [],
+  underlyingAssets: [],
+  minTvl: DEFAULT_MIN_TVL,
   showStrategies: false,
   showLegacyVaults: false,
   showHiddenVaults: false

--- a/apps/vaults/components/list/VaultsExpandedSelector.tsx
+++ b/apps/vaults/components/list/VaultsExpandedSelector.tsx
@@ -1,75 +1,53 @@
 import { cl } from '@lib/utils'
-import { type TVaultChartTimeframe, VAULT_CHART_TIMEFRAME_OPTIONS } from '@vaults/components/detail/VaultChartsSection'
 import type { ReactElement } from 'react'
 
-export type TVaultsExpandedView = 'apy' | 'performance' | 'tvl' | 'info'
+export type TVaultsExpandedView = 'apy' | 'performance' | 'tvl' | 'strategies'
 
 type Props = {
   activeView: TVaultsExpandedView
   onViewChange: (view: TVaultsExpandedView) => void
-  timeframe: TVaultChartTimeframe
-  onTimeframeChange: (timeframe: TVaultChartTimeframe) => void
   className?: string
   rightElement?: ReactElement
 }
 
 const VIEW_OPTIONS: Array<{ id: TVaultsExpandedView; label: string }> = [
-  { id: 'apy', label: '30-Day APY' },
+  { id: 'strategies', label: 'Strategies' },
+  { id: 'apy', label: 'APY' },
   { id: 'performance', label: 'Performance' },
-  { id: 'tvl', label: 'TVL' },
-  { id: 'info', label: 'Vault Info' }
+  { id: 'tvl', label: 'TVL' }
+]
+const VIEW_GROUPS: Array<Array<{ id: TVaultsExpandedView; label: string }>> = [
+  [VIEW_OPTIONS[0], VIEW_OPTIONS[1]],
+  [VIEW_OPTIONS[2], VIEW_OPTIONS[3]]
 ]
 
-export function VaultsExpandedSelector({
-  activeView,
-  onViewChange,
-  timeframe,
-  onTimeframeChange,
-  className,
-  rightElement
-}: Props): ReactElement {
+export function VaultsExpandedSelector({ activeView, onViewChange, className, rightElement }: Props): ReactElement {
   return (
-    <div className={cl('flex flex-wrap items-center justify-between gap-3', className)}>
-      <div className={'flex items-center gap-1 rounded-lg bg-surface-secondary p-1 shadow-inner'}>
-        {VIEW_OPTIONS.map((option) => (
-          <button
-            key={option.id}
-            type={'button'}
-            className={cl(
-              'rounded-lg px-4 py-1 text-xs font-semibold tracking-wide transition-colors',
-              activeView === option.id
-                ? 'bg-surface text-text-primary'
-                : 'bg-transparent text-text-secondary hover:text-text-secondary'
-            )}
-            onClick={(): void => onViewChange(option.id)}
-          >
-            {option.label}
-          </button>
-        ))}
+    <div className={cl('flex w-full items-stretch gap-2', className)}>
+      <div className={'flex-1 rounded-lg bg-surface-secondary p-1 shadow-inner'}>
+        <div className={'flex flex-wrap gap-1'}>
+          {VIEW_GROUPS.map((group) => (
+            <div key={group.map((option) => option.id).join('-')} className={'flex flex-1 gap-1'}>
+              {group.map((option) => (
+                <button
+                  key={option.id}
+                  type={'button'}
+                  className={cl(
+                    'flex-1 rounded-lg px-2 py-2 text-xs font-semibold tracking-wide transition-colors whitespace-nowrap',
+                    activeView === option.id
+                      ? 'bg-surface text-text-primary'
+                      : 'bg-transparent text-text-secondary hover:text-text-secondary'
+                  )}
+                  onClick={(): void => onViewChange(option.id)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          ))}
+        </div>
       </div>
-
-      <div className={'flex items-center gap-2'}>
-        {activeView !== 'info' ? (
-          <div className={'flex items-center gap-1 rounded-lg bg-surface-secondary p-1 shadow-inner'}>
-            {VAULT_CHART_TIMEFRAME_OPTIONS.map((option) => (
-              <button
-                key={option.value}
-                type={'button'}
-                className={cl(
-                  'rounded-lg px-4 py-1 text-xs font-semibold uppercase tracking-wide transition-colors',
-                  option.value === timeframe
-                    ? 'bg-surface text-text-primary'
-                    : 'bg-transparent text-text-secondary hover:text-text-secondary'
-                )}
-                onClick={(): void => onTimeframeChange(option.value)}
-              >
-                {option.label}
-              </button>
-            ))}
-          </div>
-        ) : null}
-        {rightElement}
-      </div>
+      {rightElement ? <div className={'flex items-stretch'}>{rightElement}</div> : null}
     </div>
   )
 }

--- a/apps/vaults/components/list/VaultsListChip.tsx
+++ b/apps/vaults/components/list/VaultsListChip.tsx
@@ -1,5 +1,6 @@
 import { Tooltip } from '@lib/components/Tooltip'
 import { cl } from '@lib/utils'
+import { TOOLTIP_DELAY_MS } from '@vaults/utils/vaultTagCopy'
 import type { ReactElement, ReactNode } from 'react'
 
 type TVaultsListChipProps = {
@@ -8,6 +9,9 @@ type TVaultsListChipProps = {
   isActive?: boolean
   isCollapsed?: boolean
   showCollapsedTooltip?: boolean
+  tooltipDescription?: string
+  tooltip?: string | ReactElement
+  tooltipDelayMs?: number
   onClick?: () => void
   ariaLabel?: string
   disabled?: boolean
@@ -19,13 +23,15 @@ export function VaultsListChip({
   isActive = false,
   isCollapsed = false,
   showCollapsedTooltip = false,
+  tooltipDescription,
+  tooltip,
+  tooltipDelayMs,
   onClick,
   ariaLabel,
   disabled = false
 }: TVaultsListChipProps): ReactElement {
   const isInteractive = Boolean(onClick) && !disabled
   const shouldCollapse = isCollapsed && Boolean(icon)
-  const shouldShowTooltip = shouldCollapse && showCollapsedTooltip
   const iconNode = icon ? (
     <span className={'flex size-4 items-center justify-center text-text-secondary'}>{icon}</span>
   ) : null
@@ -58,23 +64,41 @@ export function VaultsListChip({
     </button>
   )
 
-  if (!shouldShowTooltip) {
+  const tooltipContent =
+    tooltip ||
+    (tooltipDescription ? (
+      <div
+        className={
+          'max-w-[220px] rounded-lg border border-border bg-surface-secondary px-3 py-2 text-xs text-text-primary shadow-md'
+        }
+      >
+        <div className={'flex items-center gap-1 font-semibold'}>
+          {iconNode}
+          <span>{label}</span>
+        </div>
+        <p className={'text-text-secondary'}>{tooltipDescription}</p>
+      </div>
+    ) : shouldCollapse && showCollapsedTooltip ? (
+      <div
+        className={
+          'flex items-center gap-1 rounded-lg border border-border bg-surface-secondary px-2 py-1 text-xs font-medium text-text-primary shadow-md'
+        }
+      >
+        {iconNode}
+        <span>{label}</span>
+      </div>
+    ) : null)
+
+  if (!tooltipContent) {
     return chip
   }
 
   return (
     <Tooltip
       className={'h-auto'}
-      tooltip={
-        <div
-          className={
-            'flex items-center gap-1 rounded-lg border border-border bg-surface-secondary px-2 py-1 text-xs font-medium text-text-primary shadow-md'
-          }
-        >
-          {iconNode}
-          <span>{label}</span>
-        </div>
-      }
+      openDelayMs={tooltipDelayMs ?? (tooltipDescription || tooltip ? TOOLTIP_DELAY_MS : 0)}
+      tooltip={tooltipContent}
+      align={'start'}
     >
       {chip}
     </Tooltip>

--- a/apps/vaults/components/list/VaultsListRow.tsx
+++ b/apps/vaults/components/list/VaultsListRow.tsx
@@ -2,21 +2,31 @@ import Link from '@components/Link'
 import { RenderAmount } from '@lib/components/RenderAmount'
 import { TokenLogo } from '@lib/components/TokenLogo'
 import { Tooltip } from '@lib/components/Tooltip'
+import { useWeb3 } from '@lib/contexts/useWeb3'
 import { IconChevron } from '@lib/icons/IconChevron'
 import { IconCirclePile } from '@lib/icons/IconCirclePile'
 import { IconEyeOff } from '@lib/icons/IconEyeOff'
 import { IconMigratable } from '@lib/icons/IconMigratable'
 import { IconRewind } from '@lib/icons/IconRewind'
+import { IconScissors } from '@lib/icons/IconScissors'
 import { IconStablecoin } from '@lib/icons/IconStablecoin'
 import { IconStack } from '@lib/icons/IconStack'
 import { IconVolatile } from '@lib/icons/IconVolatile'
-import { cl, toAddress, toNormalizedBN } from '@lib/utils'
+import { cl, formatAmount, toAddress, toNormalizedBN } from '@lib/utils'
 import type { TYDaemonVault } from '@lib/utils/schemas/yDaemonVaultsSchemas'
 import { getNetwork } from '@lib/utils/wagmi'
-import type { TVaultChartTimeframe } from '@vaults/components/detail/VaultChartsSection'
 import { type TVaultForwardAPYVariant, VaultForwardAPY } from '@vaults/components/table/VaultForwardAPY'
 import { VaultHoldingsAmount } from '@vaults/components/table/VaultHoldingsAmount'
 import { deriveListKind } from '@vaults/utils/vaultListFacets'
+import {
+  getCategoryDescription,
+  getChainDescription,
+  getKindDescription,
+  getProductTypeDescription,
+  HIDDEN_TAG_DESCRIPTION,
+  MIGRATABLE_TAG_DESCRIPTION,
+  RETIRED_TAG_DESCRIPTION
+} from '@vaults/utils/vaultTagCopy'
 import type { ReactElement } from 'react'
 import { lazy, Suspense, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
@@ -81,9 +91,9 @@ export function VaultsListRow({
   const href = hrefOverride ?? `/vaults/${currentVault.chainID}/${toAddress(currentVault.address)}`
   const network = getNetwork(currentVault.chainID)
   const chainLogoSrc = `${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/chains/${currentVault.chainID}/logo-32.png`
+  const { isActive: isWalletActive } = useWeb3()
   const [isExpanded, setIsExpanded] = useState(false)
-  const [expandedView, setExpandedView] = useState<TVaultsExpandedView>('apy')
-  const [expandedTimeframe, setExpandedTimeframe] = useState<TVaultChartTimeframe>('all')
+  const [expandedView, setExpandedView] = useState<TVaultsExpandedView>('strategies')
   const listKind = deriveListKind(currentVault)
   const isAllocatorVault = listKind === 'allocator' || listKind === 'strategy'
   const isLegacyVault = listKind === 'legacy'
@@ -111,7 +121,10 @@ export function VaultsListRow({
   const leftColumnSpan = 'col-span-12'
   const rightColumnSpan = 'col-span-12'
   const rightGridColumns = 'md:grid-cols-12'
-  const metricsColumnSpan = 'col-span-4'
+  const showHoldingsColumn = isWalletActive
+  const apyColumnSpan = showHoldingsColumn ? 'col-span-4' : 'col-span-6'
+  const tvlColumnSpan = showHoldingsColumn ? 'col-span-4' : 'col-span-5'
+  const holdingsColumnSpan = 'col-span-4'
   const showCompareToggle = Boolean(onToggleCompare)
   const vaultKey = `${currentVault.chainID}_${toAddress(currentVault.address)}`
   const isCompareSelected = compareVaultKeys?.includes(vaultKey) ?? false
@@ -141,6 +154,15 @@ export function VaultsListRow({
     ) : kindType === 'single' ? (
       <IconStack className={'size-3.5'} />
     ) : null
+  const chainDescription = getChainDescription(currentVault.chainID)
+  const categoryDescription = getCategoryDescription(currentVault.category)
+  const productTypeDescription = getProductTypeDescription(listKind)
+  const kindDescription = getKindDescription(kindType, kindLabel)
+  const fees = currentVault.apr?.fees
+  const showFeesChip = Boolean(fees) && !isChipsCompressed
+  const feesChipLabel = fees
+    ? `${formatAmount((fees.management || 0) * 100, 0, 2)}% | ${formatAmount((fees.performance || 0) * 100, 0, 2)}%`
+    : ''
   const migratableIcon = <IconMigratable className={'size-3.5'} />
   const retiredIcon = <span className={'text-xs leading-none'}>{'⚠️'}</span>
   const tvlNativeTooltip = (
@@ -164,7 +186,7 @@ export function VaultsListRow({
 
   useEffect(() => {
     if (isExpanded) {
-      setExpandedView('apy')
+      setExpandedView('strategies')
     }
   }, [isExpanded])
 
@@ -288,6 +310,7 @@ export function VaultsListRow({
                     isActive={activeChainIds.includes(currentVault.chainID)}
                     isCollapsed={isChipsCompressed}
                     showCollapsedTooltip={showCollapsedTooltip}
+                    tooltipDescription={chainDescription}
                     onClick={onToggleChain ? (): void => onToggleChain(currentVault.chainID) : undefined}
                     ariaLabel={`Filter by ${network.name}`}
                   />
@@ -299,6 +322,7 @@ export function VaultsListRow({
                     isActive={activeCategoryLabels.includes(currentVault.category)}
                     isCollapsed={isChipsCompressed}
                     showCollapsedTooltip={showCollapsedTooltip}
+                    tooltipDescription={categoryDescription || undefined}
                     onClick={onToggleCategory ? (): void => onToggleCategory(currentVault.category) : undefined}
                     ariaLabel={`Filter by ${currentVault.category}`}
                   />
@@ -310,8 +334,18 @@ export function VaultsListRow({
                     isActive={isProductTypeActive}
                     isCollapsed={shouldCollapseProductType}
                     showCollapsedTooltip={showCollapsedTooltip}
+                    tooltipDescription={productTypeDescription}
                     onClick={onToggleVaultType ? (): void => onToggleVaultType(productType) : undefined}
                     ariaLabel={productTypeAriaLabel}
+                  />
+                ) : null}
+                {showFeesChip ? (
+                  <VaultsListChip
+                    label={feesChipLabel}
+                    icon={<IconScissors className={'size-3.5'} />}
+                    isCollapsed={isChipsCompressed}
+                    showCollapsedTooltip={showCollapsedTooltip}
+                    tooltipDescription={'Management fee | Performance fee'}
                   />
                 ) : null}
                 {showKindChip && kindLabel ? (
@@ -321,6 +355,7 @@ export function VaultsListRow({
                     isActive={isKindActive}
                     isCollapsed={isChipsCompressed}
                     showCollapsedTooltip={showCollapsedTooltip}
+                    tooltipDescription={kindDescription}
                     onClick={kindType && onToggleType ? (): void => onToggleType(kindType) : undefined}
                     ariaLabel={`Filter by ${kindLabel}`}
                   />
@@ -331,6 +366,7 @@ export function VaultsListRow({
                     icon={retiredIcon}
                     isCollapsed={isChipsCompressed}
                     showCollapsedTooltip={showCollapsedTooltip}
+                    tooltipDescription={RETIRED_TAG_DESCRIPTION}
                   />
                 ) : null}
                 {flags?.isMigratable ? (
@@ -339,6 +375,7 @@ export function VaultsListRow({
                     icon={migratableIcon}
                     isCollapsed={isChipsCompressed}
                     showCollapsedTooltip={showCollapsedTooltip}
+                    tooltipDescription={MIGRATABLE_TAG_DESCRIPTION}
                   />
                 ) : null}
                 {isHiddenVault ? (
@@ -347,6 +384,7 @@ export function VaultsListRow({
                     icon={<IconEyeOff className={'size-3.5'} />}
                     isCollapsed={isChipsCompressed}
                     showCollapsedTooltip={showCollapsedTooltip}
+                    tooltipDescription={HIDDEN_TAG_DESCRIPTION}
                   />
                 ) : null}
               </div>
@@ -354,7 +392,7 @@ export function VaultsListRow({
             {/* Mobile Holdings + APY + TVL inline */}
             <div className={'hidden max-md:flex items-center shrink-0 gap-4 text-right'}>
               {/* Holdings - shown on wider mobile screens */}
-              {flags?.hasHoldings ? (
+              {showHoldingsColumn ? (
                 <div className={'hidden min-[420px]:block'}>
                   <p className={'text-xs text-text-primary/60'}>{'Holdings'}</p>
                   <VaultHoldingsAmount currentVault={currentVault} valueClassName={'text-sm font-semibold'} />
@@ -383,7 +421,7 @@ export function VaultsListRow({
                   />
                 </p>
                 {/* Holdings indicator dot - shown on narrow screens when user has holdings */}
-                {flags?.hasHoldings ? (
+                {showHoldingsColumn && flags?.hasHoldings ? (
                   <div
                     className={'absolute -right-2 top-0 size-2 rounded-full bg-green-500 min-[420px]:hidden'}
                     title={'You have holdings in this vault'}
@@ -398,7 +436,7 @@ export function VaultsListRow({
         <div
           className={cl(rightColumnSpan, 'z-10 gap-4 mt-4', 'hidden md:mt-0 md:grid md:items-center', rightGridColumns)}
         >
-          <div className={cl('yearn--table-data-section-item', metricsColumnSpan)} datatype={'number'}>
+          <div className={cl('yearn--table-data-section-item', apyColumnSpan)} datatype={'number'}>
             <VaultForwardAPY
               currentVault={currentVault}
               showSubline={false}
@@ -408,7 +446,7 @@ export function VaultsListRow({
             />
           </div>
           {/* TVL */}
-          <div className={cl('yearn--table-data-section-item', metricsColumnSpan)} datatype={'number'}>
+          <div className={cl('yearn--table-data-section-item', tvlColumnSpan)} datatype={'number'}>
             <div className={'flex justify-end text-right'}>
               <Tooltip
                 className={'tvl-subline-tooltip gap-0 h-auto md:justify-end'}
@@ -431,9 +469,12 @@ export function VaultsListRow({
               </Tooltip>
             </div>
           </div>
-          <div className={cl('yearn--table-data-section-item', metricsColumnSpan)} datatype={'number'}>
-            <VaultHoldingsAmount currentVault={currentVault} />
-          </div>
+          {!showHoldingsColumn ? <div className={'col-span-1'} /> : null}
+          {showHoldingsColumn ? (
+            <div className={cl('yearn--table-data-section-item', holdingsColumnSpan)} datatype={'number'}>
+              <VaultHoldingsAmount currentVault={currentVault} />
+            </div>
+          ) : null}
         </div>
       </Link>
 
@@ -442,10 +483,11 @@ export function VaultsListRow({
           <VaultsListRowExpandedContent
             currentVault={currentVault}
             expandedView={expandedView}
-            expandedTimeframe={expandedTimeframe}
             onExpandedViewChange={setExpandedView}
-            onExpandedTimeframeChange={setExpandedTimeframe}
             onNavigateToVault={() => navigate(href)}
+            showKindTag={showKindChip}
+            showHiddenTag={isHiddenVault}
+            isHidden={isHiddenVault}
           />
         </Suspense>
       ) : null}

--- a/apps/vaults/components/list/VaultsListRowExpandedContent.tsx
+++ b/apps/vaults/components/list/VaultsListRowExpandedContent.tsx
@@ -31,70 +31,70 @@ const EXPANDED_VIEW_TO_CHART_TAB: Record<
 type TVaultsListRowExpandedContentProps = {
   currentVault: TYDaemonVault
   expandedView: TVaultsExpandedView
-  expandedTimeframe: TVaultChartTimeframe
   onExpandedViewChange: (nextView: TVaultsExpandedView) => void
-  onExpandedTimeframeChange: (nextTimeframe: TVaultChartTimeframe) => void
   onNavigateToVault: () => void
+  showKindTag?: boolean
+  showHiddenTag?: boolean
+  isHidden?: boolean
 }
 
 export default function VaultsListRowExpandedContent({
   currentVault,
   expandedView,
-  expandedTimeframe,
   onExpandedViewChange,
-  onExpandedTimeframeChange,
-  onNavigateToVault
+  onNavigateToVault,
+  showKindTag = true,
+  showHiddenTag = false,
+  isHidden
 }: TVaultsListRowExpandedContentProps): ReactElement {
+  const chartTimeframe: TVaultChartTimeframe = '1y'
+
   return (
     <div className={'hidden md:block bg-surface'}>
-      <div className={'px-6 pb-6 pt-3'}>
-        <div className={' bg-surface'}>
-          <VaultsExpandedSelector
-            className={'p-3'}
-            activeView={expandedView}
-            onViewChange={onExpandedViewChange}
-            timeframe={expandedTimeframe}
-            onTimeframeChange={onExpandedTimeframeChange}
-            rightElement={
-              <button
-                type={'button'}
-                onClick={(event): void => {
-                  event.stopPropagation()
-                  onNavigateToVault()
-                }}
-                className={
-                  'rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400'
-                }
-              >
-                {'Go to Vault'}
-              </button>
-            }
-          />
-
-          {expandedView in EXPANDED_VIEW_TO_CHART_TAB ? (
-            <div className={'px-3 pb-4'}>
+      <div className={'px-6 pb-6 md'}>
+        <div className={'grid gap-6 md:grid-cols-24'}>
+          <div className={'col-span-12 border-r border-border'}>
+            <VaultAboutSection
+              currentVault={currentVault}
+              className={'p-0'}
+              showKindTag={showKindTag}
+              showHiddenTag={showHiddenTag}
+              isHidden={isHidden}
+            />
+          </div>
+          <div className={'col-span-12 flex flex-col gap-4'}>
+            <VaultsExpandedSelector
+              activeView={expandedView}
+              onViewChange={onExpandedViewChange}
+              rightElement={
+                <button
+                  type={'button'}
+                  onClick={(event): void => {
+                    event.stopPropagation()
+                    onNavigateToVault()
+                  }}
+                  className={
+                    'h-full rounded-lg bg-primary px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-primary/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400'
+                  }
+                >
+                  {'Go to Vault'}
+                </button>
+              }
+            />
+            {expandedView in EXPANDED_VIEW_TO_CHART_TAB ? (
               <VaultChartsSection
                 chainId={currentVault.chainID}
                 vaultAddress={currentVault.address}
                 shouldRenderSelectors={false}
                 chartTab={EXPANDED_VIEW_TO_CHART_TAB[expandedView as keyof typeof EXPANDED_VIEW_TO_CHART_TAB]}
-                timeframe={expandedTimeframe}
+                timeframe={chartTimeframe}
                 chartHeightPx={200}
                 chartHeightMdPx={200}
               />
-            </div>
-          ) : null}
-
-          {expandedView === 'info' ? (
-            <div className={'grid md:grid-cols-2 divide-y divide-border md:divide-y-0 md:divide-x'}>
-              <div className={'p-4 md:p-6'}>
-                <VaultStrategyAllocationPreview currentVault={currentVault} />
-              </div>
-              <div className={'p-4 md:p-6'}>
-                <VaultAboutSection currentVault={currentVault} className={'p-0'} />
-              </div>
-            </div>
-          ) : null}
+            ) : (
+              <VaultStrategyAllocationPreview currentVault={currentVault} />
+            )}
+          </div>
         </div>
       </div>
     </div>
@@ -207,29 +207,31 @@ function VaultStrategyAllocationPreview({ currentVault }: { currentVault: TYDaem
   }
 
   return (
-    <div className={'flex flex-col gap-6'}>
-      <div className={'flex flex-col gap-6 lg:flex-row lg:items-center'}>
-        <AllocationChart allocationChartData={allocationChartData} />
-        <div className={'flex flex-col gap-3'}>
+    <div className={'flex flex-col pl-4 gap-6'}>
+      <div className={'flex flex-row-reverse items-center gap-6'}>
+        <div className={'flex-2'}>
+          <AllocationChart allocationChartData={allocationChartData} />
+        </div>
+        <div className={'flex min-w-0 flex-3 flex-col gap-3'}>
           {activeStrategyData.map((item, index) => (
-            <div key={item.id} className={'flex flex-row items-center gap-3'}>
+            <div key={item.id} className={'flex min-w-0 flex-row items-center gap-3'}>
               <div
-                className={'h-3 w-3 rounded-sm'}
+                className={'h-3 w-3 shrink-0 rounded-sm'}
                 style={{
                   backgroundColor: legendColors[index % legendColors.length]
                 }}
               />
-              <div className={'flex flex-col'}>
-                <span className={'text-sm text-text-primary'}>{item.name}</span>
+              <div className={'flex min-w-0 flex-col'}>
+                <span className={'text-sm text-text-primary break-words'}>{item.name}</span>
                 <span className={'text-xs text-text-secondary'}>{item.amount}</span>
               </div>
             </div>
           ))}
           {unallocatedData ? (
-            <div className={'flex flex-row items-center gap-3'}>
-              <div className={'h-3 w-3 rounded-sm bg-surface-tertiary'} />
-              <div className={'flex flex-col'}>
-                <span className={'text-sm text-text-secondary'}>{'Unallocated'}</span>
+            <div className={'flex min-w-0 flex-row items-center gap-3'}>
+              <div className={'h-3 w-3 shrink-0 rounded-sm bg-surface-tertiary'} />
+              <div className={'flex min-w-0 flex-col'}>
+                <span className={'text-sm text-text-secondary break-words'}>{'Unallocated'}</span>
                 <span className={'text-xs text-text-secondary'}>{unallocatedData.amount}</span>
               </div>
             </div>

--- a/apps/vaults/components/table/VaultForwardAPY.tsx
+++ b/apps/vaults/components/table/VaultForwardAPY.tsx
@@ -180,7 +180,6 @@ export function VaultForwardAPY({
                 <div className={'flex items-center gap-2'}>
                   {fixedTermIndicator}
                   <span className={cl('flex items-center gap-1', valueInteractiveClass)}>
-                    {'⚔️ '}
                     <RenderAmount value={data.katanaTotalApr} symbol={'percent'} decimals={6} />
                   </span>
                 </div>

--- a/apps/vaults/components/table/VaultHoldingsAmount.tsx
+++ b/apps/vaults/components/table/VaultHoldingsAmount.tsx
@@ -1,5 +1,6 @@
 import { RenderAmount } from '@lib/components/RenderAmount'
 import { useWallet } from '@lib/contexts/useWallet'
+import { useWeb3 } from '@lib/contexts/useWeb3'
 import { useYearn } from '@lib/contexts/useYearn'
 import type { TNormalizedBN } from '@lib/types'
 import { cl, toNormalizedBN } from '@lib/utils'
@@ -15,6 +16,7 @@ export function VaultHoldingsAmount({
   valueClassName?: string
 }): ReactElement {
   const { getToken } = useWallet()
+  const { isActive: isWalletActive } = useWeb3()
   const { getPrice } = useYearn()
 
   const { tokenPrice, staked, hasBalance } = useMemo(() => {
@@ -53,6 +55,7 @@ export function VaultHoldingsAmount({
   const value = staked.normalized * tokenPrice.normalized
 
   const isDusty = value < 0.01
+  const shouldShowDash = isWalletActive && !hasBalance
 
   return (
     <div className={'flex flex-col items-end pt-0 text-right'}>
@@ -63,16 +66,20 @@ export function VaultHoldingsAmount({
           valueClassName
         )}
       >
-        <RenderAmount
-          value={isDusty ? 0 : value}
-          symbol={'USD'}
-          decimals={0}
-          options={{
-            shouldCompactValue: true,
-            maximumFractionDigits: 2,
-            minimumFractionDigits: 2
-          }}
-        />
+        {shouldShowDash ? (
+          '-'
+        ) : (
+          <RenderAmount
+            value={isDusty ? 0 : value}
+            symbol={'USD'}
+            decimals={0}
+            options={{
+              shouldCompactValue: true,
+              maximumFractionDigits: 2,
+              minimumFractionDigits: 2
+            }}
+          />
+        )}
       </p>
       {/* <small
         className={cl(

--- a/apps/vaults/utils/constants.ts
+++ b/apps/vaults/utils/constants.ts
@@ -12,6 +12,7 @@ export const V2_DEFAULT_TYPES = ['factory']
 export const AGGRESSIVENESS_OPTIONS: TVaultAggressiveness[] = ['Conservative', 'Moderate', 'Aggressive']
 export const V3_ASSET_CATEGORIES = [ALL_VAULTSV3_CATEGORIES.Stablecoin, ALL_VAULTSV3_CATEGORIES.Volatile]
 export const V2_ASSET_CATEGORIES = ['Stablecoin', 'Volatile']
+export const DEFAULT_MIN_TVL = 500
 
 export function toggleInArray<T>(current: T[] | null, next: T): T[] {
   const existing = current ?? []

--- a/apps/vaults/utils/vaultTagCopy.ts
+++ b/apps/vaults/utils/vaultTagCopy.ts
@@ -1,0 +1,68 @@
+import { getNetwork } from '@lib/utils/wagmi'
+import type { TVaultListKind } from './vaultListFacets'
+
+export const TOOLTIP_DELAY_MS = 400
+
+export const ALL_CHAINS_DESCRIPTION = 'Shows vaults across all supported chains.'
+
+const CHAIN_DESCRIPTIONS: Record<number, string> = {
+  1: 'Ethereum mainnet is the heart of the Ethereum ecosystem. It usually has the highest liquidity and security, but transaction fees can be higher.',
+  10: 'Optimism is the coordination layer of the "SuperChain". It is an optimistic rollup on Ethereum with lower fees and fast confirmations.',
+  137: 'Polygon is a PoS sidechain to Ethereum with low fees and fast blocks.',
+  42161: 'Arbitrum is an optimistic rollup on Ethereum with low fees and high throughput.',
+  8453: "Base is an Coinbase's Ethereum L2 built on the OP Stack with low fees and fast confirmations.",
+  747474:
+    'Katana is a DeFi focused zk-rollup chain with an innovative liquidity flywheel, low fees, and fast confirmations.'
+}
+
+const CHAIN_WEBSITES: Record<number, string> = {
+  1: 'https://ethereum.org',
+  10: 'https://www.optimism.io/',
+  137: 'https://polygon.technology/',
+  42161: 'https://offchainlabs.com/#arbitrum-one',
+  8453: 'https://base.org/',
+  747474: 'https://katana.network'
+}
+
+export const RETIRED_TAG_DESCRIPTION = 'Deposits are disabled; withdrawals remain available.'
+export const MIGRATABLE_TAG_DESCRIPTION = 'A retired vault with a migration path available to a newer vault.'
+export const HIDDEN_TAG_DESCRIPTION = 'Hidden from the default list. Enable hidden vaults to view.'
+
+export function getChainDescription(chainId: number): string {
+  return CHAIN_DESCRIPTIONS[chainId] || `${getNetwork(chainId).name} network.`
+}
+export function getChainWebsite(chainId: number): string | null {
+  return CHAIN_WEBSITES[chainId] || null
+}
+
+export function getCategoryDescription(category?: string | null): string | null {
+  if (!category) return null
+  const normalized = category.toLowerCase()
+  if (normalized === 'stablecoin') {
+    return 'This vault holds a USD-pegged or USD-targeted asset designed to maintain its price.'
+  }
+  if (normalized === 'volatile') {
+    return 'This vault holds an asset whose price fluctuates due to market-driven events.'
+  }
+  return `${category} asset category.`
+}
+
+export function getProductTypeDescription(listKind: TVaultListKind): string {
+  if (listKind === 'legacy') {
+    return 'These vaults use a Legacy Yearn vault architecture. They were previously called "v2 Vaults").'
+  }
+  if (listKind === 'factory') {
+    return 'LP token vaults auto-compound fees and incentives from liquidity positions. They were previously called "v2 Factory Vaults".'
+  }
+  return 'Single-asset vaults accept one token and allocate it across strategies. They were previously called "v3 Vaults".'
+}
+
+export function getKindDescription(kindType?: 'multi' | 'single', kindLabel?: string): string {
+  if (kindType === 'multi') {
+    return 'Allocator vaults route deposits across multiple strategies.'
+  }
+  if (kindType === 'single') {
+    return 'Strategy vaults contain a single active strategy and are allocated to by Allocator vaults.'
+  }
+  return kindLabel ? `${kindLabel} vault classification from Yearn.` : 'Vault strategy classification from Yearn.'
+}

--- a/apps/vaults/utils/vaultTypeCopy.ts
+++ b/apps/vaults/utils/vaultTypeCopy.ts
@@ -15,10 +15,20 @@ export const VAULT_TYPE_COPY: Record<TVaultType, { label: string; emoji: string 
   }
 }
 
+export const VAULT_TYPE_DESCRIPTION: Record<TVaultType, string | null> = {
+  all: null,
+  v3: 'Deposits a single token; Yearn allocates it across strategies.',
+  factory: 'Deposits a DEX LP token; yield comes from fees and incentives, auto-compounded.'
+}
+
 export function getVaultTypeLabel(vaultType: TVaultType): string {
   return VAULT_TYPE_COPY[vaultType].label
 }
 
 export function getVaultTypeEmoji(vaultType: TVaultType): string {
   return VAULT_TYPE_COPY[vaultType].emoji
+}
+
+export function getVaultTypeDescription(vaultType: TVaultType): string | null {
+  return VAULT_TYPE_DESCRIPTION[vaultType]
 }

--- a/pages/portfolio/index.tsx
+++ b/pages/portfolio/index.tsx
@@ -91,12 +91,12 @@ function PortfolioHeaderSection({
       />
       <div>
         <h1 className={'text-4xl font-black text-text-primary'}>{'Account Overview'}</h1>
+        <p className={'mt-2 text-base text-text-secondary'}>
+          {'Monitor your balances, returns, and discover new vaults.'}
+        </p>
       </div>
       {isActive ? (
         <div>
-          <p className={'mt-2 text-base text-text-secondary'}>
-            {'Monitor your balances, returns, and discover new vaults.'}
-          </p>
           <div className={'grid grid-cols-1 gap-4 md:grid-cols-4'}>
             <div className={'rounded-3xl border border-border bg-surface p-6'}>
               <p className={'text-sm font-semibold uppercase tracking-wide text-text-secondary'}>{'Total balance'}</p>

--- a/pages/vaults/[chainID]/[address].tsx
+++ b/pages/vaults/[chainID]/[address].tsx
@@ -74,7 +74,7 @@ function Index(): ReactElement | null {
     charts: true
   })
   const collapsibleTitles: Record<SectionKey, string> = {
-    about: 'Description',
+    about: 'Vault Info',
     risk: 'Risk Score',
     strategies: 'Strategies',
     info: 'More Info',

--- a/pages/vaults/hooks/useVaultsListModel.ts
+++ b/pages/vaults/hooks/useVaultsListModel.ts
@@ -27,6 +27,8 @@ type TVaultsListModelArgs = {
   listV3Types: string[]
   listCategories: string[] | null
   listAggressiveness: string[] | null
+  listUnderlyingAssets: string[] | null
+  listMinTvl: number
   listShowLegacyVaults: boolean
   listShowHiddenVaults: boolean
   searchValue: string
@@ -42,6 +44,7 @@ type TVaultsListModel = {
   holdingsVaults: TYDaemonVault[]
   availableVaults: TYDaemonVault[]
   vaultFlags: Record<string, { hasHoldings: boolean; isMigratable: boolean; isRetired: boolean; isHidden: boolean }>
+  underlyingAssetVaults: Record<string, TYDaemonVault>
   pinnedSections: TVaultsPinnedSection[]
   pinnedVaults: TYDaemonVault[]
   mainVaults: TYDaemonVault[]
@@ -57,6 +60,8 @@ export function useVaultsListModel({
   listV3Types,
   listCategories,
   listAggressiveness,
+  listUnderlyingAssets,
+  listMinTvl,
   listShowLegacyVaults,
   listShowHiddenVaults,
   searchValue,
@@ -92,6 +97,8 @@ export function useVaultsListModel({
     searchValue,
     isV3View ? listCategoriesSanitized : null,
     isV3View ? listAggressivenessSanitized : null,
+    isV3View ? listUnderlyingAssets : null,
+    listMinTvl,
     isV3View ? listShowHiddenVaults : undefined,
     isV3View
   )
@@ -102,6 +109,8 @@ export function useVaultsListModel({
     searchValue,
     isV2View ? listCategoriesSanitized : null,
     isV2View ? listAggressivenessSanitized : null,
+    isV2View ? listUnderlyingAssets : null,
+    listMinTvl,
     listShowHiddenVaults,
     isV2View
   )
@@ -112,6 +121,8 @@ export function useVaultsListModel({
     '',
     isV2View ? listCategoriesSanitized : null,
     isV2View ? listAggressivenessSanitized : null,
+    isV2View ? listUnderlyingAssets : null,
+    listMinTvl,
     listShowHiddenVaults,
     isV2View
   )
@@ -175,6 +186,8 @@ export function useVaultsListModel({
     '',
     isV3View ? listCategoriesSanitized : null,
     isV3View ? listAggressivenessSanitized : null,
+    isV3View ? listUnderlyingAssets : null,
+    listMinTvl,
     isV3View ? listShowHiddenVaults : undefined,
     isV3View
   )
@@ -273,6 +286,15 @@ export function useVaultsListModel({
   }, [listVaultType, suggestedV3Vaults, suggestedV2Vaults])
 
   const defaultCategories = isV3View ? V3_ASSET_CATEGORIES : V2_ASSET_CATEGORIES
+  const underlyingAssetVaults = useMemo(() => {
+    if (listVaultType === 'all') {
+      return { ...v3FilterResult.underlyingAssetVaults, ...v2FilterResult.underlyingAssetVaults }
+    }
+    if (listVaultType === 'v3') {
+      return v3FilterResult.underlyingAssetVaults
+    }
+    return v2FilterResult.underlyingAssetVaults
+  }, [listVaultType, v2FilterResult.underlyingAssetVaults, v3FilterResult.underlyingAssetVaults])
 
   return {
     defaultCategories,
@@ -280,6 +302,7 @@ export function useVaultsListModel({
     holdingsVaults,
     availableVaults,
     vaultFlags,
+    underlyingAssetVaults,
     pinnedSections,
     pinnedVaults,
     mainVaults,

--- a/pages/vaults/index.tsx
+++ b/pages/vaults/index.tsx
@@ -11,7 +11,6 @@ import { VaultsAuxiliaryList } from '@vaults/components/list/VaultsAuxiliaryList
 import { VaultsListEmpty } from '@vaults/components/list/VaultsListEmpty'
 import { VaultsListHead } from '@vaults/components/list/VaultsListHead'
 import { VaultsListRow } from '@vaults/components/list/VaultsListRow'
-import { TrendingVaults } from '@vaults/components/TrendingVaults'
 import { toggleInArray } from '@vaults/utils/constants'
 import { getVaultTypeLabel } from '@vaults/utils/vaultTypeCopy'
 import type { CSSProperties, ReactElement, ReactNode } from 'react'
@@ -61,7 +60,7 @@ function VaultsListSection({ isSwitchingVaultType, listHead, children }: TVaults
 export default function Index(): ReactElement {
   const { refs, header, filtersBar, list } = useVaultsPageModel()
   const { varsRef, filtersRef } = refs
-  const { vaultType, suggestedVaults } = header
+  const { vaultType } = header
   const { search, filters, chains, shouldStackFilters, isSwitchingVaultType, activeVaultType, onChangeVaultType } =
     filtersBar
   const {
@@ -259,7 +258,7 @@ export default function Index(): ReactElement {
   const compareCount = compareVaultKeys.length
   const shouldShowCompareBar = isCompareMode && compareCount >= 1 && !isCompareOpen
   const compareBarElement = shouldShowCompareBar ? (
-    <div className={'fixed bottom-4 left-1/2 z-[55] w-[calc(100%-2rem)] max-w-[720px] -translate-x-1/2'}>
+    <div className={'fixed bottom-4 left-1/2 z-55 w-[calc(100%-2rem)] max-w-[720px] -translate-x-1/2'}>
       <div
         className={
           'flex flex-col gap-3 rounded-2xl border border-border bg-surface p-4 shadow-xl sm:flex-row sm:items-center sm:justify-between'
@@ -317,7 +316,8 @@ export default function Index(): ReactElement {
                   { label: getVaultTypeLabel(vaultType), isCurrent: true }
                 ]}
               />
-              <TrendingVaults suggestedVaults={suggestedVaults} />
+              {/* turn back on when ready for primetime */}
+              {/* <TrendingVaults suggestedVaults={suggestedVaults} /> */}
               <VaultsFiltersBar
                 search={{
                   ...search,


### PR DESCRIPTION
 ## Description:
- This reshapes the expanded section of the Vault List elements to move the Vault info to a place of higher prominence over the charts and makes it persistent. It does this by moving the info to the left side of the expanded section and keeping the strategies and charts on the right. They are toggled and only change on the right side.
- The Vault info section has been re-designed to have info on the chain, type, underling assets, etc with expandable section to get more information.
- Charts in the expanded vault list elements are forced to the 1-year timeframe due to a lack of room for a timeframe selector. Different timeframes are still available in the main vault page.
- New tooltips were added for the vault selector and chain selectors, and all chips now have tooltips
- There is a new fees chip
- The Vault Descriptions has section on the Vaults page has been renamed to "Vault Info" and has the same information as in the expanded vault list section.
- Updated the chart styling to be more "full bleed" and move the Y axis labels inside the chart
- **Removes the trending vaults section for now.**
- add ability to set min TVL in filters menu
- add ability to filter by asset in filters menu

## Screenshots

<img width="1275" height="792" alt="Screenshot 2026-01-18 at 7 11 39 PM" src="https://github.com/user-attachments/assets/ba2de5cd-3b03-4a63-b828-1d09e1f8e0a8" />

<img width="1260" height="786" alt="image" src="https://github.com/user-attachments/assets/da2a4712-541e-4060-a273-dee94617663b" />
