### PR TITLE
fix review comments

### DIFF
--- a/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/src/components/pages/vaults/[chainID]/[address].tsx
@@ -114,6 +114,20 @@ const splitFirstSentence = (message: string): { title: string; body?: string } =
   return body ? { title, body } : { title }
 }
 
+const isSnapshotLikelyV3Vault = (snapshot: TKongVaultSnapshot): boolean => {
+  const apiVersion = snapshot.apiVersion ?? ''
+  if (apiVersion.startsWith('3') || apiVersion.startsWith('~3')) {
+    return true
+  }
+
+  const normalizedKind = snapshot.meta?.kind?.toLowerCase() ?? ''
+  if (normalizedKind === 'single strategy' || normalizedKind === 'multi strategy') {
+    return true
+  }
+
+  return (snapshot.composition?.length ?? 0) > 0 || (snapshot.strategies?.length ?? 0) > 0
+}
+
 const buildSnapshotBackedVault = (snapshot: TKongVaultSnapshot): TKongVault => {
   const token = snapshot.meta?.token
   const asset = snapshot.asset
@@ -146,7 +160,7 @@ const buildSnapshotBackedVault = (snapshot: TKongVaultSnapshot): TKongVault => {
     category: snapshot.meta?.category ?? null,
     type: snapshot.meta?.type ?? null,
     kind: snapshot.meta?.kind ?? null,
-    v3: snapshot.apiVersion?.startsWith('3') ?? false,
+    v3: isSnapshotLikelyV3Vault(snapshot),
     yearn: true,
     isRetired: snapshot.meta?.isRetired ?? false,
     isHidden: snapshot.meta?.isHidden ?? false,

--- a/src/components/pages/vaults/components/widget/deposit/useDepositError.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositError.ts
@@ -46,6 +46,10 @@ export const useDepositError = ({
     }
 
     // Route-dependent validation - wait for debounce and route fetch
+    if (routeType === 'NO_ROUTE' && debouncedAmount > 0n && !isDebouncing) {
+      return 'No route available for selected token'
+    }
+
     if (routeType === 'ENSO' && flowError && !isLoadingRoute && debouncedAmount > 0n && !isDebouncing) {
       return 'Unable to find route'
     }


### PR DESCRIPTION
## Summary

This PR fixes two issues identified in review and includes the original review text below for traceability.

## Review findings (full text)

### 1) [P2] Handle missing `apiVersion` in snapshot-backed vaults
**Location:** [src/components/pages/vaults/[chainID]/[address].tsx:149](/Users/ross/Code/yearn/yearn.fi-worktree-1/src/components/pages/vaults/[chainID]/[address].tsx:149)

`buildSnapshotBackedVault` infers `v3` with `snapshot.apiVersion?.startsWith('3')` only, but snapshot payloads allow `apiVersion` to be null. On vault detail loads that rely on snapshot-backed fallback data, this causes `getVaultVersion` to fall back to `vault.v3=false`, misclassifying a v3 vault as v2 and driving incorrect downstream behavior (kind/type gating and action availability). Infer v3 from both `3`/`~3` prefixes and a secondary signal when `apiVersion` is absent.

### 2) [P2] Report `NO_ROUTE` as a deposit validation error
**Location:** [src/components/pages/vaults/components/widget/deposit/useDepositError.ts:49](/Users/ross/Code/yearn/yearn.fi-worktree-1/src/components/pages/vaults/components/widget/deposit/useDepositError.ts:49)

`useDepositRoute` now returns `NO_ROUTE`, but the deposit error hook only surfaces route failures when `routeType === 'ENSO'`. If Enso is unavailable and a non-direct token is selected/prefilled, the action remains disabled without any user-facing error, leaving the flow unrecoverable from the widget state. Add an explicit `NO_ROUTE` validation branch so users see why the deposit cannot proceed.

## What was changed

- Added resilient v3 inference for snapshot-backed vaults in [src/components/pages/vaults/[chainID]/[address].tsx](/Users/ross/Code/yearn/yearn.fi-worktree-1/src/components/pages/vaults/[chainID]/[address].tsx) by checking:
  - `apiVersion` prefixes `3` and `~3`
  - `meta.kind` (`single strategy`/`multi strategy`)
  - non-empty `composition` or `strategies` as fallback signal
- Added explicit `NO_ROUTE` error handling in [src/components/pages/vaults/components/widget/deposit/useDepositError.ts](/Users/ross/Code/yearn/yearn.fi-worktree-1/src/components/pages/vaults/components/widget/deposit/useDepositError.ts) with user-facing message: `No route available for selected token`.

## Validation

- `bun run lint:fix` passed
- `bun run build` passed

Not convinced these are super important, but maybe worth throwing in before full merge.