### PR TITLE
remove env remapper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,28 +1,28 @@
-# Keys will be remapped with VITE_ prefix.
-RPC_URI_FOR_1=
-RPC_URI_FOR_10=
-RPC_URI_FOR_100=
-RPC_URI_FOR_137=
-RPC_URI_FOR_146=
-RPC_URI_FOR_250=
-RPC_URI_FOR_8453=
-RPC_URI_FOR_42161=
-RPC_URI_FOR_747474=
+# Client-exposed env vars must be prefixed with VITE_. Server-only vars must NOT be prefixed.
+VITE_RPC_URI_FOR_1=
+VITE_RPC_URI_FOR_10=
+VITE_RPC_URI_FOR_100=
+VITE_RPC_URI_FOR_137=
+VITE_RPC_URI_FOR_146=
+VITE_RPC_URI_FOR_250=
+VITE_RPC_URI_FOR_8453=
+VITE_RPC_URI_FOR_42161=
+VITE_RPC_URI_FOR_747474=
 
-ALCHEMY_KEY=
-INFURA_KEY=
-PARTNER_ID_ADDRESS=
-SHOULD_USE_PARTNER_CONTRACT=true
-WALLETCONNECT_PROJECT_ID=
-BASE_YEARN_ASSETS_URI=https://cdn.jsdelivr.net/gh/yearn/tokenassets@main
-YDAEMON_BASE_URI=https://ydaemon.yearn.fi
-KONG_REST_URL=https://kong.yearn.fi/api/rest
-SENTRY_DSN=
+VITE_ALCHEMY_KEY=
+VITE_INFURA_PROJECT_ID=
+VITE_PARTNER_ID_ADDRESS=
+VITE_SHOULD_USE_PARTNER_CONTRACT=true
+VITE_WALLETCONNECT_PROJECT_ID=
+VITE_BASE_YEARN_ASSETS_URI=https://cdn.jsdelivr.net/gh/yearn/tokenassets@main
+VITE_YDAEMON_BASE_URI=https://ydaemon.yearn.fi
+VITE_KONG_REST_URL=https://kong.yearn.fi/api/rest
+VITE_SENTRY_DSN=
 
-CLUSTERS_API_URL=https://api.clusters.xyz/v1
-CLUSTERS_API_KEY=
+VITE_CLUSTERS_API_URL=https://api.clusters.xyz/v1
+VITE_CLUSTERS_API_KEY=
 
 # Balance fetching strategy: 'enso' (default) | 'multicall'
 # Enso reduces RPC load by fetching all balances via their API in a single call
-BALANCE_SOURCE=
+VITE_BALANCE_SOURCE=
 ENSO_API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ api/                      # Vercel serverless functions
 Supported networks (configured in `src/components/shared/utils/constants.tsx`):
 - Ethereum (1), Optimism (10), Gnosis (100), Polygon (137), Fantom (250), Arbitrum (42161), Base (8453)
 
-RPC URIs configured via environment variables: `RPC_URI_FOR_<chainId>`
+RPC URIs configured via environment variables: `VITE_RPC_URI_FOR_<chainId>`
 
 ## Environment Setup
 

