### PR TITLE
fix: 0 est apy not showing

### DIFF
--- a/src/components/pages/vaults/hooks/useVaultApyData.ts
+++ b/src/components/pages/vaults/hooks/useVaultApyData.ts
@@ -56,6 +56,8 @@ export function useVaultApyData(vault: TYDaemonVault): TVaultApyData {
   const shouldUseKatanaAPRs = vault.chainID === KATANA_CHAIN_ID
 
   const baseForwardApr = vault.apr.forwardAPR.netAPR
+  const hasForwardAprSource = vault.apr.forwardAPR.type === 'oracle' || vault.apr.forwardAPR.type === 'estimated'
+  const hasForwardApr = hasForwardAprSource || !isZero(baseForwardApr)
   const netApr = vault.apr.netAPR
   const rewardsAprSum = vault.apr.extra.stakingRewardsAPR + vault.apr.extra.gammaRewardAPR
   const isBoosted =
@@ -104,7 +106,7 @@ export function useVaultApyData(vault: TYDaemonVault): TVaultApyData {
       }
       return { mode: 'rewards' }
     }
-    if (!isZero(baseForwardApr)) {
+    if (hasForwardApr) {
       return { mode: 'spot' }
     }
     return { mode: 'historical' }

--- a/src/components/shared/utils/vaultApy.ts
+++ b/src/components/shared/utils/vaultApy.ts
@@ -21,12 +21,13 @@ export function calculateVaultEstimatedAPY(vault: TYDaemonVault, katanaAprs: Par
   }
 
   const sumOfRewardsAPY = (vault.apr?.extra?.stakingRewardsAPR || 0) + (vault.apr?.extra?.gammaRewardAPR || 0)
-  const hasCurrentAPY = !isZero(vault?.apr?.forwardAPR?.netAPR || 0)
+  const hasForwardAPYSource = vault.apr?.forwardAPR?.type === 'oracle' || vault.apr?.forwardAPR?.type === 'estimated'
+  const hasForwardAPY = hasForwardAPYSource || !isZero(vault?.apr?.forwardAPR?.netAPR || 0)
 
   if (sumOfRewardsAPY > 0) {
     return sumOfRewardsAPY + (vault.apr?.forwardAPR?.netAPR || 0)
   }
-  if (hasCurrentAPY) {
+  if (hasForwardAPY) {
     return vault.apr?.forwardAPR?.netAPR || 0
   }
   return vault.apr?.netAPR || 0


### PR DESCRIPTION
## Description

Fix bug where 0% APY values in the est APY data were falling back to show the 30 day APY, even if the 0% estimated is correct.

## Motivation and Context

Bug reported

## How Has This Been Tested?
locally

## Screenshots (if appropriate):

before:
<img width="1618" height="522" alt="image" src="https://github.com/user-attachments/assets/a9b1c77c-cc18-46c5-b7bf-aa785503a9fc" />

after: 
<img width="1624" height="510" alt="image" src="https://github.com/user-attachments/assets/83299dce-69a5-45fe-bc11-7985d5eaeb84" />
