### PR TITLE
fix connect wallet bug

### DIFF
--- a/src/components/shared/contexts/useWeb3.tsx
+++ b/src/components/shared/contexts/useWeb3.tsx
@@ -44,7 +44,7 @@ export const Web3ContextApp = (props: { children: ReactElement }): ReactElement 
   const { connectors, connectAsync } = useConnect()
   const { disconnect } = useDisconnect()
   const { data: ensName, isLoading: isEnsLoading } = useEnsName({
-    address: address,
+    address: isConnected ? address : undefined,
     chainId: mainnet.id
   })
   const { openAccountModal } = useAccountModal()
@@ -103,7 +103,7 @@ export const Web3ContextApp = (props: { children: ReactElement }): ReactElement 
   ])
 
   useAsyncTrigger(async (): Promise<void> => {
-    if (!isAddress(address)) {
+    if (!isConnected || !isAddress(address)) {
       setClusters(undefined)
       setIsFetchingClusters(false)
       return
@@ -124,7 +124,7 @@ export const Web3ContextApp = (props: { children: ReactElement }): ReactElement 
     } finally {
       setIsFetchingClusters(false)
     }
-  }, [address])
+  }, [address, isConnected])
 
   useEffect(() => {
     if (isConnecting) {
@@ -146,9 +146,9 @@ export const Web3ContextApp = (props: { children: ReactElement }): ReactElement 
 
   const contextValue = useMemo(
     () => ({
-      address: address ? toAddress(address) : undefined,
-      ens: ensName || '',
-      clusters,
+      address: isConnected && address ? toAddress(address) : undefined,
+      ens: isConnected && ensName ? ensName : undefined,
+      clusters: isConnected ? clusters : undefined,
       chainID,
       isActive: isConnected,
       isWalletSafe,


### PR DESCRIPTION
## Description

Fix “ghost connected” wallet state when user cancels reconnect

### Summary
  When a user disconnects and then starts a new wallet connection but cancels it in their wallet, the UI could still
  appear connected (showing identity/balances) while actions would prompt to connect again.

### Root cause
  Wagmi can surface an address (and downstream identity like ENS/Clusters) during the connecting state even when
  isConnected is still false, which our UI treated as “connected enough”.

### Fix

  - Gate identity lookups (ENS + Clusters) behind isConnected.
  - Only expose address, ens, and clusters from useWeb3() when isConnected === true, so the UI can’t show a connected
    state during a canceled/failed connection attempt.

## Testing

steps to recreate bug in older branch:
1. connect wallet and fully connect via wallet interface
2. disconnect wallet
3. click connect wallet again, but decline connection. wallet will show as "connected"

In new version, do the same, but wallet will not be connected until actual wallet connection is completed.