### PR TITLE
chore: update yearn morpho link

### DIFF
--- a/src/components/shared/components/HeaderNavMenu.tsx
+++ b/src/components/shared/components/HeaderNavMenu.tsx
@@ -88,7 +88,7 @@ export function HeaderNavMenu({ isHomePage, isDarkTheme }: THeaderNavMenuProps):
     },
     {
       name: 'Curation',
-      href: 'https://app.morpho.org/ethereum/earn?v2=false&curators=yearn',
+      href: 'https://app.morpho.org/ethereum/curator/yearn',
       description: 'Lending Market Curation',
       icon: <LogoCuration className={'size-11'} back={'text-transparent'} front={'text-primary'} />
     },

--- a/src/components/shared/components/MobileNavMenu.tsx
+++ b/src/components/shared/components/MobileNavMenu.tsx
@@ -173,7 +173,7 @@ export function MobileNavMenu({
     },
     {
       name: 'Curation',
-      href: 'https://app.morpho.org/ethereum/earn?v2=false&curators=yearn',
+      href: 'https://app.morpho.org/ethereum/curator/yearn',
       description: 'Lending Market Curation',
       icon: <LogoCuration className={'size-11'} back={'text-transparent'} front={'text-primary'} />
     },


### PR DESCRIPTION
Use a better link to the Morpho website, which lists all vaults curated by Yearn instead of just ones on mainnet