### PR TITLE
add automatic deposit pop-up

### DIFF
--- a/src/components/pages/landing/components/sections/Hero.tsx
+++ b/src/components/pages/landing/components/sections/Hero.tsx
@@ -1,7 +1,9 @@
+import { usePlausible } from '@hooks/usePlausible'
 import { Button } from '@shared/components/Button'
 import { SectionHeader } from '@shared/components/SectionHeader'
 import { TvlStat } from '@shared/components/TvlStat'
 import { useFetch } from '@shared/hooks/useFetch'
+import { PLAUSIBLE_EVENTS } from '@shared/utils/plausible'
 import type { ReactElement } from 'react'
 import * as z from 'zod'
 import Image from '/src/components/Image'
@@ -71,6 +73,7 @@ function AnimatedLogos(): ReactElement {
 }
 
 export function Hero(): ReactElement {
+  const trackEvent = usePlausible()
   const { data: tvl } = useFetch<number>({
     endpoint: 'https://api.llama.fi/tvl/yearn',
     schema: z.number()
@@ -107,7 +110,7 @@ export function Hero(): ReactElement {
                 description={"Yearn is DeFi's Yield Aggregator"}
               />
               <div className={'flex flex-row items-center justify-center gap-4'}>
-                <Link href={'/vaults'}>
+                <Link href={'/vaults'} onClick={() => trackEvent(PLAUSIBLE_EVENTS.LANDER_CTA_EXPLORE_VAULTS, {})}>
                   <Button className={'!text-[18px] max-w-xs !px-4 !py-3 !rounded-full !bg-primary'} variant={'primary'}>
                     {'Explore Vaults'}
                   </Button>
@@ -149,7 +152,11 @@ export function Hero(): ReactElement {
               description={"DeFi's most battle tested yield aggregator"}
             />
             <div className={'flex flex-col items-center justify-center'}>
-              <Link href={'/vaults'} className={'block w-full max-w-[280px]'}>
+              <Link
+                href={'/vaults'}
+                className={'block w-full max-w-[280px]'}
+                onClick={() => trackEvent(PLAUSIBLE_EVENTS.LANDER_CTA_EXPLORE_VAULTS, {})}
+              >
                 <Button
                   className={
                     '!text-[16px] sm:!text-[18px] w-full !px-6 !py-4 sm:!py-5 !rounded-full !bg-primary min-h-[48px]'

--- a/src/components/pages/landing/components/sections/Vaults.tsx
+++ b/src/components/pages/landing/components/sections/Vaults.tsx
@@ -1,6 +1,8 @@
+import { usePlausible } from '@hooks/usePlausible'
 import { SectionHeader } from '@shared/components/SectionHeader'
 import { useYearn } from '@shared/contexts/useYearn'
 import { formatPercent } from '@shared/utils/format'
+import { PLAUSIBLE_EVENTS } from '@shared/utils/plausible'
 import type { FC } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import Image from '/src/components/Image'
@@ -11,6 +13,8 @@ type TRow = {
   description?: string
   href: string
   address?: string
+  symbol?: string
+  chainID?: string
   bgClass?: string
 }
 
@@ -100,6 +104,7 @@ const appRows: TRow[] = [
 
 export const Vaults: FC = () => {
   const { vaults, isLoadingVaultList } = useYearn()
+  const trackEvent = usePlausible()
   const [activeSlide, setActiveSlide] = useState(0)
   const [isAnimating, setIsAnimating] = useState(false)
   const [isHovering, setIsHovering] = useState(false)
@@ -115,7 +120,9 @@ export const Vaults: FC = () => {
             icon: vault.icon,
             text: `Earn on ${vault.symbol}`,
             href: vault.href,
-            address: vault.address
+            address: vault.address,
+            symbol: vault.symbol,
+            chainID: '1'
           }
         }
         // safely pull out APR parts
@@ -128,7 +135,9 @@ export const Vaults: FC = () => {
           icon: vault.icon,
           text: apr > 0 ? `Earn up to ${formatPercent(apr * 100, 2, 2)} on ${vault.symbol}` : `Earn on ${vault.symbol}`,
           href: vault.href,
-          address: vault.address
+          address: vault.address,
+          symbol: vault.symbol,
+          chainID: vaultData.chainID.toString()
         }
       }),
       appRows.map((app, index) => {
@@ -260,6 +269,21 @@ export const Vaults: FC = () => {
                         <a
                           key={row.href}
                           href={row.href}
+                          onClick={() => {
+                            if (row.symbol) {
+                              trackEvent(PLAUSIBLE_EVENTS.LANDER_VAULT_CLICK, {
+                                props: {
+                                  vaultAddress: row.address ?? '',
+                                  vaultSymbol: row.symbol,
+                                  chainID: row.chainID ?? ''
+                                }
+                              })
+                            } else {
+                              trackEvent(PLAUSIBLE_EVENTS.LANDER_APP_CLICK, {
+                                props: { name: row.text }
+                              })
+                            }
+                          }}
                           className={`${row.bgClass} flex min-h-[48px] cursor-pointer items-center justify-between rounded-[12px] p-3 transition-opacity duration-200 hover:opacity-50 sm:min-h-[52px] md:rounded-[16px] md:p-[8px]`}
                         >
                           <div className={'flex items-center'}>

--- a/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/src/components/pages/vaults/[chainID]/[address].tsx
@@ -266,9 +266,19 @@ function Index(): ReactElement | null {
     address: params.address
   })
   const isSnapshotNotFound = (snapshotError as any)?.response?.status === 404
-  const shouldDisableStakingForDeposit = Boolean(snapshotVault?.meta?.shouldDisableStaking)
 
   const baseMergedVault = useMemo(() => mergeVaultSnapshot(baseVault, snapshotVault), [baseVault, snapshotVault])
+  const isFactoryVault = useMemo(() => {
+    if (!baseMergedVault) return false
+    return deriveListKind(baseMergedVault) === 'factory'
+  }, [baseMergedVault])
+  const snapshotShouldDisableStaking = snapshotVault?.meta?.shouldDisableStaking
+  const shouldDisableStakingForDeposit = useMemo(() => {
+    if (isFactoryVault) {
+      return true
+    }
+    return snapshotShouldDisableStaking === true
+  }, [snapshotShouldDisableStaking, isFactoryVault])
 
   const isYBold = useMemo(() => {
     if (!baseMergedVault?.address && !params.address) return false

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -182,6 +182,7 @@ export const WidgetDeposit: FC<Props> = ({
     account,
     isLoadingRoute: activeFlow.periphery.isLoadingRoute,
     flowError: activeFlow.periphery.error,
+    routeType,
     selectedToken,
     vaultAddress,
     isAutoStakingEnabled

--- a/src/components/pages/vaults/components/widget/deposit/useDepositError.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositError.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import type { Address } from 'viem'
+import type { DepositRouteType } from './types'
 
 interface UseDepositErrorProps {
   // Amount state
@@ -13,6 +14,7 @@ interface UseDepositErrorProps {
   // Flow state
   isLoadingRoute: boolean
   flowError?: unknown
+  routeType: DepositRouteType
   // Settings
   selectedToken?: Address
   vaultAddress: Address
@@ -27,6 +29,7 @@ export const useDepositError = ({
   account,
   isLoadingRoute,
   flowError,
+  routeType,
   selectedToken,
   vaultAddress,
   isAutoStakingEnabled
@@ -43,7 +46,7 @@ export const useDepositError = ({
     }
 
     // Route-dependent validation - wait for debounce and route fetch
-    if (flowError && !isLoadingRoute && debouncedAmount > 0n && !isDebouncing) {
+    if (routeType === 'ENSO' && flowError && !isLoadingRoute && debouncedAmount > 0n && !isDebouncing) {
       return 'Unable to find route'
     }
 
@@ -56,6 +59,7 @@ export const useDepositError = ({
     account,
     isLoadingRoute,
     flowError,
+    routeType,
     selectedToken,
     vaultAddress,
     isAutoStakingEnabled

--- a/src/components/shared/utils/plausible.ts
+++ b/src/components/shared/utils/plausible.ts
@@ -22,5 +22,8 @@ export const PLAUSIBLE_EVENTS = {
   VAULT_CLICK_COMPARE: 'vault_click_compare',
   COMPARE_MODE_TOGGLE: 'compare_mode_toggle',
   COMPARE_VAULT_ADD: 'compare_vault_add',
-  COMPARE_MODAL_OPEN: 'compare_modal_open'
+  COMPARE_MODAL_OPEN: 'compare_modal_open',
+  LANDER_CTA_EXPLORE_VAULTS: 'lander_cta_explore_vaults',
+  LANDER_VAULT_CLICK: 'lander_vault_click',
+  LANDER_APP_CLICK: 'lander_app_click'
 } as const


### PR DESCRIPTION
## Summary

  This PR improves multi-step transaction UX by automatically continuing from intermediate approval steps to the next executable step in the transaction overlay.

  ## What changed

  - Added optional props to TransactionOverlay:
  - autoContinueToNextStep?: boolean
  - Added guarded auto-continue behavior in TransactionOverlay so it only auto-advances when:
  - The next step is ready
  - The step label has changed (prevents replaying the same step)
  - It has not already auto-continued from that step label
  - deposit/index.tsx
  - withdraw/index.tsx
  - migrate/index.tsx
  - Allowed auto-continue labels in those flows: ['Approve', 'Sign Permit']

  ## User impact

  - Users no longer need to click “Continue” after successful Approve/Sign Permit in multi-step deposit, withdraw, and migrate flows.
  - Final step completion behavior remains unchanged.

  ## How to test (manual)

  1. Test deposit with approval required: choose an ERC-20/vault combo with insufficient allowance, start deposit, approve in wallet, and verify the overlay automatically moves to
     the deposit step without clicking Continue.
  2. Test withdraw with approval required: use a route that requires approval, approve in wallet, and verify the overlay automatically advances to the withdraw step.
  3. Test migrate with permit flow: use a vault migration path that shows Sign Permit, sign permit in wallet, and verify the overlay auto-advances to Migrate.
  4. Test migrate with approval flow: use a migration path that requires Approve, approve in wallet, and verify the overlay auto-advances to Migrate.
  5. Regression check for single-step flows: run a deposit/withdraw/migrate path with no approval/permit step and confirm behavior is unchanged.
  6. Regression check for duplicate triggering: close the overlay and run the same flow again; verify no duplicate auto-continue or repeated wallet prompt occurs.