### PR TITLE
fix v2 withdrawal routing issue

### DIFF
--- a/src/components/pages/vaults/components/widget/index.tsx
+++ b/src/components/pages/vaults/components/widget/index.tsx
@@ -123,6 +123,7 @@ export const Widget = forwardRef<TWidgetRef, Props>(
               stakingAddress={resolvedStakingAddress}
               chainId={chainId}
               vaultSymbol={currentVault?.symbol || ''}
+              vaultVersion={currentVault?.version}
               isVaultRetired={Boolean(currentVault?.info?.isRetired)}
               vaultUserData={vaultUserData}
               handleWithdrawSuccess={handleSuccess}

--- a/src/components/pages/vaults/components/widget/withdraw/index.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/index.tsx
@@ -35,6 +35,7 @@ export const WidgetWithdraw: FC<
   stakingAddress,
   chainId,
   vaultSymbol,
+  vaultVersion,
   vaultUserData,
   handleWithdrawSuccess: onWithdrawSuccess,
   onOpenSettings,
@@ -129,6 +130,7 @@ export const WidgetWithdraw: FC<
 
   const withdrawInput = useDebouncedInput(assetToken?.decimals ?? 18)
   const [withdrawAmount, , setWithdrawInput] = withdrawInput
+  const usesErc4626 = Boolean(vaultVersion?.startsWith('3') || vaultVersion?.startsWith('~3'))
 
   const isMaxWithdraw = useMemo(() => {
     return (
@@ -173,7 +175,8 @@ export const WidgetWithdraw: FC<
     slippage: zapSlippage,
     withdrawalSource,
     isUnstake,
-    isDebouncing: withdrawAmount.isDebouncing
+    isDebouncing: withdrawAmount.isDebouncing,
+    useErc4626: usesErc4626
   })
 
   const isCrossChain = destinationChainId !== chainId

--- a/src/components/pages/vaults/components/widget/withdraw/types.ts
+++ b/src/components/pages/vaults/components/widget/withdraw/types.ts
@@ -10,6 +10,7 @@ export interface WithdrawWidgetProps {
   stakingAddress?: `0x${string}`
   chainId: number
   vaultSymbol: string
+  vaultVersion?: string
   isVaultRetired?: boolean
   vaultUserData: VaultUserData
   handleWithdrawSuccess?: () => void

--- a/src/components/pages/vaults/components/widget/withdraw/useWithdrawFlow.ts
+++ b/src/components/pages/vaults/components/widget/withdraw/useWithdrawFlow.ts
@@ -36,6 +36,7 @@ interface UseWithdrawFlowProps {
   withdrawalSource: WithdrawalSource
   isUnstake: boolean
   isDebouncing: boolean
+  useErc4626: boolean
 }
 
 export interface WithdrawFlowResult {
@@ -65,7 +66,8 @@ export const useWithdrawFlow = ({
   slippage,
   withdrawalSource,
   isUnstake,
-  isDebouncing
+  isDebouncing,
+  useErc4626
 }: UseWithdrawFlowProps): WithdrawFlowResult => {
   // Determine routing type
   const routeType = useWithdrawRoute({
@@ -89,7 +91,8 @@ export const useWithdrawFlow = ({
     chainId,
     decimals: assetDecimals,
     vaultDecimals,
-    enabled: routeType === 'DIRECT_WITHDRAW' && amount > 0n
+    enabled: routeType === 'DIRECT_WITHDRAW' && amount > 0n,
+    useErc4626
   })
 
   // Direct unstake flow (staking → vault)

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
@@ -131,6 +131,16 @@ export const useSolverEnso = ({
       const data: EnsoRouteResponse & EnsoError = await response.json()
 
       if (data.error) {
+        console.warn('[Enso] Route error', {
+          chainId,
+          destinationChainId,
+          tokenIn,
+          tokenOut,
+          amountIn: amountIn.toString(),
+          statusCode: data.statusCode || response.status,
+          message: data.message,
+          requestId: data.requestId
+        })
         setError(data)
         // Only trigger fallback for server errors (5xx) or auth issues (401/403)
         // Normal errors like "no route found" (4xx) should not disable Enso
@@ -147,7 +157,13 @@ export const useSolverEnso = ({
       if (err instanceof TypeError && err.message.includes('fetch')) {
         setEnsoFailed(true)
       }
-      console.error('Failed to get Enso route:', err)
+      console.error('Failed to get Enso route:', err, {
+        chainId,
+        destinationChainId,
+        tokenIn,
+        tokenOut,
+        amountIn: amountIn.toString()
+      })
     } finally {
       setIsLoadingRoute(false)
     }


### PR DESCRIPTION
##  Problem
  Factory/legacy (v2) vaults were using the ERC‑4626 withdraw path (redeem/withdraw), which reverts on v2 contracts. This surfaced as “Transaction not ready. Please try again.” in the UI because useSimulateContract failed during prepare, and the overlay couldn’t proceed. V3 vaults were unaffected.

##  Solution

  - Pass the vault version into the withdraw widget and determine whether to use ERC‑4626 based on version (startsWith('3' | '~3')).
  - For v2 vaults, use the legacy vault ABI and withdraw(maxShares, recipient) (share-based).
  - Keep ERC‑4626 withdraw/redeem for v3 vaults.
  - This ensures correct contract calls for factory/legacy vaults and avoids simulation reverts.

##  Changes

  - src/components/pages/vaults/components/widget/index.tsx: pass vaultVersion to withdraw widget.
  - src/components/pages/vaults/components/widget/withdraw/types.ts: add vaultVersion to props.
  - src/components/pages/vaults/components/widget/withdraw/index.tsx: compute usesErc4626 and pass into flow.
  - src/components/pages/vaults/components/widget/withdraw/useWithdrawFlow.ts: forward useErc4626 flag to direct withdraw hook.
  - src/components/pages/vaults/hooks/actions/useDirectWithdraw.ts: split ERC‑4626 vs v2 withdraw simulation.

 ## How to Test

  1. Open a factory/legacy vault (e.g., “Curve RSUP‑WETH Factory yVault”, v2).
  2. Attempt a direct withdraw (same chain, same asset).
  3. Confirm the transaction proceeds without “Transaction not ready” and the simulation succeeds.
  4. Open a v3 vault and repeat withdraw to confirm ERC‑4626 path still works.