--- a/src/components/shared/contexts/WithTokenList.tsx
+++ b/src/components/shared/contexts/WithTokenList.tsx
@@ -73,6 +73,7 @@ export const WithTokenList = ({
     'https://cdn.jsdelivr.net/gh/yearn/tokenLists@main/lists/tokenlistooor.json'
   ]
 }: TTokenListProviderProps): ReactElement => {
+  const isDevelopment = import.meta.env.MODE === 'development'
   const { chainID } = useWeb3()
   const { value: extraTokenlist } = useLocalStorageValue<string[]>('extraTokenlists')
   const { value: extraTokens, set: setExtraTokens } = useLocalStorageValue<TTokenList['tokens']>('extraTokens')
@@ -128,11 +129,7 @@ export const WithTokenList = ({
        ** If we are in development mode, we also want to add the token to our list, but only
        ** if the token's chainID is 1 (Ethereum).
        *************************************************************************************/
-      if (
-        import.meta.env.VITE_NODE_ENV === 'development' &&
-        Boolean(import.meta.env.VITE_SHOULD_USE_FORKNET) &&
-        eachToken.chainId === 1
-      ) {
+      if (isDevelopment && Boolean(import.meta.env.VITE_SHOULD_USE_FORKNET) && eachToken.chainId === 1) {
         if (!tokenListTokens[1337]) {
           tokenListTokens[1337] = {}
         }
@@ -194,11 +191,7 @@ export const WithTokenList = ({
            ** If we are in development mode, we also want to add the token to our list, but only
            ** if the token's chainID is 1 (Ethereum).
            *************************************************************************************/
-          if (
-            import.meta.env.VITE_NODE_ENV === 'development' &&
-            Boolean(import.meta.env.VITE_SHOULD_USE_FORKNET) &&
-            chainId === 1
-          ) {
+          if (isDevelopment && Boolean(import.meta.env.VITE_SHOULD_USE_FORKNET) && chainId === 1) {
             if (!tokenListTokens[1337]) {
               tokenListTokens[1337] = {}
             }
@@ -252,11 +245,7 @@ export const WithTokenList = ({
          ** If we are in development mode, we also want to add the token to our list, but only
          ** if the token's chainID is 1 (Ethereum).
          *************************************************************************************/
-        if (
-          import.meta.env.VITE_NODE_ENV === 'development' &&
-          Boolean(import.meta.env.VITE_SHOULD_USE_FORKNET) &&
-          eachToken.chainId === 1
-        ) {
+        if (isDevelopment && Boolean(import.meta.env.VITE_SHOULD_USE_FORKNET) && eachToken.chainId === 1) {
           if (!tokenListTokens[1337]) {
             tokenListTokens[1337] = {}
           }

--- a/src/components/shared/utils/wagmi/actions.ts
+++ b/src/components/shared/utils/wagmi/actions.ts
@@ -47,6 +47,8 @@ const ALTERNATE_ERC20_APPROVE_ABI = [
   }
 ] as const
 
+const isDevelopment = import.meta.env.MODE === 'development'
+
 /*******************************************************************************
  ** isApprovedERC20 is a _VIEW_ function that checks if a token is approved for
  ** a spender.
@@ -116,7 +118,7 @@ export async function approveERC20(props: TApproveERC20): Promise<TTxResponse> {
     return await handleTx(propsWithoutOnTrySomethingElse, {
       address: toAddress(props.contractAddress),
       abi: ALTERNATE_ERC20_APPROVE_ABI,
-      confirmation: props.confirmation ?? (import.meta.env.VITE_NODE_ENV === 'development' ? 1 : undefined),
+      confirmation: props.confirmation ?? (isDevelopment ? 1 : undefined),
       functionName: 'approve',
       args: [props.spenderAddress, props.amount]
     })
@@ -125,7 +127,7 @@ export async function approveERC20(props: TApproveERC20): Promise<TTxResponse> {
   return await handleTx(props, {
     address: props.contractAddress,
     abi: erc20Abi,
-    confirmation: props.confirmation ?? (import.meta.env.VITE_NODE_ENV === 'development' ? 1 : undefined),
+    confirmation: props.confirmation ?? (isDevelopment ? 1 : undefined),
     functionName: 'approve',
     args: [props.spenderAddress, props.amount]
   })
@@ -153,7 +155,7 @@ export async function deposit(props: TDeposit): Promise<TTxResponse> {
     abi: VAULT_ABI,
     functionName: 'deposit',
     args: [props.amount, wagmiProvider.address],
-    confirmation: props.confirmation ?? (import.meta.env.VITE_NODE_ENV === 'development' ? 1 : undefined)
+    confirmation: props.confirmation ?? (isDevelopment ? 1 : undefined)
   })
 }
 

--- a/src/components/shared/utils/wagmi/config.ts
+++ b/src/components/shared/utils/wagmi/config.ts
@@ -14,7 +14,7 @@ import type { Chain } from 'viem/chains'
 import type { Config, ResolvedRegister } from 'wagmi'
 import { cookieStorage, createStorage, custom, fallback, http, unstable_connector, webSocket } from 'wagmi'
 import { injected, safe } from 'wagmi/connectors'
-import { getNetwork } from './utils'
+import { getNetwork, getRpcUriFor } from './utils'
 
 let CONFIG: Config | undefined
 let CONFIG_CHAINS: Chain[] = []
@@ -49,7 +49,7 @@ export function getConfig({ chains }: { chains: Chain[] }): ResolvedRegister['co
     /**************************************************************************************
      ** Assign the transport via the env variables
      *************************************************************************************/
-    const newRPC = import.meta.env.VITE_RPC_URI_FOR?.[chain.id] || ''
+    const newRPC = getRpcUriFor(chain.id)
     const oldRPC = import.meta.env.VITE_JSON_RPC_URI?.[chain.id] || import.meta.env.VITE_JSON_RPC_URL?.[chain.id]
     const defaultJsonRPCURL = chain?.rpcUrls?.public?.http?.[0]
     const envRPC = newRPC || oldRPC || defaultJsonRPCURL
@@ -138,7 +138,7 @@ export function getConfig({ chains }: { chains: Chain[] }): ResolvedRegister['co
       wsURI = 'ws' + wsURI
     }
     const availableRPCs: string[] = []
-    const newRPC = import.meta.env.VITE_RPC_URI_FOR?.[chain.id] || ''
+    const newRPC = getRpcUriFor(chain.id)
     const oldRPC = import.meta.env.VITE_JSON_RPC_URI?.[chain.id] || import.meta.env.VITE_JSON_RPC_URL?.[chain.id]
     const defaultJsonRPCURL = chain?.rpcUrls?.public?.http?.[0]
     const injectedRPC = newRPC || oldRPC || defaultJsonRPCURL || ''

--- a/src/components/shared/utils/wagmi/utils.ts
+++ b/src/components/shared/utils/wagmi/utils.ts
@@ -87,6 +87,15 @@ const isChain = (chain: wagmiChains.Chain | unknown): chain is wagmiChains.Chain
   )
 }
 
+export function getRpcUriFor(chainId: number | string): string {
+  const key = `VITE_RPC_URI_FOR_${chainId}`
+  const value = import.meta.env[key]
+  if (typeof value !== 'string') {
+    return ''
+  }
+  return value.trim()
+}
+
 function getAlchemyBaseURL(chainID: number): string {
   switch (chainID) {
     case wagmiChains.mainnet.id:
@@ -145,11 +154,13 @@ function initIndexedWagmiChains(): TNDict<TExtendedChain> {
         ...extendedChain.contracts
       }
 
-      const newRPC = import.meta.env.VITE_RPC_URI_FOR?.[extendedChain.id] || ''
+      const newRPC = getRpcUriFor(extendedChain.id)
       const oldRPC =
         import.meta.env.VITE_JSON_RPC_URI?.[extendedChain.id] || import.meta.env.VITE_JSON_RPC_URL?.[extendedChain.id]
       if (!newRPC && oldRPC) {
-        console.debug(`JSON_RPC_URI[${extendedChain.id}] is deprecated. Please use RPC_URI_FOR[${extendedChain.id}]`)
+        console.debug(
+          `VITE_JSON_RPC_URI[${extendedChain.id}] is deprecated. Please use VITE_RPC_URI_FOR_${extendedChain.id}`
+        )
       }
       const defaultJsonRPCURL = extendedChain?.rpcUrls?.public?.http?.[0]
 
@@ -202,7 +213,7 @@ export function getClient(chainID: number): PublicClient {
   }
   const chainConfig = indexedWagmiChains?.[chainID] || retrieveConfig().chains.find((chain) => chain.id === chainID)
 
-  const newRPC = import.meta.env.VITE_RPC_URI_FOR?.[chainID] || ''
+  const newRPC = getRpcUriFor(chainID)
   const oldRPC = import.meta.env.VITE_JSON_RPC_URI?.[chainID] || import.meta.env.VITE_JSON_RPC_URL?.[chainID]
 
   const url =

--- a/src/config/wagmi.ts
+++ b/src/config/wagmi.ts
@@ -1,4 +1,4 @@
-import { getNetwork, registerConfig } from '@shared/utils/wagmi'
+import { getNetwork, getRpcUriFor, registerConfig } from '@shared/utils/wagmi'
 import { connectorsForWallets } from '@rainbow-me/rainbowkit'
 import {
   frameWallet,
@@ -45,7 +45,7 @@ function buildTransports(): Record<TSupportedChainId, Transport> {
       availableTransports.push(http(network.defaultRPC, { batch: true }))
     }
 
-    const envRPC = import.meta.env.VITE_RPC_URI_FOR?.[chain.id]
+    const envRPC = getRpcUriFor(chain.id)
     if (envRPC) {
       availableTransports.push(http(envRPC, { batch: true }))
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import react from '@vitejs/plugin-react'
 import path from 'path'
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig } from 'vite'
 import webfontDownload from 'vite-plugin-webfont-dl'
 
 const API_PROXY_TARGET = 'http://localhost:3001'
@@ -41,46 +41,6 @@ async function pingApi() {
   }
 }
 
-function envRemapper() {
-  return {
-    name: 'env-remapper',
-    config(_: any, { mode }: any) {
-      const env = loadEnv(mode, process.cwd(), '')
-      const remappedEnv: Record<string, string | any> = {}
-      const rpcUriFor: Record<string, string> = {}
-
-      // Map non-VITE_ prefixed env vars to VITE_ prefixed ones
-      Object.keys(env).forEach((key) => {
-        if (!key.startsWith('VITE_')) {
-          // Special handling for RPC_URI_FOR_* variables
-          if (key.startsWith('RPC_URI_FOR_')) {
-            const chainId = key.replace('RPC_URI_FOR_', '')
-            rpcUriFor[chainId] = env[key]
-          } else if (key === 'INFURA_KEY') {
-            // Map INFURA_KEY to VITE_INFURA_PROJECT_ID for compatibility
-            // biome-ignore lint/complexity/useLiteralKeys: it's ok
-            remappedEnv['VITE_INFURA_PROJECT_ID'] = env[key]
-          } else {
-            remappedEnv[`VITE_${key}`] = env[key]
-          }
-        }
-      })
-
-      // Add the aggregated RPC_URI_FOR object
-      if (Object.keys(rpcUriFor).length > 0) {
-        // biome-ignore lint/complexity/useLiteralKeys: it's ok
-        remappedEnv['VITE_RPC_URI_FOR'] = rpcUriFor
-      }
-
-      return {
-        define: Object.fromEntries(
-          Object.entries(remappedEnv).map(([key, value]) => [`import.meta.env.${key}`, JSON.stringify(value)])
-        )
-      }
-    }
-  }
-}
-
 function previewApiGuard() {
   return {
     name: 'preview-api-guard',
@@ -106,7 +66,6 @@ function previewApiGuard() {
 export default defineConfig({
   plugins: [
     react(),
-    envRemapper(),
     previewApiGuard(),
     webfontDownload(['https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;500;600;700&display=swap'], {
       injectAsStyleTag: true,


### PR DESCRIPTION
Removes the env remapper due to security concerns of leaking keys.

ENV var names will need to be updated in our deployment configs

