### PR TITLE
Focused retired vault messaging

### DIFF
--- a/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/src/components/pages/vaults/[chainID]/[address].tsx
@@ -335,13 +335,12 @@ function Index(): ReactElement | null {
   ])
 
   const vaultShareBalance =
-    address && isActive && currentVault?.address && Number.isInteger(currentVault?.chainID)
+    !!address && currentVault?.address && Number.isInteger(currentVault?.chainID)
       ? getBalance({ address: toAddress(currentVault.address), chainID: currentVault.chainID }).raw
       : 0n
 
   const stakingShareBalance =
-    address &&
-    isActive &&
+    !!address &&
     currentVault?.staking.available &&
     !isZeroAddress(currentVault?.staking.address) &&
     Number.isInteger(currentVault?.chainID)


### PR DESCRIPTION
## Description

Updated the retired vault messages and logic to show them.

- The retired vault alert message is computed by getRetiredVaultAlertMessage(vault, hasUserFundsInVault).
- hasUserFundsInVault is true if the user has either vault shares (vaultShareBalance > 0) or staked shares (stakingShareBalance > 0).

### Messages

  - Message 0 (no funds): “This vault is retired.”
  - Message 1 (stern + migration): “This vault is retired. Please withdraw or migrate your funds.”
  - Message 2 (soft + migration): “This vault is retired, but still earning yield. It is still recommended to migrate
    your funds to the newest vault for the best experience and yield. Deposits are no longer allowed, but withdrawals
    will remain open indefinitely.”
  - Message 3 (stern + no migration): “This vault is retired. Please withdraw your funds.”
  - Message 4 (soft + no migration): “This vault is retired but still earning yield. Deposits are no longer allowed, but
    withdrawals will remain open indefinitely.”

### Message selection logic (retired vaults only)

1. If the user has no funds in the vault (no shares and no staked shares):

- Show Message 0

2. If the user has funds:

  - If vault.symbol contains "yv^2":
      - Show Message 2 (always)
  - Else:
      - Determine hasMigration = vault.migration.available
      - Determine isSoftRetired (still earning yield) if either:
          - Any strategy has status === "active" and strategy.name includes "router" (case-insensitive), OR
          - vault.apr.points.monthAgo > 0 AND vault.chainID !== 250
      - If hasMigration:
          - If isSoftRetired → Message 2
          - Else → Message 1
      - If !hasMigration:
          - If isSoftRetired → Message 4
          - Else → Message 3

## Motivation and Context

as requested

## How Has This Been Tested?

Easiest way to test is to impersonate the yearn treasury (0x93A62dA5a14C80f265DAbC077fCEE437B1a0Efde), click on portfolio and select retired vaults to see the messages. connect, disconnect wallet to see states when not connected, and try with a wallet that doesn't have funds in the vault.

## Screenshots (if appropriate):

user has no funds in vault or disconnected: 
<img width="796" height="626" alt="image" src="https://github.com/user-attachments/assets/c9339c40-1166-4e03-9e36-2355b0c3414d" />

user has funds in vault:

<img width="793" height="688" alt="image" src="https://github.com/user-attachments/assets/eb48a9ae-fa75-4084-9d1b-9e31e9304fa6" />

user has funds, retired with no migration: 
<img width="808" height="603" alt="image" src="https://github.com/user-attachments/assets/b098cb6d-8ebe-44e3-b730-7e4ff659ed0d" />
