### PR TITLE
chore: catch request failure

### DIFF
--- a/src/components/pages/vaults/hooks/useTokens.ts
+++ b/src/components/pages/vaults/hooks/useTokens.ts
@@ -23,38 +23,26 @@ async function fetchTokenData(config: any, addresses: Address[], chainId: number
 
   const results = await Promise.all(
     addresses.map(async (address) => {
-      try {
-        const contract = getContract({
-          address,
-          abi: erc20Abi,
-          client
-        })
+      const contract = getContract({
+        address,
+        abi: erc20Abi,
+        client
+      })
 
-        const [decimals, symbol, name, balance] = await Promise.all([
-          contract.read.decimals(),
-          contract.read.symbol(),
-          contract.read.name(),
-          account ? contract.read.balanceOf([account]) : Promise.resolve(0n)
-        ])
+      const [decimals, symbol, name, balance] = await Promise.all([
+        contract.read.decimals(),
+        contract.read.symbol(),
+        contract.read.name(),
+        account ? contract.read.balanceOf([account]) : Promise.resolve(0n)
+      ])
 
-        return {
-          address,
-          decimals: Number(decimals),
-          symbol: String(symbol),
-          name: String(name),
-          chainID: chainId,
-          balance: toNormalizedBN(balance, Number(decimals))
-        }
-      } catch (error) {
-        console.error(`Failed to fetch token ${address}:`, error)
-        return {
-          address,
-          decimals: 18,
-          symbol: '???',
-          name: 'Unknown',
-          chainID: chainId,
-          balance: toNormalizedBN(0n, 18)
-        }
+      return {
+        address,
+        decimals: Number(decimals),
+        symbol: String(symbol),
+        name: String(name),
+        chainID: chainId,
+        balance: toNormalizedBN(balance, Number(decimals))
       }
     })
   )


### PR DESCRIPTION
Removed the per-token try-catch in fetchTokenData (lines 26-58 → now 25-42). Previously, RPC failures were caught and replaced with fallback data (symbol: '???'), which TanStack Query cached as a successful result with no retry. 

Now errors propagate to TanStack Query, which retries 3 times with exponential backoff by default. 

### Bug: 
To test original bug, open https://yearn.fi/vaults/747474/0x80c34BD3A3569E126e7055831036aa7b212cB159 load vaults page, quickly hit the Withdraw tab. Request will then fail and return and cache '???' as the token symbol