### PR TITLE
fix: scroll to top

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import { cl } from '@shared/utils'
 import { isIframe } from '@shared/utils/helpers'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { ReactElement } from 'react'
-import { useEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import { Toaster } from 'react-hot-toast'
 import { useLocation } from 'react-router'
 import { WagmiProvider } from 'wagmi'
@@ -52,7 +52,7 @@ function App(): ReactElement {
 
   // Scroll to top on route change
   // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on pathname change only
-  useEffect(() => {
+  useLayoutEffect(() => {
     window.scrollTo(0, 0)
   }, [location.pathname])
 


### PR DESCRIPTION
## Description

There was a bug where the scroll to top effect was not hitting before the header compression check, so if a user navigated from a scrolled down page to a vault page, the header started in the compressed state. fixed with useLayoutEffect.

## Motivation and Context

bug fix

## How Has This Been Tested?

To test, go to /vaults. Scroll down and then open a vault. new page should open with the uncompressed header
