### PR TITLE
Fix incorrect portfolio total balance calculation

### DIFF
--- a/apps/lib/contexts/useWallet.tsx
+++ b/apps/lib/contexts/useWallet.tsx
@@ -137,7 +137,9 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
               chainID: tokenData.chainID
             })
 
-            stakingValue = stakingBalance.normalized * tokenPrice.normalized
+            if (!allVaults?.[toAddress(stakingAddress)]) {
+              stakingValue = stakingBalance.normalized * tokenPrice.normalized
+            }
           }
         }
 


### PR DESCRIPTION
Hey, I noticed the portfolio total balance was getting calculated incorrectly because of some double counting. Specifically, if a token was both a staking token for a vault and also listed as a vault itself, its balance was being added twice in the cumulated value. 

I added a check to skip adding the staking value if that staking token is already being processed as a vault in the main loop. This should fix the total balance issue reported in #1013.

Cheers!