### PR TITLE
Use est APY data for strategies from kong

### DIFF
--- a/src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
+++ b/src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
@@ -70,8 +70,7 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TYDaemo
   const unallocatedValue = totalAssets > allocatedDebt ? totalAssets - allocatedDebt : 0n
 
   const filteredVaultList = useMemo(() => {
-    const strategies = mergedList.filter((vault) => vault.status !== 'not_active')
-    return strategies
+    return mergedList
   }, [mergedList])
 
   const sortedVaultsToDisplay = useSortVaults(filteredVaultList, sortBy, sortDirection) as (TYDaemonVault & {
@@ -202,8 +201,8 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TYDaemo
               .map((strategy) => (
                 <VaultsListStrategy
                   key={strategy.address}
-                  isUnallocated={false}
                   details={strategy.details}
+                  status={strategy.status}
                   chainId={currentVault.chainID}
                   allocation={formatCounterValue(
                     toNormalizedBN(strategy.details?.totalDebt || 0, currentVault.token.decimals).display,
@@ -245,7 +244,12 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TYDaemo
                       datatype={'number'}
                     >
                       <p className={'inline text-start text-xs text-text-primary/60 md:hidden'}>{'Amount'}</p>
-                      <p>{toNormalizedBN(unallocatedValue, currentVault.token.decimals).display}</p>
+                      <p>
+                        {formatCounterValue(
+                          toNormalizedBN(unallocatedValue, currentVault.token.decimals).display,
+                          tokenPrice
+                        )}
+                      </p>
                     </div>
                     <div
                       className={'flex flex-row justify-between sm:flex-col md:col-span-5 md:text-right'}
@@ -269,8 +273,8 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TYDaemo
               .map((strategy) => (
                 <VaultsListStrategy
                   key={strategy.address}
-                  isUnallocated={true}
                   details={strategy.details}
+                  status={strategy.status}
                   chainId={currentVault.chainID}
                   allocation={formatCounterValue(
                     toNormalizedBN(strategy.details?.totalDebt || 0, currentVault.token.decimals).display,

--- a/src/components/pages/vaults/utils/normalizeVaultSnapshot.ts
+++ b/src/components/pages/vaults/utils/normalizeVaultSnapshot.ts
@@ -258,6 +258,8 @@ const mapSnapshotComposition = (
     return []
   }
 
+  const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60
+  const nowSeconds = Math.floor(Date.now() / 1000)
   const strategies: TYDaemonVaultStrategy[] = []
   composition.forEach((entry, index) => {
     const resolvedAddress = toAddress(entry.address ?? entry.strategy)
@@ -271,14 +273,20 @@ const mapSnapshotComposition = (
     const totalLoss = entry.totalLoss ?? '0'
     const performanceFee = normalizeNumber(entry.performanceFee ?? 0)
     const lastReport = normalizeNumber(entry.lastReport ?? 0)
+    const lastReportSeconds = lastReport > 1_000_000_000_000 ? Math.floor(lastReport / 1000) : lastReport
     const hasAllocation = toBigInt(totalDebt) > 0n || debtRatio > 0
+    const shouldUseLatestReportApr =
+      hasAllocation && lastReportSeconds > 0 && nowSeconds - lastReportSeconds <= ONE_WEEK_IN_SECONDS
     const status = normalizeCompositionStatus(entry.status, hasAllocation)
     const name = entry.name?.trim() || `Strategy ${index + 1}`
-    const resolvedApr = pickNumberOrNull(
-      entry.performance?.oracle?.apy,
-      entry.performance?.historical?.net,
-      entry.latestReportApr
-    )
+    const resolvedApr = hasAllocation
+      ? pickNumberOrNull(
+          entry.performance?.estimated?.apy,
+          shouldUseLatestReportApr ? entry.latestReportApr : undefined,
+          entry.performance?.oracle?.apy,
+          entry.performance?.historical?.net
+        )
+      : null
     strategies.push({
       address: resolvedAddress,
       name,
@@ -458,17 +466,40 @@ const buildSnapshotVault = (
   const tvlUsd = pickNumber(snapshot.tvl?.close, base?.tvl.tvl, 0)
   const price = computePrice(totalAssets, token.decimals, tvlUsd, base?.tvl.price)
 
+  const estimated = snapshot.performance?.estimated
   const historical = snapshot.performance?.historical
   const netApr = pickNumber(snapshot.apy?.net, historical?.net, base?.apr.netAPR, 0)
   const weekNet = pickNumber(snapshot.apy?.weeklyNet, historical?.weeklyNet, base?.apr.points?.weekAgo, 0)
   const monthNet = pickNumber(snapshot.apy?.monthlyNet, historical?.monthlyNet, base?.apr.points?.monthAgo, 0)
   const inceptionNet = pickNumber(snapshot.apy?.inceptionNet, historical?.inceptionNet, base?.apr.points?.inception, 0)
-  const forwardNet = pickNumber(snapshot.performance?.oracle?.apr, base?.apr.forwardAPR.netAPR, 0)
+  const forwardNet = pickNumber(
+    estimated?.apy,
+    estimated?.apr,
+    snapshot.performance?.oracle?.apy,
+    snapshot.performance?.oracle?.apr,
+    base?.apr.forwardAPR.netAPR,
+    0
+  )
 
-  const forwardType =
-    snapshot.performance?.oracle?.apr !== null && snapshot.performance?.oracle?.apr !== undefined
+  const forwardType = estimated
+    ? 'estimated'
+    : snapshot.performance?.oracle?.apr !== null && snapshot.performance?.oracle?.apr !== undefined
       ? 'oracle'
       : (base?.apr.forwardAPR.type ?? 'unknown')
+
+  const forwardComposite = estimated
+    ? {
+        ...base?.apr.forwardAPR.composite,
+        boost: estimated.components?.boost ?? base?.apr.forwardAPR.composite?.boost ?? 0,
+        poolAPY: estimated.components?.poolAPY ?? base?.apr.forwardAPR.composite?.poolAPY ?? 0,
+        boostedAPR: estimated.components?.boostedAPR ?? base?.apr.forwardAPR.composite?.boostedAPR ?? 0,
+        baseAPR: estimated.components?.baseAPR ?? base?.apr.forwardAPR.composite?.baseAPR ?? 0,
+        rewardsAPR: estimated.components?.rewardsAPR ?? base?.apr.forwardAPR.composite?.rewardsAPR ?? 0,
+        cvxAPR: estimated.components?.cvxAPR ?? base?.apr.forwardAPR.composite?.cvxAPR ?? 0,
+        keepCRV: estimated.components?.keepCRV ?? base?.apr.forwardAPR.composite?.keepCRV ?? 0,
+        keepVELO: estimated.components?.keepVelo ?? base?.apr.forwardAPR.composite?.keepVELO ?? 0
+      }
+    : base?.apr.forwardAPR.composite
 
   const feesPerformance = snapshot.fees ? normalizeFee(snapshot.fees.performanceFee) : (base?.apr.fees.performance ?? 0)
   const feesManagement = snapshot.fees ? normalizeFee(snapshot.fees.managementFee) : (base?.apr.fees.management ?? 0)
@@ -534,7 +565,7 @@ const buildSnapshotVault = (
       forwardAPR: {
         type: forwardType,
         netAPR: forwardNet,
-        composite: base?.apr.forwardAPR.composite ?? undefined
+        composite: forwardComposite ?? undefined
       }
     },
     featuringScore: base?.featuringScore ?? 0,

--- a/src/components/shared/utils/schemas/kongVaultSnapshotSchema.ts
+++ b/src/components/shared/utils/schemas/kongVaultSnapshotSchema.ts
@@ -87,8 +87,30 @@ const snapshotRiskSchema = z
   .optional()
   .default(null)
 
+const estimatedAprSchema = z.object({
+  apr: z.union([z.number(), z.string()]).transform((value) => Number(value)),
+  apy: z.union([z.number(), z.string()]).transform((value) => Number(value)),
+  type: z.string().optional().default('').catch(''),
+  components: z
+    .object({
+      boost: nullableNumberSchema.nullish(),
+      poolAPY: nullableNumberSchema.nullish(),
+      boostedAPR: nullableNumberSchema.nullish(),
+      baseAPR: nullableNumberSchema.nullish(),
+      rewardsAPR: nullableNumberSchema.nullish(),
+      rewardsAPY: nullableNumberSchema.nullish(),
+      cvxAPR: nullableNumberSchema.nullish(),
+      keepCRV: nullableNumberSchema.nullish(),
+      keepVelo: nullableNumberSchema.nullish()
+    })
+    .partial()
+    .optional()
+    .default({})
+})
+
 const snapshotPerformanceSchema = z
   .object({
+    estimated: estimatedAprSchema.optional().catch(undefined),
     oracle: z
       .object({
         apr: nullableNumberSchema.optional().catch(null),
@@ -144,6 +166,7 @@ const snapshotCompositionSchema = z
     latestReportApr: nullableNumberSchema.optional().catch(null),
     performance: z
       .object({
+        estimated: estimatedAprSchema.optional().catch(undefined),
         oracle: z
           .object({
             apr: nullableNumberSchema.optional().catch(null),


### PR DESCRIPTION
### Summary

  - Updated Kong REST /snapshot parsing + normalization to use the new performance.estimated data for both vault-level
    and strategy-level APY/APR, especially for factory vaults.
  - Strategy APY in VaultStrategiesSection now prefers performance.estimated.apy when available and avoids showing stale
    APRs from legacy sources.
  - Improved strategy row rendering for unallocated / inactive strategies to use placeholder values instead of
    misleading 0 / $0.00.

### What Changed

  - Kong snapshot schema updates
      - Added support for the new performance.estimated shape on:
          - Vault-level snapshot.performance.estimated
          - Strategy composition entries composition[].performance.estimated
      - This matches the new EstimatedAprSchema shape (apr/apy/type/components) and tolerates partial/missing component
        fields.
      - Files:
          - src/components/shared/utils/schemas/kongVaultSnapshotSchema.ts
  - Vault-level Est. APY (header) now uses performance.estimated
      - apr.forwardAPR.netAPR is now populated from snapshot.performance.estimated.apy (fallback to estimated.apr, then
        legacy oracle values).
      - apr.forwardAPR.type is set to estimated when present.
      - estimated.components are mapped into forwardAPR.composite so boosted/forward-APY breakdowns remain consistent
        (including keepVelo → keepVELO mapping).
      - Fixes factory vault headers showing the same value for “Est. APY” and “30 Day APY”.
      - Files:
          - src/components/pages/vaults/utils/normalizeVaultSnapshot.ts
  - Strategy APY source preference + stale report protection
      - For composition-based strategies, APY now prefers:
          1. composition[].performance.estimated.apy
          2. composition[].latestReportApr (only if the report is <= 7 days old AND the strategy has allocation)
          3. legacy oracle/historical fallbacks
      - Added a 1-week freshness guard based on now - lastReport.
      - /reports fallback APR (used for some v2/non-vault strategies) now:
          - Filters out reports older than 1 week.
          - Only runs for status === 'active' rows.
      - Files:
          - src/components/pages/vaults/utils/normalizeVaultSnapshot.ts
          - src/components/pages/vaults/domain/reports/findLatestReportApr.ts
          - src/components/pages/vaults/components/detail/VaultsListStrategy.tsx
  - Strategy row UI behavior for inactive/unallocated
      - Strategy rows now render placeholders (dash -) for Allocation %, Amount, and APY when status is unallocated or
        not_active, instead of showing 0% / $0.00.
      - Inactive strategies are no longer filtered out of the strategies list so they can display with placeholders.
      - The vault-level “Unallocated” funds row now displays the amount as USD (includes $).
      - Files:
          - src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
          - src/components/pages/vaults/components/detail/VaultsListStrategy.tsx

 ### Behavioral Notes

  - Strategy APRs from old latestReportApr and old /reports entries will no longer surface after the 7-day cutoff.
  - Unallocated/inactive strategies show - rather than misleading zero values.

  Smoke Test Checklist

  1. Start the app: bun run dev
  2. Factory vault header
      - Open a factory vault detail page (e.g. a Curve/CRV factory vault).
      - Confirm “Est. APY” differs from “30 Day APY” when snapshot.performance.estimated is present.
  3. Strategy list APY source
      - On a factory vault with composition[].performance.estimated, confirm strategy APY matches estimated.apy (not
        latestReportApr/lastReport).
  4. Stale report suppression
      - Find a vault where a strategy has an old lastReport (older than 7 days) and a non-null latestReportApr.
      - Confirm the strategy row does not show that stale APR.
  5. Unallocated/inactive row placeholders
      - Open a vault with composition entries marked unallocated and inactive.
      - Confirm Allocation %, Amount, and APY show - (not 0% / $0.00).
  6. Vault-level unallocated funds row
      - On a vault with unallocated funds, confirm the “Unallocated” row Amount displays as $....