### PR TITLE
Test rpc.yearn.fi as public RPC proxy

### DIFF
--- a/src/components/shared/utils/wagmi/utils.ts
+++ b/src/components/shared/utils/wagmi/utils.ts
@@ -88,12 +88,7 @@ const isChain = (chain: wagmiChains.Chain | unknown): chain is wagmiChains.Chain
 }
 
 export function getRpcUriFor(chainId: number | string): string {
-  const key = `VITE_RPC_URI_FOR_${chainId}`
-  const value = import.meta.env[key]
-  if (typeof value !== 'string') {
-    return ''
-  }
-  return value.trim()
+  return `https://rpc.yearn.fi/chain/${chainId}`
 }
 
 function getAlchemyBaseURL(chainID: number): string {


### PR DESCRIPTION
## Summary
- Hardcodes `rpc.yearn.fi` as the RPC provider for all chains, bypassing env var configuration
- This preview deployment is for testing the RPC proxy publicly before rolling it out to production

## Notes
- **Do not merge** — this is a throwaway PR for Vercel preview testing only
- Once validated, configure `rpc.yearn.fi` in Vercel env vars and close this PR without merging

## Test plan
Please use this preview in place of the main app for a few days and report any issues.

- [ ] Vault list loads and filters as expected
- [ ] Deposit into a vault and confirm your balances update on the vault detail page
- [ ] Withdraw from a vault and confirm your balances reflect the withdrawal
- [ ] Portfolio page shows correct balances and updates after deposits/withdrawals
- [ ] Balances refresh with live data — no stale or stuck values after on-chain activity
- [ ] General browsing feels responsive