### PR TITLE
feat: add curation page

### DIFF
--- a/src/components/pages/curation/components/ReportMarkdown.tsx
+++ b/src/components/pages/curation/components/ReportMarkdown.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from 'react'
+import ReactMarkdown from 'react-markdown'
+
+type TReportMarkdownProps = {
+  content: string
+}
+
+export function ReportMarkdown({ content }: TReportMarkdownProps): ReactElement {
+  return (
+    <div className={'curation-prose'}>
+      <ReactMarkdown
+        skipHtml
+        components={{
+          a: ({ node: _node, ...props }) => <a {...props} target={'_blank'} rel={'noopener noreferrer'} />,
+          code: ({ node: _node, className, children, ...props }) => (
+            <code {...props} className={className}>
+              {children}
+            </code>
+          )
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/src/components/pages/curation/components/ScoreBadge.tsx
+++ b/src/components/pages/curation/components/ScoreBadge.tsx
@@ -1,0 +1,25 @@
+import { scoreColor, scoreTextColor } from '@pages/curation/lib/colors'
+import { cl } from '@shared/utils'
+import type { ReactElement } from 'react'
+
+type TScoreBadgeProps = {
+  score: number
+  size?: 'small' | 'large'
+}
+
+export function ScoreBadge({ score, size = 'small' }: TScoreBadgeProps): ReactElement {
+  const color = scoreColor(score)
+  const textColor = scoreTextColor(score)
+
+  return (
+    <span
+      className={cl(
+        'inline-block whitespace-nowrap rounded-md font-bold tabular-nums',
+        size === 'large' ? 'px-3 py-1.5 text-xl' : 'px-2 py-0.5 text-sm'
+      )}
+      style={{ background: color, color: textColor }}
+    >
+      {score.toFixed(1)}
+    </span>
+  )
+}

--- a/src/components/pages/curation/components/ScoreTable.tsx
+++ b/src/components/pages/curation/components/ScoreTable.tsx
@@ -1,0 +1,213 @@
+import { scoreColor, scoreTextColor, scoreTier } from '@pages/curation/lib/colors'
+import type { TCategoryScore } from '@pages/curation/lib/parseReport'
+import type { ReactElement } from 'react'
+import { useMemo, useState } from 'react'
+
+type TTooltipData = {
+  category: string
+  weight: string
+  score: number
+  x: number
+  y: number
+}
+
+type TPieSegment = TCategoryScore & {
+  startAngle: number
+  endAngle: number
+  color: string
+}
+
+function polarToCartesian(cx: number, cy: number, radius: number, angle: number): { x: number; y: number } {
+  const radians = ((angle - 90) * Math.PI) / 180
+  return {
+    x: cx + radius * Math.cos(radians),
+    y: cy + radius * Math.sin(radians)
+  }
+}
+
+function buildArcPath(cx: number, cy: number, radius: number, start: number, end: number): string {
+  const startPoint = polarToCartesian(cx, cy, radius, start)
+  const endPoint = polarToCartesian(cx, cy, radius, end)
+  const isLargeArc = end - start > 180 ? 1 : 0
+
+  return `M ${cx} ${cy} L ${startPoint.x} ${startPoint.y} A ${radius} ${radius} 0 ${isLargeArc} 1 ${endPoint.x} ${endPoint.y} Z`
+}
+
+function getLabelPosition(
+  cx: number,
+  cy: number,
+  radius: number,
+  start: number,
+  end: number
+): { x: number; y: number } {
+  const midAngle = (start + end) / 2
+  return polarToCartesian(cx, cy, radius * 0.65, midAngle)
+}
+
+type TScoreTableProps = {
+  scores: TCategoryScore[]
+  finalScore: number
+}
+
+export function ScoreTable({ scores, finalScore }: TScoreTableProps): ReactElement {
+  const [tooltip, setTooltip] = useState<TTooltipData | undefined>(undefined)
+
+  const totalWeight = useMemo(() => {
+    return scores.reduce((sum, score) => sum + (Number.parseFloat(score.weight) || 0), 0)
+  }, [scores])
+
+  const segments = useMemo((): TPieSegment[] => {
+    if (scores.length === 0 || totalWeight <= 0) {
+      return []
+    }
+
+    return scores.reduce<{ accumulated: number; segments: TPieSegment[] }>(
+      (state, score) => {
+        const weight = Number.parseFloat(score.weight) || 0
+        const startAngle = (state.accumulated / totalWeight) * 360
+        const nextAccumulated = state.accumulated + weight
+        const endAngle = (nextAccumulated / totalWeight) * 360
+
+        return {
+          accumulated: nextAccumulated,
+          segments: [
+            ...state.segments,
+            {
+              ...score,
+              startAngle,
+              endAngle,
+              color: scoreColor(score.score)
+            }
+          ]
+        }
+      },
+      { accumulated: 0, segments: [] }
+    ).segments
+  }, [scores, totalWeight])
+
+  if (scores.length === 0) {
+    return <p className={'text-text-secondary'}>{'No score breakdown is available for this report yet.'}</p>
+  }
+
+  return (
+    <div className={'curation-score-section'}>
+      <div className={'curation-table-wrap curation-score-table-area'}>
+        <table className={'curation-table'}>
+          <thead>
+            <tr>
+              <th>{'Category'}</th>
+              <th>{'Weight'}</th>
+              <th>{'Score'}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {scores.map((score) => (
+              <tr key={score.category}>
+                <td>
+                  <span className={'curation-score-dot'} style={{ background: scoreColor(score.score) }} />
+                  {score.category}
+                </td>
+                <td>{score.weight}</td>
+                <td style={{ color: scoreColor(score.score) }}>{score.score.toFixed(2)}</td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colSpan={2}>
+                <strong>{'Final Score'}</strong>
+              </td>
+              <td style={{ color: scoreColor(finalScore), fontWeight: 700 }}>{`${finalScore.toFixed(1)} / 5.0`}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      <div className={'curation-chart-area'}>
+        <div className={'curation-chart-container'}>
+          <svg viewBox={'0 0 200 200'} className={'curation-pie-chart'} role={'img'} aria-label={'Risk score chart'}>
+            {segments.map((segment) => (
+              <path
+                key={segment.category}
+                d={buildArcPath(100, 100, 90, segment.startAngle, segment.endAngle)}
+                fill={segment.color}
+                stroke={'var(--color-app)'}
+                strokeWidth={2}
+                className={'curation-pie-segment'}
+                onMouseEnter={(event) => {
+                  const chartBounds = event.currentTarget.ownerSVGElement?.getBoundingClientRect()
+                  if (!chartBounds) {
+                    return
+                  }
+
+                  setTooltip({
+                    category: segment.category,
+                    weight: segment.weight,
+                    score: segment.score,
+                    x: event.clientX - chartBounds.left + 12,
+                    y: event.clientY - chartBounds.top - 10
+                  })
+                }}
+                onMouseMove={(event) => {
+                  const chartBounds = event.currentTarget.ownerSVGElement?.getBoundingClientRect()
+                  if (!chartBounds) {
+                    return
+                  }
+
+                  setTooltip({
+                    category: segment.category,
+                    weight: segment.weight,
+                    score: segment.score,
+                    x: event.clientX - chartBounds.left + 12,
+                    y: event.clientY - chartBounds.top - 10
+                  })
+                }}
+                onMouseLeave={() => setTooltip(undefined)}
+              />
+            ))}
+            {segments.map((segment) => {
+              const labelWeight = Number.parseFloat(segment.weight)
+              if (labelWeight < 10) {
+                return null
+              }
+
+              const labelPosition = getLabelPosition(100, 100, 90, segment.startAngle, segment.endAngle)
+              return (
+                <text
+                  key={`${segment.category}-label`}
+                  x={labelPosition.x}
+                  y={labelPosition.y}
+                  textAnchor={'middle'}
+                  dominantBaseline={'central'}
+                  fill={scoreTextColor(segment.score)}
+                  fontSize={11}
+                  fontWeight={600}
+                  className={'curation-pie-label'}
+                >
+                  {segment.weight}
+                </text>
+              )
+            })}
+          </svg>
+
+          {tooltip && (
+            <div className={'curation-chart-tooltip visible'} style={{ left: tooltip.x, top: tooltip.y }}>
+              <strong>{tooltip.category}</strong>
+              <br />
+              {`Weight: ${tooltip.weight}`}
+              <br />
+              {`Score: ${tooltip.score.toFixed(2)}`}
+            </div>
+          )}
+        </div>
+
+        <div
+          className={'curation-risk-tier-badge'}
+          style={{ background: scoreColor(finalScore), color: scoreTextColor(finalScore) }}
+        >
+          {scoreTier(finalScore)}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pages/curation/curation.css
+++ b/src/components/pages/curation/curation.css
@@ -1,0 +1,498 @@
+.curation-page {
+  min-height: calc(100dvh - var(--header-height));
+  background: var(--color-app);
+  color: var(--color-text-primary);
+}
+
+.curation-container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+}
+
+.curation-heading {
+  font-size: 2rem;
+  line-height: 1.2;
+  margin-bottom: 1.5rem;
+}
+
+.curation-heading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.curation-heading-row .curation-heading {
+  margin-bottom: 0;
+}
+
+.curation-layout-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: 0.5rem 0.9rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-border);
+  color: var(--color-text-primary);
+  background: var(--color-surface);
+  font-size: 0.875rem;
+  font-weight: 600;
+  white-space: nowrap;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.curation-layout-toggle:hover {
+  text-decoration: none;
+  border-color: var(--color-border-hover);
+  background: var(--color-surface-secondary);
+}
+
+.curation-table-wrap {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.curation-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.curation-table th,
+.curation-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.curation-table th {
+  background: var(--color-surface-secondary);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.curation-col-icon {
+  width: 36px;
+  padding-right: 0;
+}
+
+.curation-icon-stack {
+  position: relative;
+  width: 24px;
+  height: 24px;
+}
+
+.curation-protocol-icon {
+  display: block;
+  border-radius: 50%;
+}
+
+.curation-chain-icon {
+  position: absolute;
+  bottom: -4px;
+  right: -6px;
+  border-radius: 50%;
+  border: 1.5px solid var(--color-app);
+  background: var(--color-app);
+}
+
+.curation-icon-placeholder {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--color-surface-secondary);
+}
+
+.curation-mono {
+  font-family: var(--font-family-aeonik-mono);
+  font-size: 0.85em;
+}
+
+.curation-clickable-row {
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.curation-clickable-row:hover,
+.curation-clickable-row:focus-visible {
+  background: var(--color-surface-secondary);
+  outline: none;
+}
+
+.curation-page-link {
+  color: var(--color-primary);
+}
+
+.curation-page-link:hover {
+  text-decoration: underline;
+}
+
+.curation-back-link {
+  display: inline-block;
+  margin-bottom: 1.5rem;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.curation-report-header {
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.curation-report-header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.curation-report-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.curation-report-title h1 {
+  font-size: 1.5rem;
+  line-height: 1.2;
+}
+
+.curation-report-protocol-icon {
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.curation-meta {
+  margin-top: 0.5rem;
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.curation-meta-sep {
+  margin: 0 0.25rem;
+  opacity: 0.4;
+}
+
+.curation-github-link {
+  display: inline-block;
+  margin-top: 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.curation-github-link:hover {
+  text-decoration: underline;
+}
+
+.curation-section {
+  margin-bottom: 2.5rem;
+}
+
+.curation-section h2 {
+  font-size: 1.2rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.curation-score-section {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.curation-score-table-area {
+  flex: 2;
+  min-width: 0;
+}
+
+.curation-score-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 0.5rem;
+  vertical-align: middle;
+}
+
+.curation-table tfoot td {
+  border-top: 2px solid var(--color-border);
+  padding-top: 0.75rem;
+}
+
+.curation-chart-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.curation-chart-container {
+  position: relative;
+}
+
+.curation-pie-chart {
+  width: 180px;
+  height: 180px;
+}
+
+.curation-pie-segment {
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.curation-pie-segment:hover {
+  opacity: 0.82;
+}
+
+.curation-pie-label {
+  pointer-events: none;
+}
+
+.curation-chart-tooltip {
+  display: none;
+  position: absolute;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10;
+  box-shadow: 0 8px 22px rgb(0 0 0 / 0.25);
+}
+
+.curation-chart-tooltip.visible {
+  display: block;
+}
+
+.curation-risk-tier-badge {
+  padding: 0.3rem 1rem;
+  border-radius: 6px;
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  white-space: nowrap;
+}
+
+.curation-prose p {
+  margin-bottom: 0.75rem;
+}
+
+.curation-prose ul,
+.curation-prose ol {
+  margin-bottom: 0.75rem;
+  padding-left: 1.5rem;
+}
+
+.curation-prose li {
+  margin-bottom: 0.25rem;
+}
+
+.curation-prose a {
+  color: var(--color-primary);
+}
+
+.curation-prose strong {
+  color: var(--color-text-primary);
+}
+
+.curation-prose code {
+  background: var(--color-surface-secondary);
+  padding: 0.15rem 0.35rem;
+  border-radius: 3px;
+  font-size: 0.85em;
+}
+
+.curation-prose pre {
+  background: var(--color-surface-secondary);
+  padding: 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin-bottom: 0.75rem;
+}
+
+.curation-prose pre code {
+  background: none;
+  padding: 0;
+}
+
+.curation-prose h3 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.05rem;
+}
+
+.curation-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.curation-prose th,
+.curation-prose td {
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.curation-prose th {
+  background: var(--color-surface-secondary);
+  color: var(--color-text-secondary);
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+.curation-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.curation-report-card {
+  display: block;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  text-decoration: none;
+  padding: 1rem;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.curation-report-card:hover,
+.curation-report-card:focus-visible {
+  border-color: var(--color-border-hover);
+  background: var(--color-surface-secondary);
+  text-decoration: none;
+  outline: none;
+}
+
+.curation-report-card-content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.curation-report-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.curation-report-card-title {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.curation-report-card-row {
+  margin-top: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.curation-report-card-footer {
+  margin-top: auto;
+  padding-top: 0.9rem;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.curation-report-card-risk {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.curation-report-card-score {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+}
+
+.curation-report-card-label {
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 640px) {
+  .curation-container {
+    padding-top: 1.5rem;
+  }
+
+  .curation-heading {
+    font-size: 1.7rem;
+  }
+
+  .curation-table {
+    font-size: 0.8rem;
+  }
+
+  .curation-table th,
+  .curation-table td {
+    padding: 0.4rem 0.5rem;
+  }
+
+  .curation-heading-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .curation-score-section {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .curation-score-table-area,
+  .curation-chart-area {
+    flex: 1;
+  }
+
+  .curation-chart-area {
+    align-items: center;
+  }
+
+  .curation-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 641px) and (max-width: 1024px) {
+  .curation-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/src/components/pages/curation/index.tsx
+++ b/src/components/pages/curation/index.tsx
@@ -1,0 +1,137 @@
+import Link from '@components/Link'
+import { ScoreBadge } from '@pages/curation/components/ScoreBadge'
+import { scoreTier } from '@pages/curation/lib/colors'
+import type { TReportData } from '@pages/curation/lib/parseReport'
+import { getAllReports } from '@pages/curation/lib/reports'
+import type { KeyboardEvent, ReactElement } from 'react'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+import '@pages/curation/curation.css'
+
+function onRowKeyDown(event: KeyboardEvent<HTMLTableRowElement>, activate: () => void): void {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    activate()
+  }
+}
+
+function Index(): ReactElement {
+  const navigate = useNavigate()
+  const [reports, setReports] = useState<TReportData[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    const lifecycle = { isCancelled: false }
+
+    void getAllReports()
+      .then((loadedReports) => {
+        if (lifecycle.isCancelled) {
+          return
+        }
+        setReports(loadedReports)
+        setError(undefined)
+      })
+      .catch((caughtError: unknown) => {
+        if (lifecycle.isCancelled) {
+          return
+        }
+        const message = caughtError instanceof Error ? caughtError.message : 'Failed to load curation reports.'
+        setError(message)
+      })
+      .finally(() => {
+        if (lifecycle.isCancelled) {
+          return
+        }
+        setIsLoading(false)
+      })
+
+    return () => {
+      lifecycle.isCancelled = true
+    }
+  }, [])
+
+  return (
+    <div className={'curation-page'}>
+      <main className={'curation-container'}>
+        <div className={'curation-heading-row'}>
+          <h1 className={'curation-heading'}>{'Risk Assessment Reports'}</h1>
+          <Link href={'/curation-test-1'} className={'curation-layout-toggle'}>
+            {'Try card layout'}
+          </Link>
+        </div>
+
+        {isLoading && <p className={'text-text-secondary'}>{'Loading reports...'}</p>}
+        {!isLoading && error && <p className={'text-red'}>{error}</p>}
+
+        {!isLoading && !error && (
+          <div className={'curation-table-wrap'}>
+            <table className={'curation-table'}>
+              <thead>
+                <tr>
+                  <th className={'curation-col-icon'} />
+                  <th>{'Protocol'}</th>
+                  <th>{'Token'}</th>
+                  <th>{'Score'}</th>
+                  <th>{'Risk Tier'}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reports.map((report) => {
+                  const reportPath = `/curation/report/${report.slug}`
+
+                  return (
+                    <tr
+                      key={report.slug}
+                      className={'curation-clickable-row'}
+                      tabIndex={0}
+                      onClick={() => navigate(reportPath)}
+                      onKeyDown={(event) => onRowKeyDown(event, () => navigate(reportPath))}
+                    >
+                      <td className={'curation-col-icon'}>
+                        <div className={'curation-icon-stack'}>
+                          {report.iconUrl ? (
+                            <img
+                              src={report.iconUrl}
+                              alt={''}
+                              width={24}
+                              height={24}
+                              className={'curation-protocol-icon'}
+                              loading={'lazy'}
+                            />
+                          ) : (
+                            <div className={'curation-icon-placeholder'} />
+                          )}
+
+                          {report.chainIconUrl && (
+                            <img
+                              src={report.chainIconUrl}
+                              alt={''}
+                              width={14}
+                              height={14}
+                              className={'curation-chain-icon'}
+                              loading={'lazy'}
+                            />
+                          )}
+                        </div>
+                      </td>
+
+                      <td>{report.name}</td>
+                      <td className={'curation-mono'}>{report.token}</td>
+                      <td>
+                        <ScoreBadge score={report.finalScore} />
+                      </td>
+                      <td>{scoreTier(report.finalScore)}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default Index

--- a/src/components/pages/curation/lib/colors.ts
+++ b/src/components/pages/curation/lib/colors.ts
@@ -1,0 +1,38 @@
+export function scoreColor(score: number): string {
+  if (score <= 1.5) {
+    return '#22C55E'
+  }
+  if (score <= 2.5) {
+    return '#86EFAC'
+  }
+  if (score <= 3.5) {
+    return '#FACC15'
+  }
+  if (score <= 4.5) {
+    return '#FB923C'
+  }
+  return '#EF4444'
+}
+
+export function scoreTier(score: number): string {
+  if (score <= 1.5) {
+    return 'Minimal Risk'
+  }
+  if (score <= 2.5) {
+    return 'Low Risk'
+  }
+  if (score <= 3.5) {
+    return 'Medium Risk'
+  }
+  if (score <= 4.5) {
+    return 'Elevated Risk'
+  }
+  return 'High Risk'
+}
+
+export function scoreTextColor(score: number): string {
+  if (score <= 3.5) {
+    return '#0C0C0C'
+  }
+  return '#FFFFFF'
+}

--- a/src/components/pages/curation/lib/parseReport.ts
+++ b/src/components/pages/curation/lib/parseReport.ts
@@ -1,0 +1,192 @@
+export type TReportType = 'Protocol' | 'Asset'
+
+export type TReportMeta = {
+  slug: string
+  name: string
+  date: string
+  token: string
+  chain: string
+  finalScore: number
+  type: TReportType
+  iconUrl: string
+  chainIconUrl: string
+}
+
+export type TCategoryScore = {
+  category: string
+  score: number
+  weight: string
+  weighted: number
+}
+
+export type TReportData = TReportMeta & {
+  overviewMarkdown: string
+  scoreTable: TCategoryScore[]
+  riskSummaryMarkdown: string
+}
+
+const TYPE_OVERRIDES: Record<string, TReportType> = {
+  'unit-ubtc': 'Asset'
+}
+
+const DEFILLAMA_SLUG_OVERRIDES: Record<string, string> = {
+  'midas-mhyper': 'midas-rwa',
+  infinifi: 'infinifi',
+  'reserve-ethplus': 'reserve-protocol'
+}
+
+const CHAIN_ID_MAP: Record<string, number> = {
+  ethereum: 1,
+  arbitrum: 42161,
+  base: 8453,
+  polygon: 137,
+  optimism: 10,
+  bnb: 56,
+  avalanche: 43114
+}
+
+const FALLBACK_CATEGORY_PATTERNS = [
+  { name: 'Audits & Historical', weight: '20%' },
+  { name: 'Centralization & Control', weight: '30%' },
+  { name: 'Funds Management', weight: '30%' },
+  { name: 'Liquidity Risk', weight: '15%' },
+  { name: 'Operational Risk', weight: '5%' }
+] as const
+
+function parseDefillamaSlug(slug: string, content: string): string {
+  const override = DEFILLAMA_SLUG_OVERRIDES[slug]
+  if (override) {
+    return override
+  }
+
+  const match = content.match(/defillama\.com\/protocol\/([a-z0-9-]+)/i)
+  return match?.[1] ?? ''
+}
+
+function getIconUrl(defillamaSlug: string): string {
+  if (!defillamaSlug) {
+    return ''
+  }
+  return `https://icons.llamao.fi/icons/protocols/${defillamaSlug}?w=48&h=48`
+}
+
+function getChainIconUrl(chain: string): string {
+  const lowerChain = chain.toLowerCase()
+  if (lowerChain.includes('hyperliquid') || lowerChain.includes('hyperev')) {
+    return 'https://icons.llamao.fi/icons/chains/rsz_hyperliquid?w=48&h=48'
+  }
+
+  const matchingChain = Object.entries(CHAIN_ID_MAP).find(([key]) => lowerChain.includes(key))
+  if (!matchingChain) {
+    return ''
+  }
+
+  const chainId = matchingChain[1]
+  return `https://token-assets-one.vercel.app/api/chains/${chainId}/logo-32.png?fallback=true`
+}
+
+function extractSection(content: string, heading: string): string {
+  const sections = content.split(/(?=^## )/m)
+  const matchingSection = sections.find((section) => section.startsWith(`## ${heading}`))
+
+  if (!matchingSection) {
+    return ''
+  }
+
+  return matchingSection.split('\n').slice(1).join('\n').trim()
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function parseScoreTable(content: string): TCategoryScore[] {
+  const tableMatch = content.match(/\| Category \| Score \| Weight \| Weighted \|[\s\S]*?(?=\n\n|\n[^|])/)
+  if (tableMatch) {
+    return tableMatch[0]
+      .split('\n')
+      .filter((row) => row.startsWith('|'))
+      .slice(2)
+      .map((row): TCategoryScore | undefined => {
+        const cells = row
+          .split('|')
+          .map((cell) => cell.trim())
+          .filter(Boolean)
+
+        if (cells.length < 4) {
+          return undefined
+        }
+
+        const category = cells[0].replaceAll('**', '')
+        if (/final|weighted score|category-weighted/i.test(category)) {
+          return undefined
+        }
+
+        return {
+          category,
+          score: Number.parseFloat(cells[1]) || 0,
+          weight: cells[2],
+          weighted: Number.parseFloat(cells[3]) || 0
+        }
+      })
+      .filter((row): row is TCategoryScore => Boolean(row))
+  }
+
+  return FALLBACK_CATEGORY_PATTERNS.map((categoryConfig): TCategoryScore | undefined => {
+    const safeCategoryName = escapeRegExp(categoryConfig.name)
+    const pattern = new RegExp(`#{3,4}\\s*\\d*\\.?\\s*${safeCategoryName}[^\\n]*\\n\\*\\*Score:\\s*([\\d.]+)`, 'i')
+    const match = content.match(pattern)
+    if (!match) {
+      return undefined
+    }
+
+    const score = Number.parseFloat(match[1])
+    const weightRatio = Number.parseFloat(categoryConfig.weight) / 100
+
+    return {
+      category: categoryConfig.name,
+      score,
+      weight: categoryConfig.weight,
+      weighted: Math.round(score * weightRatio * 1000) / 1000
+    }
+  }).filter((row): row is TCategoryScore => Boolean(row))
+}
+
+function parseMeta(slug: string, content: string): TReportMeta {
+  const titleMatch = content.match(/^# (?:Protocol|Asset) Risk Assessment:\s*(.+)$/m)
+  const name = titleMatch?.[1]?.trim() ?? slug
+
+  const derivedType: TReportType = content.match(/^# Asset/m) ? 'Asset' : 'Protocol'
+  const type = TYPE_OVERRIDES[slug] ?? derivedType
+
+  const dateMatch = content.match(/\*\*Assessment Date:\*\*\s*(.+)/)
+  const tokenMatch = content.match(/\*\*Token:\*\*\s*(.+)/)
+  const chainMatch = content.match(/\*\*Chain:\*\*\s*(.+)/)
+  const scoreMatch = content.match(/\*\*Final Score:\s*([\d.]+)\/5\.0\*\*/)
+
+  const chain = chainMatch?.[1]?.trim() ?? ''
+  const defillamaSlug = parseDefillamaSlug(slug, content)
+
+  return {
+    slug,
+    name,
+    date: dateMatch?.[1]?.trim() ?? '',
+    token: tokenMatch?.[1]?.trim() ?? '',
+    chain,
+    finalScore: Number.parseFloat(scoreMatch?.[1] ?? '0'),
+    type,
+    iconUrl: getIconUrl(defillamaSlug),
+    chainIconUrl: getChainIconUrl(chain)
+  }
+}
+
+export function parseReport(slug: string, content: string): TReportData {
+  const meta = parseMeta(slug, content)
+
+  return {
+    ...meta,
+    overviewMarkdown: extractSection(content, 'Overview + Links'),
+    scoreTable: parseScoreTable(content),
+    riskSummaryMarkdown: extractSection(content, 'Risk Summary')
+  }
+}

--- a/src/components/pages/curation/lib/reports.ts
+++ b/src/components/pages/curation/lib/reports.ts
@@ -1,0 +1,68 @@
+import { parseReport, type TReportData } from '@pages/curation/lib/parseReport'
+
+type TMarkdownLoader = () => Promise<string>
+
+const REPORT_MODULES = import.meta.glob('/src/components/pages/curation/reports/*.md', {
+  query: '?raw',
+  import: 'default'
+}) as Record<string, TMarkdownLoader>
+
+const REPORT_LOADERS_BY_SLUG = Object.entries(REPORT_MODULES).reduce<Record<string, TMarkdownLoader>>(
+  (accumulator, [path, loader]) => {
+    const slug = path.split('/').pop()?.replace(/\.md$/, '') ?? ''
+    if (!slug) {
+      return accumulator
+    }
+
+    accumulator[slug] = loader
+    return accumulator
+  },
+  {}
+)
+
+const REPORT_CACHE: {
+  allReportsPromise?: Promise<TReportData[]>
+  bySlugPromise: Record<string, Promise<TReportData | undefined>>
+} = {
+  bySlugPromise: {}
+}
+
+const GITHUB_REPORT_BASE_URL = 'https://github.com/yearn/risk-score/blob/master/reports/report'
+
+export async function getAllReports(): Promise<TReportData[]> {
+  if (!REPORT_CACHE.allReportsPromise) {
+    REPORT_CACHE.allReportsPromise = Promise.all(
+      Object.entries(REPORT_LOADERS_BY_SLUG).map(async ([slug, loader]) => {
+        const content = await loader()
+        return parseReport(slug, content)
+      })
+    ).then((reports) => reports.sort((a, b) => a.finalScore - b.finalScore))
+  }
+
+  return REPORT_CACHE.allReportsPromise
+}
+
+export async function getReportBySlug(slug: string): Promise<TReportData | undefined> {
+  const normalizedSlug = slug.trim().toLowerCase()
+  const existing = REPORT_CACHE.bySlugPromise[normalizedSlug]
+  if (existing) {
+    return existing
+  }
+
+  const loader = REPORT_LOADERS_BY_SLUG[normalizedSlug]
+  if (!loader) {
+    return undefined
+  }
+
+  const promise = loader().then((content) => parseReport(normalizedSlug, content))
+  REPORT_CACHE.bySlugPromise[normalizedSlug] = promise
+  return promise
+}
+
+export function getAllSlugs(): string[] {
+  return Object.keys(REPORT_LOADERS_BY_SLUG).sort()
+}
+
+export function getGitHubReportUrl(slug: string): string {
+  return `${GITHUB_REPORT_BASE_URL}/${slug}.md`
+}

--- a/src/components/pages/curation/report/[slug].tsx
+++ b/src/components/pages/curation/report/[slug].tsx
@@ -1,0 +1,138 @@
+import Link from '@components/Link'
+import { ReportMarkdown } from '@pages/curation/components/ReportMarkdown'
+import { ScoreBadge } from '@pages/curation/components/ScoreBadge'
+import { ScoreTable } from '@pages/curation/components/ScoreTable'
+import type { TReportData } from '@pages/curation/lib/parseReport'
+import { getGitHubReportUrl, getReportBySlug } from '@pages/curation/lib/reports'
+import type { ReactElement } from 'react'
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router'
+import '@pages/curation/curation.css'
+
+function ReportDetailPage(): ReactElement {
+  const { slug } = useParams()
+  const [report, setReport] = useState<TReportData | undefined>(undefined)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (!slug) {
+      setError('Missing report slug.')
+      setIsLoading(false)
+      return
+    }
+
+    const lifecycle = { isCancelled: false }
+
+    void getReportBySlug(slug)
+      .then((loadedReport) => {
+        if (lifecycle.isCancelled) {
+          return
+        }
+
+        if (!loadedReport) {
+          setError('Report not found.')
+          setReport(undefined)
+          return
+        }
+
+        setReport(loadedReport)
+        setError(undefined)
+      })
+      .catch((caughtError: unknown) => {
+        if (lifecycle.isCancelled) {
+          return
+        }
+        const message = caughtError instanceof Error ? caughtError.message : 'Failed to load report.'
+        setError(message)
+      })
+      .finally(() => {
+        if (lifecycle.isCancelled) {
+          return
+        }
+        setIsLoading(false)
+      })
+
+    return () => {
+      lifecycle.isCancelled = true
+    }
+  }, [slug])
+
+  return (
+    <div className={'curation-page'}>
+      <main className={'curation-container'}>
+        <Link href={'/curation'} className={'curation-back-link'}>
+          {'<- All Reports'}
+        </Link>
+
+        {isLoading && <p className={'text-text-secondary'}>{'Loading report...'}</p>}
+        {!isLoading && error && <p className={'text-red'}>{error}</p>}
+
+        {!isLoading && !error && report && (
+          <>
+            <div className={'curation-report-header'}>
+              <div className={'curation-report-header-top'}>
+                <div className={'curation-report-title'}>
+                  {report.iconUrl && (
+                    <img
+                      src={report.iconUrl}
+                      alt={''}
+                      width={32}
+                      height={32}
+                      className={'curation-report-protocol-icon'}
+                      loading={'lazy'}
+                    />
+                  )}
+                  <h1>{report.name}</h1>
+                </div>
+                <ScoreBadge score={report.finalScore} size={'large'} />
+              </div>
+
+              <div className={'curation-meta'}>
+                <span>{report.token}</span>
+                <span className={'curation-meta-sep'}>{'/'}</span>
+                <span>{report.chain}</span>
+                <span className={'curation-meta-sep'}>{'/'}</span>
+                <span>{report.date}</span>
+              </div>
+
+              <a
+                href={getGitHubReportUrl(report.slug)}
+                className={'curation-github-link'}
+                target={'_blank'}
+                rel={'noopener noreferrer'}
+              >
+                {'View full report on GitHub ->'}
+              </a>
+            </div>
+
+            <section className={'curation-section'}>
+              <h2>{'Score Breakdown'}</h2>
+              <ScoreTable scores={report.scoreTable} finalScore={report.finalScore} />
+            </section>
+
+            <section className={'curation-section'}>
+              <h2>{'Overview'}</h2>
+              {report.overviewMarkdown ? (
+                <ReportMarkdown content={report.overviewMarkdown} />
+              ) : (
+                <p className={'text-text-secondary'}>{'No overview is available for this report.'}</p>
+              )}
+            </section>
+
+            <section className={'curation-section'}>
+              <h2>{'Risk Summary'}</h2>
+              {report.riskSummaryMarkdown ? (
+                <ReportMarkdown content={report.riskSummaryMarkdown} />
+              ) : (
+                <p className={'text-text-secondary'}>{'No risk summary is available for this report.'}</p>
+              )}
+            </section>
+          </>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default ReportDetailPage

--- a/src/components/pages/curation/reports/fluid.md
+++ b/src/components/pages/curation/reports/fluid.md
@@ -1,0 +1,484 @@
+# Protocol Risk Assessment: Fluid Lending Protocol
+
+- **Assessment Date:** February 12, 2026
+- **Token:** fTokens (fUSDC, fUSDT, fWETH)
+- **Chain:** Ethereum Mainnet
+- **Token Address:** [`0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33`](https://etherscan.io/address/0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33) (fUSDC)
+- **Final Score: 1.1/5.0**
+
+## Overview + Links
+
+This assessment focuses on the **Fluid Lending Protocol (fTokens)** — an ERC4626-compliant lending product built on top of Fluid's unified Liquidity Layer. Users supply assets (USDC, USDT, WETH, wstETH, etc.) and receive fTokens representing their share of the lending pool. Yield is generated from borrower interest via the Vault Protocol.
+
+**Architecture dependency chain relevant to lending risk:**
+
+```
+fTokens (Lending Protocol)
+    ↓ deposits/withdraws via
+Liquidity Layer (central fund store, 0x52Aa...)
+    ↑ borrows against collateral
+Vault Protocol (borrowers, liquidations, oracles)
+```
+
+fToken holders are exposed to risks across this entire stack: the Lending Protocol itself, the Liquidity Layer that holds all funds, and the Vault Protocol whose borrowers generate the yield. The DEX Protocol and stETH Protocol also interact with the Liquidity Layer but are secondary dependencies.
+
+Fluid is governed by FLUID token holders via on-chain GovernorBravo governance with a 1-day Timelock. The protocol was developed by Instadapp Labs and launched in February 2024.
+
+**Links:**
+
+- [Protocol Documentation](https://docs.fluid.instadapp.io/)
+- [Protocol App](https://fluid.io/)
+- [Security/Audits Page](https://docs.fluid.instadapp.io/audits-and-security.html)
+- [GitHub (Public Contracts)](https://github.com/Instadapp/fluid-contracts-public)
+- [Deployments](https://github.com/Instadapp/fluid-contracts-public/blob/main/deployments/deployments.md)
+- [Governance Forum](https://gov.instadapp.io/)
+- [Snapshot Governance](https://snapshot.org/#/instadapp-gov.eth)
+- [DeFiLlama — Fluid Lending](https://defillama.com/protocol/fluid-lending)
+
+## Contract Addresses (Ethereum Mainnet)
+
+All contracts verified on Etherscan. Compiled with Solidity 0.8.21.
+
+### fToken Contracts (Lending)
+
+| fToken | Address | Underlying | Underlying Address |
+|--------|---------|------------|--------------------|
+| **fUSDC** | [`0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33`](https://etherscan.io/address/0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33) | USDC | [`0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48`](https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48) |
+| **fUSDT** | [`0x5C20B550819128074FD538Edf79791733ccEdd18`](https://etherscan.io/address/0x5C20B550819128074FD538Edf79791733ccEdd18) | USDT | [`0xdAC17F958D2ee523a2206206994597C13D831ec7`](https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7) |
+| **fWETH** | [`0x90551c1795392094FE6D29B758EcCD233cFAa260`](https://etherscan.io/address/0x90551c1795392094FE6D29B758EcCD233cFAa260) | WETH | [`0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2`](https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2) |
+| **fwstETH** | [`0x2411802D8BEA09be0aF8fD8D08314a63e706b29C`](https://etherscan.io/address/0x2411802D8BEA09be0aF8fD8D08314a63e706b29C) | wstETH | [`0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0`](https://etherscan.io/address/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0) |
+| **fGHO** | [`0x6A29A46E21C730DcA1d8b23d637c101cec605C5B`](https://etherscan.io/address/0x6A29A46E21C730DcA1d8b23d637c101cec605C5B) | GHO | [`0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f`](https://etherscan.io/address/0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f) |
+| **fsUSDS** | [`0x2BBE31d63E6813E3AC858C04dae43FB2a72B0D11`](https://etherscan.io/address/0x2BBE31d63E6813E3AC858C04dae43FB2a72B0D11) | sUSDS | [`0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD`](https://etherscan.io/address/0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD) |
+| **fUSDtb** | [`0x15e8c742614b5D8Db4083A41Df1A14F5D2bFB400`](https://etherscan.io/address/0x15e8c742614b5D8Db4083A41Df1A14F5D2bFB400) | USDtb | [`0xC139190F447e929f090Edeb554D95AbB8b18aC1C`](https://etherscan.io/address/0xC139190F447e929f090Edeb554D95AbB8b18aC1C) |
+
+### fToken On-Chain State (Ethereum Mainnet, as of Feb 2026)
+
+| fToken | Total Assets | Exchange Rate | Supply Rate | Approx TVL |
+|--------|-------------|---------------|-------------|------------|
+| fUSDC | 274.8M USDC | 1.1853 | 4.59% | ~$274.8M |
+| fUSDT | 167.5M USDT | 1.1788 | 3.99% | ~$167.5M |
+| fGHO | 42.3M GHO | 1.0975 | 7.32% | ~$42.3M |
+| fwstETH | 2,874 wstETH | 1.0381 | 0.26% | ~$8.9M |
+| fUSDtb | 5.8M USDtb | 1.0171 | 1.82% | ~$5.8M |
+| fWETH | 1,773 WETH | 1.0682 | 2.56% | ~$4.7M |
+| fsUSDS | 15,025 sUSDS | 1.0021 | 0.00% | ~$15.8K |
+| **Total Ethereum fTokens** | | | | **~$504M** |
+
+All exchange rates are >1.0, confirming accumulated yield since launch. No rewards programs currently active on any fToken — yields are purely organic from supply/borrow spreads.
+
+### Core Infrastructure (Dependency for Lending)
+
+- **Liquidity Layer**: [`0x52Aa899454998Be5b000Ad077a46Bbe360F4e497`](https://etherscan.io/address/0x52Aa899454998Be5b000Ad077a46Bbe360F4e497) — Central contract holding all funds. Upgradeable proxy (Instadapp Infinite Proxy) with AdminModule and UserModule.
+- **LendingFactory**: [`0x54B91A0D94cb471F37f949c60F7Fa7935b551D03`](https://etherscan.io/address/0x54B91A0D94cb471F37f949c60F7Fa7935b551D03) — Creates fToken markets. Owner: Timelock.
+- **Timelock**: [`0x2386DC45AdDed673317eF068992F19421B481F4c`](https://etherscan.io/address/0x2386DC45AdDed673317eF068992F19421B481F4c) — Owner of Liquidity Layer, LendingFactory, VaultFactory, DexFactory. 1-day delay.
+- **GovernorBravo**: [`0x0204Cd037B2ec03605CFdFe482D8e257C765fA1B`](https://etherscan.io/address/0x0204Cd037B2ec03605CFdFe482D8e257C765fA1B) — On-chain governance. 117 proposals executed.
+- **Avocado Multisig**: [`0x4F6F977aCDD1177DCD81aB83074855EcB9C2D49e`](https://etherscan.io/address/0x4F6F977aCDD1177DCD81aB83074855EcB9C2D49e) — Timelock guardian (cancel-only). Also owns DeployerFactory.
+- **FLUID Token**: [`0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb`](https://etherscan.io/address/0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb) — Governance token. 100M max supply, ~77.5M circulating.
+
+### Resolvers (Read-Only Periphery)
+
+- **FluidLiquidityResolver**: [`0xD7588F6c99605Ab274C211a0AFeC60947668A8Cb`](https://etherscan.io/address/0xD7588F6c99605Ab274C211a0AFeC60947668A8Cb) — Active resolver for supply/borrow rates, exchange prices, rate model params
+- **RevenueResolver**: [`0x0A84741D50B4190B424f57425b09FAe60C330F32`](https://etherscan.io/address/0x0A84741D50B4190B424f57425b09FAe60C330F32)
+
+## Audits and Due Diligence Disclosures
+
+Fluid has undergone **8 distinct security audits** across 4 audit firms, covering all major protocol components. The Lending Protocol was covered in the PeckShield and StateMind full-protocol audits. The Liquidity Layer (critical dependency for lending) was audited by both MixBytes and StateMind in 2025 using a dual-audit approach. All audit reports are available on the [audits and security page](https://docs.fluid.instadapp.io/audits-and-security.html).
+
+| # | Firm | Date | Scope | Critical | High | Medium | Low | Info | Total |
+|---|------|------|-------|----------|------|--------|-----|------|-------|
+| 1 | PeckShield | Nov 2023 | Full Protocol (incl. Lending) | 0 | 4 | 4 | 5 | 0 | 13 |
+| 2 | StateMind | Oct–Dec 2023 | Full Protocol (incl. Lending) | 3 | 8 | 15 | 0 | 40 | 66 |
+| 3 | MixBytes | Mar–Jun 2024 | Vault Protocol | 0 | 0 | 2 | 4 | 0 | 6 |
+| 4 | Cantina | Sep–Oct 2024 | DEX Protocol | 0 | 0 | 2 | 7 | 4 | 13 |
+| 5 | MixBytes | Oct 2024 | DEX Protocol | 0 | 0 | 0 | 3 | 0 | 3 |
+| 6 | MixBytes | Sep–Dec 2025 | Liquidity Layer | 0 | 0 | 0 | 2 | 0 | 2 |
+| 7 | StateMind | Sep–Oct 2025 | Liquidity Layer | 0 | 1 | 0 | 0 | 4 | 5 |
+| **Total** | | | | **3** | **13** | **23** | **21** | **48** | **108** |
+
+**Lending-relevant audit details:**
+
+- **PeckShield — Full Protocol** ([report](https://docs.fluid.instadapp.io/Peckshield_Fluid_Audit.pdf)): Covered lending/fToken contracts. All 13 issues resolved (12 resolved, 1 mitigated — "Trust Issue of Admin Keys").
+- **StateMind — Full Protocol** ([report](https://docs.fluid.instadapp.io/Statemind_Fluid_Audit.pdf)): Covered Lending/iTokens (now fTokens), Liquidity Layer, Vaults, Oracles. Critical finding: **LendingRewardRateModel returns rate with incorrect decimals** (pool-draining risk) — **fixed**. Also: incorrect supplyExchangePrice calculation, DOS of iToken markets — **all fixed**.
+- **MixBytes — Liquidity Layer** ([report](https://docs.fluid.instadapp.io/MixBytes_Fluid_Liquidity_Audit.pdf)): Directly impacts lending withdrawal/supply mechanics. 2 Low findings.
+- **StateMind — Liquidity Layer Updates** ([report](https://docs.fluid.instadapp.io/Statemind_Fluid_Liquidity_Updates_Audit.pdf)): 1 High: incorrect net transfer calculation causing user overpayment — **fixed**.
+- **MixBytes — Vault Protocol** ([report](https://docs.fluid.instadapp.io/Mixbytes_Fluid_Vault_Protocol_Audit.pdf)): Vault borrowers generate fToken yield. Relevant for lending counterparty risk. Insufficient reentrancy protection — **fixed**.
+
+No formal verification (Certora, Halmos, etc.) has been performed.
+
+### Bug Bounty
+
+[Immunefi Bug Bounty Program](https://immunefi.com/bug-bounty/instadapp/) — Active program under the "Instadapp" name. Last updated 2024-12-15. **Fluid Lending Protocol is explicitly in scope.**
+
+| Category | Severity | Min Reward | Max Reward | Calculation |
+|----------|----------|------------|------------|-------------|
+| Smart Contract | Critical | $25,000 | $500,000 | 10% of directly affected funds |
+| Smart Contract | High | $5,000 | $100,000 | 50% of affected funds value |
+| Web/App | Critical | $5,000 | $50,000 | Range model |
+| Web/App | High | $5,000 | $10,000 | Range model |
+
+**Fluid scope**: Liquidity Layer, **Lending Protocol**, Vault Protocol (excluding periphery folder). [Source repo](https://github.com/Instadapp/fluid-contracts-public).
+
+**Payment**: USDC, USDT, or DAI on Ethereum. Medium/Low severity levels are not in scope.
+
+## Historical Track Record
+
+- **Production History**: Fluid launched on Ethereum mainnet on **February 20, 2024** (first TVL recorded). The protocol has been in production for approximately **~2 years** (722 days as of February 2026).
+- **Lending TVL**: **$1.28B** across all chains (88.7% of Fluid's total $1.45B TVL). Lending is the dominant product. TVL peaked at $2.68B (Oct 2025). TVL maintained >$500M for over 1.5 years.
+- **Multi-chain Lending Deployment**:
+
+| Chain | Lending Supply TVL | % of Lending | Borrowed | Utilization |
+|-------|-------------------|--------------|----------|-------------|
+| Ethereum | $718.9M | 56.1% | $682.7M | **95.0%** |
+| Plasma | $366.9M | 28.6% | $279.3M | 76.1% |
+| Arbitrum | $146.7M | 11.4% | $77.9M | 53.1% |
+| Base | $43.2M | 3.4% | $20.0M | 46.3% |
+| Polygon | $5.4M | 0.4% | $2.6M | 47.8% |
+| **Total** | **$1.28B** | **100%** | **$1.06B** | **82.9%** |
+
+- **Incidents**: **No reported security incidents or exploits** found. Not listed in DeFi Llama hacks database. No rekt.news entries for Fluid or Instadapp.
+- **TVL Stability**: Only 1 daily drop >15% in entire history (August 6, 2024, -16.1%, aligned with broader crypto market selloff). Average daily volatility of 2.53% over past 90 days.
+- **Instadapp Legacy**: Instadapp has been operating since 2019, maintaining ~$2B TVL through 2023. Fluid represents the team's most ambitious protocol built on years of DeFi infrastructure experience.
+
+## Funds Management
+
+### How fTokens Work
+
+fTokens are **ERC4626-compliant vault tokens**. When a user deposits an underlying asset (e.g., USDC), the fToken contract:
+
+1. Calls `LIQUIDITY.operate()` to deposit the underlying into the Liquidity Layer
+2. The Liquidity Layer triggers a callback; the fToken transfers the underlying via SafeTransfer or Permit2
+3. Shares are minted to the user based on the current exchange rate
+
+On withdrawal, the reverse occurs: shares are **burned before** the underlying is withdrawn from the Liquidity Layer (burn-first pattern for safety).
+
+**Exchange rate**: Computed on-chain as `tokenExchangePrice / EXCHANGE_PRICES_PRECISION` (1e12 precision). The rate is monotonically increasing — it can never decrease. It incorporates:
+- Yield from the Liquidity Layer (borrower interest)
+- Optional rewards from a `LendingRewardsRateModel` (currently **inactive** for all fTokens; yields are purely organic)
+
+**Safety mechanisms in fToken contracts:**
+- Custom reentrancy guard (deposit/withdraw/rebalance all protected)
+- Callback validation: checks caller = Liquidity AND token = ASSET AND status = ENTERED
+- Burn-before-withdraw pattern
+- BigMath precision with SafeCast overflow protection
+- Rewards rate capped at 50% APR maximum
+
+### Accessibility
+
+- **Supplying**: Permissionless — anyone can deposit via fTokens. No whitelist required.
+- **Redemption**: fToken withdrawals via `withdraw()` or `redeem()` (standard ERC4626). Subject to Liquidity Layer withdrawal limits. If utilization is very high, withdrawals may be temporarily throttled until limits expand or borrows are repaid.
+- **Fees**: No explicit deposit/withdrawal fees. Interest rates are algorithmically determined by utilization via a kink-based model.
+
+### Yield Source and Counterparty Risk
+
+fToken yield comes from **borrower interest**. Borrowers use the Vault Protocol to deposit collateral and borrow assets from the Liquidity Layer. This means fToken holders are exposed to:
+
+- **Vault Protocol solvency**: If borrowers default and liquidations fail to recover full value, bad debt could affect lending reserves
+- **Liquidation effectiveness**: The tick-based liquidation mechanism must function correctly to prevent bad debt accumulation
+- **Oracle correctness**: Vault liquidations depend on Chainlink, UniswapV3 TWAP, and Redstone price feeds. Oracle failures could delay liquidations
+
+**Collateral quality backing fToken yield** (borrower collateral types):
+- Blue-chip: ETH, WETH, wstETH, weETH, WBTC, cbBTC
+- Stablecoins: USDC, USDT, sUSDe, GHO
+- Others: PAXG, XAUt, various LSTs
+
+### Collateralization
+
+- **Backing**: All lending positions are over-collateralized on-chain. Borrowers must maintain collateral ratios (80-95% LTV depending on the pair).
+- **Liquidations**: Fully on-chain tick-based mechanism. Liquidation penalty as low as 0.1% for correlated pairs (wstETH/ETH), higher for uncorrelated pairs.
+- **Withdrawal Gap**: Extra gap on Liquidity Layer limits reserved for liquidations to ensure they can always execute.
+
+### Provability
+
+- **Transparency**: All reserves are fully on-chain and verifiable via resolver contracts (FluidLiquidityResolver at [`0xD7588F6c99605Ab274C211a0AFeC60947668A8Cb`](https://etherscan.io/address/0xD7588F6c99605Ab274C211a0AFeC60947668A8Cb)).
+- **Exchange Rate**: fToken exchange rates are computed programmatically on-chain (ERC4626 standard). No off-chain oracle or admin input needed. Rate is monotonically increasing.
+- **Interest Rates**: Algorithmically determined based on utilization. USDC rate model: kink at 85% utilization (5.5% rate), second kink at 93% (8.5%), max rate 40%.
+- **Revenue**: Protocol revenue is calculated and verifiable via the RevenueResolver contract.
+
+### Interest Rate Model (USDC example, verified on-chain)
+
+| Parameter | Value |
+|-----------|-------|
+| Model Type | Kinked (V2) |
+| Kink 1 | 85% utilization |
+| Rate at Kink 1 | 5.50% |
+| Kink 2 | 93% utilization |
+| Rate at Kink 2 | 8.50% |
+| Max Rate | 40.00% |
+| Fee | 10% of spread |
+
+## Liquidity Risk
+
+### Lending-Specific Liquidity Concerns
+
+fToken holders face liquidity risk from the **shared Liquidity Layer** architecture. The Liquidity Layer serves not only lending but also Vaults, DEX, and stETH protocols. This means:
+
+- **Shared pool**: fToken withdrawals compete with all other withdrawal demand on the Liquidity Layer
+- **High utilization**: Ethereum lending utilization is **95.0%** (borrowing $682.7M of $718.9M supplied). Overall cross-chain lending utilization is **82.9%**. This is very high.
+- **Withdrawal limits**: The Liquidity Layer enforces per-token expandable withdrawal limits. `maxWithdraw()` returns the minimum of: (1) the withdrawal limit at Liquidity, (2) actual liquid balance. If a large withdrawal exceeds the current expanded limit, users must wait for the limit to expand.
+
+### Exit Mechanisms
+
+- **Normal exit**: Call `withdraw()` or `redeem()` on fToken. Subject to available liquidity and withdrawal limits.
+- **Secondary market**: fTokens are ERC20 tokens and can be traded on secondary markets, though no significant DEX liquidity for fTokens was observed.
+- **Throttled exit**: During high utilization, the expansion-rate mechanism throttles large withdrawals. This prevents bank runs but delays exit for large holders.
+
+### Lending TVL by Asset Type (Ethereum)
+
+| Asset Type | TVL | % of Ethereum Lending |
+|------------|-----|----------------------|
+| Stablecoins | $368.8M | 51.3% |
+| ETH/LSTs | $265.1M | 36.9% |
+| BTC tokens | $54.4M | 7.6% |
+| Other (Gold, FLUID, etc.) | $30.7M | 4.3% |
+| **Total** | **$718.9M** | 100% |
+
+### Top Supply Assets (All Chains)
+
+| Rank | Token | Supply TVL | % of Total |
+|------|-------|-----------|------------|
+| 1 | wstUSR | $242.5M | 18.9% |
+| 2 | wstETH | $130.3M | 10.2% |
+| 3 | USDT0 | $125.3M | 9.8% |
+| 4 | USDC | $124.4M | 9.7% |
+| 5 | weETH | $113.1M | 8.8% |
+| 6 | sUSDe | $103.8M | 8.1% |
+| 7 | USDT | $77.7M | 6.1% |
+| 8 | WBTC | $55.1M | 4.3% |
+| 9 | syrupUSDC | $51.3M | 4.0% |
+| 10 | syrupUSDT | $51.0M | 4.0% |
+
+**Concentration risk**: wstUSR is the single largest supply asset at 18.9% of total lending TVL. Top 5 assets account for 57.6%.
+
+### Historical Liquidity Performance
+
+- During the August 2024 market stress (only >15% TVL drop), the protocol maintained operations normally. TVL recovered and continued growing.
+- No recorded instances of withdrawal limit throttling causing prolonged user lockouts.
+
+## Centralization & Control Risks
+
+### Governance
+
+- **Governance Model**: On-chain GovernorBravo governance. FLUID token holders vote on proposals that execute through a timelock. Discussion on [governance forum](https://gov.instadapp.io/), on-chain voting via [GovernorBravo](https://etherscan.io/address/0x0204Cd037B2ec03605CFdFe482D8e257C765fA1B), and off-chain signaling via [Snapshot](https://snapshot.org/#/instadapp-gov.eth).
+- **Timelock**: [`0x2386DC45AdDed673317eF068992F19421B481F4c`](https://etherscan.io/address/0x2386DC45AdDed673317eF068992F19421B481F4c) — **1-day (86,400s) delay**. Admin of GovernorBravo is the Timelock itself (standard circular pattern). The Timelock guardian is the Avocado multisig (can cancel queued transactions). Min delay: 1 hour, max delay: 30 days.
+- **Owner/Admin**: All core contracts (Liquidity Layer proxy admin, LendingFactory, VaultFactory, DexFactory) are owned by the **Timelock** (`0x2386DC45...`), not directly by the multisig. Verified on-chain via `owner()` calls and EIP-1967 admin slot reads.
+- **GovernorBravo Parameters** (verified on-chain):
+  - Quorum: 4,000,000 FLUID (4% of total supply)
+  - Proposal threshold: 1,000,000 FLUID (1% of total supply)
+  - Voting delay: 7,200 blocks (~1 day)
+  - Voting period: 14,400 blocks (~2 days)
+  - Proposals executed: 117
+  - Minimum time from proposal to execution: ~4 days (1d delay + 2d voting + 1d timelock)
+
+### Lending-Specific Admin Controls
+
+| Role | Who | What They Can Do to Lending |
+|------|-----|---------------------------|
+| **Timelock** (governance) | [`0x2386DC45...`](https://etherscan.io/address/0x2386DC45AdDed673317eF068992F19421B481F4c) | Upgrade Liquidity Layer implementation, change LendingFactory owner, change supply/borrow configs, change rate models |
+| **LendingFactory Auths** | Set by Timelock | Update fToken rewards config, change rebalancer address, rescue stuck tokens, set fToken creation code |
+| **LendingFactory Deployers** | Set by Timelock | Create new fToken contracts |
+| **Rebalancer** | [`0x724d...b9b6`](https://etherscan.io/address/0x724d0c9497Fa89B2C6A4585e08380c91a92ab9b6) (fUSDC/fUSDT only) | Deposit underlying without minting shares (adds as rewards). Cannot withdraw. |
+| **Guardian** (Avocado multisig) | [`0x4F6F977a...`](https://etherscan.io/address/0x4F6F977aCDD1177DCD81aB83074855EcB9C2D49e) | Pause Class 0 protocols only. **Cannot move or withdraw funds.** Cancel timelock transactions. |
+
+**Key finding**: No admin role can directly access or move user funds deposited via fTokens. The most powerful action is the Timelock upgrading the Liquidity Layer implementation (1-day delay).
+
+### Programmability
+
+- **System Operations**: Largely programmatic. Interest rates and exchange rates are all computed on-chain algorithmically.
+- **Oracle System** (dependency via Vault Protocol): Chainlink primary, with UniswapV3 TWAP, Redstone, and custom center-price oracles as fallbacks. Modular per vault.
+- **Rate Model**: Interest rates determined algorithmically via kink-based utilization model. Parameters set by governance.
+- **Keepers/Automation**: No keepers needed for lending. Liquidations (in Vaults) are incentivized and performed by external liquidators.
+
+### External Dependencies
+
+- **Liquidity Layer**: Critical dependency — holds all fToken deposits. Upgradeable proxy controlled by Timelock.
+- **Vault Protocol**: Generates fToken yield. Vault borrowers, liquidations, and oracles all affect lending counterparty risk.
+- **Chainlink**: Indirect dependency via Vault Protocol oracle system. Multiple fallback oracle paths reduce risk.
+- **Permit2**: Supported for deposits (Uniswap's `0x000000000022D473030F116dDEE9F6B43aC78BA3`).
+
+## Operational Risk
+
+- **Team**: Instadapp Labs. Founded by **Sowmay Jain** and **Samyak Jain** — both are publicly known, India-based founders active since 2019. Key GitHub contributors include **thrilok209**, **KABBOUCHI**, and **SamarendraGouda**.
+- **Funding**: Well-funded by top-tier VCs: Pantera Capital, Coinbase Ventures, Standard Crypto, additional undisclosed investors.
+- **Legal Structure**: Instadapp Labs. No formal DAO legal wrapper disclosed.
+- **Documentation**: Comprehensive technical documentation at [docs.fluid.instadapp.io](https://docs.fluid.instadapp.io/). Full source code on GitHub.
+- **Communication**: Active [governance forum](https://gov.instadapp.io/), [Discord](https://discord.com/invite/C76CeZc), Twitter [@0xfluid](https://x.com/0xfluid), [Blog](https://blog.instadapp.io/).
+- **Incident Response**: No documented formal incident response plan found. However, Guardian role can pause protocols immediately. Team has ~6 years of operational history with zero security incidents.
+
+## Monitoring
+
+### Contracts to Monitor
+
+| Contract | Address | Why Monitor |
+|----------|---------|-------------|
+| **fUSDC** | [`0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33`](https://etherscan.io/address/0x9Fb7b4477576Fe5B32be4C1843aFB1e55F251B33) | Largest fToken (~$274.8M). Exchange rate, deposits/withdrawals |
+| **fUSDT** | [`0x5C20B550819128074FD538Edf79791733ccEdd18`](https://etherscan.io/address/0x5C20B550819128074FD538Edf79791733ccEdd18) | Second largest (~$167.5M). Exchange rate, deposits/withdrawals |
+| **Liquidity Layer** | [`0x52Aa899454998Be5b000Ad077a46Bbe360F4e497`](https://etherscan.io/address/0x52Aa899454998Be5b000Ad077a46Bbe360F4e497) | Holds all fToken deposits. Admin changes, implementation upgrades |
+| **Timelock** | [`0x2386DC45AdDed673317eF068992F19421B481F4c`](https://etherscan.io/address/0x2386DC45AdDed673317eF068992F19421B481F4c) | Owner of all core contracts — queued/executed transactions |
+| **GovernorBravo** | [`0x0204Cd037B2ec03605CFdFe482D8e257C765fA1B`](https://etherscan.io/address/0x0204Cd037B2ec03605CFdFe482D8e257C765fA1B) | Governance proposals, voting, execution |
+
+### Key Events to Watch
+
+| Contract | Event | Significance |
+|----------|-------|-------------|
+| **Timelock** | `QueueTransaction` / `ExecuteTransaction` | Governance actions queued/executed — 1 day warning |
+| **Timelock** | `CancelTransaction` | Guardian cancelled a queued action |
+| **Liquidity Layer** | `LogUpdateAuth` | Auth permissions changed — affects who can modify lending configs |
+| **Liquidity Layer** | `LogUpdateGuardian` | Guardian address changed |
+| **Liquidity Layer** | `LogPauseUser` / `LogUnpauseUser` | Protocol paused/unpaused — directly affects fToken operations |
+| **Liquidity Layer** | `LogUpdateUserSupplyConfigs` | Supply limits changed — affects max fToken deposits |
+| **Liquidity Layer** | `LogUpdateUserBorrowConfigs` | Borrow limits changed — affects utilization and withdrawal availability |
+| **Liquidity Layer** | `LogUpdateRateDataV1` / `LogUpdateRateDataV2` | Interest rate parameters changed — affects fToken yield |
+| **LendingFactory** | New fToken creation | New lending market created |
+
+## Risk Summary
+
+### Key Strengths
+
+- **Lending-specific**: ERC4626-compliant fTokens with monotonically increasing exchange rates, no admin ability to access funds
+- Battle-tested team with ~6 years of DeFi operational history (Instadapp since 2019), zero security incidents
+- 8 security audits from 4 reputable firms (PeckShield, StateMind, MixBytes, Cantina) — **Lending Protocol directly covered** in 2 of them, Liquidity Layer (critical dependency) covered in 4
+- On-chain GovernorBravo governance with 1-day Timelock and 117 proposals executed — all core contracts owned by Timelock
+- $1.28B lending TVL across 5 chains, ~2 years in production with zero incidents
+- Active Immunefi bug bounty ($500K max) with Lending Protocol explicitly in scope
+- Fully programmatic interest rates and exchange rates — no off-chain oracle needed for lending
+
+### Key Risks
+
+- **Shared Liquidity Layer**: fToken deposits are commingled in the Liquidity Layer with Vault, DEX, and stETH protocol funds. A vulnerability in any protocol on the stack affects fToken holders.
+- **Liquidity Layer upgradeability**: Upgradeable proxy controlled by Timelock with only 1-day delay. Malicious upgrade could affect all deposited funds.
+- **Complex counterparty chain**: fToken yield depends on Vault Protocol borrowers → liquidation mechanism → oracle system. Failure at any point could lead to bad debt.
+- **Concentration risk**: wstUSR is 18.9% of all lending TVL. Top 5 assets = 57.6% of lending TVL.
+- **No formal verification** (Certora, Halmos) has been performed
+
+### Critical Risks
+
+- None identified that would trigger automatic score of 5. All contracts verified, reserves fully on-chain, governance is via on-chain GovernorBravo + Timelock. No EOA control. Guardian can only pause.
+
+---
+
+## Risk Score Assessment
+
+### Critical Risk Gates
+
+- [x] **No audit** — PASSED. 8 audits by 4 reputable firms. Lending Protocol directly covered.
+- [x] **Unverifiable reserves** — PASSED. All reserves verifiable on-chain via resolver contracts. fToken exchange rates computed programmatically.
+- [x] **Total centralization** — PASSED. On-chain GovernorBravo governance with 1-day Timelock. No EOA control. Guardian can only pause.
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+- **Audits**: Exceptional coverage — 8 audits across 4 firms. Lending covered in PeckShield and StateMind full-protocol audits. Liquidity Layer (critical lending dependency) separately audited by MixBytes and StateMind in 2025. All 3 criticals and 13 highs fixed.
+- **History**: ~2 years in production. Lending TVL $1.28B across 5 chains. Zero security incidents.
+- **Bounty**: Active Immunefi bug bounty ($500K max) with Lending Protocol explicitly in scope.
+- **Note**: No formal verification performed. StateMind found a critical lending-specific bug pre-launch (LendingRewardRateModel incorrect decimals, pool-draining risk) — **fixed before launch**.
+
+**Score: 1.5/5** — 8 audits from 4 reputable firms with all critical/high findings resolved. Lending-specific critical bug caught and fixed pre-launch. ~2 years in production with zero incidents.
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+**Subcategory A: Governance — 2.0**
+- Full on-chain GovernorBravo governance with 117 proposals executed
+- 1-day timelock delay between GovernorBravo and contract execution
+- All core contracts owned by the Timelock, not directly by a multisig
+- Avocado multisig serves only as Timelock guardian (cancel-only role)
+- No admin role can directly access or withdraw fToken user funds
+- Timelock delay (1 day) is on the shorter side but adequate with on-chain governance
+
+**Subcategory B: Programmability — 1.5**
+- Fully programmatic: interest rates and fToken exchange rates all on-chain
+- ERC4626 fTokens with algorithmically computed, monotonically increasing exchange rates
+- No off-chain keepers or oracles needed for lending operations
+- Rebalancer role exists but can only deposit (not withdraw) — currently active only for fUSDC/fUSDT
+
+**Subcategory C: Dependencies — 2.0**
+- Critical dependency on Liquidity Layer (upgradeable proxy, shared with Vaults/DEX)
+- Indirect dependency on Chainlink via Vault Protocol oracle system
+- Multiple fallback oracle paths (UniswapV3, Redstone) reduce oracle risk
+- Permit2 integration is standard and well-audited
+
+**Score: 1.83/5** — (2.0 + 1.5 + 2.0) / 3 = 1.83. Full on-chain governance with timelock. No admin can access lending funds. Highly programmatic exchange rate computation.
+
+#### Category 3: Funds Management (Weight: 30%)
+
+**Subcategory A: Collateralization — 1.5**
+- All lending is over-collateralized via Vault Protocol
+- Blue-chip collateral assets dominate (ETH, wstETH, WBTC, USDC, USDT)
+- Advanced tick-based liquidation mechanism
+- All reserves fully on-chain and verifiable
+
+**Subcategory B: Provability — 1.0**
+- fToken exchange rates computed programmatically (ERC4626), monotonically increasing
+- Interest rates algorithmically determined via kink-based model
+- All reserves verifiable on-chain via FluidLiquidityResolver
+- No off-chain reporting dependencies
+
+**Score: 1.25/5** — (1.5 + 1.0) / 2 = 1.25. Excellent on-chain verifiability with programmatic, monotonically increasing exchange rates.
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+- **Exit**: fToken withdrawals subject to Liquidity Layer withdrawal limits and available liquidity
+- **Utilization**: Standard lending utilization dynamics apply — high utilization temporarily limits withdrawals, consistent with all lending protocols (Morpho, Aave, Compound). Kink-based rate model incentivizes rebalancing.
+- **Withdrawal limits**: Expandable limits throttle large exits. Users must wait for limits to expand.
+- **Shared pool risk**: Liquidity Layer serves lending, vaults, DEX, and stETH — fToken withdrawals compete with all other demand
+- **Concentration**: Top 5 assets = 57.6% of lending TVL. wstUSR alone = 18.9%.
+- **Stress test**: Handled August 2024 market stress (only >15% drop) without operational issues
+- **Secondary market**: No significant DEX liquidity for fTokens themselves
+
+**Score: 2.0/5** — Shared Liquidity Layer adds withdrawal competition beyond standard lending protocol dynamics. Concentration risk in top assets. Expandable limits provide gradual access but delay large exits. Offset by strong TVL depth ($1.28B) and kink-based rate model that incentivizes utilization rebalancing.
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+- **Team**: Publicly known founders (Sowmay Jain, Samyak Jain). Active since 2019. Strong DeFi reputation.
+- **Funding**: Well-funded by Pantera Capital, Coinbase Ventures, and others.
+- **Docs**: Comprehensive documentation and open-source code.
+- **Legal**: No formal DAO legal wrapper. Instadapp Labs as operational entity.
+- **Incident Response**: No formal plan documented, but Guardian pause capability exists. Zero incidents in ~6 years.
+
+**Score: 1.5/5** — Publicly known team with strong reputation, well-funded, comprehensive documentation. Minor deduction for no formal legal wrapper.
+
+### Final Score Calculation
+
+```
+Final Score = (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Audits × 0.20) + (Liquidity × 0.15) + (Operational × 0.05)
+```
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 1.5 | 20% | 0.30 |
+| Centralization & Control | 1.83 | 30% | 0.549 |
+| Funds Management | 1.25 | 30% | 0.375 |
+| Liquidity Risk | 2.0 | 15% | 0.300 |
+| Operational Risk | 1.5 | 5% | 0.075 |
+| **Final Score** | | | **1.60** |
+
+**Optional Modifiers:**
+- Protocol live >2 years with no incidents: **-0.5** → Not applied yet (1.98 years, borderline — will qualify at reassessment)
+- TVL maintained >$500M for >1 year: **-0.5** → Applied
+
+**Final Score: 1.10** (capped at minimum 1.0)
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|-------------|-----------|----------------|
+| 1.0-1.5 | Minimal Risk | Approved, high confidence |
+| 1.5-2.5 | Low Risk | Approved with standard monitoring |
+| 2.5-3.5 | Medium Risk | Approved with enhanced monitoring |
+| 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
+| 4.5-5.0 | High Risk | Not recommended |
+
+**Final Risk Tier: MINIMAL RISK**
+
+The Fluid Lending Protocol (fTokens) is a well-designed ERC4626-compliant lending product with strong security properties: 8 audits, on-chain GovernorBravo governance with timelock, monotonically increasing exchange rates, and no admin ability to access user funds. The primary risk is the **shared Liquidity Layer** architecture which means fToken holders are indirectly exposed to risks across the entire Fluid protocol stack (Vaults, DEX, oracles). This is substantially mitigated by the breadth of audit coverage, the programmatic nature of the protocol, and the ~2-year track record with zero incidents.
+
+---
+
+## Reassessment Triggers
+
+- **Time-based**: Reassess in 6 months (August 2026) — protocol will have >2.5 years history. Apply >2 year modifier (-0.5) at that time.
+- **Utilization-based**: Reassess if Ethereum utilization exceeds 99% (negative — withdrawal availability critically constrained)
+- **TVL-based**: Reassess if lending TVL changes by more than 50%
+- **Incident-based**: Reassess after any exploit, governance change, or significant parameter modification
+- **Governance**: Reassess if GovernorBravo parameters change (quorum, timelock delay, voting period) or if Avocado multisig signers change
+- **Dependency**: Reassess if Liquidity Layer implementation is upgraded or if a new protocol is added to the shared liquidity pool

--- a/src/components/pages/curation/reports/infinifi.md
+++ b/src/components/pages/curation/reports/infinifi.md
@@ -1,0 +1,659 @@
+# Protocol Risk Assessment: InfiniFi
+
+- **Assessment Date:** February 12, 2026
+- **Token:** siUSD (Staked iUSD)
+- **Chain:** Ethereum Mainnet
+- **Token Address:** [`0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB`](https://etherscan.io/address/0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB)
+- **Final Score: 2.8/5.0**
+
+## Overview + Links
+
+InfiniFi is a stablecoin protocol that allows users to deposit assets (USDC, USDT, USDe, sUSDe) to mint iUSD, a stablecoin pegged to the US Dollar. The protocol automatically deploys deposited collateral into various DeFi yield strategies including liquid farms (Aave, Fluid, Euler, Spark) and illiquid farms (Pendle, Ethena, Gauntlet Frontier, Reservoir wsrUSD, Fasanara Genesis Fund, Tokemak autoUSD). See Appendix A for detailed analysis of high-risk farm deployments.
+
+The protocol offers three tiers of tokens:
+
+1. **iUSD**: The base stablecoin (deposit receipt). Not yield bearing directly but liquid.
+2. **siUSD**: Staked iUSD. Yield-bearing and liquid (can be exited via secondary markets).
+3. **liUSD**: Locked iUSD. Highest yield, governance power, but locked for 1-13 weeks. Serves as "first loss" capital.
+
+**Links:**
+
+- [Protocol Documentation](https://docs.infinifi.xyz/)
+- [Protocol App](https://infinifi.xyz/)
+- [Protocol Analytics](https://stats.infinifi.xyz/)
+- [GitHub](https://github.com/InfiniFi-Labs/infinifi-protocol)
+- [Audits](https://docs.infinifi.xyz/audits)
+
+
+## Contract Addresses
+
+All contracts verified on Blockscout/Etherscan. Compiled with Solidity 0.8.28 (except Gnosis Safe: 0.7.6).
+
+- **iUSD (ReceiptToken)**: [`0x48f9e38f3070AD8945DFEae3FA70987722E3D89c`](https://etherscan.io/address/0x48f9e38f3070AD8945DFEae3FA70987722E3D89c) — ERC20, restricted mint/burn via CoreControlled roles
+- **siUSD (StakedToken)**: [`0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB`](https://etherscan.io/address/0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB) — ERC4626 vault wrapping iUSD
+- **InfiniFiCore (AccessControl)**: [`0xF6d48735EcCf12bDC1DF2674b1ce3fcb3bD25490`](https://etherscan.io/address/0xF6d48735EcCf12bDC1DF2674b1ce3fcb3bD25490) — Central AccessControlEnumerable, 17+ roles. DEFAULT_ADMIN_ROLE has 0 holders (renounced).
+- **Gateway (Proxy)**: [`0x3f04b65Ddbd87f9CE0A2e7Eb24d80e7fb87625b5`](https://etherscan.io/address/0x3f04b65Ddbd87f9CE0A2e7Eb24d80e7fb87625b5) — TransparentUpgradeableProxy → InfiniFiGatewayV3 (`0xb44e494535A8fC1f0081F4F9289BCc7c57FbffB6`)
+- **Gateway ProxyAdmin**: [`0x21071E0f9D600571Ffe47873e95fffF2FAc9141c`](https://etherscan.io/address/0x21071E0f9D600571Ffe47873e95fffF2FAc9141c) — Owned by Long Timelock (7-day delay for upgrades)
+- **Liquid Farms (Instant Liquidity)**:
+  - **Fluid USDC (ERC4626Farm)**: [`0x1484d6C834Ac99B9E50B17e57F85C8603F65657A`](https://etherscan.io/address/0x1484d6C834Ac99B9E50B17e57F85C8603F65657A) — targets fUSDC vault
+  - **Euler Sentora USDC (ERC4626Farm)**: [`0x6FBc446f25Ab5141C4F7E7711E52DFc0AdA407A5`](https://etherscan.io/address/0x6FBc446f25Ab5141C4F7E7711E52DFc0AdA407A5) — targets eUSDC-70 EVK vault
+  - **Aave v3 Horizon (AaveV3Farm)**: [`0x817d93DbdFd8190bbef0a73fCf5Dd9DA5A87E032`](https://etherscan.io/address/0x817d93DbdFd8190bbef0a73fCf5Dd9DA5A87E032) — targets aHorRwaUSDC
+  - **Spark USDC Vault (SparkSUSDCFarm)**: [`0xd880D7C5CaFdbE2AEc281250995abF612235e563`](https://etherscan.io/address/0xd880D7C5CaFdbE2AEc281250995abF612235e563) — targets sUSDC
+  - **Aave (AaveV3Farm)**: [`0xbFd5FC8DecA3C6128bfCE0FE46c25616811c3580`](https://etherscan.io/address/0xbFd5FC8DecA3C6128bfCE0FE46c25616811c3580) — targets aEthUSDC
+- **Team Multisig**: [`0x80608f852D152024c0a2087b16939235fEc2400c`](https://etherscan.io/address/0x80608f852D152024c0a2087b16939235fEc2400c) — Gnosis Safe v1.4.1, **4/7 threshold**, 7 EOA signers, nonce 287
+- **Long Timelock (7 days)**: [`0x3D18480CC32B6AB3B833dCabD80E76CfD41c48a9`](https://etherscan.io/address/0x3D18480CC32B6AB3B833dCabD80E76CfD41c48a9) — 604,800s delay
+- **Short Timelock (1 day)**: [`0x4B174afbeD7b98BA01F50E36109EEE5e6d327c32`](https://etherscan.io/address/0x4B174afbeD7b98BA01F50E36109EEE5e6d327c32) — 86,400s delay
+
+## Audits and Due Diligence Disclosures
+
+InfiniFi has undergone extensive security review via Certora, Spearbit/Cantina Code, and a Cantina public competition, plus multiple ongoing upgrade reviews.
+
+- **Spearbit / Cantina Code** (March-April 2025): Main protocol security review. Report published April 1, 2025. Findings: **8 High, 6 Medium, 25 Low, 4 Gas, 24 Informational**. Auditors: Noah Marconi (Lead), R0bert (Lead), Slowfi, Jonatas Martins. [Report PDF](https://raw.githubusercontent.com/spearbit/portfolio/master/pdfs/InfiniFi-Spearbit-Security-Review-March-2025.pdf).
+- **Certora**: Formal Verification & Security Assessment (March 21 – May 20, 2025). Report published June 4, 2025. Covers formal verification via Certora Prover and manual review. [Report](https://www.certora.com/reports/infinifi-protocol-formal-verification-report).
+- **Cantina Public Competition** (April 2025): Public audit competition. [Competition link](https://cantina.xyz/competitions/2ac7f906-1661-47eb-bfd6-519f5db0d36b). Reward pool claimed ~$40,000 ($35k + $5k) — amount unconfirmed via automation.
+- **Ongoing Cantina Code / Spearbit Managed Reviews** (6+ additional reviews of upgrades):
+  - siUSD rewards interpolation update
+  - Pendle SY farm integration
+  - Multiasset farms (new farm types)
+  - PR 209: Multiple new farms
+  - PR 228: J-Curve Smoother, ReservoirFarm, Fluid rewards
+  - PR 224: Crosschain support (CCIP + LayerZero)
+  All PDFs accessible via [auditor portfolio](https://r0bert-ethack.github.io/).
+Note: The initial Spearbit audit and "Cantina Code" review appear to be the **same engagement** (same auditors, same date, same file size). They should not be counted as separate audits.
+
+### Bug Bounty
+
+- [Bug Bounty Program on Cantina](https://cantina.xyz/bounties/509e46d0-a107-43aa-b46e-b2fe7e2ea591)
+
+## Historical Track Record
+
+- **Production History**: The protocol launched in June 2025 with a points program beginning June 1, 2025, designed to reward participation during its six month launch phase.
+- **TVL**: $177.69M. (03.02.26)
+- **Incidents**: No reported security incidents or exploits found.
+- **Peg Stability**: iUSD is designed to be redeemable 1:1. Users can mint iUSD against deposits.
+
+## Funds Management
+
+The protocol acts as an asset manager, deploying user funds into other protocols.
+
+- **Strategy**: Funds are deployed into liquid DeFi platforms (Aave, Fluid, Euler, Spark) and illiquid fixed-maturity strategies (Pendle, Ethena, Gauntlet Frontier vaults, Reservoir wsrUSD, Fasanara Genesis Fund, Tokemak autoUSD). **Critical: Several illiquid farms involve high-risk strategies including RWA exposure and explicit insolvency risk (see Appendix A).**
+- **Asset Allocation**: As of February 2026, $37.78M (21%) is held in Liquid Farms (instant withdrawal available) and $139.91M (79%) in Illiquid Farms (locked maturity).
+- **Risk Hierarchy**: Losses are socialized based on a "liability ladder":
+  1. liUSD (Locked) holders take the first loss.
+  2. siUSD (Staked) holders take the next loss.
+  3. iUSD (Stablecoin) holders are the last to be affected.
+
+### Accessibility
+
+- **Minting**: Users deposit supported assets (USDC, USDT, USDe, sUSDe) to mint iUSD.
+- **Redemption**:
+
+  - **Instant**: Users can instantly redeem iUSD for USDC as long as there is sufficient liquidity in the _Liquid Farms_ (currently ~$37.78M). No queue, whitelisting not required, anyone can redeem. When this reserve is depleted, there will be a FIFO queue.
+
+  - **Queue**: If liquid reserves are depleted, redemption requests enter a **FIFO Queue**. Pending requests are fulfilled as capital is unwound from illiquid strategies or new deposits enter.
+  - **Whitelisting**: No whitelist for redemption; anyone holding iUSD can redeem or enter the queue.
+
+### Collateralization
+
+- **Backing**: iUSD is backed by the assets deployed in the underlying strategies.
+- **Verification**: The protocol uses a "Self-Laddering Engine" to match asset duration with liability duration (locked periods).
+- **Off-chain Risks**: **CRITICAL**: Despite initial appearance of "100% on-chain DeFi", the protocol deploys into strategies with significant off-chain exposure:
+  - **Reservoir wsrUSD**: Backed by Real World Assets (RWAs) including T-Bills, introducing off-chain custodial risk, asset valuation complexity, and illiquidity during crisis.
+  - **Fasanara Genesis Fund**: Tokenized traditional hedge fund/money market fund, likely includes institutional credit and RWA exposure similar to Maple.
+  - **Gauntlet Frontier vaults**: Explicitly labeled as "higher-risk/higher-yield" strategies that "may lead to higher risks of insolvency" per Gauntlet's own documentation.
+  - **Tokemak autoUSD**: Multi-protocol aggregator adding compounded smart contract risk and algorithmic allocation dependency.
+- **Token Breakdown**: 115.07M siUSD (Staked), 43.34M liUSD (Locked), 24.86M iUSD (Liquid/Unstaked).
+
+### Provability
+
+- **Transparency**: Reserves and allocations are verifiable on-chain.
+- **Reserves**: $37.78M in liquid reserves.
+
+## Liquidity Risk
+
+- **Exit Liquidity**:
+  - **iUSD**: $3.3M on-chain DEX liquidity. Instant redemptions against the $37.78M liquid reserve.
+  - **Coverage**: The $37.78M liquid reserve fully covers the circulating unstaked iUSD supply (24.86M).
+    - **siUSD**: The holders of siUSD can exit with this flow: siUSD --> iUSD --> USDC.
+    - **liUSD**: Locked (1-13 weeks) but represented by a transferable ERC20 token, allowing for potential secondary market exit.
+- **Withdrawal Queues**: "Only time there'd be a queue is if there was a mass withdrawal event & these funds depleted." The protocol manages this via the liability ladder and keeping significant liquid reserves.
+
+## Centralization & Control Risks
+
+### Governance
+
+The governance system is split into three branches to check and balance power:
+
+1.  **Allocators (Active Management)**: Decide "How much" capital goes to specific strategies. They cannot route funds to arbitrary addresses.
+    - _Timelock_: Changes to capital allocation parameters (e.g., Farm Registry updates) use the **Short Timelock** (1 day delay).
+2.  **Verifiers (Token Holders - liUSD)**: Vote to approve the "Allowlist" of safe protocols.
+    - _Scope_: Adding a new protocol to the allowlist requires a governance vote and must pass through the **Short Timelock** (1 day delay).
+3.  **Vetoers (Guardians)**: A council of 5 entities. A single Vetoer can block any new protocol or product. This acts as a safety brake.
+
+- **Team Multisig**: Gnosis Safe v1.4.1 at [`0x80608f852D152024c0a2087b16939235fEc2400c`](https://etherscan.io/address/0x80608f852D152024c0a2087b16939235fEc2400c). **4/7 threshold**, 7 anonymous EOA signers.
+
+  | # | Signer | Additional Roles |
+  |---|--------|------------------|
+  | 1 | `0x7055E782B94b15BB6142aaFB326a9CeC36399eE5` | — |
+  | 2 | `0xDAdB38219425c761dd0f3a4d684Fc36f533af7bD` | EXECUTOR_ROLE (timelock) |
+  | 3 | `0xa9BDBEb17c81677Cb1830B74B1832C16Ec5CEF61` | — |
+  | 4 | `0x6DFa1A32604088EB969242AafFb92420F78373f6` | EXECUTOR_ROLE (timelock) |
+  | 5 | `0xd53Ffb2DB125015aB4D461bAD3fA959Ef1a1e685` | PAUSE |
+  | 6 | `0xfd4691dfA327Adb0d6f3c7b4224B3cc881D4F6fa` | EXECUTOR_ROLE (timelock) |
+  | 7 | `0x383965940c950008a4B67BfaA477Fdf6AC91a7F7` | EXECUTOR_ROLE (timelock), PAUSE |
+
+- **Timelocks**: Both are custom `Timelock.sol` extending OZ TimelockController. They override `hasRole()` to delegate role checks to the central `InfiniFiCore` contract. Both have DEFAULT_ADMIN_ROLE renounced (immutable role configuration).
+
+  - **Long Timelock (7 days)**: [`0x3D18480CC32B6AB3B833dCabD80E76CfD41c48a9`](https://etherscan.io/address/0x3D18480CC32B6AB3B833dCabD80E76CfD41c48a9) — 604,800s confirmed on-chain.
+  - **Short Timelock (1 day)**: [`0x4B174afbeD7b98BA01F50E36109EEE5e6d327c32`](https://etherscan.io/address/0x4B174afbeD7b98BA01F50E36109EEE5e6d327c32) — 86,400s confirmed on-chain.
+
+  **Role assignments on both timelocks** (verified on-chain via InfiniFiCore):
+
+  | Role | Holder(s) |
+  |------|-----------|
+  | PROPOSER_ROLE | Multisig (4/7 required to schedule) |
+  | CANCELLER_ROLE | Multisig (4/7 required to cancel) |
+  | EXECUTOR_ROLE | 5 individual EOAs: signers #2, #4, #6, #7 + deployer EOA (`0xdecaDAc8778D088A30eE811b8Cc4eE72cED9Bf22`) |
+
+  Governance flow: **Multisig proposes (4/7) → Timelock delay → Any 1 of 5 executor EOAs triggers execution.**
+
+- **GOVERNOR role holders** (3 contracts, verified on InfiniFiCore):
+  - Long Timelock (`0x3D18480CC32B6AB3B833dCabD80E76CfD41c48a9`)
+  - MinorRolesManager (`0xa08Bf802dCecd3c44E6420a52d5158867366be9b`) — can only grant/revoke PAUSE, PERIODIC_REBALANCER, FARM_SWAP_CALLER
+  - FluidRewardsClaimer (`0xD0ec80032C0da717BD78B9569321D9069365241E`) — can only claim Fluid rewards
+  - Deployer EOA has properly **renounced** GOVERNOR. DEFAULT_ADMIN_ROLE has **0 holders** on Core.
+
+- **Actions by timelock tier**:
+
+    **Long Timelock (7 days) — GOVERNOR role:**
+    enableBucket, setMaxLossPercentage, setAddress (gateway), setAfterMintHook, setBeforeRedeemHook, setYieldSharing, enableAsset, disableAsset, setLendingPool, setSafeAddress, emergencyAction, proxy upgrades (owns ProxyAdmin), all role grants/revokes (except MinorRolesManager-delegated roles)
+
+    **Short Timelock (1 day) — PROTOCOL_PARAMETERS role:**
+    setBucketMultiplier, setMinAssetAmount, setSafetyBufferSize, setPerformanceFeeAndRecipient, setLiquidReturnMultiplier, setTargetIlliquidRatio, setCap, setMaxSlippage, addFarms, removeFarms, setEnabledRouter, setPendleRouter, setCooldown, setAssetRebalanceThreshold
+
+    **Short Timelock (1 day) — ORACLE_MANAGER role:**
+    setOracle, setPrice
+    Note: ORACLE_MANAGER has 4 holders: Short Timelock + Accounting contract + YieldSharingV2 contract + Oracle Factory contract.
+
+    **Multisig WITHOUT timelock:**
+    | Role | Capability |
+    |------|-----------|
+    | UNPAUSE | Unpause any paused contract |
+    | EMERGENCY_WITHDRAWAL | Move funds from farms to predefined safe address, deprecate farms |
+    | MANUAL_REBALANCER | Rebalance funds between whitelisted farms |
+    | FARM_SWAP_CALLER | Trigger swap operations in farms |
+    | MINOR_ROLES_MANAGER | Grant/revoke PAUSE, PERIODIC_REBALANCER, FARM_SWAP_CALLER via MinorRolesManager contract |
+
+- **PAUSE role holders** (4 individual EOAs can pause the protocol without multisig/timelock):
+  - `0x383965940c950008a4B67BfaA477Fdf6AC91a7F7` (multisig signer #7)
+  - `0xd53Ffb2DB125015aB4D461bAD3fA959Ef1a1e685` (multisig signer #5)
+  - `0x6ef71cA9cD708883E129559F5edBFb9d9D5C1d8A`
+  - `0x0652412777f0c1F46b1164d5cdF3295Bdf43F2f2`
+
+- **emergencyAction bypass analysis**: The `Timelock.sol` contract **overrides emergencyAction to a no-op**, preventing any GOVERNOR holder from using it to bypass timelock delays. This is a deliberate safety mechanism confirmed in source code.
+
+### Programmability
+
+- **Hybrid Model**: The "Self-Laddering Engine" algorithmically matches asset duration with liability duration. "Allocators" actively manage the amount of capital deployed to specific allowlisted strategies.
+- **Oracle**: Protocol uses Chainlink price feeds for asset pricing to maintain the 1:1 mint ratio and calculate collateral value.
+- **Oracle Updates**: Oracles are upgradeable via governance (**Short Timelock**, 1-day delay). The iUSD price oracle (`0x8ABc952f91dB6695E765744ae340BC5eA4B344c1`) is a FixedPriceOracle — price changes only during loss socialization events (de-peg).
+
+### External Dependencies
+
+- **Dependency**: Heavily dependent on the performance and security of **Aave, Fluid, Pendle, and Ethena**. A failure in any of these protocols would result in losses (absorbed first by liUSD).
+- **Stablecoins**: Dependent on USDC, USDT, USDe, sUSDe pegs.
+
+## Operational Risk
+
+- **Team**: InfiniFi Labs. Pseudonymous/semi-anonymous team. Key contributors identified via GitHub:
+  - **eswak (Erwan Beauvois)**: Lead architect. Former Fei Protocol core dev (2021-2022), Ethereum Credit Guild core dev (2022-2024). Toulouse, France.
+  - **RobAnon (@RobAnon94)**: Contributor. Former sole developer of Revest Finance core contracts. Note: Revest Finance was exploited for ~$2M via reentrancy in March 2022.
+  - **nikollamalic (Nikola Malic)**: Developer. Former Revest Finance infrastructure contributor.
+  - No public team page. GitHub org has zero public members listed.
+- **Funding**: $3M Pre-Seed (Feb 2025) led by Electric Capital, with participation from New Form Capital, Axiom, Kraynos Capital, Sam Kazemian (Frax Finance founder), Defi Dad.
+- **Legal Structure**: No disclosed legal entity, jurisdiction, or DAO structure. TODO.
+- **Documentation**: Technical documentation in the GitHub README is comprehensive. Public docs at [docs.infinifi.xyz](https://docs.infinifi.xyz/) behind Cloudflare protection (content not independently verified).
+- **Communication**: Twitter/X at [@infinifilabs](https://x.com/infinifilabs). No public governance forum found (not on Snapshot, Tally, or Commonwealth).
+- **Incident Response**: No documented incident response plan found. Emergency capabilities exist via EMERGENCY_WITHDRAWAL role (multisig, no timelock) and system pause (4 individual EOAs).
+
+## Monitoring
+
+### Contracts to Monitor
+
+| Contract | Address | Why Monitor Directly |
+|----------|---------|---------------------|
+| **Long Timelock** | [`0x3D18480CC32B6AB3B833dCabD80E76CfD41c48a9`](https://etherscan.io/address/0x3D18480CC32B6AB3B833dCabD80E76CfD41c48a9) | All critical governance actions (GOVERNOR role) |
+| **Short Timelock** | [`0x4B174afbeD7b98BA01F50E36109EEE5e6d327c32`](https://etherscan.io/address/0x4B174afbeD7b98BA01F50E36109EEE5e6d327c32) | Parameter changes (PROTOCOL_PARAMETERS, ORACLE_MANAGER) |
+| **EmergencyWithdrawal** | [`0xa406aFC7967C63C5c454AD1f0e0dB9a761fe26e9`](https://etherscan.io/address/0xa406aFC7967C63C5c454AD1f0e0dB9a761fe26e9) | Multisig-direct, no timelock |
+| **ORACLE_IUSD** | [`0x8ABc952f91dB6695E765744ae340BC5eA4B344c1`](https://etherscan.io/address/0x8ABc952f91dB6695E765744ae340BC5eA4B344c1) | De-peg event (autonomous, triggered by loss socialization) |
+| **LockingController** | [`0x1d95cC100D6Cd9C7BbDbD7Cb328d99b3D6037fF7`](https://etherscan.io/address/0x1d95cC100D6Cd9C7BbDbD7Cb328d99b3D6037fF7) | First-loss buffer for liUSD holders. `LossesApplied` = protocol taking damage. Auto-pauses if losses exceed `maxLossPercentage` threshold. |
+| **siUSD** | [`0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB`](https://etherscan.io/address/0xDBDC1Ef57537E34680B898E1FEBD3D68c7389bCB) | `VaultLoss` = losses exceeded liUSD first-loss buffer, now hitting siUSD stakers |
+| **UnwindingModule** | [`0x7092A43aE5407666C78dBEa657a1891f42b3dFcc`](https://etherscan.io/address/0x7092A43aE5407666C78dBEa657a1891f42b3dFcc) | Handles forced liquidation of illiquid positions (e.g. Pendle fixed-term). `CriticalLoss` = losses during unwinding exceed module balance. |
+
+Note: Contracts whose state changes only via timelocks (InfiniFiCore, Gateway, FarmRegistry, Accounting, MintController, RedeemController, YieldSharingV2, MinorRolesManager, JCurveSmoother, etc.) do not need separate monitoring — all their changes appear as `CallScheduled`/`CallExecuted` on the timelocks.
+
+### Governance Monitoring (Timelocks + Multisig)
+
+All timelocked actions (GOVERNOR, PROTOCOL_PARAMETERS, ORACLE_MANAGER) are captured by monitoring the timelock events. No need to separately monitor downstream contract events that can only be triggered via timelocks.
+
+| Contract | Event | Significance |
+|----------|-------|-------------|
+| **Long/Short Timelock** | `CallScheduled(bytes32 id, uint256 index, address target, uint256 value, bytes data, bytes32 predecessor, uint256 delay)` | New governance action proposed — decode `data` to understand what will change. Early warning window (7d or 1d). |
+| **Long/Short Timelock** | `CallExecuted(bytes32 id, uint256 index, address target, uint256 value, bytes data)` | Governance action executed — verify expected outcome |
+| **Long/Short Timelock** | `Cancelled(bytes32 id)` | Scheduled action cancelled — may indicate contested governance |
+| **Long/Short Timelock** | `MinDelayChange(uint256 oldDuration, uint256 newDuration)` | Timelock delay changed — reduction is critical |
+
+### Non-Timelocked Events — Immediate Alert
+
+These events bypass the timelock and can be triggered directly by the multisig or individual role holders.
+
+| Contract | Event | Triggered By | Significance |
+|----------|-------|-------------|-------------|
+| **Any CoreControlled** | `Paused(address account)` | 4 individual PAUSE EOAs | Emergency pause — no multisig or timelock required |
+| **Any CoreControlled** | `Unpaused(address account)` | Multisig (UNPAUSE, no timelock) | System resumed |
+| **EmergencyWithdrawal** | `EmergencyWithdraw(uint256 timestamp, address farm, uint256 amount)` | Multisig (no timelock) | Emergency fund extraction from farm |
+
+### Protocol Health Events — Immediate Alert
+
+Autonomous events triggered by protocol state, not governance actions.
+
+| Contract | Event | Significance |
+|----------|-------|-------------|
+| **ORACLE_IUSD** | `PriceSet(uint256 timestamp, uint256 price)` | iUSD price changed — price below 1.0 = de-peg (loss socialization to iUSD holders) |
+| **LockingController** | `LossesApplied(uint256 timestamp, uint256 amount)` | First-loss tranche consuming — liUSD holders taking losses |
+| **siUSD** | `VaultLoss(uint256 timestamp, uint256 epoch, uint256 assets)` | Losses cascading past first-loss tranche to siUSD holders |
+| **UnwindingModule** | `CriticalLoss(uint256 timestamp, uint256 amount)` | Losses during forced liquidation of illiquid positions exceed module balance |
+
+### Key State to Poll
+
+- **TVL**: Monitor total protocol TVL via liquid + illiquid farm balances
+- **Liquid Reserve Ratio**: Liquid reserves vs total TVL
+
+## Risk Summary
+
+### Key Strengths
+
+- Strong risk segmentation design with liability ladder (liUSD first-loss → siUSD → iUSD)
+- Comprehensive audit coverage: Spearbit/Cantina Code main review + 6 ongoing upgrade reviews + Certora formal verification + public competition
+- Robust governance: 4/7 multisig + dual timelock (7d/1d) + separation of powers. DEFAULT_ADMIN renounced. emergencyAction bypass prevented via no-op override in Timelock.
+- All contracts verified on-chain, all farms properly target expected DeFi protocols
+- Backed by reputable investors (Electric Capital, Sam Kazemian)
+
+### Key Risks
+
+- **High-risk illiquid farm deployments**: Protocol deploys into Gauntlet Frontier vaults (explicit "insolvency risk" warning), Reservoir wsrUSD (RWA/off-chain exposure including T-Bills), Fasanara Genesis Fund (tokenized TradFi hedge fund), and Tokemak autoUSD (multi-layer compounding). All are locked until maturity. See Appendix A for detailed risk analysis.
+- **Off-chain/RWA exposure**: Contrary to initial impression of "100% on-chain DeFi," protocol has significant exposure to Real World Assets (T-Bills via Reservoir, institutional credit via Fasanara) introducing custodial risk, valuation complexity, and traditional finance dependencies.
+- Short operational history (<1 year in production since June 2025)
+- Compounded smart contract risk from underlying strategies (Aave, Fluid, Pendle, Ethena, Maple, plus high-risk farms)
+- Pseudonymous team with notable history concerns: key contributor (RobAnon) authored Revest Finance contracts exploited for $2M; lead dev's prior projects (Fei, ECG) have wound down
+- 79% of assets in illiquid strategies (including high-risk farms) — a mass redemption exceeding $37.78M liquid reserves would trigger a queue. If high-risk farms suffer losses, this could simultaneously reduce reserves AND trigger redemption panic.
+- Multisig has significant non-timelocked powers (EMERGENCY_WITHDRAWAL, MANUAL_REBALANCER, UNPAUSE)
+- No disclosed legal entity or incident response plan
+- Certora formal verification report published but finding severity breakdown not available on the landing page (full PDF required for detailed review)
+
+### Critical Risks
+
+- None identified that would trigger automatic score of 5. All contracts verified, reserves on-chain, multisig governance with timelocks in place.
+
+---
+
+## Risk Score Assessment
+
+### Critical Risk Gates
+
+- [x] **No audit** — PASSED. Multiple audits by reputable firms (Spearbit, Certora, Cantina).
+- [x] **Unverifiable reserves** — PASSED. All reserves verifiable on-chain.
+- [x] **Total centralization** — PASSED. 4/7 multisig with dual timelocks, DEFAULT_ADMIN renounced.
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+- **Audits**: Strong coverage — Spearbit/Cantina Code main review (8H/6M/25L), Certora formal verification ([report](https://www.certora.com/reports/infinifi-protocol-formal-verification-report)), Cantina public competition, 6+ upgrade reviews.
+- **History**: <1 year in production (Launch June 2025). TVL >$100M.
+- **Bounty**: [Active on Cantina](https://cantina.xyz/bounties/509e46d0-a107-43aa-b46e-b2fe7e2ea591).
+
+**Score: 2.5/5** — Extensive audit coverage including ongoing upgrade reviews and formal verification, offset by short production history (<1 year).
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+**Subcategory A: Governance — 2.5**
+- 4/7 multisig (Gnosis Safe v1.4.1) with dual timelocks (7d for critical, 1d for routine)
+- Separation of powers design (Allocators/Verifiers/Vetoers)
+- DEFAULT_ADMIN renounced on both timelocks and Core
+- However: multisig signers are all anonymous EOAs; multisig has significant non-timelocked powers (EMERGENCY_WITHDRAWAL, MANUAL_REBALANCER, UNPAUSE)
+
+**Subcategory B: Programmability — 3.0**
+- Hybrid model: algorithmic Self-Laddering Engine + active Allocator management
+- Oracle-dependent for pricing (Chainlink feeds, upgradeable via Short Timelock)
+- emergencyAction safely disabled on timelocks
+
+**Subcategory C: Dependencies — 3.5**
+- Heavily dependent on 4+ external protocols (Aave, Fluid, Pendle, Ethena)
+- Dependent on USDC, USDT, USDe, sUSDe pegs
+- Failure in any underlying would cause losses (absorbed by liability ladder)
+
+**Score: 3.0/5** — (2.5 + 3.0 + 3.5) / 3 = 3.0. Solid governance architecture offset by anonymous signers, significant non-timelocked powers, and heavy external dependencies.
+
+#### Category 3: Funds Management (Weight: 30%)
+
+**Subcategory A: Collateralization — 4.0**
+- **NOT 100% on-chain**: Significant exposure to Real World Assets (RWAs) via Reservoir wsrUSD (backed by T-Bills) and Fasanara Genesis Fund (tokenized TradFi).
+- Deploying into **explicitly high-risk strategies**: Gauntlet Frontier vaults are labeled by Gauntlet as "may lead to higher risks of insolvency" and "potentially higher volatility markets that may face liquidity risks."
+- **Multi-layer compounding risk**: InfiniFi → Gauntlet → Frontier → Morpho Markets, and InfiniFi → Tokemak autoUSD → multiple underlying protocols.
+- **Illiquid locked positions**: High-risk farms are all "locked until maturity" — protocol cannot quickly de-risk or exit positions.
+- **Off-chain counterparty risk**: RWA issuers, T-Bill custodians, traditional hedge fund structures.
+- First-loss tranches (liUSD → siUSD) provide some protection for iUSD holders, but are tested by high-risk deployments.
+- All farm contracts verified and target stated protocols (verification confirmed, but underlying strategies are high-risk).
+
+**Subcategory B: Provability — 2.5**
+- On-chain reserves verifiable via farm contracts.
+- **Underlying RWA valuations NOT verifiable on-chain** (Reservoir T-Bills, Fasanara fund assets).
+- Gauntlet Frontier allocations into Morpho markets add opacity layers.
+- Tokemak autoUSD algorithmic allocations not fully transparent.
+- Exchange rate (siUSD) computed programmatically via ERC4626 standard.
+- YieldSharing and Accounting contracts handle on-chain yield calculation.
+
+**Score: 3.3/5** — (4.0 + 2.5) / 2 = 3.25 rounded to 3.3. Significant off-chain exposure and high-risk strategy deployments increase funds management risk substantially.
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+- **Exit**: Instant 1:1 redemption for iUSD against liquid reserves ($37.78M).
+- **Depth**: Liquid reserves ($37.78M) > circulating unstaked iUSD (24.86M). $3.3M DEX liquidity as secondary exit.
+- **Queue**: FIFO queue activates only if liquid reserves depleted.
+- **Concern**: 79% of TVL in illiquid strategies. Mass redemption beyond liquid reserves would trigger queue delays.
+
+**Score: 2.0/5** — Strong primary liquidity (reserves > floating supply). Queue mechanism is a mild concern but mitigated by the liability ladder design.
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+- **Team**: Semi-pseudonymous. Experienced DeFi developers (Fei, Revest, ECG backgrounds). One contributor's prior project (Revest) was hacked for $2M.
+- **Funding**: $3M Pre-Seed from reputable VCs.
+- **Docs**: Above average technical documentation.
+- **Legal**: No disclosed entity or jurisdiction.
+- **Incident Response**: No documented plan. Emergency capabilities exist on-chain.
+
+**Score: 2.5/5** — Experienced team with VC backing, but pseudonymous with concerning prior project history, no legal entity, and no incident response plan.
+
+### Final Score Calculation
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 2.5 | 20% | 0.50 |
+| Centralization & Control | 3.0 | 30% | 0.90 |
+| Funds Management | 3.3 | 30% | 0.99 |
+| Liquidity Risk | 2.0 | 15% | 0.30 |
+| Operational Risk | 2.5 | 5% | 0.125 |
+| **Final Score** | | | **2.815** |
+
+**Final Score: 2.8**
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|-------------|-----------|----------------|
+| 1.0-1.5 | Minimal Risk | Approved, high confidence |
+| 1.5-2.5 | Low Risk | Approved with standard monitoring |
+| 2.5-3.5 | Medium Risk | Approved with enhanced monitoring |
+| 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
+| 4.5-5.0 | High Risk | Not recommended |
+
+**Final Risk Tier: MEDIUM RISK**
+
+InfiniFi is a stablecoin model with a strong focus on risk segmentation (liUSD absorbing first losses). The main risks are:
+- **High-risk illiquid farm deployments**: Gauntlet Frontier vaults (explicit insolvency risk), Reservoir wsrUSD (RWA/off-chain exposure), Fasanara Genesis Fund (TradFi structure), Tokemak autoUSD (compounded complexity). See Appendix A for detailed farm risk analysis.
+- **Short operational history** (<1 year, launched June 2025) — not yet battle tested.
+- **79% in illiquid strategies** including the high-risk farms above, creating potential liquidity crisis if mass redemptions occur.
+- **Significant non-timelocked powers** held by anonymous multisig (emergency withdrawal, rebalancing).
+- **Off-chain dependencies** via RWA exposure contradict initial impression of "100% on-chain DeFi."
+
+---
+
+## Reassessment Triggers
+
+- **Time-based**: Reassess in 6 months (August 2026) — protocol will have >1 year history
+- **TVL-based**: Reassess if TVL changes by more than 50%
+- **Incident-based**: Reassess after any exploit, governance change, collateral modification, or signer change on the multisig
+- **Farm-based**: Reassess if protocol adds new high-risk farms or significantly changes allocation to existing high-risk farms (Gauntlet Frontier, Reservoir, Fasanara, autoUSD)
+
+---
+
+## Appendix A: High-Risk Illiquid Farm Analysis
+
+InfiniFi deploys a significant portion of its assets into illiquid farms (locked until maturity). Analysis of the [InfiniFi Transparency Dashboard](https://stats.infinifi.xyz/) reveals deployment into several high-risk strategies that warrant detailed examination. These farms introduce risks beyond standard DeFi protocols and materially impact the overall risk profile.
+
+### Summary Table: High-Risk Illiquid Farms
+
+| Farm Name | Type | Primary Risk | Off-Chain Exposure | Liquidity | Individual Risk Score |
+|-----------|------|--------------|-------------------|-----------|---------------------|
+| **Gauntlet Alpha (gtUSDa)** | Morpho vault aggregator | Explicit insolvency risk | Minimal (on-chain DeFi) | Locked until maturity | **4.0/5** |
+| **Reservoir wsrUSD** | RWA-backed stablecoin | Off-chain custodial, RWA valuation | **High** (T-Bills, institutional) | Locked until maturity | **4.5/5** |
+| **Fasanara Genesis Fund** | Tokenized TradFi fund | Traditional finance risk, opacity | **Very High** (hedge fund assets) | Locked until maturity | **4.5/5** |
+| **Tokemak autoUSD** | Multi-protocol aggregator | Compounded smart contract risk | Minimal (DeFi protocols) | Locked until maturity | **3.5/5** |
+
+### Detailed Farm Risk Assessments
+
+---
+
+#### 1. Gauntlet Alpha (gtUSDa) - Frontier Vault Deployment
+
+**Risk Score: 4.0/5**
+
+**Description:**
+[Gauntlet USD Alpha](https://app.gauntlet.xyz/vaults/gtusda) is a multi-strategy vault that provides cross-chain yield on stablecoins. Gauntlet operates three risk tiers: Prime (ultra-conservative), Core (balanced), and Frontier (high-risk/high-yield). Evidence suggests InfiniFi is deploying into **Gauntlet Frontier vaults**, the highest-risk tier.
+
+**Explicit Risk Warnings from Gauntlet:**
+
+Per [Gauntlet's Frontier Vault announcement](https://www.gauntlet.xyz/resources/introducing-gauntlet-frontier-vaults-on-the-hunt-for-defi-yields):
+
+> "The Gauntlet USDC Frontier Vault **targets maximum yield by allocating to potentially higher volatility markets that may face liquidity risks** in exchange for the potential of greater supplier returns."
+
+> "Gauntlet Frontier Vaults offer the highest yields, allocating to **riskier markets that may lead to higher risks of insolvency**."
+
+**Key Risk Factors:**
+
+| Risk Category | Assessment | Details |
+|--------------|------------|---------|
+| **Smart Contract Risk** | High | Multi-layer exposure: InfiniFi → Gauntlet → Frontier → Morpho Markets → underlying lending markets |
+| **Insolvency Risk** | **Very High** | Explicitly acknowledged by Gauntlet in product documentation |
+| **Liquidity Risk** | Very High | Frontier vaults target "potentially higher volatility markets that may face liquidity risks" |
+| **Transparency** | Medium | Allocation decisions made by Gauntlet algorithms, full position breakdown requires monitoring Morpho markets |
+| **Off-chain Risk** | Low | Primarily on-chain DeFi protocols |
+
+**Why This Matters:**
+
+- InfiniFi's liability ladder (liUSD → siUSD → iUSD) assumes losses will be gradual and manageable
+- A Gauntlet Frontier insolvency event could create **sudden, large losses** that exhaust the liUSD first-loss buffer rapidly
+- InfiniFi funds are **locked until maturity** in this farm — cannot quickly exit even if risk escalates
+- During a crisis, Gauntlet Frontier may face redemption queues or emergency withdrawals, potentially forcing fire sales
+
+**Mitigating Factors:**
+- Gauntlet has strong risk management reputation and uses Agent-Based Simulations for allocation
+- Multiple audits and ongoing monitoring by Gauntlet team
+- Morpho Markets architecture provides some risk isolation
+
+**References:**
+- [Gauntlet Frontier Vaults Announcement](https://www.gauntlet.xyz/resources/introducing-gauntlet-frontier-vaults-on-the-hunt-for-defi-yields)
+- [Gauntlet VaultBook - Morpho Vaults](https://vaultbook.gauntlet.xyz/vaults/morpho-vaults)
+
+---
+
+#### 2. Reservoir wsrUSD (Wrapped Savings rUSD)
+
+**Risk Score: 4.5/5**
+
+**Description:**
+[Wrapped Savings rUSD](https://www.coingecko.com/en/coins/wrapped-savings-rusd) is the yield-bearing wrapper of Reservoir's rUSD stablecoin. Reservoir is a multicollateral stablecoin protocol backed by **Real World Assets (RWAs)** and on-chain strategies including T-Bills, overcollateralized on-chain lending, and funding rate strategies.
+
+**Key Risk Factors:**
+
+| Risk Category | Assessment | Details |
+|--------------|------------|---------|
+| **Off-Chain Custodial Risk** | **Very High** | T-Bills and RWAs require trusted custodians to hold off-chain assets |
+| **Asset Valuation Risk** | **Very High** | RWA valuations depend on external oracles, appraisers, and market conditions; not verifiable on-chain |
+| **Liquidity Risk** | **Very High** | During crisis, selling RWAs (T-Bills) can be slow, expensive, or impossible; cannot instantly redeem like on-chain DeFi |
+| **Counterparty Risk** | Very High | Institutional custodians, T-Bill issuers, banking infrastructure required |
+| **Transparency** | Low | Full composition of RWA backing not fully transparent; institutional relationships opaque |
+| **Regulatory Risk** | High | RWAs subject to securities laws, potential regulatory action could freeze assets |
+| **Smart Contract Risk** | Medium | Standard DeFi risks plus integration with off-chain infrastructure |
+
+**Why This Matters:**
+
+- **Contradicts "100% on-chain" claim**: Initial assessment stated "100% on-chain DeFi assets. No off-chain or custodial holdings" — this is false.
+- **Traditional finance failure modes**: If T-Bill custodian faces issues (bankruptcy, regulatory freeze, operational failure), assets could become inaccessible
+- **Valuation manipulation risk**: RWA values can be manipulated or become stale during market stress
+- **Redemption mismatch**: Reservoir may implement redemption queues if RWA liquidation cannot keep pace with outflows
+- **InfiniFi's locked position**: Cannot quickly exit if Reservoir faces RWA-related issues
+
+**Stated Mitigations (from Reservoir):**
+
+Per [Reservoir documentation](https://fortunafi.beehiiv.com/p/hello-reservoir):
+- **Peg Stability Module**: Allows conversion of rUSD to USDC at parity with no cost
+- **Credit Enforcer**: Automatically checks liquidity ratios, asset ratios, and capital ratios during every interaction, reverting risky transactions
+- **Multi-asset collateral**: Mix of liquid DeFi assets and RWA collateral for diversification
+
+**Critical Questions:**
+- What percentage of wsrUSD backing is RWAs vs. on-chain DeFi? (Not disclosed)
+- Who are the custodians for T-Bills? (Not disclosed)
+- What happens if Reservoir's RWA custodian fails?
+
+**References:**
+- [CoinGecko - Wrapped Savings rUSD](https://www.coingecko.com/en/coins/wrapped-savings-rusd)
+- [Introducing Reservoir](https://fortunafi.beehiiv.com/p/hello-reservoir)
+
+---
+
+#### 3. Fasanara Genesis Fund
+
+**Risk Score: 4.5/5**
+
+**Description:**
+Fasanara Capital is a London-based institutional investment manager with $4B+ AUM that has launched tokenized fund products. The [Genesis Alpha Fund](https://www.rcmalternatives.com/fund/genesis-alpha-fund-fasanara-digital/) is a hedge fund strategy tokenized on-chain. InfiniFi appears to be depositing into USDC-denominated Fasanara products.
+
+**Key Risk Factors:**
+
+| Risk Category | Assessment | Details |
+|--------------|------------|---------|
+| **Off-Chain Exposure** | **Extreme** | Entire fund structure operates in traditional finance with blockchain only for token representation |
+| **Custodial Risk** | **Extreme** | Fund assets held by traditional custodians, not on-chain; counterparty risk to Fasanara and sub-custodians |
+| **Transparency** | **Very Low** | Hedge fund strategies typically opaque; holdings, positions, and risk exposures not disclosed publicly |
+| **Regulatory Risk** | **Very High** | Subject to UK/EU fund regulations; regulatory action could freeze redemptions or assets |
+| **Liquidity Risk** | **Very High** | Hedge funds typically have redemption gates, lock-up periods, notice requirements; may not be liquid during crisis |
+| **Investment Risk** | High | Hedge fund investment strategies carry market risk, credit risk, leverage risk depending on mandate |
+| **Operational Risk** | Medium-High | Depends on Fasanara's operational capabilities, controls, and fund administration |
+| **Legal Risk** | High | Fund structure, jurisdiction, bankruptcy remoteness unclear |
+
+**Why This Matters:**
+
+- **This is NOT DeFi**: Fasanara Genesis Fund is a **traditional hedge fund** with a blockchain token wrapper. The underlying assets and risks are entirely TradFi.
+- **Extreme opacity**: InfiniFi users have no visibility into what Fasanara is actually investing in
+- **Redemption risk**: Hedge funds commonly implement gates, suspensions, or forced lock-ups during market stress
+- **Counterparty concentration**: If Fasanara faces operational issues, fraud, or insolvency, funds could be lost
+- **InfiniFi's locked position**: Cannot exit quickly if Fasanara faces issues
+
+**Critical Questions:**
+- What is the Genesis Alpha Fund's investment strategy? (Not disclosed in public docs)
+- What are the redemption terms? Lock-up period? Notice requirements?
+- What custodian holds the fund's assets?
+- Is the fund domiciled in a bankruptcy-remote structure?
+- What is Fasanara's track record with this fund?
+
+**Mitigating Factors:**
+- Fasanara is an established institutional manager with $4B+ AUM and regulatory oversight
+- Tokenization via ERC-3643 standard provides some structural compliance
+
+**References:**
+- [Ledger Insights - Fasanara Tokenized MMF](https://www.ledgerinsights.com/uk-asset-manager-fasanara-capital-latest-to-launch-tokenized-mmf/)
+- [Genesis Alpha Fund Overview](https://www.rcmalternatives.com/fund/genesis-alpha-fund-fasanara-digital/)
+- [Fasanara Capital Website](https://www.fasanara.com/)
+
+---
+
+#### 4. Tokemak autoUSD (now "Auto Finance")
+
+**Risk Score: 3.5/5**
+
+**Description:**
+[autoUSD](https://blog.auto.finance/post/the-stablecoin-autopool-autousd-is-now-live) is an autonomous liquidity pool that aggregates stablecoin yield opportunities across multiple DeFi protocols. It automatically allocates capital between lending protocols (Aave, Fluid, Morpho), DEXs (Curve, Balancer), and yield-bearing stablecoins (sUSDe, sUSDS, sFRAX, scrvUSD) to optimize returns. Launched April 9, 2025.
+
+**Note on Rebrand:** Tokemak [rebranded to Auto Finance](https://x.com/autopools/status/1968786026190504417) — same team, same protocol, new name. TOKE tokens convert to AUTO at 1:1. The rebrand is framed as product evolution from "liquidity infrastructure" to "automated onchain finance." Tokemak v1 had a known systemic design risk where its "Reactor" model absorbed impermanent loss for depositors — if losses exceeded reserves, depositors could lose funds. TOKE token price declined from ~$40+ (2021) to under $1, reflecting significant loss of market confidence. No confirmed exploits found, but a [privilege escalation vulnerability](https://www.trust-security.xyz/post/tokemak-liquidity-operator-can-steal-funds) was disclosed where a liquidity operator could potentially steal funds.
+
+**Key Risk Factors:**
+
+| Risk Category | Assessment | Details |
+|--------------|------------|---------|
+| **Compounded Smart Contract Risk** | **Very High** | Multi-layer exposure: InfiniFi → autoUSD → (Aave, Compound, DEXs, other protocols). Each layer multiplies risk. |
+| **Algorithmic Allocation Risk** | High | Tokemak's proprietary algorithms decide where to deploy funds; if logic is flawed, funds could be allocated poorly or to risky venues |
+| **Dependency Risk** | High | Relies on Tokemak protocol security, governance, and ongoing operation |
+| **Transparency** | Medium | Allocation decisions made algorithmically; current positions visible on-chain but future allocations unpredictable |
+| **Liquidity Risk** | Medium-High | Ability to redeem depends on underlying protocol liquidity and autoUSD's ability to rebalance |
+| **Governance Risk** | Medium | Tokemak governance could change allocation strategies or parameters |
+| **Off-chain Risk** | Low | Primarily deploys to on-chain DeFi protocols |
+
+**Why This Matters:**
+
+- **Complexity compounds risk**: Each additional layer (InfiniFi → autoUSD → underlying protocols) introduces new failure modes
+- **Black box allocation**: Users don't directly control where funds go; Tokemak algorithms make decisions
+- **Multiple attack surfaces**: Exploit in autoUSD contract, OR exploit in any underlying protocol, OR flawed allocation logic all create loss potential
+- **InfiniFi's locked position**: Cannot quickly exit if autoUSD faces issues or allocates to risky venues
+
+**Mitigating Factors:**
+- Tokemak is an established DeFi protocol with significant TVL and track record
+- Algorithmic allocation can respond faster than manual management to changing yield opportunities
+- Diversification across multiple protocols provides some risk distribution
+- On-chain transparency allows monitoring of current allocations
+
+**Critical Questions:**
+- What are autoUSD's allocation rules and constraints?
+- Can Tokemak governance direct allocations to high-risk protocols?
+- What is autoUSD's track record during market stress events?
+
+**References:**
+- [Auto Finance Blog - autoUSD Launch](https://blog.auto.finance/post/the-stablecoin-autopool-autousd-is-now-live)
+- [Auto Finance Rebrand Announcement](https://x.com/autopools/status/1968786026190504417)
+- [Trust Security - Tokemak Vulnerability Disclosure](https://www.trust-security.xyz/post/tokemak-liquidity-operator-can-steal-funds)
+
+---
+
+### Aggregate Risk Assessment
+
+**Combined Impact on InfiniFi:**
+
+1. **Cascading Failure Potential**: A loss event in any high-risk farm could trigger:
+   - liUSD first-loss buffer consumption
+   - Panic redemptions from siUSD and iUSD holders
+   - Depletion of liquid reserves ($37.78M)
+   - Queue activation → potential de-peg fears → bank run dynamics
+
+2. **Illiquidity Trap**: All high-risk farms are "locked until maturity":
+   - InfiniFi cannot quickly exit positions even if risk escalates
+   - During crisis, protocol forced to rely on $37.78M liquid buffer (21% of TVL)
+   - 79% in illiquid strategies means limited ability to meet mass redemptions
+
+3. **Off-Chain Dependency**: Despite marketing as DeFi protocol:
+   - Reservoir: RWA/T-Bill exposure
+   - Fasanara: Complete TradFi hedge fund
+   - Combined, these introduce traditional finance failure modes (custodian insolvency, regulatory freeze, valuation manipulation, redemption gates)
+
+4. **Disclosure Gap**: Initial protocol documentation emphasizes "Aave, Fluid, Pendle, Ethena" but:
+   - Omits mention of Gauntlet Frontier (highest-risk tier)
+   - Omits mention of RWA exposure via Reservoir
+   - Omits mention of TradFi exposure via Fasanara
+   - Omits mention of compounding complexity via autoUSD
+
+**Recommendation:**
+
+Users and protocols integrating with InfiniFi should:
+- Treat InfiniFi as having **significant off-chain/RWA exposure** (not pure DeFi)
+- Understand that **79% of TVL is locked** in illiquid strategies including high-risk farms
+- Monitor the **$37.78M liquid reserve** closely — this is the only buffer against redemption requests
+- Watch for **governance proposals** that increase allocation to high-risk farms
+- Implement **enhanced monitoring** of the farms listed above, especially:
+  - Gauntlet Frontier vault health and Morpho market conditions
+  - Reservoir's RWA composition and redemption queue status
+  - Fasanara Genesis Fund NAV and redemption terms
+  - Tokemak autoUSD allocation decisions
+
+**Data Sources:**
+- [InfiniFi Transparency Dashboard](https://stats.infinifi.xyz/) - farm allocations
+- Farm-specific documentation linked in each section above

--- a/src/components/pages/curation/reports/kinetiq-khype.md
+++ b/src/components/pages/curation/reports/kinetiq-khype.md
@@ -1,0 +1,490 @@
+# Protocol Risk Assessment: Kinetiq kHYPE
+
+- **Assessment Date:** February 17, 2026
+- **Token:** kHYPE
+- **Chain:** HyperEVM (Hyperliquid L1 ecosystem)
+- **Token Address:** [`0xfd739d4e423301ce9385c1fb8850539d657c296d`](https://hyperevmscan.io/address/0xfd739d4e423301ce9385c1fb8850539d657c296d)
+- **Final Score: 2.315/5.0**
+
+## Overview + Links
+
+Kinetiq is a liquid staking protocol for HYPE on Hyperliquid L1. Users stake HYPE and receive `kHYPE`, a yield-bearing liquid staking token whose redemption value appreciates from staking rewards. kHYPE uses an exchange-rate model (not rebasing) — 1 kHYPE currently represents ~2.26 HYPE.
+
+Kinetiq routes stake through a `StakingPool` contract that manages validator delegation, queue-based unstaking, and fee collection. Additional products include `vaultHYPE` / `xkHYPE` and Kinetiq Markets.
+
+**Links:**
+
+- [Kinetiq app](https://kinetiq.xyz/)
+- [Kinetiq docs](https://docs.kinetiq.xyz/)
+- [kHYPE docs](https://docs.kinetiq.xyz/kinetiq-lsd/khype)
+- [StakeHub docs](https://docs.kinetiq.xyz/kinetiq-lsd/stakehub)
+- [Contracts page](https://docs.kinetiq.xyz/resources/contracts)
+- [Audits page](https://docs.kinetiq.xyz/resources/audits)
+- [Kinetiq bug bounty (Cantina)](https://cantina.xyz/bounties/a98129d7-dd15-4c16-b2cb-d8cc42f87de4)
+- [CoinGecko kHYPE](https://www.coingecko.com/en/coins/kinetiq-staked-hype)
+- [DeFiLlama Kinetiq](https://defillama.com/protocol/kinetiq)
+
+## Contract Addresses
+
+All contracts are deployed on HyperEVM (Hyperliquid L1). Explorer: [HyperEVMScan](https://hyperevmscan.io).
+
+**On-chain verified contracts (have deployed bytecode):**
+
+| Contract | Address | Type |
+|----------|---------|------|
+| kHYPE | [`0xfd739d4e423301ce9385c1fb8850539d657c296d`](https://hyperevmscan.io/address/0xfd739d4e423301ce9385c1fb8850539d657c296d) | Proxy (ERC-20 LST) |
+| kHYPE Implementation | [`0xfe3216d46448efd7708435eeb851950742681975`](https://hyperevmscan.io/address/0xfe3216d46448efd7708435eeb851950742681975) | Implementation |
+| kHYPE ProxyAdmin | [`0x9c1e8db004d8158a52e83ffdc63e37eabea8304c`](https://hyperevmscan.io/address/0x9c1e8db004d8158a52e83ffdc63e37eabea8304c) | EIP-1967 Admin |
+| StakingPool (Minter/Burner) | [`0x393D0B87Ed38fc779FD9611144aE649BA6082109`](https://hyperevmscan.io/address/0x393D0B87Ed38fc779FD9611144aE649BA6082109) | Proxy |
+| StakingPool Implementation | [`0x69d4c44398fc95bbe86755ea481b467fc6a09c84`](https://hyperevmscan.io/address/0x69d4c44398fc95bbe86755ea481b467fc6a09c84) | Implementation |
+| StakingPool ProxyAdmin | [`0x8194aa9eca9225f96a690072b22a9ad0dd064f64`](https://hyperevmscan.io/address/0x8194aa9eca9225f96a690072b22a9ad0dd064f64) | EIP-1967 Admin |
+| PauserRegistry | [`0x752E76ea71960Da08644614E626c9F9Ff5a50547`](https://hyperevmscan.io/address/0x752E76ea71960Da08644614E626c9F9Ff5a50547) | Proxy |
+| PauserRegistry ProxyAdmin | [`0xd26c2c4a8bd4f78c64212318424ed794be120ea6`](https://hyperevmscan.io/address/0xd26c2c4a8bd4f78c64212318424ed794be120ea6) | EIP-1967 Admin |
+| Governance Multisig | [`0x18A82c968b992D28D4D812920eB7b4305306f8F1`](https://hyperevmscan.io/address/0x18A82c968b992D28D4D812920eB7b4305306f8F1) | Gnosis Safe (4-of-7) |
+| Treasury Multisig | [`0x64bD77698Ab7C3Fd0a1F54497b228ED7a02098E3`](https://hyperevmscan.io/address/0x64bD77698Ab7C3Fd0a1F54497b228ED7a02098E3) | Gnosis Safe (4-of-7) |
+
+All three ProxyAdmin contracts are owned by the [`Governance Multisig`](https://hyperevmscan.io/address/0x18A82c968b992D28D4D812920eB7b4305306f8F1). The **4-of-7 multisig can upgrade all contract implementations** without timelock.
+
+## How Hyperliquid Staking Works (Context)
+
+Hyperliquid staking is validator-based. HYPE is delegated to validators, and rewards depend on validator performance and network-level staking parameters.
+
+Important slashing context (as of February 12, 2026, per official Hyperliquid docs):
+- **No automatic slashing is implemented** ("There is currently no automatic slashing implemented").
+- Slashing is "reserved for provably malicious behavior such as double-signing blocks at the same round."
+- Validator penalties are jailing-only: jailed validators produce no rewards for delegators, but no principal loss occurs.
+- Validators may be jailed by peer quorum vote for inadequate latency/frequency of consensus messages.
+- Jailed validators can unjail themselves subject to on-chain rate limits.
+- Self-delegation requirement: 10,000 HYPE (locked 1 year). Delegation lockup: 1 day.
+- Unstaking queue (staking → spot): **7 days**. Max 5 pending withdrawals per address.
+- Governance can still change staking/penalty rules in future.
+
+Implication for kHYPE:
+- Current tail risk is more validator-performance/liveness and queue-liquidity related than immediate automatic slash haircut.
+- Governance-introduced slashing would materially change kHYPE risk profile and should trigger reassessment.
+
+## Audits and Due Diligence Disclosures
+
+Kinetiq hosts audit reports in a [Google Drive folder](https://drive.google.com/drive/folders/1T3ZGl6HNmt5LaKwdCmrA9HS7MsXheOys) (linked from `https://audits.kinetiq.xyz/`).
+
+### kHYPE / staking-core relevant audits (verified from Google Drive)
+
+| Date | Auditor | Scope | Link |
+|---|---|---|---|
+| Mar 2025 | Pashov Audit Group | kHYPE LST | [PDF](https://drive.google.com/file/d/1k9jA3JJ_e85AtI-EJRBdo-cq4JOvBok3/view) |
+| Mar 2025 | Zenith | kHYPE LST | [PDF](https://drive.google.com/file/d/1S5Xm1rinC7kOt826eXhwrVbX7WtdwsWr/view) |
+| Apr 2025 | Code4rena | kHYPE LST ($35K, 69+ wardens) | [Report](https://code4rena.com/audits/2025-04-kinetiq) |
+| Jun 2025 | Spearbit | kHYPE LST | [PDF](https://drive.google.com/file/d/121JxhR9TpWGEoa1-GGm9fNbl3ByjOOhe/view) |
+| Nov 2025 | Pashov Audit Group | kHYPE instant unstake | [PDF](https://drive.google.com/file/d/1ada6eazjmtatQIt38_QrZ3Nks7pYTly1/view) |
+
+### Broader protocol audits (additional context)
+
+| Date | Auditor | Scope | Link |
+|---|---|---|---|
+| Nov 2025 | Spearbit | kmHYPE | [PDF](https://drive.google.com/file/d/1uffwIAjfRDdCLCTpN66h1zK_Qji41Fr-/view) |
+| Nov 2025 | Zenith | kmHYPE | [PDF](https://drive.google.com/file/d/1pMti8B4qM15-v61AyGe-hEdi8zcXR6at/view) |
+| Jan 2026 | Spearbit | skNTQ | [PDF](https://drive.google.com/file/d/1LSZWM2sheoh1qeBqjkwkkl_1wO8gtI6H/view) |
+
+Architecture complexity: high-moderate. kHYPE relies on multiple upgradeable proxy contracts (kHYPE token, StakingPool, PauserRegistry), which increases integration/control-plane risk compared to single-contract wrappers.
+
+### Bug Bounty
+
+- **Platform:** Cantina
+- **Max Reward:** up to **$5,000,000** (Critical severity)
+- **Scope:** kHYPE, StakingManager, StakingAccountant, ValidatorManager, PauserRegistry, OracleManager, OracleAdapter
+- **Status:** Live since September 15, 2025; 294 findings submitted
+- **Link:** https://cantina.xyz/bounties/a98129d7-dd15-4c16-b2cb-d8cc42f87de4
+
+## Historical Track Record
+
+- Listed on DeFiLlama since **July 17, 2025** (~7 months at assessment date).
+- **Current TVL**: ~$683M (February 2026, per DeFiLlama).
+- **Peak TVL**: ~$2.65B (October 4, 2025).
+- **TVL trend**: Significant decline from peak, currently at ~26% of ATH. Likely driven by broader HYPE price movements.
+- **CoinGecko market data**: kHYPE price $29.73, market cap ~$657M, 24h volume ~$12.8M. ATH $59.44 on September 18, 2025.
+- **totalSupply (on-chain)**: 22,104,091.53 kHYPE.
+- No Kinetiq entry found in [DeFiLlama Hacks database](https://defillama.com/hacks) or [Rekt News](https://rekt.news/).
+- Shorter operating history and evolving module set (kHYPE + xkHYPE/skHYPE/kmHYPE) imply higher change risk.
+
+## Funds Management
+
+kHYPE manages deposited HYPE through a StakingPool contract and validator delegation, not a passive 1:1 wrapper.
+
+### Accessibility
+
+- Minting via stake flow is permissionless through app/contract path (`whitelistEnabled()` = false on-chain).
+- Unstaking is queue-based, not instant.
+- On-chain verified unstaking parameters:
+  - **`withdrawalDelay()`**: 604,800 seconds = **7 days** exact
+  - **`unstakeFeeRate()`**: 10 (0.10% in basis points)
+  - `withdrawalPaused()`: false
+  - `stakingPaused()`: false
+
+### Collateralization
+
+On-chain state (verified February 12, 2026):
+- **kHYPE totalSupply**: 22,104,091.53 kHYPE
+- **StakingPool totalStaked**: 50,013,410.11 HYPE
+- **Implied exchange rate**: 1 kHYPE = 2.2626 HYPE
+- **StakingPool liquid HYPE**: 203,958.26 HYPE (0.41% of totalStaked held as liquid buffer)
+- **StakingPool kHYPE held**: 960,784.91 kHYPE
+- **totalQueuedWithdrawals**: 971,460.09 HYPE
+- **totalClaimed**: 27,987,503.62 HYPE
+
+Economic backing is staked HYPE plus liquid reserves. Backing quality is primarily dependent on Hyperliquid validator set quality and staking outcomes. No off-chain custodial reserve model is disclosed for core kHYPE backing.
+
+### Provability
+
+- Core staking and token accounting are on-chain.
+- All core contracts (kHYPE, StakingPool, PauserRegistry and their implementations) are **source-code verified on HyperEVMScan** (exact match).
+- Key on-chain readable functions verified: `totalSupply()`, `totalStaked()`, `totalQueuedWithdrawals()`, `totalClaimed()`, `withdrawalDelay()`, `unstakeFeeRate()`.
+- Exchange rate is derived from totalStaked / totalSupply — updated via staking operations, not admin oracle.
+- Contracts use OpenZeppelin AccessControlEnumerable (verified via `supportsInterface`). kHYPE supports EIP-2612 Permit.
+- kHYPE is **not** ERC4626 (`convertToAssets`, `totalAssets`, `asset` all revert).
+
+## Liquidity Risk
+
+kHYPE exit routes:
+
+1. Protocol unstake queue (primary deterministic exit)
+- On-chain `withdrawalDelay()` = 7 days
+- Fee-bearing exit path (0.10%)
+- Queue delay can expand under stress
+
+2. Secondary market liquidity (per DeFiLlama, February 2026)
+
+**Total DEX liquidity: ~$44M** across 39 pools on HyperEVM DEXes.
+
+Top DEX pools:
+
+| DEX | Pair | TVL | 24h Volume |
+|-----|------|-----|------------|
+| Project X | WHYPE/KHYPE | $8,206,746 | $6,933,060 |
+| Project X | USDT0/KHYPE | $2,337,679 | $312,037 |
+| Ramses HL | WHYPE/KHYPE | $281,206 | $1,512,669 |
+| HyperSwap V3 | WHYPE/KHYPE | $268,244 | $599,408 |
+
+**Lending protocol deposits** dominate external kHYPE usage: ~$170M HyperLend, ~$215M Morpho, ~$27M Pendle. These are not exit liquidity.
+
+All trading is DEX-based on HyperEVM. No centralized exchange listings found.
+
+Given queue dependence and same-ecosystem DEX liquidity, kHYPE liquidity risk is materially higher than WHYPE but better than stHYPE (which has ~$403K DEX depth vs kHYPE's $44M).
+
+## Centralization & Control Risks
+
+### Governance
+
+On-chain verified governance data:
+
+- **Multisig address**: [`Governance Multisig`](https://hyperevmscan.io/address/0x18A82c968b992D28D4D812920eB7b4305306f8F1) (Gnosis Safe on HyperEVM)
+- **Threshold**: **4-of-7** (verified via `getThreshold()`)
+- **Version**: 1.3.0
+- **Nonce**: 32 transactions executed
+- **Timelock**: **None.** Exhaustive on-chain verification confirmed no timelock exists — Safe has no modules (`getModulesPaginated` returns empty), no guard (storage slot `0x4a204f...` is zero), all three ProxyAdmins are standard OpenZeppelin (881 bytes, owned directly by multisig), and no `EnabledModule` events have ever been emitted.
+- **Signer identities**: All 7 signers are pseudonymous.
+
+**Role structure (verified via AccessControlEnumerable):**
+
+| Contract | Role | Holder |
+|----------|------|--------|
+| kHYPE | DEFAULT_ADMIN | Governance Multisig (4/7) |
+| kHYPE | MINTER | [`StakingPool`](https://hyperevmscan.io/address/0x393D0B87Ed38fc779FD9611144aE649BA6082109) |
+| kHYPE | BURNER | [`StakingPool`](https://hyperevmscan.io/address/0x393D0B87Ed38fc779FD9611144aE649BA6082109) |
+| StakingPool | DEFAULT_ADMIN | Governance Multisig (4/7) |
+| StakingPool | MANAGER | Governance Multisig (4/7) |
+| StakingPool | OPERATOR | [`OPERATOR EOA`](https://hyperevmscan.io/address/0x23A4604cDFe8e9e2e9Cf7C10D7492B0F3f4B4038) |
+| PauserRegistry | DEFAULT_ADMIN | Governance Multisig (4/7) |
+
+**Key concern:** The OPERATOR role on the StakingPool is held by a single **EOA** ([`OPERATOR EOA`](https://hyperevmscan.io/address/0x23A4604cDFe8e9e2e9Cf7C10D7492B0F3f4B4038)), not the multisig. This address is a Kinetiq automated bot (6,421 nonce) that calls `generatePerformance()` and `updateValidatorMetrics()` on a regular basis.
+
+### Programmability
+
+- Hybrid on-chain system with multiple upgradeable proxy contracts.
+- Exchange rate is derived from on-chain state (totalStaked / totalSupply), not admin-set.
+- StakingPool has significant admin functions: `pauseWithdrawal()`, `pauseStaking()`, `setWithdrawalDelay()`, `setUnstakeFeeRate()`, `executeEmergencyWithdrawal()`, `rescueToken()`.
+- Emergency withdrawal and token rescue capabilities exist — powerful admin functions.
+
+### External Dependencies
+
+Critical dependencies:
+1. Hyperliquid L1 consensus/liveness.
+2. Hyperliquid validator performance and staking/slashing rules.
+3. HyperEVM execution environment.
+4. DEX liquidity conditions for kHYPE/HYPE exits.
+
+Dependency concentration on Hyperliquid ecosystem is structurally high. **HyperEVM is NOT a separate chain** — it shares the same HyperBFT consensus as HyperCore. There is no bridge risk between HyperCore and HyperEVM; the risk is pure L1 liveness.
+
+**Important:** Hyperliquid is a highly centralized chain — Hyper Foundation controls 56.4% of validator stake via 5 validators, exceeding the 1/3 BFT blocking minority. HYPE staking cannot be considered as safe as ETH staking, where validator set decentralization is significantly stronger (~1M validators, no single entity near blocking minority). This centralization risk is inherited by kHYPE and should be weighed accordingly.
+
+### Hyperliquid Validator Set Dependency (Quantified)
+
+Source: Hyperliquid L1 API (`POST https://api.hyperliquid.xyz/info`)
+
+Verify validator data: [Hyperliquid Staking Portal](https://app.hyperliquid.xyz/staking) | [Validator Performance](https://app.hyperliquid.xyz/staking/validatorPerformance) | [HypurrScan Staking](https://hypurrscan.io/staking)
+
+**Network overview (February 2026):**
+
+| Metric | Value |
+|--------|-------|
+| Total validators | 30 (24 active, 5 jailed, 1 inactive) |
+| Total network stake | 436.2M HYPE |
+| Active stake | 431.9M HYPE |
+| Jailed stake | 4.3M HYPE (0.99%) |
+
+**Concentration risk:**
+- **Hyper Foundation operates 5 validators** controlling **56.4%** of active stake (243.4M HYPE). This exceeds the **1/3 blocking minority** for BFT consensus.
+- Top 5 validators (4 HF + Anchorage) = 60.1% of active stake.
+- Top 10 validators = 83.4% of active stake.
+- Kinetiq represents **11.5% of total network stake** — the single largest protocol-level staker on Hyperliquid.
+
+**Kinetiq's delegation strategy:**
+- **ValidatorManager** has 22 pre-approved validators registered; 9 receive active delegations.
+- StakeHub autonomously scores and delegates via algorithmic selection.
+- Total L1 delegated: **21.5M HYPE** (vs 50.0M `totalStaked` on EVM — the ~28.5M gap is likely undelegated buffer or unstaking queue).
+
+| Validator | Delegation (HYPE) | % of Kinetiq | Lock Status |
+|-----------|-------------------|-------------|-------------|
+| **Kinetiq x Hyperion** (own) | 6,003,900 | **27.9%** | Locked |
+| Hyper Foundation 1-5 (×4) | 1,936,320 each | 9.0% each (45.0% total) | Unlocked |
+| infinitefield.xyz | 1,936,320 | 9.0% | Unlocked |
+| Hypurrscanning | 1,936,320 | 9.0% | Unlocked |
+| Nansen x HypurrCollective | 1,936,320 | 9.0% | Unlocked |
+
+- **Delegation HHI: 1,429** (competitive range, below 1,500 threshold).
+- **45.0%** of Kinetiq delegations go to Hyper Foundation validators; **55.0%** to non-HF validators.
+- All delegated validators have 99.9-100% uptime and APR in the 2.16-2.25% range.
+- **Zero exposure to currently jailed validators.**
+
+**Slashing/jailing context:**
+- **No automatic slashing is implemented** on Hyperliquid (per [official docs](https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/staking)). However, slashing may be enforced in the future and must be considered a forward-looking risk if Kinetiq delegates to validators that suffer a slashing event (per [Kinetiq risk disclosures](https://kinetiq.xyz/stake-hype#what-are-the-potential-risks)).
+- Jailing = reward cessation only, no principal loss. Jailed validators visible on [Hyperliquid Staking Portal](https://app.hyperliquid.xyz/staking).
+- Validators can be jailed by peer vote for latency/responsiveness issues (see [validator prison docs](https://hyperliquid.gitbook.io/hyperliquid-docs/hypercore/staking)).
+- Unstaking queue from L1 validators: **7 days**.
+
+**L1 incident history:** No Hyperliquid L1 consensus or liveness incidents found in the DeFiLlama hacks database. Three HyperEVM application-level exploits were recorded (HyperVault $3.6M rugpull, Hyperdrive $773K router exploit, Raga Finance $18.5K exploit) — none affecting L1 itself.
+
+## Operational Risk
+
+- Audit depth is reasonable for protocol age (5 core audits from 4 firms).
+- Bug bounty at $5M max is strong and has 294 submissions.
+- **Team/legal entity:** Two entity names are used inconsistently — **"Kinetiq Labs"** (Terms of Use) vs **"Kinetiq Research"** (Privacy Policy, GitHub org, footer copyright). GitHub org lists **Singapore** as location; Privacy Policy references **Panama** for data transfers. Terms of Use do not name a governing law jurisdiction. No registered address or company registration number is publicly disclosed.
+- **Known team members** (via GitHub commit history on `github.com/kinetiq-research`):
+  - **Justin Greenberg** ([@justingreenberg](https://github.com/justingreenberg), Twitter: @greenbergz) — primary developer on `f1rewall` repo, PGP-signed commits.
+  - **GregTheDev** ([@0xgregthedev](https://github.com/0xgregthedev)) — Rust/Solidity developer, primary contributor to `hl-rs` (Hyperliquid Rust SDK). `gregthedev.eth` funded governance Safe Signer 2.
+  - **mektigboy** ([@mektigboy](https://github.com/mektigboy), Twitter: @mektigboy) — self-identified "driver @kinetiq-research" in GitHub bio. Prior experience with sherlock-audit and security audit orgs.
+- Contact: security@kinetiq.xyz (with PGP key at `kinetiq.xyz/.well-known/pubkey.asc`), contact@kinetiq.xyz, info@kinetiq.xyz.
+- No public "About" or "Team" page exists on kinetiq.xyz or docs.kinetiq.xyz. Twitter: [@Kinetiq_xyz](https://twitter.com/Kinetiq_xyz).
+- Contracts are **not open-source on GitHub** — the Kinetiq GitHub org (`github.com/kinetiq-research`) has only SDK/utility repos, no smart contract code. However, all core contracts are **source-code verified on HyperEVMScan** (exact match).
+- No public formal verification disclosure found.
+
+## Monitoring
+
+Key contracts to monitor:
+- kHYPE Proxy: [`kHYPE`](https://hyperevmscan.io/address/0xfd739d4e423301ce9385c1fb8850539d657c296d)
+- StakingPool Proxy: [`StakingPool`](https://hyperevmscan.io/address/0x393D0B87Ed38fc779FD9611144aE649BA6082109)
+- PauserRegistry Proxy: [`PauserRegistry`](https://hyperevmscan.io/address/0x752E76ea71960Da08644614E626c9F9Ff5a50547)
+- Governance Multisig: [`Governance Multisig`](https://hyperevmscan.io/address/0x18A82c968b992D28D4D812920eB7b4305306f8F1) (Gnosis Safe 4-of-7)
+
+### 1. Governance Monitoring (MANDATORY)
+
+Monitor all privileged role actions and parameter changes for:
+- RoleGranted / RoleRevoked events on kHYPE and StakingPool (AccessControl)
+- Upgraded events on proxy contracts (implementation changes)
+- AddedOwner / RemovedOwner / ChangedThreshold on Governance Safe
+
+Immediate alerts:
+- ownership/multisig signer changes
+- threshold changes
+- implementation upgrades
+- emergency pause activations
+- parameter changes (withdrawalDelay, unstakeFeeRate, stakingLimit)
+
+### 2. Backing & Supply Monitoring (MANDATORY)
+
+Track:
+- `kHYPE.totalSupply()` (currently 22.1M)
+- `StakingPool.totalStaked()` (currently 50.0M HYPE)
+- Implied exchange rate trend
+- StakingPool native HYPE balance (liquid buffer)
+
+Alert thresholds:
+- backing ratio drift >1% in 24h (unless expected market event)
+- liquid buffer drops below 50K HYPE
+
+### 3. Queue Health Monitoring (MANDATORY)
+
+Track:
+- `StakingPool.totalQueuedWithdrawals()` (currently 971K HYPE)
+- queue size and average wait time
+- daily enqueue/dequeue flow
+
+Alert thresholds:
+- average unstake latency >10 days sustained
+- queue size growth >30% day-over-day
+
+### 4. Market Liquidity Monitoring
+
+Track:
+- kHYPE/HYPE and kHYPE/stable liquidity depth on Project X, Ramses, HyperSwap
+- implied NAV discount/premium
+- slippage for standard notional buckets
+
+Alert thresholds:
+- discount >2% sustained for 24h
+- liquidity depth decline >40% day-over-day
+
+### 5. Hyperliquid Base Risk Monitoring
+
+Track official Hyperliquid updates for:
+- validator jailing waves
+- staking parameter changes
+- any governance introduction of automatic validator slashing
+- chain liveness/finality incidents
+
+## Risk Summary
+
+### Key Strengths
+
+1. Significant TVL (~$683M) and DeFi integration (~$493M across 52 pools).
+2. 5 core audits from reputable firms (Pashov, Zenith, Code4rena, Spearbit) across 2025.
+3. Active Cantina bug bounty with $5M maximum and 294 submissions.
+4. On-chain verifiable staking economics with AccessControl role enumeration.
+5. 4-of-7 multisig governance (stronger than many DeFi protocol minimums).
+
+### Key Risks
+
+1. Queue-based unstake path (7 days on-chain) introduces redemption delay risk.
+2. Multi-contract upgradeable proxy architecture adds integration and control-plane complexity.
+3. OPERATOR role on StakingPool held by single EOA (automated bot, not multisig-protected).
+4. **No timelock on multisig** — confirmed exhaustively on-chain (no modules, no guard, no timelock contract). Upgrades can be executed immediately.
+5. **Hyper Foundation controls 56.4% of network stake** — exceeds 1/3 BFT blocking minority. Kinetiq delegates 45% of its stake to HF validators.
+6. **Multisig signer independence is questionable** — inter-signer funding chains, shared funders (Signers 4+7), one inactive signer (Signer 7 = 0 nonce), all appear team-associated rather than independent external parties.
+7. Contracts not open-sourced on GitHub (but verified on-chain on HyperEVMScan).
+8. ~28.5M HYPE gap between EVM `totalStaked` (50M) and L1 actual delegated (21.5M) — needs monitoring.
+9. Legal entity ambiguity: "Kinetiq Labs" (Terms) vs "Kinetiq Research" (Privacy/GitHub) with no specific governing law jurisdiction named.
+
+### Critical Risks
+
+- `executeEmergencyWithdrawal()` and `rescueToken()` functions give admin significant power over funds.
+
+---
+
+## Risk Score Assessment
+
+### Critical Risk Gates
+
+- [x] **No audit** -> **PASS** (5 core audits from 4 reputable firms)
+- [x] **Unverifiable reserves** -> **PASS** (on-chain staking model with readable state)
+- [x] **Total centralization** -> **PASS** (4-of-7 multisig, not single EOA)
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+- 5 core audits by reputable firms (Pashov x2, Zenith, Code4rena, Spearbit) from Mar-Nov 2025.
+- Cantina bug bounty at $5M max with 294 submissions. High bug bounty (>$5M) reduces score by 0.5.
+- ~7 months in production, TVL ~$683M (peaked ~$2.65B).
+- Per rubric: 3+ audits by top firms, active bug bounty >$1M -> score 1 range for audits. 6-12 months, TVL >$100M fits score 2-3 for track record. Net: 1.5 + track record penalty.
+
+**Score: 2.0/5**
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+Subscores:
+- Governance: **4.0** — 4-of-7 multisig (verified on-chain), but: **no timelock** (confirmed exhaustively), signer independence is questionable (inter-signer funding, shared funders, 1 inactive signer, all team-associated), powerful admin functions (emergency withdrawal, rescue, parameter changes). Effectively a team-controlled multisig, not an independent governance body. Per rubric: formal structure is 4/7 but real independence is much weaker.
+- Programmability: **2.0** — Hybrid on-chain system with upgradeable proxies. Exchange rate is on-chain derived (not admin-set). All core contracts are source-code verified on-chain (exact match).
+- External dependencies: **4.0** — Critical single-ecosystem dependency on Hyperliquid L1. Hyper Foundation controls 56.4% of validator stake (blocking minority). Kinetiq delegates 45% of its stake to HF validators.
+
+Centralization score = (4.0 + 2.0 + 4.0) / 3 = **3.33**
+
+**Score: 3.3/5**
+
+#### Category 3: Funds Management (Weight: 30%)
+
+Subscores:
+- Collateralization: **2.0** — 100% on-chain collateral (staked HYPE). Liquid buffer only 0.41% of totalStaked. Collateral quality = single-asset (HYPE), high quality within Hyperliquid ecosystem. Exchange rate verified at 2.26x.
+- Provability: **1.5** — Key state readable on-chain via AccessControlEnumerable. Exchange rate derived programmatically. All core contracts (kHYPE, StakingPool, PauserRegistry and their implementations) are source-code verified on HyperEVMScan (exact match), enabling independent verification.
+
+Funds management score = (2.0 + 1.5) / 2 = **1.75**
+
+**Score: 1.75/5**
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+- Queue-based withdrawals: 7-day standard unstaking period (verified on-chain), standard for LSTs.
+- DEX liquidity is strong relative to TVL: ~$44M total across 39 pools (~6.4% of TVL). Largest pool ~$8.2M with $6.9M daily volume.
+- All liquidity is on HyperEVM DEXes — no CEX listings, but sufficient DEX depth for the asset class.
+
+**Score: 2.0/5**
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+- Docs present but client-side rendered (verification difficult).
+- Audits and bounty are strong for protocol age.
+- Team transparency: unknown/anon. Contracts not on GitHub but verified on-chain.
+- No public incident response plan documented.
+
+**Score: 2.0/5**
+
+### Final Score Calculation
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 2.0 | 20% | 0.40 |
+| Centralization & Control | 3.3 | 30% | 0.99 |
+| Funds Management | 1.75 | 30% | 0.525 |
+| Liquidity Risk | 2.0 | 15% | 0.30 |
+| Operational Risk | 2.0 | 5% | 0.10 |
+| **Final Score** | | | **2.315 / 5.0** |
+
+## Overall Risk Score: **2.3 / 5.0**
+
+### Risk Tier: **MEDIUM RISK**
+
+Rationale:
+- kHYPE is a well-audited LST with significant TVL ($683M) and DeFi adoption.
+- Governance is formally 4-of-7 multisig but signer independence is weak — inter-signer funding, shared funders, 1 inactive signer, all team-associated.
+- No timelock (confirmed exhaustively on-chain) and powerful admin functions (emergency withdrawal, rescue).
+- Hyper Foundation controls 56.4% of network validator stake; Kinetiq delegates 45% of its stake to HF validators.
+- Liquidity is decent for an LST ($44M DEX depth) but all on HyperEVM.
+- Three identified team members via GitHub but no public team page, ambiguous legal entity (Labs vs Research), no specified governing jurisdiction.
+
+## Reassessment Triggers
+
+- **Time-based**: Reassess in 3 months
+- **TVL-based**: Reassess if TVL changes by more than 50%
+1. Any Hyperliquid staking governance change that introduces automatic validator slashing.
+2. Any kHYPE exploit or emergency pause activation.
+3. Unstake queue latency >10 days sustained for >72h.
+4. kHYPE discount >3% sustained for >24h.
+5. Any privileged role threshold reduction or owner structure downgrade.
+6. Major contract migration or implementation upgrade.
+7. OPERATOR EOA change or role reassignment.
+8. Timelock implementation (positive trigger — would warrant score improvement).
+
+## Sources
+
+- Kinetiq app: https://kinetiq.xyz/
+- Kinetiq docs: https://docs.kinetiq.xyz/
+- kHYPE docs: https://docs.kinetiq.xyz/kinetiq-lsd/khype
+- StakeHub docs: https://docs.kinetiq.xyz/kinetiq-lsd/stakehub
+- Kinetiq FAQ: https://docs.kinetiq.xyz/resources/faq
+- Kinetiq contracts: https://docs.kinetiq.xyz/resources/contracts
+- Kinetiq audits: https://docs.kinetiq.xyz/resources/audits
+- Kinetiq audit PDFs (Google Drive): https://drive.google.com/drive/folders/1T3ZGl6HNmt5LaKwdCmrA9HS7MsXheOys
+- Code4rena Kinetiq audit: https://code4rena.com/audits/2025-04-kinetiq
+- Kinetiq bug bounty (Cantina): https://cantina.xyz/bounties/a98129d7-dd15-4c16-b2cb-d8cc42f87de4
+- CoinGecko kHYPE: https://www.coingecko.com/en/coins/kinetiq-staked-hype
+- DeFiLlama Kinetiq: https://defillama.com/protocol/kinetiq
+- Hyperliquid staking docs: https://hyperliquid.gitbook.io/hyperliquid-docs/hype-staking
+- Hyperliquid validator prison docs: https://hyperliquid.gitbook.io/hyperliquid-docs/hype-staking/validator-prison
+- Hyperliquid risks docs: https://hyperliquid.gitbook.io/hyperliquid-docs/risks
+- On-chain verification via `cast` against HyperEVM RPC (`rpc.hyperliquid.xyz/evm`)
+- Hyperliquid L1 API: `POST https://api.hyperliquid.xyz/info` (validator summaries, delegations)
+- Kinetiq GitHub org: https://github.com/kinetiq-research
+- Kinetiq Terms of Use: https://kinetiq.xyz/terms
+- Kinetiq Privacy Policy: https://kinetiq.xyz/privacy
+- Kinetiq security.txt: https://kinetiq.xyz/.well-known/security.txt
+- ENS reverse lookup via `0x3671aE578E63FdF66ad4F3E12CC0c0d71Ac7510C` (getNames)
+- RouteScan API for HyperEVM (chain 999) transaction tracing
+- Etherscan V2 API for cross-chain address verification

--- a/src/components/pages/curation/reports/maple-syrupusdc.md
+++ b/src/components/pages/curation/reports/maple-syrupusdc.md
@@ -1,0 +1,650 @@
+# Protocol Risk Assessment: Maple Finance
+
+- **Assessment Date:** February 17, 2026
+- **Token:** syrupUSDC
+- **Chain:** Ethereum Mainnet
+- **Token Address:** [`0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b`](https://etherscan.io/address/0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b)
+- **Final Score: 2.33/5.0**
+
+## Overview + Links
+
+syrupUSDC is Maple Finance's yield-bearing stablecoin (ERC-4626 vault token). Users deposit USDC into the Syrup pool and receive syrupUSDC LP tokens that appreciate over time as yield accrues. Yield is primarily generated from fixed-rate, overcollateralized loans to institutional borrowers who post liquid digital assets (BTC, ETH, LBTC, SOL, tETH) as collateral. Additional yield comes from DeFi strategies deployed via Aave and Sky (MakerDAO) strategy contracts.
+
+Deposits are gated by a permission system for regulatory compliance (first-time authorization required, subsequent deposits permissionless). Withdrawals are queue-based (FIFO) and typically processed within minutes to 2 days, with a maximum of 30 days in low-liquidity scenarios.
+
+- **Current Price:** ~$1.15
+- **Total Supply:** ~1,459M syrupUSDC
+- **Market Cap:** ~$1.68B
+- **Total Holders:** 2,768
+- **Total Syrup TVL (all pools):** ~$3.70B
+- **Collateral Ratio:** 168.96%
+- **Current APY:** ~4.42% (base pool: 3.37% + collateral boost: 1.05%)
+- **Management Fee:** 8.33% of gross borrower interest (Delegate: 3.33% + Platform: 5.00%, verified on-chain via PoolManager `delegateManagementFeeRate()` and MapleGlobals `platformManagementFeeRate()`)
+
+**Links:**
+
+- [Protocol Documentation](https://docs.maple.finance/)
+- [Syrup Lender Documentation](https://docs.maple.finance/syrupusdc-usdt-for-lenders/introduction)
+- [Protocol App](https://syrup.fi/)
+- [App Details / Allocations](https://app.maple.finance/earn/details)
+- [Smart Contract Integration](https://docs.maple.finance/integrate/ethereum-mainnet/smart-contract-integrations)
+- [Security / Audits](https://docs.maple.finance/technical-resources/security/security)
+- [GitHub (maple-core-v2)](https://github.com/maple-labs/maple-core-v2)
+- [DeFiLlama](https://defillama.com/protocol/maple-finance)
+- [Dune Dashboard](https://dune.com/maple-finance/maple-finance)
+- [Bug Bounty (Immunefi)](https://immunefi.com/bounty/maple/)
+- [LlamaRisk Assessment (Aave Governance)](https://governance.aave.com/t/arfc-onboard-syrupusdc-to-aave-v3-core-instance/22456/5)
+- [Maple Address Registry (GitHub)](https://github.com/maple-labs/address-registry/blob/main/MapleAddressRegistryETH.md)
+- [Maple Legal Docs (GitHub)](https://github.com/maple-labs/maple-docs/tree/master/legal)
+
+## Contract Addresses
+
+| Contract | Address |
+|----------|---------|
+| syrupUSDC Pool (ERC-4626) | [`0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b`](https://etherscan.io/address/0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b) |
+| SyrupRouter | [`0x134cCaaA4F1e4552eC8aEcb9E4A2360dDcF8df76`](https://etherscan.io/address/0x134cCaaA4F1e4552eC8aEcb9E4A2360dDcF8df76) |
+| PoolManager | [`0x7aD5fFa5fdF509E30186F4609c2f6269f4B6158F`](https://etherscan.io/address/0x7aD5fFa5fdF509E30186F4609c2f6269f4B6158F) |
+| FixedTermLoanManager | [`0x4A1c3F0D9aD0b3f9dA085bEBfc22dEA54263371b`](https://etherscan.io/address/0x4A1c3F0D9aD0b3f9dA085bEBfc22dEA54263371b) |
+| OpenTermLoanManager | [`0x6ACEb4cAbA81Fa6a8065059f3A944fb066A10fAc`](https://etherscan.io/address/0x6ACEb4cAbA81Fa6a8065059f3A944fb066A10fAc) |
+| WithdrawalManagerQueue | [`0x1bc47a0Dd0FdaB96E9eF982fdf1F34DC6207cfE3`](https://etherscan.io/address/0x1bc47a0Dd0FdaB96E9eF982fdf1F34DC6207cfE3) |
+| PoolDelegateCover | [`0x9e62FE15d0E99cE2b30CE0D256e9Ab7b6893AfF5`](https://etherscan.io/address/0x9e62FE15d0E99cE2b30CE0D256e9Ab7b6893AfF5) |
+| PoolPermissionManager | [`0xBe10aDcE8B6E3E02Db384E7FaDA5395DD113D8b3`](https://etherscan.io/address/0xBe10aDcE8B6E3E02Db384E7FaDA5395DD113D8b3) |
+| AaveStrategy | [`0x560B3A85Af1cEF113BB60105d0Cf21e1d05F91d4`](https://etherscan.io/address/0x560B3A85Af1cEF113BB60105d0Cf21e1d05F91d4) |
+| SkyStrategy | [`0x859C9980931fa0A63765fD8EF2e29918Af5b038C`](https://etherscan.io/address/0x859C9980931fa0A63765fD8EF2e29918Af5b038C) |
+| Governor (Timelock) | [`0x2eFFf88747EB5a3FF00d4d8d0f0800E306C0426b`](https://etherscan.io/address/0x2eFFf88747EB5a3FF00d4d8d0f0800E306C0426b) |
+| DAO Multisig | [`0xd6d4Bcde6c816F17889f1Dd3000aF0261B03a196`](https://etherscan.io/address/0xd6d4Bcde6c816F17889f1Dd3000aF0261B03a196) |
+| Security Admin | [`0x6b1A78C1943b03086F7Ee53360f9b0672bD60818`](https://etherscan.io/address/0x6b1A78C1943b03086F7Ee53360f9b0672bD60818) |
+| Operational Admin | [`0xCe1cE7c7F436DCc4E28Bc8bf86115514d3DC34E8`](https://etherscan.io/address/0xCe1cE7c7F436DCc4E28Bc8bf86115514d3DC34E8) |
+| MapleGlobals (v301) | [`0x804a6F5F667170F545Bf14e5DDB48C70B788390C`](https://etherscan.io/address/0x804a6F5F667170F545Bf14e5DDB48C70B788390C) |
+| SYRUP Token | [`0x643c4e15d7d62ad0abec4a9bd4b001aa3ef52d66`](https://etherscan.io/address/0x643c4e15d7d62ad0abec4a9bd4b001aa3ef52d66) |
+
+## Audits and Due Diligence Disclosures
+
+Maple Finance has been extensively audited across 7+ releases by multiple reputable firms. The protocol has accumulated **20+ audit reports from 8+ different auditing firms** including Trail of Bits, Spearbit, Sherlock, Three Sigma, 0xMacro, Dedaub, Sigma Prime, PeckShield, and Code4rena. All reported issues have been addressed prior to each release.
+
+Full audit report list: [Appendix A — Audit Reports](#appendix-a--audit-reports)
+
+**Smart Contract Complexity:** High — Upgradeable proxy pattern, multiple loan managers (fixed-term and open-term), withdrawal queue, permission system, DeFi strategy integrations (Aave, Sky), Chainlink oracles, cross-chain CCIP integration.
+
+### Bug Bounty
+
+- **Platform:** Immunefi
+- **Maximum Payout:** $500,000 (Critical)
+- **High Severity:** $25,000 - $50,000
+- **Link:** https://immunefi.com/bounty/maple/
+
+### Safe Harbor
+
+Maple Finance is **not** listed on the SEAL Safe Harbor registry.
+
+## Historical Track Record
+
+- **V1 Launch:** 2021
+- **V2 Launch:** December 14, 2022
+- **Syrup Launch:** August 2024 (~18 months in production for V2, ~6 months for Syrup-specific contracts)
+- **Smart Contract Exploits:** None. No smart contract vulnerabilities have been exploited.
+- **Credit Event (V1, Late 2022):** ~$36M in defaults from the Orthogonal Trading pool following the FTX collapse. This was a **credit/counterparty risk event**, not a smart contract exploit. Maple subsequently restructured, launched V2, and shifted entirely to overcollateralized lending.
+- **TVL:** Total Syrup TVL (all pools): ~$3.70B. syrupUSDC pool collateral: ~$1.24B. TVL has shown strong growth since Syrup launch, with some fluctuations.
+- **Holder Distribution:** Top holders are protocol infrastructure contracts, which is standard for DeFi integrations. Top 5 holders (via Ethplorer): ALMProxy (35.4%, Maple infrastructure), Chainlink CCIP LockReleaseTokenPool (31.9%, backs cross-chain syrupUSDC), ALMProxy (11.7%, Maple infrastructure), Morpho Blue (4.7%, lending protocol integration), Fluid Liquidity Proxy (3.6%, Instadapp integration). Only 2,768 total holders for a $1.68B market cap. No significant external whale concentration risk.
+- **Peg Stability:** syrupUSDC is not pegged 1:1 to USDC — it's a yield-bearing vault token that appreciates over time ($1.055 ATL to $1.16 ATH), reflecting accrued interest. The exchange rate has been monotonically increasing as expected.
+
+## Funds Management
+
+Maple delegates deposited USDC to institutional borrowers via overcollateralized loans. Borrowers post liquid digital assets as collateral.
+
+### Yield Sources
+
+1. **Overcollateralized Institutional Lending** — Primary yield source. Fixed-rate loans to creditworthy crypto-native institutions.
+2. **Futures Basis Trading** — Cash-and-carry strategies targeting spreads between futures and spot markets.
+3. **DeFi Strategies** — Deployments via Aave and Sky (MakerDAO) strategy contracts.
+
+### Accessibility
+
+- **Deposits:** Gated by `PoolPermissionManager` — first-time depositors require a one-time on-chain authorization, subsequent deposits are permissionless. Atomic, single-transaction. See [Appendix B — Deposit Flow](#appendix-b--deposit-flow) for details.
+- **Withdrawals:** Queue-based (FIFO). Call `pool.requestRedeem(shares, receiver)` to enter queue. Assets sent directly to wallet when processed. No penalties. Yield stops accruing once withdrawal requested.
+- **Withdrawal Timing:** Typically minutes to 2 days. Maximum 30 days in low-liquidity scenarios.
+- **Fees:** Total management fee of 8.33% on gross borrower interest (Delegate fee: 3.33% + Platform fee: 5.00%, verified on-chain). DeFi strategy performance fees charged on yield generated.
+- **Alternative Exit:** syrupUSDC can be swapped on Uniswap (~$20M liquidity in syrupUSDC/USDC pool).
+
+### Collateralization
+
+Loans are overcollateralized with liquid digital assets. Current allocation data fetched from Maple Finance GraphQL API (Feb 17, 2026):
+
+| Asset | Amount | USD Value | Allocation % |
+|-------|--------|-----------|-------------|
+| BTC | 9,811 BTC | $667M | **53.92%** |
+| XRP | 215.9M XRP | $314M | **25.38%** |
+| USTB | 18.2M USTB | $200M | **16.16%** |
+| LBTC | 442 LBTC | $30M | **2.43%** |
+| weETH | 6,085 weETH | $13.2M | **1.06%** |
+| HYPE | 439,400 HYPE | $13M | **1.05%** |
+| **TOTAL** | | **$1.24B** | **100%** |
+
+Inactive/zero-allocation assets: ETH, SOL, tETH, sUSDS, USR, LP_USR, OrcaLP_PYUSDC, jitoSOL, PT_sUSDE.
+
+**LTV Parameters (from prior assessment, unchanged in docs):**
+
+| Collateral Asset | Margin Call LTV | Liquidation LTV |
+|-----------------|----------------|-----------------|
+| BTC | 85% | 90% |
+| LBTC | 75% | 85% |
+| ETH | 70% | 85% |
+
+**Collateral Concerns:**
+- **BTC dominance:** BTC represents ~54% of all collateral — high concentration in a single asset class (BTC + LBTC = 56.35%)
+- **XRP is the second-largest collateral (25.38%):** XRP is more volatile than BTC/ETH and carries regulatory uncertainty. This is a notable change from the Feb 2025 allocation where SOL was the largest position.
+- **USTB (Superstate US T-Bills):** 16% allocation in tokenized US Treasury bills provides stable backing but introduces dependency on Superstate protocol
+- **HYPE token (1.05%):** Hyperliquid's native token, lower liquidity and newer asset — small allocation limits risk
+
+**Liquidation Mechanism:**
+- Maple's smart contracts monitor all loans in real-time for adherence to collateralization levels
+- If collateralization reaches liquidation level, Maple has full rights to liquidate collateral
+- Liquidations performed by external Keepers, constrained by protocol rules
+- Chainlink oracles used for price feeds
+- Oracle wrappers add safety checks on top of Chainlink feeds (staleness validation, min/max price bounds, sequence checks) to prevent liquidations at stale or manipulated prices
+- Minimum liquidation price parameter prevents liquidation at unfairly low prices
+
+**Impairment Mechanism:**
+- Maple can impair loans before technical default if they assess borrower won't repay
+- Impairment temporarily reduces loan value, distributing potential losses across current lenders
+- Prevents some lenders from withdrawing unaffected while shifting burden to remaining lenders
+- If borrower repays, impairment is reversed and pool value restored
+- Lenders withdrawing during impairment take a permanent loss and cannot claim future recoveries
+
+### Provability
+
+- Loans are verifiable on-chain with transparent margin call and liquidation levels for each loan
+- syrupUSDC exchange rate is computed on-chain (ERC-4626 `convertToAssets()`/`convertToShares()`)
+- Collateral data can be fetched via Maple API and verified on Etherscan
+- Loan-level data (principal, collateral, rates) is on-chain
+- However, the actual lending operations (borrower creditworthiness assessment, loan origination) are managed off-chain by Maple Direct (the Pool Delegate)
+- DeFi strategy allocations are on-chain and verifiable
+
+## Liquidity Risk
+
+- **Primary Exit:** Queue-based redemption at smart contract exchange rate (no slippage). Typical processing: minutes to 2 days. Maximum: 30 days.
+- **Secondary Exit:** Uniswap syrupUSDC/USDC pool with ~$20M liquidity and ~$726K daily volume.
+- **Slippage (Uniswap V4, estimated via DexScreener):**
+  - $100K: ~0.6% (concentrated liquidity estimate)
+  - $1M: ~5.4%
+  - $10M: ~44% (pool only has ~$14.9M USDC reserve, physically cannot fill)
+- **DEX Liquidity:** $20.1M TVL in Uniswap V4 pool (syrupUSDC reserve: $5.2M, USDC reserve: $14.9M). Only ~$726K daily volume. Trading is highly one-directional (8 buys, 0 sells in 24h). DEX liquidity is only **1.2% of market cap** — vast majority of exits must use Maple's native withdrawal queue.
+- **Withdrawal Queue Behavior:** FIFO ordering. Yield stops accruing once requested. No penalties. Assets sent directly to wallet when liquidity available.
+- **Stress Scenario:** In a scenario where many lenders request redemption simultaneously (e.g., credit concern), withdrawals could take up to 30 days. The pool would need to recall loans or wait for loan maturities to generate liquidity.
+- **Historical Stress:** The V1 credit event (FTX collapse, 2022) caused significant withdrawal pressure, but V2 has not experienced a comparable stress test.
+
+## Centralization & Control Risks
+
+### Governance
+
+**Governance Structure:**
+
+```
+SYRUP Token Holders
+        │ (Stake to stSYRUP for voting)
+        ▼
+Snapshot Voting (7-day window, quorum-based)
+        │
+        ▼
+DAO Multisig (0xd6d4...a196)
+        │ PROPOSER + EXECUTOR + ROLE_ADMIN
+        ▼
+Governor Timelock (0x2eFF...426b)
+        │ MIN_DELAY: 1 day, MIN_EXECUTION_WINDOW: 1 day
+        ▼
+Protocol Contracts (MapleGlobals, PoolManager, etc.)
+```
+
+**Key Roles:**
+
+| Role | Address | Powers |
+|------|---------|--------|
+| Governor (Timelock) | [`0x2eFFf88747EB5a3FF00d4d8d0f0800E306C0426b`](https://etherscan.io/address/0x2eFFf88747EB5a3FF00d4d8d0f0800E306C0426b) | Administrative functions, global parameters, pausing |
+| DAO Multisig | [`0xd6d4Bcde6c816F17889f1Dd3000aF0261B03a196`](https://etherscan.io/address/0xd6d4Bcde6c816F17889f1Dd3000aF0261B03a196) | Proposer + Executor on Timelock |
+| Security Admin (3/6 Safe) | [`0x6b1A78C1943b03086F7Ee53360f9b0672bD60818`](https://etherscan.io/address/0x6b1A78C1943b03086F7Ee53360f9b0672bD60818) | Emergency pause |
+| Operational Admin (3/5 Safe) | [`0xCe1cE7c7F436DCc4E28Bc8bf86115514d3DC34E8`](https://etherscan.io/address/0xCe1cE7c7F436DCc4E28Bc8bf86115514d3DC34E8) | Routine operations (subset of Governor) |
+| Permissions Admin | [`0x54b130c704919320E17F4F1Ffa4832A91AB29Dca`](https://etherscan.io/address/0x54b130c704919320E17F4F1Ffa4832A91AB29Dca) | Controls deposit authorization |
+| Pool Delegate (Maple Direct) | [`0xC1e18FFD8825FfB286D177DDEbeba345EC70B49f`](https://etherscan.io/address/0xC1e18FFD8825FfB286D177DDEbeba345EC70B49f) (EOA) | Manages pool, loan origination, impairments |
+
+**Timelock (verified on-chain):** GovernorTimelock contract with `MIN_DELAY = 86400s (24h)` and `MIN_EXECUTION_WINDOW = 86400s (24h)`. Timelocked actions include: `PoolManager.upgrade()`, `LoanManager.upgrade()`, `WithdrawalManager.upgrade()`. Governor can change timelock parameters, but these changes themselves require going through the timelock.
+
+**MapleGlobals Timelock (verified on-chain, Feb 19 2026):** `defaultTimelockParameters()` on MapleGlobals (`0x804a6F5F667170F545Bf14e5DDB48C70B788390C`) returns **delay = 604800s (7 days)** and **duration = 172800s (2 days)**. This is a second timelock layer on top of the GovernorTimelock, providing robust dual-layer protection for protocol-level admin actions. A prior LlamaRisk assessment flagged `globalsV301` as having no delay at `defaultTimelockParameters` — this concern appears to have been addressed since that assessment.
+
+**Multisig Details (verified on-chain):** DAO Multisig is a **Gnosis Safe v1.3.0** with **4-of-7 threshold**. All 7 signers are EOAs (no nested multisigs). No ENS names registered. Per LlamaRisk, a minority of signers are Maple employees; the majority are long-standing external advisors and investors who have held their seats for >2 years. 922 transactions processed as of Feb 2026.
+
+**Emergency Pause:** Three-tier granular pausing system:
+1. Global pause — single switch for entire system
+2. Per-contract pause — pause specific contract instances
+3. Per-function unpause — allow specific functions in paused contracts for recovery
+
+Callable by Governor or Security Admin.
+
+**Voting:** Snapshot-based. SYRUP must be staked into stSYRUP to participate. 7-day voting window, quorum-based.
+
+### Programmability
+
+- syrupUSDC exchange rate (PPS) is calculated on-chain via ERC-4626 standard
+- Loan interest accrual is on-chain
+- Loan origination, borrower assessment, and impairment decisions are **off-chain** (managed by Maple Direct as Pool Delegate)
+- Strategy fee rates can be changed at any time by protocol admins
+- DeFi strategy allocations (Aave, Sky) are executed on-chain but allocation decisions are made off-chain
+- Liquidations are executed by external Keepers on-chain, but margin call decisions can be made off-chain
+
+### External Dependencies
+
+1. **Chainlink Oracles (Critical)** — Used for collateral price feeds. Oracle wrappers provide additional security. Failure would impact liquidation mechanics.
+2. **Aave (Medium)** — Idle capital deployed via AaveStrategy contract. Aave is a blue-chip DeFi protocol.
+3. **Sky/MakerDAO (Medium)** — Idle capital deployed via SkyStrategy contract. Another blue-chip protocol.
+4. **Chainlink CCIP (Low-Medium)** — Used for cross-chain syrupUSDC deployments (Base, Arbitrum). Not critical for Ethereum mainnet operations.
+5. **Borrower Counterparty (Critical)** — Institutional borrowers must repay loans. Default risk exists despite overcollateralization.
+
+## Operational Risk
+
+- **Team:** Sidney Powell (Co-founder & CEO, previously institutional finance/bond markets). Joe Flanagan (Co-founder & COO, previously NAB — reported as departed). Team composed of former bankers and credit investment professionals. Founded 2019.
+- **Funding:** ~$17.7M raised across 4 rounds. Investors include Framework Ventures, Polychain Capital, BlockTower Capital, Alameda Research (seed), Tioga Capital.
+- **Documentation:** Good quality. Comprehensive docs site, active GitHub. Technical integration guides available. Dune dashboard maintained.
+- **Legal:** Multi-entity structure across three jurisdictions:
+  - **Maple Labs Pty Ltd** (Australia) — operates maple.finance interface, publishes primary ToS
+  - **Syrup Ltd** (offshore) — issues and administers syrupUSDC/syrupUSDT products, operates syrup.fi
+  - **Maple International Operations SPC** (Cayman Islands Segregated Portfolio Company) — legal counterparty for loan arrangements and pool administration. Each pool is a separate segregated portfolio with ring-fenced assets and liabilities.
+  - **Maple Foundation** — acts as Security Agent for enforcement of Master Lending Agreements (MLAs)
+  - **Restricted jurisdictions:** US, Australia, and 30+ others explicitly excluded from syrupUSDC/USDT products
+  - Source: [Terms of Use](https://github.com/maple-labs/maple-docs/blob/master/legal/interface-terms-of-use.md), [syrupUSDC Terms](https://github.com/maple-labs/maple-docs/blob/master/legal/interface-terms-of-use-syrupusdc-and-syrupusdt.md), [Jurisdictions](https://github.com/maple-labs/maple-docs/blob/master/legal/syrupusdc-and-syrupusdt-available-jurisdictions.md)
+- **Incident Response:** Real-time invariant monitoring via Tenderly Web3 Actions. PagerDuty integration for critical alerts. Three-tier pause system. $500K Immunefi bug bounty. Learned from V1 credit event (restructured to overcollateralized lending).
+- **License:** BUSL 1.1 (Business Source License)
+
+## Monitoring
+
+### Key Contracts to Monitor
+
+| Contract | Address | Purpose | Key Events/Functions |
+|----------|---------|---------|---------------------|
+| syrupUSDC Pool | [`0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b`](https://etherscan.io/address/0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b) | Vault state | `Deposit`, `Withdraw`, `Transfer`, `totalAssets()`, `totalSupply()`, `convertToAssets()` |
+| PoolManager | [`0x7aD5fFa5fdF509E30186F4609c2f6269f4B6158F`](https://etherscan.io/address/0x7aD5fFa5fdF509E30186F4609c2f6269f4B6158F) | Pool configuration | Upgrades, parameter changes |
+| WithdrawalManagerQueue | [`0x1bc47a0Dd0FdaB96E9eF982fdf1F34DC6207cfE3`](https://etherscan.io/address/0x1bc47a0Dd0FdaB96E9eF982fdf1F34DC6207cfE3) | Withdrawal processing | Queue length, processing delays |
+| Governor Timelock | [`0x2eFFf88747EB5a3FF00d4d8d0f0800E306C0426b`](https://etherscan.io/address/0x2eFFf88747EB5a3FF00d4d8d0f0800E306C0426b) | Governance actions | `CallScheduled`, `CallExecuted`, `Cancelled` |
+| DAO Multisig | [`0xd6d4Bcde6c816F17889f1Dd3000aF0261B03a196`](https://etherscan.io/address/0xd6d4Bcde6c816F17889f1Dd3000aF0261B03a196) | Multisig transactions | Submitted/confirmed/executed transactions |
+| FixedTermLoanManager | [`0x4A1c3F0D9aD0b3f9dA085bEBfc22dEA54263371b`](https://etherscan.io/address/0x4A1c3F0D9aD0b3f9dA085bEBfc22dEA54263371b) | Loan health | Loan impairments, defaults, liquidations |
+| OpenTermLoanManager | [`0x6ACEb4cAbA81Fa6a8065059f3A944fb066A10fAc`](https://etherscan.io/address/0x6ACEb4cAbA81Fa6a8065059f3A944fb066A10fAc) | Loan health | Loan impairments, defaults, liquidations |
+| MapleGlobals | [`0x804a6F5F667170F545Bf14e5DDB48C70B788390C`](https://etherscan.io/address/0x804a6F5F667170F545Bf14e5DDB48C70B788390C) | Global parameters | `defaultTimelockParameters()`, parameter changes |
+| AaveStrategy | [`0x560B3A85Af1cEF113BB60105d0Cf21e1d05F91d4`](https://etherscan.io/address/0x560B3A85Af1cEF113BB60105d0Cf21e1d05F91d4) | DeFi allocation | Deposits, withdrawals, allocation changes |
+| SkyStrategy | [`0x859C9980931fa0A63765fD8EF2e29918Af5b038C`](https://etherscan.io/address/0x859C9980931fa0A63765fD8EF2e29918Af5b038C) | DeFi allocation | Deposits, withdrawals, allocation changes |
+
+### Critical Monitoring Points
+
+- **PPS (Price Per Share):** Track `convertToAssets(1e6)` — should be monotonically increasing. Alert on any decrease (would indicate impairment or loss).
+- **Collateralization Health:** Monitor individual loan collateralization ratios via Maple API. Alert when approaching margin call or liquidation levels.
+- **Withdrawal Queue:** Monitor queue length and average processing time. Alert if queue exceeds 7 days.
+- **Governance:** Monitor Timelock scheduled calls and executions. Monitor proxy implementation slot changes.
+- **Impairments:** Monitor for loan impairment events — these directly reduce pool value.
+- **Large Movements:** Alert on deposits/withdrawals >5% of TVL in 24h.
+- **Strategy Allocations:** Monitor Aave and Sky strategy deposits/withdrawals.
+- **Recommended Frequency:** Hourly for PPS and collateralization. Daily for governance and queue metrics.
+
+## Risk Summary
+
+### Key Strengths
+
+1. **Extensive audit coverage** — 20+ audits from 8+ firms (Trail of Bits, Spearbit, Three Sigma, 0xMacro, Sherlock, Dedaub, Sigma Prime), continuously audited with each release
+2. **Large TVL** ($2B+ protocol, $3.25B syrupUSDC pool) with strong growth trajectory
+3. **No smart contract exploits** in protocol history
+4. **Overcollateralized lending** with on-chain liquidation mechanics and Chainlink oracle integration
+5. **Dual-layer timelock protection** — GovernorTimelock (MIN_DELAY=1 day) + MapleGlobals defaultTimelockParameters (7-day delay, 2-day execution window), three-tier pause system, real-time invariant monitoring via Tenderly
+
+### Key Risks
+
+1. **Off-chain credit risk** — Loan origination and borrower assessment are off-chain (Maple Direct). The quality of lending decisions depends on the team's credit analysis capabilities.
+2. **Impairment mechanism** — Maple can unilaterally impair loans, temporarily reducing pool value. Lenders who withdraw during impairment take permanent losses.
+3. **Collateral concentration** — BTC dominates at 54% (56% with LBTC). XRP at 25% carries volatility and regulatory risk. USTB at 16% adds Superstate dependency.
+4. **Permissioned deposits** — First-time deposits require authorization from Maple, creating a gating mechanism.
+5. **Withdrawal delays** — Up to 30 days in low-liquidity scenarios. In a credit stress event, many lenders could be queued simultaneously.
+
+### Critical Risks
+
+- **V1 Credit Event Precedent:** The ~$36M default from the FTX collapse (2022) demonstrates that credit risk is real despite mitigation measures. V2's overcollateralized model significantly reduces but does not eliminate this risk.
+- **Pool Delegate Power:** The Pool Delegate (`0xC1e1...49f`, EOA) has significant power over loan management, impairments, and collateral decisions without on-chain governance approval.
+- **~~No default timelock on contract upgrades (per LlamaRisk):~~** Previously flagged by LlamaRisk, but verified on-chain (Feb 19, 2026) that `defaultTimelockParameters` is now set to 7-day delay + 2-day execution window. This concern has been addressed.
+- **Fixed USDC price oracle (per LlamaRisk):** Maple uses a hardcoded 1 USD price for USDC in internal collateral liquidations rather than a live market feed, creating risk during depeg events.
+- **Loss socialization:** No tranching or insurance fund exists; all lenders bear equal exposure to defaults via exchange rate reduction.
+
+---
+
+## Risk Score Assessment
+
+### Critical Risk Gates
+
+- [ ] **No audit** → **PASS** (20+ audits by 8+ firms including Trail of Bits, Spearbit, Sherlock)
+- [ ] **Unverifiable reserves** → **PASS** (Loans verifiable on-chain, collateral transparent, exchange rate on-chain)
+- [ ] **Total centralization** → **PASS** (GovernorTimelock + DAO Multisig, not single EOA)
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%) — **1.5**
+
+| Aspect | Assessment |
+|--------|-----------|
+| Audits | 20+ audits by 8+ top firms (Trail of Bits, Spearbit, Sherlock, Three Sigma, 0xMacro, Dedaub, Sigma Prime). Continuous auditing with each release. |
+| Bug Bounty | $500K on Immunefi (active) |
+| Time in Production | V2: ~3 years, Syrup: ~18 months. No smart contract exploits. |
+| TVL | >$2B protocol, >$3B syrupUSDC pool |
+| Historical Incident | V1 credit event ($36M defaults, 2022) — credit risk, not smart contract. V2 redesigned with overcollateralized lending. |
+
+Exceptional audit coverage and large TVL. V1 credit event was counterparty risk, not smart contract failure. High bug bounty ($500K) reduces score by 0.5 from base 2.
+
+**Score: 1.5/5**
+
+#### Category 2: Centralization & Control Risks (Weight: 30%) — **2.50**
+
+**Subcategory A: Governance — 2.0**
+
+- Dual-layer timelock protection: GovernorTimelock (MIN_DELAY=24h) + MapleGlobals defaultTimelockParameters (7-day delay, 2-day execution window), both verified on-chain
+- DAO Multisig is 4/7 Safe v1.3.0, all EOA signers. Minority are employees; majority external advisors (per LlamaRisk)
+- Snapshot-based voting with 7-day window and quorum
+- Governor can change timelock parameters (through the timelock itself)
+- Security Admin and Operational Admin have significant powers but constrained by timelock
+- Emergency pause is a reasonable security measure
+
+**Subcategory B: Programmability — 3.0**
+
+- Exchange rate (PPS) is on-chain via ERC-4626
+- Collateral is held on-chain with on-chain liquidation mechanics (Keepers + Chainlink oracles)
+- Withdrawal queue is fully on-chain
+- DeFi strategy execution (Aave, Sky) is on-chain
+- Loan origination and borrower assessment are off-chain (Pool Delegate discretion)
+- Impairment decisions and strategy allocation decisions are off-chain
+- Hybrid on-chain/off-chain operations — core protections are programmatic, lending decisions are manual
+
+**Subcategory C: External Dependencies — 2.5**
+
+- Chainlink oracles (established, reliable)
+- Aave and Sky/MakerDAO (blue-chip DeFi)
+- Borrower counterparty risk (critical dependency on institutional borrowers)
+- CCIP for cross-chain (non-critical for mainnet)
+
+**Score: (2.0 + 3.0 + 2.5) / 3 = 2.50/5**
+
+#### Category 3: Funds Management (Weight: 30%) — **2.75**
+
+**Subcategory A: Collateralization — 3.0**
+
+- Overcollateralized lending (168.96% ratio) with liquid digital assets
+- On-chain liquidation mechanics with Chainlink oracles
+- BTC dominates at 54% of collateral — concentration risk in single asset class
+- XRP at 25% — more volatile, regulatory uncertainty
+- USTB at 16% — tokenized T-Bills (Superstate dependency)
+- Impairment mechanism can reduce pool value at Maple's discretion
+- Credit risk remains despite overcollateralization (V1 precedent)
+
+**Subcategory B: Provability — 2.5**
+
+- All collateral is held and tracked on-chain — overcollateralization ratios, margin call levels, and liquidation thresholds are transparently verifiable
+- Exchange rate computed on-chain (ERC-4626 `convertToAssets()`/`convertToShares()`)
+- Loan-level data (principal, collateral, rates) is on-chain and verifiable
+- Collateral data can be cross-verified via Maple API and Etherscan
+- DeFi strategy allocations (Aave, Sky) are on-chain and verifiable
+- Borrower selection and creditworthiness assessment are off-chain (Pool Delegate discretion) — but the on-chain collateral protections ensure reserves are provable regardless of borrower quality
+- Impairment decisions are off-chain
+
+**Score: (3.0 + 2.5) / 2 = 2.75/5**
+
+#### Category 4: Liquidity Risk (Weight: 15%) — **2.5**
+
+- Queue-based redemption at smart contract exchange rate (no slippage on redemption value)
+- Typical processing: minutes to 2 days
+- Maximum 30 days in extreme scenarios
+- ~$20M Uniswap V4 liquidity as alternative exit — but only $14.9M USDC reserve, $1M swap = ~5.4% slippage
+- DEX liquidity is only 1.2% of market cap — not a viable exit for large holders
+- Top holders are protocol infrastructure contracts (Maple ALMProxy, Chainlink CCIP pool, Morpho, Fluid) — not external whale withdrawal risk
+- Same-value asset (USDC-denominated), which mitigates some waiting risk
+- Historical: No V2 stress-test of withdrawal queue during market turmoil
+- Throttle mechanism (30-day max) for large exits: +0.5
+- Same-value assets mitigate waiting risk: -0.5 (net neutral adjustment)
+
+**Score: 2.5/5**
+
+#### Category 5: Operational Risk (Weight: 5%) — **1.5**
+
+- Established team (founded 2019, ~7 years), public founders, VC-backed ($17.7M raised from Framework Ventures, Polychain Capital, BlockTower Capital)
+- Comprehensive documentation, active GitHub, Dune dashboard, technical integration guides
+- Real-time monitoring infrastructure (Tenderly Web3 Actions + PagerDuty)
+- Clear multi-entity legal structure: Maple Labs Pty Ltd (AU), Syrup Ltd (offshore), Maple Int'l Ops SPC (Cayman Islands) with segregated portfolios
+- BUSL 1.1 license
+- Demonstrated incident response: V1 credit event led to complete restructuring to overcollateralized lending
+
+**Score: 1.5/5**
+
+### Final Score Calculation
+
+```
+Final Score = (Audits × 0.20) + (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Liquidity × 0.15) + (Operational × 0.05)
+            = (1.5 × 0.20) + (2.50 × 0.30) + (2.75 × 0.30) + (2.5 × 0.15) + (1.5 × 0.05)
+            = 0.30 + 0.75 + 0.825 + 0.375 + 0.075
+            = 2.325
+            ≈ 2.33
+```
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 1.5 | 20% | 0.30 |
+| Centralization & Control | 2.50 | 30% | 0.75 |
+| Funds Management | 2.75 | 30% | 0.825 |
+| Liquidity Risk | 2.5 | 15% | 0.375 |
+| Operational Risk | 1.5 | 5% | 0.075 |
+| **Final Score** | | | **2.33 / 5.0** |
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|------------|-----------|----------------|
+| 1.0-1.5 | Minimal Risk | Approved, high confidence |
+| **1.5-2.5** | **Low Risk** | **Approved with standard monitoring** |
+| 2.5-3.5 | Medium Risk | Approved with enhanced monitoring |
+| 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
+| 4.5-5.0 | High Risk | Not recommended |
+
+**Final Risk Tier: LOW RISK**
+
+---
+
+## Reassessment Triggers
+
+- **Time-based:** Reassess in 3 months (May 2026)
+- **TVL-based:** Reassess if pool TVL drops below $1B or changes by more than 30%
+- **Incident-based:** Reassess after any loan impairment, borrower default, smart contract exploit, or governance change
+- **Collateral-based:** Reassess if collateral composition changes significantly (new asset types, concentration changes)
+- **Governance-based:** Reassess if DAO multisig composition changes or timelock parameters are modified
+
+---
+
+## Appendix A — Audit Reports
+
+### V1 Audits (2021)
+
+| Auditor | Date | Report |
+|---------|------|--------|
+| PeckShield | 2021 | [Report](https://github.com/maple-labs/maple-core/files/6423601/PeckShield-Audit-Report-Maple-v1.0.1.pdf) |
+| Code4rena | Apr 2021 | [Report](https://code423n4.com/reports/2021-04-maple/) |
+| Dedaub | 2021 | [Report](https://github.com/maple-labs/maple-core/files/6423621/Dedaub-Audit-Report-Maple-Core.2.pdf) |
+
+### V2 Audits (Dec 2022)
+
+| Auditor | Date | Report |
+|---------|------|--------|
+| Trail of Bits | Aug 2022 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2022-december/TrailOfBits-Maple.pdf) |
+| Spearbit | Oct 2022 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2022-december/Spearbit-maple.pdf) |
+| Three Sigma | Oct 2022 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2022-december/Three-Sigma-Maple-Finance-Dec-2022.pdf) |
+
+### June 2023 Release
+
+| Auditor | Date | Report |
+|---------|------|--------|
+| Cantina (Spearbit) | Jun 2023 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2023-june/Cantina-Maple.pdf) |
+| Three Sigma | Apr 2023 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2023-june/Three-Sigma-Maple-Finance-Jun-2023.pdf) |
+
+### December 2023 Release
+
+| Auditor | Date | Report |
+|---------|------|--------|
+| Three Sigma | Nov 2023 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2023-december/Three-Sigma-Maple-Finance-Dec-2023.pdf) |
+| 0xMacro | Nov 2023 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2023-december/0xMacro-Maple-Finance-Dec-2023.pdf) |
+
+### August 2024 Release (Syrup Contracts)
+
+| Auditor | Date | Report |
+|---------|------|--------|
+| Three Sigma | Aug 2024 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2024-august/Three-Sigma-Maple-Finance-Aug-2024.pdf) |
+| 0xMacro | Aug 2024 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2024-august/0xMacro-Maple-Finance-Aug-2024.pdf) |
+| Three Sigma (SyrupRouter) | May 2024 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2024-august/Three-Sigma-Maple-Finance-Aug-2024-Syrup.pdf) |
+
+### December 2024 Release
+
+| Auditor | Date | Report |
+|---------|------|--------|
+| Three Sigma | Dec 2024 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2024-december/Three-Sigma-Maple-Finance-Dec-2024%20.pdf) |
+| 0xMacro | Dec 2024 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2024-december/0xMacro-Maple-Finance-Dec-2024.pdf) |
+
+### September 2025 Release (Governor Timelock)
+
+| Auditor | Date | Report |
+|---------|------|--------|
+| Sherlock | Sep 2025 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2025-sept-governor-timelock/Sherlock-Maple-Finance-timelock-Sept-2025.pdf) |
+| 0xMacro | Sep 2025 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2025-sept-governor-timelock/0xMacro-Maple-Finance-timelock-Sept-2025.pdf) |
+
+### November 2025 Release (Withdrawal Manager)
+
+| Auditor | Date | Report |
+|---------|------|--------|
+| Spearbit | Nov 2025 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2025-november/Spearbit-Maple-Finance-WM-Nov-2025.pdf) |
+| Sherlock | Nov 2025 | [Report](https://github.com/maple-labs/maple-core-v2/blob/main/audits/2025-november/Sherlock-Maple-Finance-WM-Nov-2025.pdf) |
+
+### January 2026 Release (CCIP Cross-Chain)
+
+| Auditor | Date | Report |
+|---------|------|--------|
+| Dedaub | Nov 2025 | [Report](https://github.com/maple-labs/maple-cross-chain-receiver/blob/main/audits/2025-november/Dedaub-Chainlink-Maple.pdf) |
+| Sigma Prime | Jan 2026 | [Report](https://github.com/maple-labs/maple-cross-chain-receiver/blob/main/audits/2026-january/SigmaPrime-Chainlink-Maple.pdf) |
+
+---
+
+## Appendix B — Deposit Flow
+
+Deposits into syrupUSDC are gated by the [`PoolPermissionManager`](https://etherscan.io/address/0xBe10aDcE8B6E3E02Db384E7FaDA5395DD113D8b3) contract via a permission bitmap system. The [`SyrupRouter`](https://etherscan.io/address/0x134cCaaA4F1e4552eC8aEcb9E4A2360dDcF8df76) handles authorization and deposits.
+
+**First-time deposit flow:**
+
+1. User connects wallet on [syrup.fi](https://syrup.fi) and enters a USDC deposit amount
+2. The frontend requests an ECDSA authorization signature from Maple's backend (checks jurisdiction, sanctions, etc.)
+3. If approved, the backend returns a signature from a permission admin ([`0x54b130c704919320E17F4F1Ffa4832A91AB29Dca`](https://etherscan.io/address/0x54b130c704919320E17F4F1Ffa4832A91AB29Dca))
+4. The frontend calls `SyrupRouter.authorizeAndDeposit()` — a single atomic transaction that:
+   - Verifies the ECDSA signature and sets the user's lender bitmap on `PoolPermissionManager`
+   - Checks `hasPermission(poolManager, owner, "P:deposit")`
+   - Transfers USDC from user → router → pool, returns syrupUSDC shares to user
+
+**Subsequent deposits:**
+
+The lender bitmap is already set on-chain, so the user calls `SyrupRouter.deposit()` or `SyrupRouter.depositWithPermit()` (EIP-2612) directly — no authorization signature needed.
+
+**Alternative (no permission required):**
+
+syrupUSDC can be purchased on Uniswap as a regular token swap, bypassing the permission system entirely. This only applies to buying existing syrupUSDC on the secondary market, not minting new shares.
+
+**Gating mechanism:** Maple can refuse to provide the authorization signature for restricted jurisdictions (US, Australia, 30+ others) or sanctioned addresses. Source: [`SyrupRouter.sol`](https://github.com/maple-labs/syrup-utils/blob/main/contracts/SyrupRouter.sol)
+
+| Function | Gated |
+|----------|-------|
+| `deposit` | Yes |
+| `depositWithPermit` | Yes |
+| `mint` | Yes |
+| `mintWithPermit` | Yes |
+| `requestRedeem` | No |
+| `redeem` | No |
+| `requestWithdraw` | Yes |
+| `withdraw` | Yes |
+| `removeShares` | Yes |
+| `transfer` | No |
+| `transferFrom` | No |
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+
+interface IPool {
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares);
+    function asset() external view returns (address);
+    function manager() external view returns (address);
+}
+
+interface IPoolManager {
+    function canCall(bytes32 functionId, address caller, bytes calldata data) external view returns (bool, string memory);
+    function poolPermissionManager() external view returns (address);
+}
+
+interface IPoolPermissionManager {
+    function hasPermission(address poolManager, address lender, bytes32 functionId) external view returns (bool);
+}
+
+interface IERC20 {
+    function balanceOf(address) external view returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool);
+}
+
+contract SyrupUSDCDepositTest is Test {
+    address constant POOL           = 0x80ac24aA929eaF5013f6436cdA2a7ba190f5Cc0b;
+    address constant USDC           = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address constant POOL_MANAGER   = 0x7aD5fFa5fdF509E30186F4609c2f6269f4B6158F;
+    address unauthorized = makeAddr("unauthorized_user");
+    // Existing EOA holder (rank 8) — already has deposit permission bitmap set
+    address constant AUTHORIZED   = 0xdf998bec7943aa893ba8542eE57ea47b78F29007;
+
+    function setUp() public {
+        uint256 mainnetFork = vm.createFork("mainnet");
+        vm.selectFork(mainnetFork);
+        // Give the unauthorized user 10,000 USDC
+        deal(USDC, unauthorized, 10_000e6);
+        deal(USDC, AUTHORIZED, 10_000e6);
+    }
+
+    function test_unauthorized_deposit_reverts() public {
+        vm.startPrank(unauthorized);
+        // Approve pool to spend USDC
+        IERC20(USDC).approve(POOL, type(uint256).max);
+
+        // Verify canCall returns false for unauthorized user
+        IPoolManager pm = IPoolManager(POOL_MANAGER);
+        bytes memory depositData = abi.encode(uint256(1000e6), unauthorized);
+        (bool allowed, string memory reason) = pm.canCall("P:deposit", unauthorized, depositData);
+        assertFalse(allowed, "Unauthorized user should NOT be allowed to deposit");
+        assertEq(reason, "PM:CC:NOT_ALLOWED", "Should fail with permission error");
+        emit log_string("canCall returned false as expected");
+        emit log_string(string.concat("Reason: ", reason));
+
+        // Verify the actual deposit call reverts
+        vm.expectRevert(bytes("PM:CC:NOT_ALLOWED"));
+        IPool(POOL).deposit(1000e6, unauthorized);
+        vm.stopPrank();
+        emit log_string("PASS: Unauthorized deposit correctly reverted");
+    }
+
+    function test_permission_manager_returns_false() public view {
+        IPoolManager pm = IPoolManager(POOL_MANAGER);
+        address ppm = pm.poolPermissionManager();
+        bool hasPermission = IPoolPermissionManager(ppm).hasPermission(POOL_MANAGER, unauthorized, "P:deposit");
+        assertFalse(hasPermission, "Random address should not have deposit permission");
+    }
+
+    // @notice Authorized user (existing holder) can deposit
+    function test_authorized_deposit_succeeds() public {
+        vm.startPrank(AUTHORIZED);
+        IERC20(USDC).approve(POOL, type(uint256).max);
+        uint256 balBefore = IERC20(POOL).balanceOf(AUTHORIZED);
+        uint256 shares = IPool(POOL).deposit(1000e6, AUTHORIZED);
+        uint256 balAfter = IERC20(POOL).balanceOf(AUTHORIZED);
+        assertGt(shares, 0, "Should receive shares");
+        assertEq(balAfter - balBefore, shares, "Balance should increase by shares");
+        vm.stopPrank();
+        emit log_named_uint("Shares received", shares);
+    }
+}
+```

--- a/src/components/pages/curation/reports/midas-mhyper.md
+++ b/src/components/pages/curation/reports/midas-mhyper.md
@@ -1,0 +1,463 @@
+# Protocol Risk Assessment: Midas mHYPER
+
+- **Assessment Date:** February 7, 2026
+- **Token:** mHYPER
+- **Chain:** Ethereum (also deployed on Monad, Plasma)
+- **Token Address:** [`0x9b5528528656DBC094765E2abB79F293c21191B9`](https://etherscan.io/token/0x9b5528528656dbc094765e2abb79f293c21191b9)
+- **Final Score: 3.3/5.0**
+
+## Overview + Links
+
+mHYPER is a tokenized certificate (Liquid Yield Token / LYT) issued by Midas Software GmbH, a German-incorporated tokenization platform. It references the performance of **market-neutral, stablecoin-focused strategies** managed by [Hyperithm](https://www.hyperithm.com/), a digital asset management firm based in Tokyo and Seoul.
+
+mHYPER is **not** a stablecoin — its value floats based on strategy performance. Yield is auto-compounded into the token price (NAV), updated on-chain weekly via a custom oracle. The token has appreciated from $1.00 at inception to ~$1.077 as of February 2026.
+
+The yield strategy includes:
+- Leveraged USDe positions on **Aave**
+- Stablecoin farming on **Pendle**
+- Basis trading on **Hyperliquid**
+- Liquidity provision on **Morpho** vaults
+- Carry trades, liquidation arbitrage, reward farming
+
+Legally, mHYPER tokens are structured as **subordinated debt instruments** of Midas Software GmbH. Investors have no legal or beneficial interest in the underlying assets — claims are subordinated to the issuer (Qualified Subordination). This is weaker than bankruptcy-remote SPV structures; in insolvency, tokenholder claims rank below all other creditors.
+
+**Key Stats:**
+- **mHYPER Market Cap:** ~$43.67M
+- **Total Supply:** ~40,557,474 mHYPER
+- **Holders:** ~387 addresses
+- **APY:** ~9.24%
+- **Midas Platform TVL:** ~$275M (per DeFiLlama, combined Midas RWA + Hyperithm entries)
+- **KYC Required:** Yes (greenlist enforced on-chain)
+
+**Links:**
+
+- [Midas Documentation](https://docs.midas.app/)
+- [Midas App - mHYPER](https://midas.app/mhyper)
+- [Midas Audits](https://docs.midas.app/resources/audits)
+- [Midas Smart Contract Addresses](https://docs.midas.app/resources/smart-contracts-addresses)
+- [Hyperithm Website](https://www.hyperithm.com/)
+- [FMA-Approved Base Prospectus (July 2024)](https://www.mfsa.mt/wp-content/uploads/2024/11/Midas-Software-GmbH-Base-Prospectus-Document-dated-17-July-2024.pdf)
+- [Hacken Audit Report](https://hacken.io/audits/midas/sca-midas-vault-dec2023/)
+- [Sherlock Audit Contest #1 (May 2024)](https://audits.sherlock.xyz/contests/332)
+- [Sherlock Audit Contest #2 (Aug 2024)](https://github.com/sherlock-audit/2024-08-midas-minter-redeemer-judging)
+- [Serenity Research - mHYPER Review](https://serenityresearch.substack.com/p/serenity-premium-on-chain-hedge-funds-1a5)
+- [Fordefi Custody Case Study](https://www.fordefi.com/customer-stories/how-midas-brings-tokenized-investment-opportunities-on-chain-with-fordefis-defi-native-custody-2ti85)
+- [Etherscan - mHYPER](https://etherscan.io/token/0x9b5528528656dbc094765e2abb79f293c21191b9)
+
+## Contract Addresses
+
+All contracts use OpenZeppelin's `TransparentUpgradeableProxy` pattern with a shared `ProxyAdmin`.
+
+| Contract | Proxy Address | Implementation Address |
+|----------|--------------|----------------------|
+| **mHYPER Token** | [0x9b5528528656DBC094765E2abB79F293c21191B9](https://etherscan.io/address/0x9b5528528656DBC094765E2abB79F293c21191B9) | [0xE4386180dF7285E7D78794148E1B31c9EDfb0689](https://etherscan.io/address/0xE4386180dF7285E7D78794148E1B31c9EDfb0689) |
+| **mHYPER/USD Oracle** (CustomAggregatorFeed) | [0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68](https://etherscan.io/address/0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68) | [0xFcA6c2087e6321385745f3080D586d088a7f707f](https://etherscan.io/address/0xFcA6c2087e6321385745f3080D586d088a7f707f) |
+| **mHYPER DataFeed** | [0x92004DCC5359eD67f287F32d12715A37916deCdE](https://etherscan.io/address/0x92004DCC5359eD67f287F32d12715A37916deCdE) | [0xE3240302aCEc5922b8549509615c16a97C05654A](https://etherscan.io/address/0xE3240302aCEc5922b8549509615c16a97C05654A) |
+| **DepositVault** | [0x6Be2f55816efd0d91f52720f096006d63c366e98](https://etherscan.io/address/0x6Be2f55816efd0d91f52720f096006d63c366e98) | [0x570C15bC5faF98531A8b351d69E22E41e3505E47](https://etherscan.io/address/0x570C15bC5faF98531A8b351d69E22E41e3505E47) |
+| **RedemptionVaultWithSwapper** | [0xbA9FD2850965053Ffab368Df8AA7eD2486f11024](https://etherscan.io/address/0xbA9FD2850965053Ffab368Df8AA7eD2486f11024) | [0xd2B5f8f1DED3D6e00965b8215b57A33c21101c63](https://etherscan.io/address/0xd2B5f8f1DED3D6e00965b8215b57A33c21101c63) |
+| **MidasAccessControl** | [0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B](https://etherscan.io/address/0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B) | [0xDd5a54bA2ab379a5e642c58f98ad793a183960e2](https://etherscan.io/address/0xDd5a54bA2ab379a5e642c58f98ad793a183960e2) |
+| **ProxyAdmin** (shared) | [0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC](https://etherscan.io/address/0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC) | N/A |
+| **Tokens Receiver** | [0xF356c5e9F69DaDB332Bb098C7Ed960Db1d3376DD](https://etherscan.io/address/0xF356c5e9F69DaDB332Bb098C7Ed960Db1d3376DD) | N/A |
+| **Deployer** | [0xa0819ae43115420beb161193b8d8ba64c9f9facc](https://etherscan.io/address/0xa0819ae43115420beb161193b8d8ba64c9f9facc) | N/A |
+
+**Other Chain Deployments:**
+- **mHYPER (Monad):** `0xd90f6bfed23ffde40106fc4498dd2e9edb95e4e7`
+- **mHYPER (Plasma):** `0xb31bea5c2a43f942a3800558b1aa25978da75f8a`
+
+## Audits and Due Diligence Disclosures
+
+**Audit Status:** Moderate — audits cover the shared Midas infrastructure (vaults, tokens, access control), but no mHYPER-specific audit exists. mHYPER extends `mTBILL` and uses the same audited vault architecture.
+
+| Audit | Firm | Date | Scope | Link |
+|-------|------|------|-------|------|
+| Midas Vault Audit | **Hacken** | Dec 2023 - Jan 2024 | mTBILL token, DepositVault, RedemptionVault, ManageableVault, access control (15 contracts) | [Report](https://hacken.io/audits/midas/sca-midas-vault-dec2023/) |
+| Midas Audit Contest #1 | **Sherlock** | May 2024 | DepositVault, RedemptionVault, MidasAccessControl, DataFeed | [Contest](https://audits.sherlock.xyz/contests/332) |
+| Midas Minter/Redeemer Contest #2 | **Sherlock** | Aug 2024 | Instant mint/redeem, BUIDL integration, new oracles. Prize pool: 36,500 USDC | [Judging](https://github.com/sherlock-audit/2024-08-midas-minter-redeemer-judging) |
+
+**Hacken Audit Results (Dec 2023):**
+- Security Score: 10/10 (post-fix). 100% branch coverage
+- 0 Critical, 1 High (Accepted — USD tokens with custom decimals), 2 Medium (1 fixed: missing oracle refresh; 1 accepted: 1:1 price assumption), 1 Low (permissive role for token burning — accepted), 4 Observations
+- **Critical note:** Auditors explicitly flagged the protocol as **"highly centralized"** with system admins controlling all critical roles
+
+**Sherlock Contest #1 (May 2024):**
+- 1 High (blacklist bypass via `renounceRole` — acknowledged), 2 Medium (corruptible upgradability pattern — fixed; excessive vault admin permissions — acknowledged)
+
+**Sherlock Contest #2 (Aug 2024):**
+- 1 High (reclassified to Medium — RedemptionVaultWithBUIDL initialization DoS), 6 Medium (BUIDL balance handling, standard redemption allowance gaps, spec/code discrepancies)
+
+**Smart Contract Complexity:** Low-Moderate
+- mHYPER extends mTBILL (simple ERC-20 with pausable, role-controlled mint/burn)
+- Standard OpenZeppelin TransparentUpgradeableProxy pattern
+- Custom oracle (CustomAggregatorFeed) wrapping Chainlink's AggregatorV3 interface — **not** a Chainlink data feed
+- Role-based access control via shared MidasAccessControl contract
+
+**Note:** Audits are from 2023-2024 and mHYPER was launched July 2025 — there may be unaudited changes to the vault architecture since then.
+
+### Bug Bounty
+
+- Listed on [HackerOne](https://hackerone.com/midas) — no explicit maximum payout specified
+- Contact: security@mid.as. Response SLA: 24 hours acknowledgment, 30 days to address. Rewards at Midas's discretion
+- Not listed on Immunefi — the HackerOne program is the only ongoing bounty. The lack of a guaranteed payout weakens its deterrent effect
+
+## Historical Track Record
+
+- **Production History:** mHYPER token created on Ethereum [July 15, 2025](https://etherscan.io/tx/0x8dd0b1216e7970be06bd897ed57ebfba3f4213ec63d68aa622740608e93ffd5f) (~7 months in production). Midas platform launched with mTBILL in mid-2024 (~20 months total)
+- **TVL Growth:** Midas grew from ~$4M (July 2024) to ~$275M (February 2026)
+- **mHYPER Market Cap:** ~$43.67M with ~387 holders
+- **Price History:** mHYPER has traded between $1.024 (ATL, Sep 2025) and $1.077 (ATH, Feb 2026) — steady appreciation consistent with yield accrual
+- **Concentration Risk:** Only ~387 holders suggests significant concentration among few large depositors
+- **Incidents:**
+  - **Stream Finance Incident (Nov 2025):** Stream Finance lost $93M due to fund misappropriation by an external asset manager. Stream held a $75M leveraged position in mHYPER via Morpho. **mHYPER itself was not exploited** — the incident was at the Stream Finance level. mHYPER successfully processed **over $150M in redemptions within 48 hours**, demonstrating the redemption mechanism functions under stress. Hyperithm confirmed Stream fully unwound its position
+  - **Recursive Lending Concerns (Oct 2025):** YieldFi (yUSD) and Stream Finance (xUSD) positions reportedly made up ~30% of mHYPER's $263M TVL, raising circular lending concerns. Hyperithm responded that exposure to both was **fully removed**
+  - No reported hacks, exploits, or security incidents on rekt.news
+- **Note:** Midas Capital (hacked in 2023) is a **completely different project** from Midas (midas.app)
+
+**Hyperithm Track Record:**
+- Founded January 2018 (7+ years operating history)
+- Co-founded by Sangrok Oh (ex-Morgan Stanley) and Woojun Lloyd Lee (Forbes 30 Under 30)
+- Backed by Coinbase Ventures, Samsung Next, Hashed, Kakao, Naver. $11M Series B (Aug 2021)
+- Dual regulatory registration: SPBQII in Japan (FSA), VASP in South Korea (KoFIU)
+- **Concern:** Co-CEO Sangrok Oh held $3M+ in TRUMP meme coin, attended Trump dinner as [13th-largest holder](https://www.koreaherald.com/article/10488051) (May 2025) — raises questions about risk management culture for a firm claiming market-neutral positioning
+- **Concern:** Alleged failure to file mandatory risk assessment with South Korean regulators before launching a new product (Dec 2025) — [reported by crypto media](https://cryptorank.io/news/feed/18676-hyperithm-regulatory-filing-accusation), no official regulatory action confirmed
+
+## Funds Management
+
+mHYPER delegates 100% of funds to Hyperithm, who deploys them across multiple DeFi protocols using market-neutral, stablecoin-focused strategies.
+
+- **Fund Manager:** Hyperithm (Tokyo/Seoul, founded 2018, AUM $300M+)
+- **Strategy:** Multi-chain stablecoin yield — leveraged USDe on Aave, farming on Pendle, basis trading on Hyperliquid, Morpho vault liquidity, carry trades, liquidation arbitrage
+- **Strategy Execution:** Off-chain by Hyperithm with discretionary investment decisions
+- **Custody:** Fordefi MPC custody with tri-party quorum (Midas + Hyperithm + independent signer). Fordefi is the primary custodian for LYT products; Midas also uses Fireblocks for other product lines
+- **Monitoring:** NAV updates provided by Hyperithm, reviewed by Midas, then published on-chain weekly
+
+### Accessibility
+
+- **KYC Required:** Yes — users must complete KYC/AML screening (1-4 business days). Once approved, added to on-chain greenlist via `Greenlistable` contract. Chainalysis Oracle integration for sanctions screening
+- **Minting:** Deposit USDC, receive mHYPER tokens. Default mode is instant issuance
+- **Redemption:** Two modes:
+  - **Instant:** Atomic on-chain at oracle price (when liquidity is available in the RedemptionVaultWithSwapper). **0.50% instant redemption fee.** Liquidity target: 1-2% of circulating supply, replenished within 2 business days. May be temporarily unavailable
+  - **Standard:** 1-7 business day queue (fallback when instant capacity is insufficient). Subject to Risk Manager setting aside funds
+- **Fees:** 0% management fee, 10% performance fee (from yield), 0% standard mint/redeem fees, 0.50% instant redemption fee
+- **Geographic Restrictions:** Not available to US persons, UK, China, and sanctioned countries. IP screening with VPN detection
+
+### Collateralization
+
+- **Backing Model:** Off-chain / hybrid — mHYPER is a **subordinated debt instrument** of Midas Software GmbH, not a direct claim on underlying assets
+- **Collateral Quality:** Strategies target stablecoin-focused, market-neutral positions across Aave (blue-chip), Pendle (established), Hyperliquid (newer, centralized perps DEX), Morpho (established). Includes leveraged positions and basis trading
+- **Verifiability:** Limited — the underlying strategy positions are managed off-chain. Hyperithm discloses some wallet addresses on a transparency page, but full portfolio composition requires off-chain reporting
+- **Risk Curation:** Hyperithm has discretion over allocation within the broad strategy framework. Midas enforces policy limits via Fordefi policy engine (address, asset, contract method, notional size)
+- **Tri-Party Governance (via Fordefi):** Midas Treasury + Hyperithm (Asset Manager) + Independent Oversight Signer. Operations within predefined rules clear automatically; anything outside routes to three-party quorum. No single group can act unilaterally for custody operations
+- **Legal Structure:** LYT holders are **subordinate creditors** of Midas Software GmbH (EUR 25,000 share capital). This is weaker than bankruptcy-remote SPV structures
+- **Previous Recursive Lending:** ~30% of TVL was from circular lending loops (since addressed, but structural risk remains)
+
+### Provability
+
+- **Reserve Transparency:** Hybrid. Strategy wallets are partially on-chain, but full portfolio composition requires off-chain reporting. Token holders cannot independently verify that reserves match the reported NAV
+- **NAV/Price Updates:** Token price updated **weekly** by Midas via a privileged role on the `CustomAggregatorFeed` oracle. Current price: ~$1.077 (round 63, 8 decimals). This is **not** programmatic — it is admin-reported. The exchange rate is determined off-chain; users cannot know the exact amount of tokens they will receive beforehand (flagged by auditors)
+- **Verification Agent:** Midas's documentation references [Ankura Trust Company](https://docs.midas.app/defi-integration/price-oracle) as a verification agent for off-chain assets (confirmed for mTBILL/mBTC). Whether Ankura specifically covers mHYPER could not be independently confirmed. The daily attestation reports referenced by Midas appear to be self-generated
+- **Third-Party Verification:** For Morpho integration, eOracle independently verifies and publishes pricing. Steakhouse applies market discounts for liquidation optimization. No Chainlink Proof of Reserve, no Merkle proofs. The oracle wraps the Chainlink AggregatorV3 interface but is **not** a Chainlink data feed
+
+## Liquidity Risk
+
+- **DEX Liquidity:** Very thin — ~$32K total on Uniswap V4 (mHYPER/USDC 0.2% pool). 24h volume ~$7.6K. Not a viable exit for any meaningful position size
+- **Primary Exit:** Via Midas redemption vaults (instant or standard mode)
+- **Instant Redemption:** Available when liquidity exists in the RedemptionVaultWithSwapper. DepositVault currently holds ~$463K USDC. Instant redemption liquidity target is only 1-2% of circulating supply (~$437K-$874K). May be temporarily unavailable
+- **Standard Redemption:** 1-7 business day queue when instant capacity is insufficient
+- **Pendle:** ~$5.53M TVL in mHYPER Pendle pools (yield tokenization, not direct swap liquidity)
+- **Stress Test:** mHYPER processed $150M+ in redemptions in 48 hours when Stream Finance unwound its $75M leveraged position. This is a positive signal for the redemption mechanism but required standard (non-instant) processing and active coordination
+- **Large Holder Impact:** With ~387 holders and $43M market cap, average position is ~$111K. Large holders likely face multi-day standard redemption queues
+
+## Centralization & Control Risks
+
+### Governance
+
+- **Contract Upgradeability:** Yes — all contracts use `TransparentUpgradeableProxy` with a shared `ProxyAdmin` at [0xbf25b58c...](https://etherscan.io/address/0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC)
+- **ProxyAdmin Owner:** [`MidasTimelockController`](https://etherscan.io/address/0xE3EEe3e0D2398799C884a47FC40C029C8e241852) — a verified OpenZeppelin `TimelockController` with a **48-hour minimum delay**. Contract upgrades must be proposed, wait 48 hours, then executed
+- **Timelock Proposer/Executor:** Gnosis Safe [0xB60842E9...](https://etherscan.io/address/0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89) — **1/3 threshold** (any single signer can propose/execute). 3 signers:
+  - `0x8003544D...` — EOA, funded by Midas deployer (active, 109 txns)
+  - `0x82B30194...` — Nested Gnosis Safe (3/7 threshold, 7 signers)
+  - `0xC50BD843...` — Dormant EOA (0 ETH, no transactions)
+- **Access Control:** Role-based via `MidasAccessControl` ([0x0312A9D1...](https://etherscan.io/address/0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B))
+- **DEFAULT_ADMIN_ROLE holder:** The same 1/3 Gnosis Safe ([0xB60842E9...](https://etherscan.io/address/0xB60842E9DaBCd1C52e354ac30E82a97661cB7E89)) holds `DEFAULT_ADMIN_ROLE` directly — **role changes (mint/burn/pause/blacklist grants) bypass the timelock** and can be executed immediately
+- **Governance Model:** No on-chain governance. Midas controls all admin functions
+- **Privileged Roles:**
+  1. **`M_HYPER_MINT_OPERATOR_ROLE`** — Can mint unlimited mHYPER tokens
+  2. **`M_HYPER_BURN_OPERATOR_ROLE`** — Can burn mHYPER tokens from any address
+  3. **`M_HYPER_PAUSE_OPERATOR_ROLE`** — Can pause/unpause the contract (freezing all transfers)
+  4. **`DEFAULT_ADMIN_ROLE`** — Can grant/revoke all other roles (held by 1/3 Safe, no timelock)
+  5. **ProxyAdmin owner** — Can upgrade all contract implementations (via 48hr timelock)
+  6. **Oracle updater** — Can set the NAV price via `CustomAggregatorFeed`
+  7. **Blacklist operator** — Can blacklist addresses from interacting with the token
+- **Fund Seizure:** Yes — the burn operator can burn tokens from any address. The blacklist operator can freeze specific addresses. The pause operator can freeze all activity. Role grants bypass the timelock, so a compromised 1/3 Safe signer could grant themselves these roles immediately
+- **Audit Assessment:** Hacken auditors explicitly flagged the protocol as **"highly centralized"** with system admins controlling all critical roles
+
+### Programmability
+
+- **System Operations:** Primarily off-chain. Strategy execution, NAV calculation, and redemption processing are handled by Midas/Hyperithm off-chain
+- **Oracle/NAV Updates:** Manual — privileged role updates the `CustomAggregatorFeed` weekly. Not programmatic
+- **PPS Definition:** The oracle price IS the PPS. It is updated by an admin role, not computed on-chain from reserves
+- **Off-Chain Dependencies:** Critical
+  - Hyperithm's strategy execution and NAV reporting
+  - Midas's redemption processing
+  - KYC/AML verification (greenlist management)
+  - Fordefi for MPC custody and transaction signing
+
+### External Dependencies
+
+- **Hyperithm (Critical):** Strategy management, NAV calculation, risk monitoring. Single external dependency for core value proposition. If Hyperithm fails or misreports, token holders have no on-chain recourse
+- **Fordefi (Critical):** MPC custody of underlying assets with tri-party governance. All fund movements depend on it
+- **Strategy Counterparties (Critical):**
+  - **Aave** — Leveraged USDe positions (blue-chip, high trust)
+  - **Pendle** — Yield token farming (established)
+  - **Hyperliquid** — Basis trading (newer, centralized perps DEX)
+  - **Morpho** — Vault liquidity provision (established)
+- **Stablecoin Dependencies:** USDC, USDe (Ethena) — depegging events could impact strategy performance
+- **Oracle:** Self-reported NAV via custom contract. No independent oracle feed
+- **Criticality:** Failure of Fordefi would prevent fund movements. Failure of underlying DeFi protocols could cause direct losses. Strategy diversification across multiple protocols provides some mitigation. The tri-party governance via Fordefi provides some protection, but ultimately Midas Software GmbH controls the on-chain system
+
+## Operational Risk
+
+- **Team Transparency:** Fully doxxed. Dennis Dinkelmeyer (CEO, ex-Goldman Sachs), Fabrice Grinda (Executive Chairman, co-founded OLX, FJ Labs), Romain Bourgois (CPO, ex-Ondo Finance). Team includes alumni from Goldman Sachs, Anchorage Digital, Capital Group
+- **Investors:** Framework Ventures (lead), BlockTower, HV Capital, Coinbase Ventures, GSR, Hack VC, Cathay Ledger, 6th Man Ventures, FJ Labs, Lattice Capital. $8.75M seed (March 2024)
+- **Documentation Quality:** Comprehensive docs at docs.midas.app covering token mechanics, fees, risk management, smart contracts. Base Prospectus publicly available (approved by FMA Liechtenstein, July 2024). Multiple Final Terms documents filed with MFSA Malta. Note: docs are behind Cloudflare protection
+- **Legal Structure:** Midas Software GmbH (Germany), sole shareholder Midas Protocol Limited (London, UK). EUR 25,000 share capital. Incorporated June 2023. BaFin-regulated, MiCA compliant. However, the issuer states it is **not required to be licensed or authorized** under current securities laws and operates **without supervision** by any authority
+- **Incident Response:** During the Stream Finance incident, Midas/Hyperithm processed $150M+ in redemptions within 48 hours and communicated publicly. Demonstrated operational capability under stress
+- **Hyperithm Concerns:** Alleged regulatory filing failure in South Korea (Dec 2025, per crypto media). Co-CEO's $3M+ TRUMP meme coin position raises risk management culture questions
+
+## Monitoring
+
+1. **Oracle/NAV Updates (CRITICAL)**
+   - **Contract:** [0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68](https://etherscan.io/address/0x43881B05C3BE68B2d33eb70aDdF9F666C5005f68) (CustomAggregatorFeed)
+   - **Monitor:** `AnswerUpdated` events, `latestRoundData()` values
+   - **Alert:** Price decrease >1%, stale price (>10 days without update), unexpected large price jumps
+   - **Frequency:** Daily
+
+2. **Access Control Changes (CRITICAL)**
+   - **Contract:** [0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B](https://etherscan.io/address/0x0312A9D1Ff2372DDEdCBB21e4B6389aFc919aC4B) (MidasAccessControl)
+   - **Monitor:** `RoleGranted`, `RoleRevoked` events
+   - **Alert:** Any role change
+   - **Frequency:** Hourly
+
+3. **Contract Upgrades (CRITICAL)**
+   - **Contract:** [0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC](https://etherscan.io/address/0xbf25b58cB8DfaD688F7BcB2b87D71C23A6600AaC) (ProxyAdmin)
+   - **Monitor:** `Upgraded` events on all proxy contracts
+   - **Alert:** Any implementation change
+   - **Frequency:** Hourly
+
+4. **Token Supply & Transfers (MANDATORY)**
+   - **Contract:** [0x9b5528528656DBC094765E2abB79F293c21191B9](https://etherscan.io/address/0x9b5528528656DBC094765E2abB79F293c21191B9) (mHYPER)
+   - **Monitor:** `Paused`/`Unpaused` events, large mint/burn events, `Blacklisted` events
+   - **Alert:** Pause events, mints >$1M, any blacklist changes
+   - **Frequency:** Hourly
+
+5. **Vault Activity (MANDATORY)**
+   - **Contract:** [0x6Be2f55816efd0d91f52720f096006d63c366e98](https://etherscan.io/address/0x6Be2f55816efd0d91f52720f096006d63c366e98) (DepositVault)
+   - **Contract:** [0xbA9FD2850965053Ffab368Df8AA7eD2486f11024](https://etherscan.io/address/0xbA9FD2850965053Ffab368Df8AA7eD2486f11024) (RedemptionVaultWithSwapper)
+   - **Monitor:** Large deposits/redemptions, vault USDC balance
+   - **Alert:** Redemptions >$5M, vault balance <$100K
+   - **Frequency:** Daily
+
+6. **External Protocol Health (RECOMMENDED)**
+   - Monitor Aave, Pendle, Hyperliquid, Morpho, and Ethena (USDe) for incidents that could impact mHYPER's underlying positions
+   - Monitor overall Midas TVL and other LYT redemption patterns for signs of platform-wide stress
+
+## Risk Summary
+
+### Key Strengths
+
+- **Doxxed team with institutional backing** — Goldman Sachs / Morgan Stanley alumni, backed by Coinbase Ventures, Framework Ventures, BlockTower
+- **Institutional-grade custody** — Fordefi MPC with tri-party governance prevents unilateral fund access
+- **Regulatory compliance** — FMA-approved prospectus, German GmbH legal structure, KYC enforcement on-chain
+- **Proven redemption capacity** — Processed $150M+ in redemptions within 48 hours under stress (Stream Finance incident)
+- **Multiple audits** — Hacken + two Sherlock contests on shared vault infrastructure. Clean track record (~7 months mHYPER, ~20 months Midas platform)
+
+### Key Risks
+
+- **Off-chain NAV / opaque reserves** — Token holders cannot independently verify that underlying assets match the reported NAV. Oracle is admin-updated weekly, not programmatic
+- **Subordinated debt structure** — Investors have no claim on underlying assets. In insolvency, token holders are subordinated creditors of a GmbH with EUR 25,000 share capital
+- **Weak multisig and partial timelock** — Contract upgrades have a 48-hour timelock, but role changes (mint/burn/pause/blacklist grants) bypass it entirely. The controlling 1/3 Gnosis Safe means any single signer can grant themselves powerful roles immediately
+- **Thin on-chain liquidity** — ~$32K on Uniswap, ~$7.6K daily volume. Exit is entirely dependent on Midas's redemption infrastructure (1-7 days)
+- **Concentration risk** — ~387 holders with $43M market cap; single entity (Stream Finance) previously held a $75M leveraged position
+
+### Critical Risks
+
+- **Single-party NAV reporting** — Hyperithm reports NAV, Midas publishes on-chain. No confirmed independent third-party verification for mHYPER specifically (Ankura Trust confirmed for mTBILL/mBTC but unconfirmed for mHYPER). A misreported NAV would directly affect all token holders
+- **Role changes bypass timelock** — While contract upgrades have a 48-hour timelock, the 1/3 Gnosis Safe can grant mint/burn/pause/blacklist roles immediately. A single compromised signer could grant themselves these roles and seize or freeze all user funds without any delay
+- **Hyperithm risk factors** — Alleged regulatory filing failure in South Korea; co-CEO's large speculative meme coin position contrasts with claimed market-neutral positioning
+
+---
+
+## Risk Score Assessment
+
+**Scoring Guidelines:**
+- Be conservative: when uncertain between two scores, choose the higher (riskier) one
+- Use decimals (e.g., 2.5) when a subcategory falls between scores
+- Prioritize on-chain evidence over documentation claims
+
+### Critical Risk Gates
+
+- [ ] **No audit** → **PASS** — Three audits (Hacken + two Sherlock contests) cover the shared vault infrastructure
+- [ ] **Unverifiable reserves** → **BORDERLINE PASS** — Reserves are managed off-chain by Hyperithm. NAV is admin-reported. No independent on-chain verification of underlying assets. However, Midas provides attestation reports, has an FMA-approved prospectus, and the tri-party custody model prevents unilateral fund access. Scoring conservatively but not auto-failing
+- [ ] **Total centralization** → **PASS** — Role-based access control, tri-party governance via Fordefi, 48-hour timelock on contract upgrades. Not a single EOA. However, 1/3 multisig threshold and role changes bypass the timelock
+
+**Result:** Protocol passes critical gates. Proceeding to category scoring with conservative bias given the borderline reserves gate.
+
+---
+
+### Category Scoring (1-5 scale, 1 = safest)
+
+#### 1. Audits & Historical Track Record (Weight: 20%)
+
+**Audits:**
+- 3 audits: 1 Hacken (reputable but not top-tier) + 2 Sherlock contests (broad coverage)
+- Audits cover shared Midas infrastructure, not mHYPER-specific code
+- Several findings accepted rather than fixed
+- Audits are 18-24 months old relative to current mHYPER deployment
+- Bug bounty present on HackerOne but with no guaranteed payout — weak deterrent
+
+**Time in Production:**
+- mHYPER: ~7 months (July 2025)
+- Midas platform: ~20 months
+- TVL ~$43M for mHYPER, ~$275M for Midas total
+- No security incidents. Survived one major stress event (Stream Finance)
+
+**Score: 3.0/5** — Multiple audits on vault infrastructure but some findings accepted not fixed, no mHYPER-specific audit, bug bounty without guaranteed payouts, and short production history for mHYPER specifically. Clean operational history partially offsets.
+
+#### 2. Centralization & Control Risks (Weight: 30%)
+
+**Subcategory A: Governance — 3.5**
+- Upgradeable proxy contracts with **48-hour timelock** on upgrades via `MidasTimelockController` — users have time to react to proposed upgrades
+- However, role changes (mint/burn/pause/blacklist grants) bypass the timelock entirely
+- Controlling multisig is a **1/3 Gnosis Safe** — any single signer can act. One signer is a nested 3/7 Safe, one is a dormant EOA
+- Admin controls all critical roles (flagged by auditors as "highly centralized")
+- Tri-party custody model (Fordefi) is a positive but applies only to fund movements, not contract administration
+- No on-chain governance mechanism
+
+**Subcategory B: Programmability — 4.0**
+- Strategy execution fully off-chain (Hyperithm)
+- NAV/oracle admin-updated weekly, not programmatic
+- PPS is admin-reported (not computed on-chain from reserves)
+- Redemption partially off-chain (standard redemptions processed by Midas team)
+- Users cannot independently compute or verify the exchange rate on-chain
+
+**Subcategory C: External Dependencies — 3.5**
+- Hyperithm: single critical dependency for strategy management and NAV calculation
+- Fordefi: critical custody infrastructure
+- Strategy counterparties: Aave (blue-chip), Pendle (established), Hyperliquid (newer), Morpho (established)
+- Stablecoin exposure: USDC, USDe (carries its own depeg risk)
+- Diversification across multiple protocols provides some resilience
+- Failure of Hyperithm or Fordefi would break core functionality
+
+**Centralization Score = (3.5 + 4.0 + 3.5) / 3 = 3.67**
+
+**Score: 3.7/5** — High centralization driven by off-chain operations, admin-controlled NAV, weak 1/3 multisig, and single-party dependency on Hyperithm. The 48-hour timelock on upgrades is a meaningful positive, but role changes bypass it. Tri-party custody partially mitigates but is itself an off-chain trust assumption.
+
+#### 3. Funds Management (Weight: 30%)
+
+**Subcategory A: Collateralization — 3.5**
+- Tokens are subordinated debt instruments — not direct claims on collateral
+- Strategies are stablecoin-focused but managed off-chain with discretionary authority by Hyperithm
+- Includes leveraged positions across multiple protocols
+- No on-chain collateral verification; no over-collateralization requirement
+- Tri-party custody via Fordefi prevents unilateral fund access
+- Previous recursive lending concerns (~30% of TVL) addressed but indicates structural vulnerability
+- EUR 25,000 share capital provides minimal corporate protection
+
+**Subcategory B: Provability — 3.5**
+- NAV reported by Hyperithm, published by Midas weekly via admin-controlled oracle
+- Reserve transparency is hybrid: some strategy wallets on-chain, full portfolio off-chain
+- Ankura Trust serves as verification agent for Midas's off-chain assets (confirmed for mTBILL/mBTC), but specific coverage of mHYPER unconfirmed
+- No Chainlink Proof of Reserve, no Merkle proofs
+- For Morpho integration, eOracle provides independent price verification
+- Token holders cannot independently compute the NAV
+
+**Funds Management Score = (3.5 + 3.5) / 2 = 3.5**
+
+**Score: 3.5/5** — Off-chain funds management with admin-reported NAV and subordinated debt structure. Some verification infrastructure exists (Ankura for broader Midas, eOracle for Morpho) but not independently confirmed for mHYPER specifically. Leveraged strategy positions add risk.
+
+#### 4. Liquidity Risk (Weight: 15%)
+
+- **Exit Mechanism:** Instant redemption at oracle price (0.50% fee) when available, otherwise standard redemption in 1-7 business days
+- **DEX Liquidity:** Very thin — ~$32K total on Uniswap V4, ~$7.6K daily volume. Not viable for any meaningful size
+- **Instant Redemption Capacity:** DepositVault holds ~$463K USDC. Liquidity target 1-2% of circulating supply. May be temporarily disabled
+- **Pendle:** ~$5.53M TVL in mHYPER pools (yield tokenization, not direct exit liquidity)
+- **Stress Performance:** Processed $150M+ in 48 hours during Stream Finance incident, but via standard redemption requiring active coordination
+- **Large Holder Impact:** ~387 holders, average ~$111K. Significant exits require multi-day standard redemption path
+
+**Score: 3.0/5** — Redemption mechanism works (proven under $150M stress), but entirely dependent on Midas infrastructure. No meaningful secondary market. Standard redemptions take up to 7 business days. Adjusted -0.5 for demonstrated stress resilience.
+
+#### 5. Operational Risk (Weight: 5%)
+
+- **Team:** Fully doxxed with strong institutional backgrounds (Goldman Sachs, Morgan Stanley, Ondo Finance, OLX). Well-funded ($8.75M from top crypto VCs)
+- **Hyperithm:** Established fund manager (founded 2018), backed by Coinbase Ventures, Samsung Next. Dual-registered (Japan FSA, South Korea KoFIU). Concerns around co-CEO's TRUMP meme coin position and alleged regulatory filing failure
+- **Documentation:** Comprehensive docs, publicly available prospectus, weekly reports
+- **Legal:** German GmbH with FMA-approved prospectus, MiCA compliant. BUT: EUR 25,000 share capital (thin), newly incorporated (2023), states it operates "without supervision" by any authority
+
+**Score: 1.5/5** — Strong team transparency and institutional credibility. Well-documented and regulated. Minor concerns about Hyperithm regulatory compliance and the thinly capitalized legal entity.
+
+### Final Score Calculation
+
+```
+Final Score = (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Audits × 0.20) + (Liquidity × 0.15) + (Operational × 0.05)
+            = (3.7 × 0.30) + (3.5 × 0.30) + (3.0 × 0.20) + (3.0 × 0.15) + (1.5 × 0.05)
+            = 1.11 + 1.05 + 0.60 + 0.45 + 0.075
+            = 3.285
+            ≈ 3.3
+```
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 3.0 | 20% | 0.60 |
+| Centralization & Control | 3.7 | 30% | 1.11 |
+| Funds Management | 3.5 | 30% | 1.05 |
+| Liquidity Risk | 3.0 | 15% | 0.45 |
+| Operational Risk | 1.5 | 5% | 0.075 |
+| **Final Score** | | | **3.3/5.0** |
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|------------|-----------|----------------|
+| 1.0-1.5 | Minimal Risk | Approved, high confidence |
+| 1.5-2.5 | Low Risk | Approved with standard monitoring |
+| **2.5-3.5** | **Medium Risk** | **Approved with enhanced monitoring** |
+| 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
+| 4.5-5.0 | High Risk | Not recommended |
+
+**Final Risk Tier: Medium Risk (3.3/5.0)**
+
+**Recommendation:** Approved with **enhanced monitoring** and strict exposure limits.
+
+**Required Conditions:**
+1. **Limited Exposure** — Cap allocation at 10-15% of vault with gradual ramp-up
+2. **Enhanced Monitoring** — Real-time alerts on oracle updates, role changes, contract upgrades, and vault activity (see Monitoring section)
+3. **Verify Multisig Configuration** — Confirm the ProxyAdmin owner and role holder multisig setup before deployment
+4. **Monthly NAV Cross-Check** — Independently estimate NAV from known strategy positions where possible
+5. **Quarterly Reassessment** — Given the off-chain nature and evolving regulatory landscape
+
+**Key Concerns Driving the Score:**
+- Off-chain NAV reporting with no confirmed independent verification for mHYPER
+- Role changes (mint/burn/pause/blacklist grants) bypass the 48-hour timelock; 1/3 multisig threshold
+- Subordinated debt structure (no direct claim on assets)
+- Thin secondary market liquidity
+- Single-party dependency on Hyperithm for strategy and NAV
+
+**Mitigating Factors:**
+- Strong team and institutional backing
+- Clean ~7-month track record (mHYPER) / ~20-month (Midas platform)
+- Proven redemption under stress ($150M+ in 48 hours)
+- Institutional-grade custody (Fordefi tri-party MPC)
+- FMA-approved prospectus and German legal entity
+- Multiple audits on shared infrastructure
+
+---
+
+## Reassessment Triggers
+
+- **Time-based**: Reassess in 3 months (May 2026)
+- **TVL-based**: Reassess if mHYPER market cap changes by more than 50%
+- **Incident-based**: Reassess after any exploit, NAV discrepancy, governance change, contract upgrade, or regulatory action
+- **Hyperithm regulatory outcome**: Reassess when South Korean regulatory filing matter is resolved
+- **Timelock expansion**: If Midas extends the 48-hour timelock to cover role changes (not just upgrades) or increases the 1/3 multisig threshold, reassess for potential score improvement
+- **Audit**: If new audit covering current mHYPER contracts is published, reassess
+- **Ankura verification**: If Ankura Trust coverage for mHYPER is confirmed or denied, adjust Provability score accordingly

--- a/src/components/pages/curation/reports/origin-arm.md
+++ b/src/components/pages/curation/reports/origin-arm.md
@@ -1,0 +1,295 @@
+# Protocol Risk Assessment: Origin ARM
+
+- **Assessment Date:** February 8, 2026
+- **Token:** ARM-WETH-stETH
+- **Chain:** Ethereum Mainnet
+- **Token Address:** [`0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6`](https://etherscan.io/address/0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6)
+- **Final Score: 1.50/5.0**
+
+## Overview + Links
+
+Origin's stETH ARM (Automated Redemption Manager) is a yield-generating ETH vault (ERC4626) that earns returns primarily through arbitraging stETH against its redemption value via Lido's withdrawal queue. Users deposit WETH, receive ARM-WETH-stETH LP tokens. The protocol buys discounted stETH, redeems it 1:1 through Lido, and captures the spread as yield. The contract also supports deploying idle capital to Morpho lending markets, currently using WETH ARM Morpho vault curated by Yearn.
+
+- **Launch Date:** October 25, 2024
+- **Performance Fee:** 20% (2,000 bps) - mutable by owner (Timelock)
+- **Backing:** Lido Ecosystem Foundation provides liquidity support
+
+**Links:**
+
+- [Protocol Documentation](https://docs.originprotocol.com/automated-redemption-manager-arm/introduction-to-arm)
+- [Protocol App](https://www.originprotocol.com/arm)
+- [GitHub Repository](https://github.com/OriginProtocol/arm-oeth)
+- [Security / Audits](https://github.com/OriginProtocol/security)
+- [Bug Bounty](https://immunefi.com/bug-bounty/originprotocol/scope/#top)
+- [DeFiLlama](https://defillama.com/protocol/origin-arm)
+
+## Contract Addresses
+
+| Contract | Address |
+|----------|---------|
+| ARM Proxy | [`0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6`](https://etherscan.io/address/0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6) |
+| ARM Implementation | [`0xC0297a0E39031F09406F0987C9D9D41c5dfbc3df`](https://etherscan.io/address/0xC0297a0E39031F09406F0987C9D9D41c5dfbc3df) |
+| Timelock Controller | [`0x35918cDE7233F2dD33fA41ae3Cb6aE0e42E0e69F`](https://etherscan.io/address/0x35918cDE7233F2dD33fA41ae3Cb6aE0e42E0e69F) |
+| Origin DeFi Governance | [`0x1D3fBD4d129Ddd2372EA85c5Fa00b2682081c9EC`](https://etherscan.io/address/0x1D3fBD4d129Ddd2372EA85c5Fa00b2682081c9EC) |
+| GOV Multisig (5/8, cancel-only) | [`0xbe2AB3d3d8F6a32b96414ebbd865dBD276d3d899`](https://etherscan.io/address/0xbe2AB3d3d8F6a32b96414ebbd865dBD276d3d899) |
+| Operator (EOA) | [`0x39878253374355DBcc15C86458F084fb6f2d6DE7`](https://etherscan.io/address/0x39878253374355DBcc15C86458F084fb6f2d6DE7) |
+| Fee Collector | [`0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c`](https://etherscan.io/address/0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c) |
+| xOGN Governance Token | [`0x63898b3b6Ef3d39332082178656E9862bee45C57`](https://etherscan.io/address/0x63898b3b6Ef3d39332082178656E9862bee45C57) |
+| Lido Withdrawal Queue | [`0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1`](https://etherscan.io/address/0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1) |
+| Morpho Vault (WETH ARM, Yearn curated) | [`0x3Dfe70B05657949A5dB340754aD664810ac63b21`](https://etherscan.io/address/0x3Dfe70B05657949A5dB340754aD664810ac63b21) |
+
+## Audits and Due Diligence Disclosures
+
+ARM has been audited by OpenZeppelin and formally verified by Certora:
+
+| # | Date | Firm | Scope | Report |
+|---|------|------|-------|--------|
+| 1 | Nov 2024 | OpenZeppelin | ARM contracts | [Report](https://github.com/OriginProtocol/security/blob/master/audits/OpenZeppelin%20-%20Origin%20Arm%20Audit%20-%20November%202024.pdf) |
+| 2 | Dec 2024 | Certora | Formal verification | [Report](https://github.com/OriginProtocol/security/blob/master/audits/Certora%20-%20Formal%20verification%20-%20December%202024.pdf) |
+| 3 | Jun 2025 | OpenZeppelin | ARM contracts | [Report](https://github.com/OriginProtocol/security/blob/master/audits/OpenZeppelin%20-%20Origin%20ARM%20-%20June%202025.pdf) |
+
+Origin Protocol has 30+ audit reports across all products (OpenZeppelin, Trail of Bits, Solidified, Nethermind, Sigma Prime, Narya, Perimeter) in their [security repository](https://github.com/OriginProtocol/security).
+
+**Smart Contract Complexity:** Moderate - Upgradeable proxy (EIP-1967), AbstractARM base contract, Lido withdrawal queue integration, operator-controlled pricing with cross-price timelock protection.
+
+### Bug Bounty
+
+- **Platform:** Immunefi
+- **Maximum Payout:** $1,000,000
+- **Scope:** ARM (stETH/WETH) contract explicitly in-scope
+- **Link:** https://immunefi.com/bug-bounty/originprotocol/scope/
+
+## Historical Track Record
+
+- **Launched:** October 25, 2024 (~16 months in production)
+- **ARM-specific incidents:** None ✓
+- **Origin Protocol incident:** November 17, 2020 - OUSD Flash Loan Reentrancy Attack ($8M loss). Different product (OUSD) with different contracts. ARM codebase built later with lessons learned. Source: [DeFiLlama Hacks DB](https://defillama.com/hacks), [rekt.news](https://rekt.news/origin-rekt/)
+- **TVL volatility:** Extreme range from $782K to $28M peak, suggesting whale concentration risk
+- **Team:** Origin Protocol since 2017. Founded by Josh Fraser & Matthew Liu. CEO: Rafael Ugolini. Backed by Pantera Capital, Founders Fund. Previously launched OETH and OUSD. Active development - expanding to EtherFi, Ethena ARM variants.
+
+## Funds Management
+
+**Strategy:** Buy discounted stETH → redeem 1:1 via Lido withdrawal queue → capture spread. Currently ~99% of assets sit in Lido withdrawal queue with a small WETH buffer.
+
+**Morpho Integration:** The contract supports deploying idle capital to the WETH ARM Morpho vault ([`0x3Dfe70B05657949A5dB340754aD664810ac63b21`](https://etherscan.io/address/0x3Dfe70B05657949A5dB340754aD664810ac63b21)) curated by Yearn. This is considered a safer option compared to the previous MEV Capital wETH vault, as Yearn's curation provides stronger risk management and oversight.
+
+### Accessibility
+
+- **Deposits:** Permissionless, atomic. Deposit WETH, receive ARM-WETH-stETH LP tokens. Cap manager currently disabled (address(0)).
+- **Withdrawals:** Two-step Request → Claim. PPS locked at request time, shares burned immediately. 10-minute minimum delay. Liquidity-dependent - exits exceeding WETH buffer require waiting for Lido withdrawal queue processing (1-3 days typical). No yield during queue.
+
+### Collateralization
+
+- 100% on-chain collateral: WETH + stETH (same-value ETH-denominated assets)
+- No debt, leverage, or liquidation mechanics
+- Operator sets buy/sell prices manually, bounded by cross-price (which requires timelock to change)
+
+### Provability
+
+- All reserves verifiable on-chain via view functions: `totalAssets()`, `totalSupply()`, `convertToAssets()`
+- PPS calculated programmatically on-chain: `totalAssets() / totalSupply()`
+- Lido withdrawal queue state verifiable: `withdrawsQueued()`, `withdrawsClaimed()`, `claimable()`
+- 100% on-chain reserves, no off-chain components
+
+## Liquidity Risk
+
+- **Exit Mechanism:** Direct vault redemption with 10-minute delay. PPS locked at request time (no slippage on redemption value). No secondary DEX liquidity for the LP token.
+- **Immediate exits** limited to WETH buffer (variable, typically small % of TVL)
+- **Larger exits** require Lido withdrawal queue processing (1-3 days)
+- No priority mechanism - first-come-first-served
+- Same-value assets (ETH/stETH) mitigate price impact risk during wait
+
+## Centralization & Control Risks
+
+### Governance
+
+**Governance Structure (all on-chain verified):**
+
+```
+xOGN Token Holders (Staked OGN)
+        │ (100K xOGN to propose, ~133.7M xOGN quorum)
+        ▼
+Origin DeFi Governance (0x1D3fBD...9EC)
+        │ (7,200 blocks voting delay + 14,416 blocks voting period)
+        ▼ PROPOSER + EXECUTOR roles
+Timelock Controller (0x35918c...69F)
+        │ 172,800 seconds (48-hour) delay        ◄── GOV Multisig (5/8) can CANCEL only
+        ▼ owner
+ARM Contract (0x85B78A...cc6)
+        ├── operator: EOA (0x39878...DE7) - codesize 0, confirmed EOA
+        └── feeCollector: contract (0xBB077...8c)
+```
+
+**Timelock Roles (verified via `hasRole()`):**
+
+| Role | Origin DeFi Governance | GOV Multisig (5/8) | address(0) |
+|------|:---:|:---:|:---:|
+| PROPOSER | ✓ | ✗ | - |
+| EXECUTOR | ✓ | ✗ | ✗ (not open) |
+| CANCELLER | ✓ | ✓ | - |
+
+- Timelock is self-administered (TIMELOCK_ADMIN_ROLE held by itself)
+- Total time from proposal to execution: ~5 days minimum (24h voting delay + 48h voting + 48h timelock)
+- No backdoor - only Origin DeFi Governance can propose/execute
+
+**GOV Multisig Signers (5-of-8):**
+`0x530d3F8C`, `0xce96ae6D`, `0x336C02D3`, `0x6AC8d65D`, `0x617a3582`, `0x17aBc3F0`, `0x39772922`, `0xa96bD9c5`
+
+**Privileged Roles:**
+
+| Role | Who | Timelock? | Powers |
+|------|-----|-----------|--------|
+| Admin (owner) | Timelock → xOGN governance | ~5 days | Upgrade proxy, set cross price, change lending markets, grant/revoke operator, set fee |
+| Operator | EOA `0x39878...DE7` | None | Set buy/sell prices (traderate0/1), trigger allocate/rebalance |
+| Cap Manager | address(0) (disabled) | - | Could restrict deposits if enabled |
+
+**Key Risk:** Operator is a single EOA (not a multisig). Can adjust buy/sell prices without timelock. Cross-price timelock limits exploitation.
+
+### Programmability
+
+- PPS calculated programmatically on-chain (`totalAssets() / totalSupply()`)
+- `allocate()` function is permissionless
+- Operator sets buy/sell prices manually (no timelock), bounded by cross-price (admin-set, 48h timelock)
+- If operator inactive, pricing could become stale (no automated price discovery)
+
+### External Dependencies
+
+1. **Lido (Critical)** - Core value proposition depends on Lido's stETH and withdrawal queue. Failure would halt all operations.
+2. **Morpho (High)** - Idle capital is deposited into WETH ARM Morpho vault curated by Yearn. Yearn curation reduces curator risk compared to previous MEV Capital setup.
+3. **DEX Aggregators (Non-critical)** - 1inch, CoWSwap for stETH acquisition. Not required for core functionality.
+
+No cross-chain dependencies.
+
+## Operational Risk
+
+- **Team:** Origin Protocol since 2017, public team, known leadership, VC-backed (Pantera, Founders Fund)
+- **Documentation:** Good. Public GitHub actively maintained, comprehensive security repo
+- **Legal:** Company structure (Origin Protocol), established entity
+- **Incident Response:** $1M bug bounty on Immunefi, learned from 2020 OUSD incident
+
+## Monitoring
+
+- **Governance:** Monitor Timelock events (`CallScheduled`, `CallExecuted`, `Cancelled`) and Origin DeFi Governance proposals. Monitor EIP-1967 implementation slot for proxy upgrades.
+- **Operator:** Monitor `traderate0()`, `traderate1()`, `crossPrice()` for changes. Alert on >5% market deviation or operator role changes.
+- **PPS & Liquidity:** Track `totalAssets() / totalSupply()`, alert on >1% sudden PPS drops. Monitor WETH buffer and Lido withdrawal queue state. Track large movements (>20% TVL change in 24h).
+- **Lending:** Monitor Morpho WETH ARM vault allocation and Yearn curator changes.
+
+## Risk Summary
+
+### Key Strengths
+
+1. On-chain xOGN governance with ~5-day total cycle, self-administered Timelock, no admin backdoor
+2. Cross-price protected by 48h timelock — limits operator manipulation
+3. 2x OpenZeppelin + Certora formal verification + $1M Immunefi bounty
+4. Simple strategy (stETH arbitrage), with lending to low risk ARM Morpho Vault curated by Yearn
+5. 16 months clean ARM track record, same-value assets (ETH/stETH)
+
+### Key Risks
+
+1. Operator is single EOA (not multisig) — can set prices without timelock
+2. Extreme TVL volatility ($782K–$28M) — whale concentration
+3. Upgradeable proxy (protected by ~5-day governance cycle)
+4. Critical Lido dependency
+
+### Critical Risks
+
+- None identified. All critical gates pass.
+
+---
+
+## Risk Score Assessment
+
+### Critical Risk Gates
+
+- [ ] **No audit** → **PASS** (2x OpenZeppelin + Certora formal verification)
+- [ ] **Unverifiable reserves** → **PASS** (100% on-chain, verifiable)
+- [ ] **Total centralization** → **PASS** (xOGN governance + Timelock; operator is EOA but admin is not)
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%) — **1.5**
+
+| Aspect | Assessment |
+|--------|-----------|
+| Audits | 2x OpenZeppelin + Certora formal verification |
+| Bug Bounty | $1M on Immunefi, ARM in scope |
+| Time in Production | ~16 months, no ARM incidents |
+| TVL | $5M |
+
+#### Category 2: Centralization & Control Risks (Weight: 30%) — **1.33**
+
+**Subcategory A: Governance — 1.0**
+- On-chain xOGN token governance with ~5-day cycle
+- 48h timelock, self-administered, GOV Multisig (5/8) cancel-only
+- No admin backdoor. Shorter than ideal 72h+ timelock.
+
+**Subcategory B: Programmability — 1.5**
+- PPS on-chain, cross-price timelocked, `allocate()` permissionless
+- Operator is single EOA with no-timelock price setting
+
+**Subcategory C: External Dependencies — 1.5**
+- Critical dependency on Lido (blue-chip)
+- Dependency on Morpho code
+- Morpho vault curated by Yearn (safer than previous MEV Capital curator)
+
+**Score: (1.0 + 1.5 + 1.5) / 3 = 1.33**
+
+#### Category 3: Funds Management (Weight: 30%) — **1.25**
+
+**Subcategory A: Collateralization — 1.5**
+- 100% on-chain, same-value assets (ETH/stETH), no leverage
+- Idle capital deposited into Yearn-curated WETH ARM Morpho vault, a safer option with stronger risk oversight than the previous MEV Capital vault
+
+**Subcategory B: Provability — 1.0**
+- Fully transparent on-chain. Minor dependency on operator pricing (bounded by cross-price)
+
+**Score: (1.5 + 1.0) / 2 = 1.25**
+
+#### Category 4: Liquidity Risk (Weight: 15%) — **2.5**
+
+- Direct redemption with PPS lock (no slippage) ✓
+- Limited immediate buffer, larger exits require multiple days Lido processing
+- Same-value assets mitigate waiting risk
+
+#### Category 5: Operational Risk (Weight: 5%) — **1.0**
+
+- Established team (2017), public, VC-backed, comprehensive security repo
+
+### Final Score Calculation
+
+```
+Final Score = (Audits × 0.20) + (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Liquidity × 0.15) + (Operational × 0.05)
+            = (1.5 × 0.20) + (1.33 × 0.30) + (1.25 × 0.30) + (2.5 × 0.15) + (1.0 × 0.05)
+            = 0.30 + 0.399 + 0.375 + 0.375 + 0.05
+            = 1.499
+            ≈ 1.50
+```
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 1.5 | 20% | 0.30 |
+| Centralization & Control | 1.33 | 30% | 0.399 |
+| Funds Management | 1.25 | 30% | 0.375 |
+| Liquidity Risk | 2.5 | 15% | 0.375 |
+| Operational Risk | 1.0 | 5% | 0.05 |
+| **Final Score** | | | **1.50 / 5.0** |
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|------------|-----------|----------------|
+| **1.0-1.5** | **Minimal Risk** | **Approved, high confidence** |
+| 1.5-2.5 | Low Risk | Approved with standard monitoring |
+| 2.5-3.5 | Medium Risk | Approved with enhanced monitoring |
+| 3.5-4.5 | Elevated Risk | Limited approval, strict limits |
+| 4.5-5.0 | High Risk | Not recommended |
+
+**Final Risk Tier: MINIMAL RISK**
+
+---
+
+## Reassessment Triggers
+
+- **Time-based:** Quarterly (next: May 2026)
+- **Incident-based:** Any security incident, pricing anomaly, or withdrawal issues
+- **Change-based:** Morpho vault curator Yearn changes, especially adding new markets. Contract upgrade, Lido WQ issues or stETH depeg

--- a/src/components/pages/curation/reports/reserve-ethplus.md
+++ b/src/components/pages/curation/reports/reserve-ethplus.md
@@ -1,0 +1,608 @@
+# Protocol Risk Assessment: Reserve Protocol
+
+- **Assessment Date:** December 22, 2025
+- **Token:** ETH+
+- **Chain:** Ethereum Mainnet
+- **Token Address:** [`0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8`](https://etherscan.io/address/0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8)
+- **Final Score: 1.9/5.0**
+
+## Overview + Links
+
+ETH+ is a yield-bearing Ethereum Liquid Staking Token basket built on Reserve Protocol. It's an over-collateralized RToken backed by a diversified basket of LST tokens (wstETH, sfrxETH, rETH, ETHx). The protocol automatically captures staking rewards from underlying LSTs and redistributes them to ETH+ holders through an appreciating exchange rate.
+
+**Yield Sources:**
+- Ethereum staking rewards from underlying LSTs
+- Automated rebalancing during basket changes
+
+**Current Basket Composition (as of December 22, 2025):**
+- 50.04% wstETH (Lido) - 18,137 ETH
+- 21.04% rETH (Rocket Pool) - 7,625 ETH
+- 20.91% sfrxETH (Frax) - 7,579 ETH
+- 8.02% ETHx (Stader) - 2,906 ETH
+
+**Total TVL:** ~$108M (~36,246 ETH)
+
+**Links:**
+- [Reserve Protocol Documentation](https://reserve.org/protocol/introduction/)
+- [ETH+ Dashboard](https://app.reserve.org/ethereum/token/0xe72b141df173b999ae7c1adcbf60cc9833ce56a8/overview)
+- [Reserve Protocol Security](https://reserve.org/protocol/security/)
+- [LlamaRisk Analysis](https://www.llamarisk.com/research/rtoken-risk-ethplus)
+
+## Audits and Due Diligence Disclosures
+
+**Audit Status:** Comprehensive
+
+The Reserve Protocol has undergone [multiple security audits and code contests](https://reserve.org/protocol/security/#smart-contract-security-audits):
+- Trail of Bits
+- Solidified
+- Ackee Blockchain
+- Halborn
+- Code4rena contests
+
+**Findings:** No critical unresolved issues. Historical issues were addressed in subsequent versions.
+
+**Smart Contract Complexity:** Moderate-High
+- Multi-contract system with RToken core, governance, basket handling, trading logic, and collateral plugins
+- Modular architecture allows independent upgrades
+- Oracle integration for price feeds (primarily Chainlink)
+
+### Bug Bounty
+
+**Platform:** Immunefi
+**Maximum Payout:** $10,000,000
+**Link:** https://immunefi.com/bug-bounty/reserve/
+
+This is one of the highest bug bounty programs in DeFi, indicating strong commitment to security.
+
+## Historical Track Record
+
+**Time in Production:**
+- Reserve Protocol: Live since 2023
+- ETH+ specifically: Launched Q2 2023 (~2.5 years)
+
+**Past Security Incidents:**
+- No major exploits or hacks on Reserve Protocol
+- No collateral defaults triggered for ETH+
+
+**Peg Stability:**
+- ETH+ maintains soft peg to ETH through basket composition
+- No significant depegging events recorded
+- Minor deviations during high volatility are expected and programmatically resolved
+
+**TVL History:**
+- ETH+ TVL has grown steadily since launch
+- Current TVL: ~$108M (~36,246 ETH as of Dec 22, 2025)
+- Stable growth pattern with no sudden drops
+
+**Team Track Record:**
+- Reserve team has been building since 2018
+- Previously launched Reserve stablecoin (RSV) on mainnet
+- Strong technical execution and transparent communication
+
+## Funds Management
+
+**Fund Delegation:** Yes - Funds are deployed into underlying LST protocols:
+- Lido (wstETH)
+- Frax Finance (sfrxETH)
+- Rocket Pool (rETH)
+- Stader (ETHx)
+
+**Due Diligence on Underlying Protocols:**
+- All LST providers are established, audited protocols
+- Each has independent security track record
+- Lido and Rocket Pool are considered blue-chip LST providers
+
+**Monitoring Fund Delegation:**
+- Basket composition is on-chain and transparent
+- Governance proposals for basket changes go through 3-day timelock
+- Alert on: basketConfig changes, collateral default events, basket refresh events
+
+### Accessibility
+
+**Minting:**
+- Permissionless - Anyone can mint ETH+
+- Atomic minting in single transaction
+- Deposit any basket collateral token or proportionally deposit all
+- Issuance throttle exists (can be monitored via contract)
+
+**Redemption:**
+- Permissionless - Anyone can redeem
+- Immediate redemption if under throttle limits
+- Redemptions return proportional basket of collateral tokens
+- Throttle mechanism: Rolling hourly limits on redemption volume
+- Direct 1:1 redemption with underlying collateral basket
+
+**Fees:**
+- No minting fees
+- No redemption fees under normal circumstances
+- Potential premium/discount if redeeming during basket rebalancing
+
+**Rate Limits:**
+- Issuance throttle (configurable by governance)
+- Redemption throttle (configurable by governance)
+- Currently set to reasonable limits for normal operations
+
+**Slippage:**
+- Minimal slippage on mint/redeem (1:1 with basket)
+- Users may face slippage when converting collateral to/from ETH+ via DEXes
+- Redemption during basket changes may have temporary inefficiencies
+
+### Collateralization
+
+**On-Chain Collateralization:** Yes
+- Fully collateralized on-chain
+- Users deposit LST tokens to mint ETH+
+- All collateral held in protocol-owned basket
+
+**Collateral Quality:** High
+- All collateral assets are established Ethereum LSTs
+- Each has independent audits and security track record
+- Diversification reduces single-protocol risk
+
+**Accepted Collateral:**
+- wstETH (Lido Staked ETH)
+- sfrxETH (Frax Staked ETH)
+- rETH (Rocket Pool ETH)
+- ETHx (Stader ETH)
+
+**Over-Collateralization:**
+- Target: 100% collateralization by basket value
+- Additional protection: RSR staking provides overcollateralization buffer
+- RSR stakers act as first-loss capital in default scenarios
+- Current RSR backing: Variable (check StRSR exchange rate)
+
+**Maintenance Ratios:**
+- Protocol monitors collateral value via oracles
+- Default triggered if collateral depegs significantly (>1% for extended period)
+- Automatic basket rebalancing in default scenarios
+
+**Liquidations:** On-chain
+- Automated collateral auctions in case of default
+- RSR seized from stakers to recapitalize if needed
+- Emergency collateral (WETH) used during recapitalization
+
+**Peg Stability Mechanisms:**
+- Arbitrage opportunities keep ETH+ near basket value
+- Direct redemption provides hard floor
+- Basket rebalancing maintains target composition
+
+**Risk Curation:**
+- Governance manages: basket composition, collateral weights, oracle addresses, throttle parameters
+- Requires 3-day timelock for changes after governance approval
+- Managed by: StRSR holders (token-weighted governance)
+
+**Off-Chain Components:** None
+- Fully on-chain collateral management
+- No custodians or off-chain reserve management
+
+**Attestations/Audits for Off-Chain:** N/A
+
+### Provability
+
+**Reserve Verification:** Easy
+- All reserves on-chain and publicly verifiable
+- Contract: `RToken.basketsNeeded()` / `RToken.totalSupply()` = backing ratio
+- Should equal 1.0 for full collateralization
+- View functions allow real-time verification
+
+**Yield Calculation:** Transparent
+- Yield accrues automatically from underlying LSTs
+- ETH+ becomes worth more of the basket over time
+- Fully calculable on-chain via basket composition and LST exchange rates
+
+**On-Chain Reporting:** Programmatic
+- No admin-controlled exchange rate
+- Rate determined by: basket value / total supply
+- Oracles provide collateral prices (Chainlink primarily)
+- Anyone can call refresh functions to update basket status
+
+**Off-Chain Reserves:** None
+- 100% on-chain reserves
+- No exchange accounts or custody wallets
+
+**Merkle Proofs:** N/A (fully on-chain)
+
+**Attestation Frequency:** Real-time
+- On-chain state updated with each transaction
+- Oracle prices updated per Chainlink feed schedules
+- No periodic reporting needed
+
+**Third-Party Verification:**
+- Chainlink Price Feeds for collateral valuation
+- Independent blockchain verification
+- LlamaRisk provides ongoing analysis
+
+## Liquidity Risk
+
+**Exit Liquidity:** Good
+
+**On-Chain Liquidity:**
+- Primary liquidity on Curve (ETH+/WETH pool)
+- Secondary liquidity on Balancer
+- Current DEX liquidity: ~$5M across pools
+- Direct redemption available as alternative exit
+
+**Slippage Analysis:**
+- <$100k: Minimal slippage (<0.5%) via direct redemption
+- $100k-$1M: Low slippage (0.5-2%) via redemption or DEX
+- >$1M: May require redemption + selling basket components
+
+**Redemption Mechanism:** Hybrid
+- Primary: Direct 1:1 redemption with basket collateral
+- Secondary: DEX trading for convenience
+- Best for large holders: Direct redemption for basket, sell components
+
+**Withdrawal Restrictions:**
+- Throttle mechanism limits hourly redemption volume
+- Typical throttle allows ~5-10% of supply per hour
+- Large exits may require multiple hours or days
+- No fixed cooldown periods
+
+**Historical Liquidity:**
+- Maintained adequate liquidity during market stress
+- March 2024 volatility: Redemptions processed smoothly
+- No liquidity crisis events
+
+**Large Holder Impact:**
+- Holders with >1% supply should plan redemptions in advance
+- Direct redemption minimizes price impact
+- DEX route only suitable for smaller amounts
+
+## Centralization & Control Risks
+
+### Governance
+
+**Contract Upgradeability:** Yes - Upgradable
+- RToken implementation can be upgraded
+- Collateral plugins can be changed
+- Basket composition can be modified
+
+**Governance Structure:**
+- Owner: Reserve Governor Anastasius (StRSR token voting)
+- Timelock: 3 days (after governance approval)
+- Voting: StRSR (staked RSR) holders vote on proposals
+- Quorum: Required for proposal passage
+
+**Multisig/Timelock:**
+- Timelock contract: [0x5f4A10aE2fF68bE3cdA7d7FB432b10C6BFA6457B](https://etherscan.io/address/0x5f4A10aE2fF68bE3cdA7d7FB432b10C6BFA6457B)
+- 3-day delay from approval to execution (259,200 seconds)
+- Allows RToken holders time to exit before changes
+
+**Privileged Roles:**
+- **Owner:** Can upgrade contracts, change basket, modify parameters
+- **Pauser:** Can pause issuance/redemption (emergency)
+- **Short Freezer:** Can freeze system for 6 hours
+- **Long Freezer:** Can freeze system for extended periods
+- **Guardian:** Can veto governance proposals
+
+**Powers Analysis:**
+- Governance cannot seize user funds directly
+- Can modify basket (changes what users redeem for)
+- Can upgrade contracts (introduces code risk)
+- Emergency roles can pause operations
+- 3-day timelock provides exit window
+
+**Risk Assessment:** Medium
+- Timelock provides protection but shorter than ideal
+- Decentralized StRSR governance
+- Emergency roles add some centralization
+- Governance changes are transparent
+
+### Programmability
+
+**System Programmability:** Highly Programmatic
+
+Reserve Protocol operations are largely automated:
+- Basket valuation: Calculated on-chain via oracle prices
+- Collateral monitoring: Automated default detection
+- Rebalancing: Automated trading during basket changes
+- Redemptions: Fully programmatic, no admin intervention
+
+**Non-Programmatic Elements:**
+- Basket composition: Set by governance, not algorithmic
+- Oracle address configuration: Governance-controlled
+- Parameter tuning: Governance sets throttles, delays, etc.
+
+**PPS Definition:** On-chain
+- PPS = basket value / total supply
+- Calculated programmatically from oracle prices
+- No off-chain accounting
+
+**Oracle Upgradeability:** Yes
+- Each collateral plugin has oracle address
+- Governance can change oracle addresses
+- Currently using Chainlink feeds (most reliable)
+- Oracle changes go through 3-day timelock
+
+**Off-Chain Dependencies:**
+- Keeper bots: Not critical, anyone can call public functions
+- Governance frontend: Users can interact directly with contracts
+- Oracle data providers: Chainlink (decentralized oracle network)
+
+### External Dependencies
+
+**Protocol Dependencies:**
+
+1. **Chainlink Oracles (Critical)**
+   - Used for collateral price feeds
+   - Failure would prevent accurate basket valuation
+   - Multiple independent feeds for redundancy
+   - Fallback: Manual oracle update by governance
+
+2. **Underlying LST Protocols (Critical)**
+   - wstETH (Lido) - Blue chip, highly decentralized
+   - rETH (Rocket Pool) - Decentralized node operators
+   - sfrxETH (Frax) - Established protocol
+   - ETHx (Stader) - Smaller but audited
+
+3. **Ethereum Mainnet**
+   - Full dependency on Ethereum L1
+   - No cross-chain risk
+
+**Dependency Criticality:**
+- LST protocol exploit: Would trigger default, RSR covers losses
+- Chainlink failure: Could freeze accurate pricing temporarily
+- No single point of failure in LST basket (diversified)
+
+**Fallback Mechanisms:**
+- Collateral default handling: Automatic auctions + RSR recapitalization
+- Emergency collateral (WETH) as fallback
+- Governance can replace failed collateral
+
+**Protocol Positions:** Yes
+- Holds LST tokens as collateral
+- Each LST represents staked ETH position
+- Indirect exposure to validator risks
+
+**Cross-Chain Dependencies:** None
+- Fully Ethereum mainnet
+- No bridge risks
+
+**Infrastructure Dependencies:**
+- RPC nodes: Standard Ethereum dependency
+- Indexers/APIs: Used by frontends, not protocol-critical
+- Reserve UI: Convenient but not required
+
+## Operational Risk
+
+**Team Transparency:**
+- Reserve team is public and doxxed
+- Core team members have known identities
+- Regular public communication
+
+**Documentation Quality:**
+- Excellent technical documentation
+- Clear explanation of mechanisms
+- Well-maintained and up-to-date
+- Developer resources available
+
+**Communication Channels:**
+- Discord: Active, responsive team
+- Twitter: @reserve_currency
+- Forum: discourse.reserve.org
+- GitHub: Public repositories
+
+**Development Activity:**
+- Active ongoing development
+- Regular protocol improvements
+- Security patches deployed promptly
+- Transparent development process
+
+**Community Engagement:**
+- Active Discord community (~5k+ members)
+- Regular governance participation
+- Multiple RTokens deployed by community
+- Strong educational resources
+
+**Legal Structure:**
+- Reserve protocol developed by Reserve Labs (company)
+- Foundation structure for decentralization
+- Jurisdiction: International team
+- Regulatory engagement for stablecoin compliance
+
+**Incident Response:**
+- Bug bounty program indicates preparedness
+- Emergency pause mechanisms in place
+- Clear security contact (security@reserve.org)
+- Past minor issues handled professionally
+
+## Monitoring
+
+**Critical Monitoring Requirements:**
+
+### 1. Governance Monitoring (MANDATORY)
+- **Timelock Contract:** [0x5f4A10aE2fF68bE3cdA7d7FB432b10C6BFA6457B](https://etherscan.io/address/0x5f4A10aE2fF68bE3cdA7d7FB432b10C6BFA6457B)
+- **Timelock Delay:** 3 days (259,200 seconds)
+- Monitor events: `CallScheduled`, `CallExecuted`, `Cancelled`
+- Monitor function calls: `schedule()`, `execute()`, `cancel()`
+- **Action:** Add to [Yearn monitoring scripts](https://github.com/yearn/monitoring-scripts-py)
+- **Frequency:** Hourly checks
+- **Alerts:** Telegram SAM bot (@sam_alerter_bot)
+
+### 2. Backing/Collateralization Monitoring (MANDATORY)
+- **RToken Contract:** [0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8](https://etherscan.io/address/0xE72B141DF173b999AE7c1aDcbF60Cc9833Ce56a8)
+- Monitor ratio: `basketsNeeded / totalSupply` (should be >1.0)
+
+### 3. RSR Exchange Rate Monitoring
+- **StRSR Contract:** [0xffa151Ad0A0e2e40F39f9e5E9F87cF9E45e819dd](https://etherscan.io/address/0xffa151Ad0A0e2e40F39f9e5E9F87cF9E45e819dd)
+- Monitor function: `exchangeRate()`
+- Falling exchange rate indicates RSR being seized (default scenario)
+- Alert on any drop in exchange rate
+
+### 4. Emergency Role Monitoring
+- Monitor Timelock contract for queued calls
+
+### 5. Basket Composition Changes
+- Monitor collateral composition changes
+
+**Monitoring Implementation:**
+1. Open PR in [Yearn monitoring repository](https://github.com/yearn/monitoring-scripts-py)
+2. Add addresses to Safe monitoring (if applicable)
+3. Set up Tenderly alerts for timelock
+4. Create Telegram group: "Reserve-ETH+-Monitoring"
+5. Invite SAM bot: @sam_alerter_bot
+6. Configure GitHub Actions: Hourly workflow for critical checks
+
+## Risk Summary
+
+### Key Findings
+
+**Critical Risks Identified:**
+1. **Governance Risk** - 3-day timelock provides protection but upgradable contracts introduce code risk; timelock on the edge of acceptable threshold
+2. **Multiple Dependencies** - Relies on 5 external protocols (Chainlink + 4 LSTs) for critical functionality; 50% concentration in Lido wstETH
+3. **Oracle Dependency** - Critical reliance on Chainlink for accurate pricing; oracle failures could impact system
+
+**Key Strengths:**
+1. **Strong Security** - $10M bug bounty, multiple audits, 2+ years without incidents
+2. **Full On-Chain Backing** - 100% transparent, verifiable reserves with direct redemption
+3. **Diversified Collateral** - Multiple LST providers reduces single-point-of-failure risk
+4. **Decentralized Governance** - StRSR token voting with 3-day timelock safeguard
+5. **Programmatic Operations** - Minimal trust, automated basket management
+
+### Recommendations
+
+**Risk Mitigation Actions:**
+1. Monitor Lido wstETH exposure closely (50% concentration risk)
+2. Set up automated alerts for collateralization ratio
+3. Review all governance proposals during 3-day timelock period (note: shorter window requires prompt review)
+4. Maintain awareness of underlying LST protocol risks (Lido, Frax, Rocket Pool, Stader)
+
+**Ongoing Monitoring Requirements:**
+- **Hourly:** Collateralization ratio, RSR exchange rate
+- **Daily:** Collateral composition changes
+- **Real-time:** Timelock queued calls
+
+---
+
+## Risk Score Assessment
+
+### Critical Risk Gates Check
+
+**Auto-Fail Criteria (if ANY true, score = 5):**
+
+- [ ] No audit → **PASS** (Multiple audits, clean)
+- [ ] Unverifiable reserves → **PASS** (Fully on-chain, verifiable)
+- [ ] Total centralization (single EOA admin) → **PASS** (Decentralized governance with 3-day timelock)
+
+**Result:** Protocol passes all critical gates ✓
+
+---
+
+### Category Scoring (1-5 scale, 1 = safest)
+
+#### 1. Audits & Historical Track Record
+**Score: 1.5**
+
+**Audits:**
+- Multiple professional audits (Trail of Bits, Solidified, etc.) ✓
+- $10M bug bounty on Immunefi (>$1M threshold) ✓
+
+**Time in Production:**
+- 2.5+ years in production (>2 years) ✓
+- TVL ~$108M (>$100M threshold) ✓
+
+**Scoring per rubric:** Should be 1.0 (meets all criteria for top tier)
+**Adjustment:** +0.5 for moderate contract complexity
+**Final:** 1.5
+
+#### 2. Centralization & Control Risks
+**Score: 2.5**
+
+**Governance (using 1-5 rubric):**
+- Decentralized DAO (StRSR voting) ✓
+- 3-day timelock (meets >3 day threshold but just barely)
+- Privileged roles exist (Owner, Pauser, Freezer, Guardian) - constrained by timelock
+- Rubric Score 1-2 range: Has DAO and >3 day timelock (Score 1), but privileged roles push toward Score 2
+- **Subcategory Score: 2.0**
+
+**Programmability (using 1-5 rubric):**
+- Mostly programmatic with minor admin governance input ✓
+- On-chain PPS calculation with parameters ✓
+- Decentralized oracle (Chainlink), governance can change ✓
+- Matches Score 2 criteria exactly
+- **Subcategory Score: 2.0**
+
+**External Dependencies (using 1-5 rubric):**
+- Chainlink oracles (1 dependency, critical for pricing)
+- 4 LST protocols: Lido, Rocket Pool, Frax, Stader (critical for collateral)
+- Total: 5 dependencies on established/blue-chip protocols
+- All critical for core functionality
+- Rubric Score 3-4 range: Many dependencies (Score 4) but all blue-chip/established (mitigating)
+- **Subcategory Score: 3.0**
+
+**Category Average: (2.0 + 2.0 + 3.0) / 3 = 2.33 ≈ 2.5**
+
+#### 3. Funds Management (Collateralization + Provability)
+**Score: 1.5**
+
+- 100% on-chain collateral ✓
+- High-quality collateral (blue-chip LSTs) ✓
+- Real-time verifiability ✓
+- Direct 1:1 redemption ✓
+- RSR overcollateralization buffer ✓
+- Minor penalty: Delegated to other protocols (LSTs)
+
+#### 4. Liquidity Risk
+**Score: 2.0**
+
+- Direct redemption mechanism available ✓
+- Reasonable DEX liquidity (~$5M) ✓
+- Throttle mechanism limits large exits (+0.5)
+- Historically stable liquidity ✓
+- Large holders need multi-day exit planning (+0.5)
+
+#### 5. Operational Risk
+**Score: 1.5**
+
+**Team Transparency:**
+- Public, doxxed team with established reputation ✓
+- Rubric Score 1: Fully doxxed, established reputation
+
+**Documentation:**
+- Excellent, comprehensive documentation ✓
+- Rubric Score 1: Excellent, comprehensive
+
+**Legal/Compliance:**
+- Established legal structure (Reserve Labs + Foundation) ✓
+- Long-term protocol (2+ years) ✓
+- Minor concern: Some regulatory uncertainty around stablecoins
+- Rubric Score 1-2 range: Clear structure but some regulatory uncertainty
+
+**Category Average: (1.0 + 1.0 + 2.0) / 3 = 1.33 ≈ 1.5**
+
+---
+
+### Weighted Final Score
+
+**Category Weights:**
+- Centralization & Control: 30%
+- Funds Management: 30%
+- Audits + Historical: 20%
+- Liquidity: 15%
+- Operational: 5%
+
+**Calculation:**
+```
+Final Score = (2.5 × 0.30) + (1.5 × 0.30) + (1.5 × 0.20) + (2.0 × 0.15) + (1.5 × 0.05)
+            = 0.75 + 0.45 + 0.30 + 0.30 + 0.075
+            = 1.875
+            ≈ 1.9
+```
+
+---
+
+## Overall Risk Score: **1.9 / 5.0**
+
+### Risk Tier: **LOW RISK**
+
+**Interpretation:**
+ETH+ (Reserve Protocol) represents a low-risk protocol suitable for integration with Yearn vaults. The protocol demonstrates strong technical security, transparent on-chain operations, and decentralized governance. The 3-day timelock provides adequate protection for users to exit before governance changes, though a longer delay would be preferable. Main risks are manageable and relate to external dependencies (Chainlink oracles, underlying LST protocols) and governance upgradeability.
+
+**Risk Tier Definitions:**
+- **1.0-1.5**: Minimal Risk (Blue chip protocols)
+- **1.5-2.5**: Low Risk (Established protocols) ← **ETH+ is here**
+- **2.5-3.5**: Medium Risk (Requires monitoring)
+- **3.5-4.5**: Elevated Risk (Limited exposure)
+- **4.5-5.0**: High Risk (Not recommended)
+
+**Recommendation:** ✅ **APPROVED** for Yearn integration with standard monitoring in place.

--- a/src/components/pages/curation/reports/resolv-rlp.md
+++ b/src/components/pages/curation/reports/resolv-rlp.md
@@ -1,0 +1,423 @@
+# Protocol Risk Assessment: Resolv RLP
+
+- **Assessment Date:** February 8, 2026
+- **Token:** RLP (Resolv Liquidity Pool)
+- **Chain:** Ethereum (primary), multi-chain (Base, BNB, Berachain, Arbitrum, HyperEVM, Soneium, TAC, Plasma)
+- **Token Address:** [`0x4956b52aE2fF65D74CA2d61207523288e4528f96`](https://etherscan.io/address/0x4956b52aE2fF65D74CA2d61207523288e4528f96)
+- **Final Score: 2.9/5.0**
+
+## Overview + Links
+
+Resolv is a protocol maintaining USR, a stablecoin pegged to the US Dollar, backed by a delta-neutral strategy using ETH, BTC, and stablecoins. The protocol hedges spot crypto holdings with short perpetual futures positions to create a market-neutral portfolio.
+
+**RLP (Resolv Liquidity Pool)** is the junior/insurance tranche of the Resolv system. It serves as a leveraged yield product that absorbs all residual risks of the delta-neutral strategy (counterparty risk, funding rate volatility, CEX exposure) to protect USR holders. In exchange for providing this protection layer, RLP holders receive a risk premium on top of their pro-rata share of base yield, resulting in higher returns with embedded leverage. RLP's price is variable and can go up or down.
+
+**Yield sources:**
+1. **Perpetual Futures Funding Rates** -- Historically positive, providing steady income from short positions
+2. **Staking Rewards** -- On-chain assets (stETH, etc.) are staked for additional yield
+3. **Risk Premium** -- RLP receives an additional allocation (currently 13.5% of net yield) exclusively as compensation for risk absorption
+
+**Key metrics (Feb 8, 2026):**
+- RLP TVL: ~$140.8M ([CoinGecko](https://www.coingecko.com/en/coins/resolv-rlp))
+- RLP Price: ~$1.28
+- RLP Supply: ~109.7M tokens
+- RLP APY: ~6.45% ([DeFiLlama](https://defillama.com/protocol/resolv))
+- USR Market Cap: ~$355.7M
+- Total Protocol TVL: ~$494.8M (Ethereum)
+
+**Links:**
+
+- [Protocol Documentation](https://docs.resolv.xyz/litepaper/)
+- [Protocol App](https://app.resolv.xyz/)
+- [Collateral Pool Dashboard](https://app.resolv.xyz/collateral-pool)
+- [Apostro Proof of Reserves](https://info.apostro.xyz/resolv-reserves)
+- [GitHub](https://github.com/resolv-im/resolv-contracts-public)
+- [Security / Audits](https://docs.resolv.xyz/litepaper/resources/security)
+- [Immunefi Bug Bounty](https://immunefi.com/bug-bounty/resolv/information/)
+- [DeFiLlama](https://defillama.com/protocol/resolv)
+
+## Contract Addresses
+
+### Core Tokens (Ethereum)
+
+| Contract | Address |
+|----------|---------|
+| USR (Stablecoin) | [`0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110`](https://etherscan.io/address/0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110) |
+| RLP (Liquidity Pool) | [`0x4956b52aE2fF65D74CA2d61207523288e4528f96`](https://etherscan.io/address/0x4956b52aE2fF65D74CA2d61207523288e4528f96) |
+| stUSR (Staked USR) | [`0x6c8984bc7DBBeDAf4F6b2FD766f16eBB7d10AAb4`](https://etherscan.io/address/0x6c8984bc7DBBeDAf4F6b2FD766f16eBB7d10AAb4) |
+| wstUSR (Wrapped Staked USR) | [`0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055`](https://etherscan.io/address/0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055) |
+| RESOLV (Governance Token) | [`0x259338656198eC7A76c729514D3CB45Dfbf768A1`](https://etherscan.io/address/0x259338656198eC7A76c729514D3CB45Dfbf768A1) |
+| stRESOLV (Staked Governance) | [`0xfe4bce4b3949c35fb17691d8b03c3cadbe2e5e23`](https://etherscan.io/address/0xfe4bce4b3949c35fb17691d8b03c3cadbe2e5e23) |
+
+### Protocol Infrastructure (Ethereum)
+
+| Contract | Address |
+|----------|---------|
+| USR Requests Manager | [`0xAC85eF29192487E0a109b7f9E40C267a9ea95f2e`](https://etherscan.io/address/0xAC85eF29192487E0a109b7f9E40C267a9ea95f2e) |
+| RLP Requests Manager | [`0x10f4d4EAd6Bcd4de7849898403d88528e3Dfc872`](https://etherscan.io/address/0x10f4d4EAd6Bcd4de7849898403d88528e3Dfc872) |
+| USR Counter | [`0xa27a69Ae180e202fDe5D38189a3F24Fe24E55861`](https://etherscan.io/address/0xa27a69Ae180e202fDe5D38189a3F24Fe24E55861) |
+| RLP Counter | [`0xc7ab90c2ea9271efb31f5fa2843eeb4b331eafa0`](https://etherscan.io/address/0xc7ab90c2ea9271efb31f5fa2843eeb4b331eafa0) |
+| Whitelist | [`0x5943026E21E3936538620ba27e01525bBA311255`](https://etherscan.io/address/0x5943026E21E3936538620ba27e01525bBA311255) |
+| RewardDistributor | [`0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9`](https://etherscan.io/address/0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9) |
+| Fee Collector | [`0x6E02e225329E32c854178d7c865cF70fE1617f02`](https://etherscan.io/address/0x6E02e225329E32c854178d7c865cF70fE1617f02) |
+
+### Custodial / Treasury Wallets
+
+| Wallet | Address |
+|--------|---------|
+| Treasury | [`0xacb7027f271b03b502d65feba617a0d817d62b8e`](https://etherscan.io/address/0xacb7027f271b03b502d65feba617a0d817d62b8e) |
+| Fireblocks (Deribit) | [`0x22062B644aADD7e7Bb11e58C37BC1b022f4Ec3aC`](https://etherscan.io/address/0x22062B644aADD7e7Bb11e58C37BC1b022f4Ec3aC) |
+| Fireblocks (Bybit) | [`0x2a144e059cd8a8200298976ce55e8938f33b1d3b`](https://etherscan.io/address/0x2a144e059cd8a8200298976ce55e8938f33b1d3b) |
+
+## Audits and Due Diligence Disclosures
+
+Resolv has undergone extensive auditing with 4 audit firms across 14+ audit engagements since May 2024. All 19 audit report links have been verified as accessible.
+
+### Audit Firms: MixBytes, Pashov Audit Group, Sherlock, Pessimistic
+
+| # | Date | Scope | Firms | Reports |
+|---|------|-------|-------|---------|
+| 1 | May-Jun 2024 | USR/RLP tokens, stUSR, Whitelist, Request Managers, RewardDistributor | MixBytes, Pessimistic | [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/stUSR), [Pessimistic](https://github.com/pessimistic-io/audits/blob/main/Resolv%20Security%20Analysis%20by%20Pessimistic.pdf) |
+| 2 | Jul-Aug 2024 | wstUSR | Pashov, Pessimistic | [Pashov](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review.pdf), [Pessimistic](https://github.com/pessimistic-io/audits/blob/main/Resolv%20WstUSR%20Security%20Analysis%20by%20Pessimistic.pdf) |
+| 3 | Aug-Sep 2024 | Treasury, AaveV3 Connector, Lido Connector, Request Managers | Pashov, MixBytes | [Pashov](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review-August.pdf), [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/Treasury) |
+| 4 | Oct 2024 | Treasury, Dinero Connector | Pashov | [Pashov](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review-October.pdf) |
+| 5 | Nov 2024 | **Full Core Protocol** (all major contracts) | **Sherlock** | [Sherlock](https://github.com/sherlock-protocol/sherlock-reports/blob/main/audits/2024.12.02%20-%20Final%20-%20Resolv%20Core%20Audit%20Report.pdf) |
+| 6 | Dec 2024 | TheCounter, RlpPriceStorage, ExternalRequestsManager, UsrRedemptionExtension | Pashov | [Pashov](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review_2024-12-09.pdf) |
+| 7 | Dec 2024 | LidoTreasuryExtension | MixBytes | [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/Treasury%20Extension) |
+| 8 | Dec 2024 | RlpPriceStorage, UsrPriceStorage, UsrRedemptionExtension | MixBytes | [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/PoR%20Oracles) |
+| 9 | Mar 2025 | TreasuryIntermediateEscrow | MixBytes | [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/Treasury%20Escrow) |
+| 10 | Apr-May 2025 | ResolvStaking, RewardDistributor with dripper | Pashov | [Pashov (Apr)](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review_2025-04-15.pdf), [Pashov (May)](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review_2025-05-14.pdf) |
+| 11 | Jul 2025 | RlpUpOnlyPriceStorage, Multicall | MixBytes | [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/Utils) |
+| 12 | Jul 2025 | EtherFiTreasuryExtension | MixBytes | [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/Treasury%20EtherFI%20Extension) |
+| 13 | Jul-Aug 2025 | ResolvStakingV2 | Pashov, MixBytes | [Pashov](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review_2025-07-25.pdf), [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/Staking) |
+| 14 | Jan 2026 | ExternalRequestsCoordinator | MixBytes | [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/ExternalRequestsCoordinator) |
+
+### Bug Bounty
+
+- **Platform**: [Immunefi](https://immunefi.com/bug-bounty/resolv/information/)
+- **Maximum Bounty**: $500,000
+- **Critical Reward**: 10% of funds at risk, up to $500K (minimum $100K guaranteed)
+- **High Reward**: $50,000 - $100,000
+- **Medium Reward**: $5,000
+- **Program Type**: Primacy of Impact
+
+**Known acknowledged issue**: An arbitrage opportunity exists in the stUSR contract where users can borrow, stake USR before reward distribution, and withdraw quickly. The team is aware and actively working on a fix.
+
+## Historical Track Record
+
+- **Production History**: Protocol launched publicly in September 2024. In production for ~17 months.
+- **TVL Growth**: From ~$9.3M at launch (Sep 2024) to ~$494.8M (Feb 2026). Significant growth.
+- **USR Supply**: ~354M ($354M circulating), peaked at ~$403M the previous week.
+- **RLP Supply**: ~109.7M tokens (~$140.8M market cap)
+- **Incidents**: No reported security incidents, exploits, or hacks found on Rekt News or DeFi Llama hacks database.
+- **Peg Stability**: USR trading at ~$0.9998, maintaining close to $1 peg.
+- **Historical Yield**: Median annual performance of delta-neutral strategy: 8.4%, with 99% of results in the 7-10% p.a. range.
+
+## Funds Management
+
+The protocol acts as a delta-neutral asset manager. User deposits are deployed into a hedged portfolio combining spot crypto holdings with short perpetual futures positions.
+
+### Collateral Pool Composition (Resolv Asset Cluster Architecture)
+
+1. **Delta-Neutral ETH/BTC**: Core yield source. Spot ETH/BTC hedged with short perps on Binance, Deribit, Bybit, and Hyperliquid
+2. **USD DeFi Allocations**: Dollar-denominated DeFi lending/money market exposure (Aave, Fluid)
+3. **Delta-Neutral Altcoins**: Higher-yield via delta-neutral structures with explicit sizing and risk limits
+4. **Real-World Assets (RWAs)**: Superstate's USCC crypto-carry fund and Aave Horizon RWA instance
+
+### Risk Hierarchy
+
+Losses are allocated entirely to RLP holders. No losses flow to USR holders unless RLP is fully depleted:
+1. RLP absorbs **all** losses first
+2. USR holders are protected as long as RLP coverage exists
+3. If RLP reaches zero, USR still redeemable for $1 but without insurance layer
+
+### Accessibility
+
+- **Minting RLP**: Deposit USDC, USDT, or ETH via `requestMint()` on the `LPExternalRequestsManager`. Minting takes ~1 minute (1-5 blocks). 0% minting fees (currently waived). Backend (`SERVICE_ROLE`) calls `completeMint()` with the mint amount determined off-chain based on current RLP price.
+- **Redeeming RLP**: Uses an **epoch-based batch burn system** (unique to RLP, not shared with USR or wstUSR):
+  1. User calls `requestBurn()` -- RLP tokens are transferred to the contract
+  2. Backend calls `processBurns()` -- groups burn requests into an epoch for batch processing
+  3. Backend calls `completeBurns()` -- determines withdrawal collateral amounts off-chain, supports partial completion across multiple epochs
+  4. User calls `withdrawAvailableCollateral()` -- claims accumulated collateral (USDC/USDT/ETH)
+  - Processed within 24 hours under normal conditions. 0% redemption fees (currently waived).
+  - **No on-chain slippage protection**: Unlike USR burn requests, RLP `requestBurn()` has no `minWithdrawalAmount` parameter.
+  - **No instant redeem**: RLP has no equivalent to USR's `UsrRedemptionExtension` instant redeem function.
+- **Access Control**: Minting/redeeming requires **allowlisted wallets** (users must apply and be verified by Resolv Digital Assets Ltd).
+- **RLP Redemption Gate**: Redemption of RLP is **suspended** if USR Collateralization Ratio (CR) falls below 110%.
+
+### Collateralization
+
+- **Backing**: USR is >100% collateralized. The excess collateral above 100% backs RLP.
+- **On-chain portion**: Majority of collateral held on-chain in protocol smart contract wallets
+- **Off-chain portion**: A portion held with institutional custodians (Fireblocks, Ceffu) as margin for futures positions
+- **Exchange exposure**: As of H2 2025, exchange-related positions contribute less than 15% of collateral pool exposure combined
+- **Collateral quality**: ETH, BTC, stETH, wstETH, stablecoins (USDC, USDT), RWAs (USCC)
+
+### Provability
+
+- **Self-reporting**: Resolv's own collateral pool dashboard at [app.resolv.xyz/collateral-pool](https://app.resolv.xyz/collateral-pool)
+- **Third-party verification**: [Apostro risk curators](https://info.apostro.xyz/resolv-reserves) provide independent proof-of-reserves dashboard showing market delta, RLP/USR ratio, overcollateralization ratio, exposure by asset, and backing assets by location
+- **RLP Price**: Updated every 24 hours based on collateral pool valuation. Calculated and published by Resolv (centralized update).
+- **Oracle feeds**: Pyth (fundamental & market), Chainlink, Chronicle, RedStone for USR. Pyth and Resolv's own oracle for RLP price.
+- **On-chain monitoring**: Continuous monitoring of smart contracts and integrated protocols
+
+## Liquidity Risk
+
+- **Exit Mechanism**: RLP can be redeemed at its current price (variable, ~$1.28) within 24 hours for USDC/USDT/ETH. No withdrawal queues under normal conditions.
+- **Redemption Gate**: RLP redemptions are **suspended** if USR Collateralization Ratio drops below 110%. This protects USR holders at the expense of RLP holders' liquidity.
+- **DEX Liquidity**: RLP available on Curve (Ethereum), Uniswap (Ethereum), Aerodrome (Base). TODO: Exact on-chain liquidity depth needs verification.
+- **RLP Trading Volume**: 7days on [Fluid Dex](https://fluid.io/stats/1/dex) is $8.5M.
+- **Bridge**: LayerZero OFT standard enables cross-chain transfers via Stargate.
+- **Multi-chain availability**: RLP deployed on 9 chains, with Ethereum as the primary (minting/redeeming only on Ethereum).
+- **Stress scenario**: In a mass redemption event, the 110% CR gate would suspend RLP redemptions, locking RLP holders while USR holders can still exit.
+
+## Centralization & Control Risks
+
+### Governance
+
+- **Multisig**: All core contracts are controlled by a **3-of-5 Gnosis Safe** at [`0xd6889f307be1b83bb355d5da7d4478fb0d2af547`](https://etherscan.io/address/0xd6889f307be1b83bb355d5da7d4478fb0d2af547). The Safe is `owner()` and `DEFAULT_ADMIN_ROLE` holder for USR, RLP, Treasury, Request Managers, RewardDistributor, and Whitelist. Nonce 366+ indicates significant operational activity. All 5 signers are EOAs (not publicly identified).
+- **Timelock**: A 3-day OpenZeppelin `TimelockController` at [`0x290d9544669c9c7a64f6899a0a3b28d563f6ebee`](https://etherscan.io/address/0x290d9544669c9c7a64f6899a0a3b28d563f6ebee) owns all ProxyAdmin contracts. Contract upgrades require a 3-day delay. The Safe is the sole proposer/executor on the timelock.
+- **Split architecture**: The multisig controls **operational parameters directly** (no delay) -- pausing, role grants, parameter changes, price updates. The timelock only gates **proxy upgrades** (implementation changes).
+- **On-chain governance not yet live**: The stRESOLV token exists but Snapshot voting has not been initiated.
+- **RDAL discretion**: From the Terms of Service, RDAL has **full discretion** over collateral pool composition and strategy parameters.
+- **Whitelist control**: RDAL controls who can mint/redeem by managing the address whitelist.
+
+### Programmability
+
+- **Hybrid Model**: The system is semi-programmatic. Smart contracts handle token operations (mint/burn requests), but a **backend system** completes mint/redeem operations via `completeMint` / `completeBurn` calls.
+- **RLP Price**: Updated by a privileged role every 24 hours. Not calculated algorithmically on-chain.
+- **Reward Distribution**: Rewards are distributed every 24 hours (epoch-based) by the protocol, not automatically by smart contracts.
+- **Collateral management**: Active management of hedging positions and collateral deployment by the team (off-chain).
+- **Oracle updates**: Resolv's own fundamental price oracles for USR and RLP are updated centrally every 24 hours.
+
+### External Dependencies
+
+- **CEX Dependencies (Critical)**: Binance (via Ceffu custody), Deribit (via Fireblocks), Bybit (via Fireblocks) for hedging futures positions. A CEX failure would directly impact the collateral pool, with losses absorbed by RLP.
+- **DEX Dependencies**: Hyperliquid for additional hedging positions.
+- **Custodians**: Fireblocks (Deribit, Bybit wallets), Ceffu (Binance omnibus wallet). These hold off-exchange margin.
+- **Oracles**: Pyth (primary for minting/redeeming), Chainlink, Chronicle, RedStone for market pricing.
+- **DeFi integrations**: Aave v3 (ETH borrowing), Lido (stETH), EtherFi (weETH), potentially Fluid.
+- **Bridge**: LayerZero for cross-chain token bridging.
+
+## Operational Risk
+
+- **Team Transparency**: Team is **not publicly doxxed** on the website or docs. No /about or /team page exists. GitHub organization (`resolv-im`) has a single contributor label (`resolv-labs`). However, CoinGecko lists team members: Ivan Kozlov (CEO), Tim Shekikhachev (CPO), Fedor Chmilev (CTO) with LinkedIn and Twitter profiles.
+- **Company founded**: 2023 (Resolv Labs).
+- **Legal Structure**: Two BVI entities: **Resolv Labs Ltd** (frontend/app) and **Resolv Digital Assets Ltd (RDAL)** (token issuance, collateral pool). A **Resolv Foundation** manages protocol revenue and buybacks.
+- **Jurisdiction**: British Virgin Islands (BVI). Dispute resolution under BVI courts.
+- **U.S. access**: Restricted to Accredited Investors under Reg D Rule 501(a).
+- **Documentation**: Comprehensive litepaper available at [docs.resolv.xyz](https://docs.resolv.xyz/). Blog posts provide quarterly reports and parameter updates.
+- **Incident Response**: No documented incident response plan found in public documentation. Bug bounty and on-chain monitoring exist.
+- **Investors**: $10M seed round led by Cyber Fund and Maven 11. Other investors include Coinbase Ventures, Arrington Capital, Robot Ventures, Animoca Brands, Ether.fi.
+
+## Monitoring
+
+### Governance Monitoring
+
+- **Multisig activity**: Monitor the 3-of-5 Gnosis Safe [`0xd6889f307be1b83bb355d5da7d4478fb0d2af547`](https://etherscan.io/address/0xd6889f307be1b83bb355d5da7d4478fb0d2af547) for owner changes, threshold changes, and module additions
+- **Timelock proposals**: Monitor the TimelockController [`0x290d9544669c9c7a64f6899a0a3b28d563f6ebee`](https://etherscan.io/address/0x290d9544669c9c7a64f6899a0a3b28d563f6ebee) for `CallScheduled`, `CallExecuted`, and `Cancelled` events (3-day window to review proxy upgrades)
+- **Whitelist Changes**: Monitor the Whitelist contract [`0x5943026E21E3936538620ba27e01525bBA311255`](https://etherscan.io/address/0x5943026E21E3936538620ba27e01525bBA311255)
+
+### RLP Liquidity & Redemption Monitoring
+
+- **RLP Requests Manager**: [`0x10f4d4EAd6Bcd4de7849898403d88528e3Dfc872`](https://etherscan.io/address/0x10f4d4EAd6Bcd4de7849898403d88528e3Dfc872)
+  - Monitor `BurnRequestCreated` events -- tracks users requesting RLP redemptions
+  - Monitor `BurnRequestProcessed` events -- tracks when burn requests enter epoch processing
+  - Monitor `BurnRequestCompleted` events -- tracks when redemptions are fulfilled and at what price
+  - Monitor `BurnRequestCancelled` events -- tracks cancellations (may indicate dissatisfaction with processing times)
+  - Track pending burn requests in `CREATED` state vs. `PROCESSING` state to detect processing backlogs
+  - Alert if burn requests remain in `CREATED` state for >24 hours (indicates processing delays)
+- **RLP Price Changes**: Monitor the RLP Counter contract [`0xc7ab90c2ea9271efb31f5fa2843eeb4b331eafa0`](https://etherscan.io/address/0xc7ab90c2ea9271efb31f5fa2843eeb4b331eafa0) for price updates. Alert on >2% daily price drops (may signal collateral pool losses).
+- **Minting activity**: Monitor `MintRequestCompleted` events on RLP Requests Manager for net flow direction (net minting vs. net burning)
+
+### Collateral & Coverage Monitoring
+
+- **Collateral Pool**: Monitor collateral composition and delta neutrality at [Apostro dashboard](https://info.apostro.xyz/resolv-reserves) and [app.resolv.xyz/collateral-pool](https://app.resolv.xyz/collateral-pool)
+- **USR Collateralization Ratio**: Alert at <120% CR (approaching the 110% redemption gate threshold)
+- **RLP/USR coverage ratio**: Track total RLP value vs. USR supply. Alert if coverage drops below 20%
+- **TVL**: Monitor total USR supply and RLP market cap for coverage ratio changes
+- **Exchange exposure**: Monitor Apostro dashboard for changes in CEX margin ratios and delta exposure
+
+### Operational Monitoring
+
+- **Reward Distribution**: Monitor RewardDistributor [`0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9`](https://etherscan.io/address/0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9) for reward distribution events and yield changes
+- **Treasury flows**: Monitor Treasury [`0xacb7027f271b03b502d65feba617a0d817d62b8e`](https://etherscan.io/address/0xacb7027f271b03b502d65feba617a0d817d62b8e) for large outflows or unexpected transfers
+- **Recommended frequency**: Daily for price/TVL/redemptions; hourly during high volatility; real-time for governance/timelock events
+
+## Risk Summary
+
+### Key Strengths
+
+- **Extensive audit coverage**: 14+ audits by 4 reputable firms (including Sherlock contest), ongoing since May 2024
+- **Strong bug bounty**: $500K max on Immunefi with Primacy of Impact
+- **Third-party verification**: Apostro provides independent proof-of-reserves dashboard
+- **Risk segregation**: Clear tranche structure where RLP absorbs all losses before USR is affected
+- **Significant TVL**: ~$494.8M total protocol TVL, ~17 months in production with no security incidents
+- **Diversified collateral**: Multiple exchange venues, custodians, and asset clusters reduce single points of failure
+
+### Key Risks
+
+- **Centralized operations**: Backend processes minting/redeeming, RLP price updates are centralized (24h cycle), team has full discretion over collateral pool
+- **CEX counterparty risk**: Futures positions on Binance, Deribit, Bybit create counterparty exposure. A CEX failure directly impacts RLP value.
+- **Governance not yet live**: No on-chain governance. 3-of-5 multisig controls operations directly (no delay). 3-day timelock only for proxy upgrades. RDAL retains full discretion over collateral pool.
+- **RLP as first-loss capital**: By design, RLP absorbs all losses. Severe market events or exchange failures could significantly impair RLP value.
+- **Liquidity gate**: RLP redemptions are suspended below 110% CR -- in a stress scenario, RLP holders cannot exit while losses mount.
+- **Whitelisting requirement**: Not permissionless; access controlled by RDAL.
+
+### Critical Risks
+
+- **Operational parameters not timelocked**: While a 3-of-5 multisig exists and proxy upgrades have a 3-day timelock, operational parameters (pausing, role grants, price updates, whitelist changes) are controlled by the multisig **without any timelock delay**. This means 3 of 5 anonymous signers can immediately change critical operational parameters.
+- **RLP price is entirely off-chain**: The backend determines how much collateral to return for burned RLP with no on-chain price oracle or slippage protection in the contract. Users must trust the backend to apply fair pricing.
+
+---
+
+## Risk Score Assessment
+
+**Scoring Guidelines:**
+- Be conservative: when uncertain between two scores, choose the higher (riskier) one
+- Use decimals (e.g., 2.5) when a subcategory falls between scores
+- Prioritize on-chain evidence over documentation claims
+
+### Critical Risk Gates
+
+- [x] **No audit** -- Protocol has been audited by 4 reputable firms across 14+ engagements. **PASS**
+- [x] **Unverifiable reserves** -- Reserves verifiable via on-chain wallets and Apostro third-party dashboard. **PASS**
+- [x] **Total centralization** -- 3-of-5 Gnosis Safe multisig controls all contracts. 3-day timelock for proxy upgrades. Not a single EOA. **PASS**
+
+**All gates pass.** Proceed to category scoring.
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+- **Audits**: 4 audit firms (MixBytes, Pashov, Sherlock, Pessimistic), 14+ separate engagements covering all major contracts. Continuous auditing as new features are added. Sherlock contest for core protocol.
+- **Bug Bounty**: $500K max on Immunefi (Primacy of Impact) - strong.
+- **Time in Production**: ~17 months (Sep 2024 - Feb 2026).
+- **TVL**: ~$494.8M (>$100M threshold).
+- **Incidents**: None reported.
+
+**Score: 1.5/5** -- Exceptional audit coverage with 4 firms and 14+ audits. Strong bug bounty ($500K). >1 year production with >$100M TVL and no incidents. The volume of audits and continuous engagement is best-in-class.
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+**Subcategory A: Governance**
+
+- **3-of-5 Gnosis Safe** multisig ([`0xd6889...af547`](https://etherscan.io/address/0xd6889f307be1b83bb355d5da7d4478fb0d2af547)) is `owner()` and `DEFAULT_ADMIN_ROLE` for all core contracts.
+- **3-day OpenZeppelin TimelockController** ([`0x290d9...6ebee`](https://etherscan.io/address/0x290d9544669c9c7a64f6899a0a3b28d563f6ebee)) owns all ProxyAdmin contracts (upgrades only).
+- Operational parameters (pause, role grants, price updates, whitelist) controlled by multisig **directly with no timelock**.
+- No on-chain governance live yet. stRESOLV exists but voting not initiated.
+- RDAL has full discretion per Terms of Service.
+- All 5 signers are anonymous EOAs.
+
+**Governance Score: 3.5** -- 3/5 multisig with 3-day upgrade timelock is a meaningful improvement over EOA control, but operational parameters lack delay. Anonymous signers and no active governance reduce confidence. RDAL retains full discretion per ToS.
+
+**Subcategory B: Programmability**
+
+- Hybrid on-chain/off-chain operations. Smart contracts handle token accounting but backend completes operations.
+- RLP price updated off-chain every 24 hours by privileged role.
+- Reward distribution managed off-chain.
+- Collateral management is fully manual/off-chain.
+
+**Programmability Score: 4.0** -- Significant manual intervention required. Price and rewards are admin-controlled with 24h update cycles. Core financial decisions happen off-chain.
+
+**Subcategory C: External Dependencies**
+
+- 3 CEXes (Binance, Deribit, Bybit) + 1 DEX (Hyperliquid) for hedging
+- 2 institutional custodians (Fireblocks, Ceffu)
+- 4 oracle providers (Pyth, Chainlink, Chronicle, RedStone)
+- DeFi protocols (Aave, Lido, EtherFi)
+- LayerZero for bridging
+
+**Dependencies Score: 3.5** -- Multiple critical dependencies, but well-diversified across venues and custodians. CEX failure is the most acute risk but exposure has been reduced to <15% of collateral pool.
+
+**Centralization Score = (3.5 + 4.0 + 3.5) / 3 = 3.67**
+
+**Score: 3.7/5** -- Centralized operational control with multisig but no timelocked parameter changes. No active on-chain governance. Partially mitigated by upgrade timelock, diversified custodians, and exchange venues.
+
+#### Category 3: Funds Management (Weight: 30%)
+
+**Subcategory A: Collateralization**
+
+- USR >100% collateralized on-chain; excess backs RLP.
+- Collateral: ETH, BTC, stETH, stablecoins, RWAs -- mix of high-quality and newer assets.
+- Majority on-chain, ~15% CEX margin exposure.
+- **RLP is first-loss capital**: By design, RLP absorbs **all** losses from the delta-neutral strategy (funding rate losses, CEX counterparty failure, liquidation events) before any impact to USR. RLP price is variable and can decrease.
+- No on-chain slippage protection on RLP burns -- backend determines collateral return amounts off-chain.
+
+**Collateralization Score: 3.5** -- Verifiable on-chain collateral with third-party dashboard, but RLP is explicitly designed as loss-absorbing capital. Price is variable and can decrease. Mixing on-chain assets with off-chain futures margin and CEX exposure. Partially custodial. The first-loss tranche design means depositors face embedded structural risk beyond typical collateralization concerns.
+
+**Subcategory B: Provability**
+
+- Self-reporting dashboard + Apostro third-party verification.
+- RLP price calculated off-chain, updated by admin every 24 hours.
+- Multiple oracle sources for market pricing.
+- Exchange position data visible on Apostro dashboard.
+
+**Provability Score: 2.5** -- Good transparency with both self-reporting and third-party verification. However, fundamental price is admin-updated, not fully programmatic. Off-chain components (futures positions, custodial balances) require trust.
+
+**Funds Management Score = (3.5 + 2.5) / 2 = 3.0**
+
+**Score: 3.0/5** -- Verifiable collateral with third-party dashboard, but RLP is first-loss capital by design -- holders face embedded loss risk from the delta-neutral strategy. Hybrid on-chain/off-chain nature, admin-controlled pricing, and no on-chain slippage protection add further trust requirements.
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+- **Exit Mechanism**: RLP redeemable within 24 hours at current price. No withdrawal queue under normal conditions.
+- **Liquidity Gate**: RLP redemptions suspended below 110% CR -- critical restriction that could lock RLP holders during stress.
+- **DEX liquidity**: Available on Curve, Uniswap, Aerodrome. TODO: Exact depth not verified.
+- **24h processing**: Not instant. Up to 24-hour delay is a moderate concern.
+- **Multi-chain**: Cross-chain liquidity fragmented across 9 chains.
+
+**Score: 3.0/5** -- 24h redemption delay, not instant. Redemption gate at 110% CR could lock RLP holders during the exact moments they most need to exit. DEX liquidity exists but depth unverified. Same-value redemption partially mitigates the time concern, but the gate mechanism adds significant risk.
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+- **Team**: Partially doxxed (CoinGecko lists CEO, CPO, CTO with LinkedIn/Twitter), but not prominently displayed on protocol website/docs.
+- **Documentation**: Comprehensive litepaper and quarterly reports. Good transparency on yield distribution parameters.
+- **Legal Structure**: Two BVI entities + Foundation. BVI jurisdiction.
+- **Investors**: Strong investor base (Coinbase Ventures, Maven 11, Cyber Fund, etc.) with $10M seed.
+- **Incident Response**: No documented plan found.
+
+**Score: 2.5/5** -- Team partially identifiable via CoinGecko, strong investors, good documentation. Weakened by BVI jurisdiction, lack of documented incident response plan, and no prominent team disclosure.
+
+### Final Score Calculation
+
+```
+Final Score = (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Audits × 0.20) + (Liquidity × 0.15) + (Operational × 0.05)
+```
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 1.5 | 20% | 0.30 |
+| Centralization & Control | 3.7 | 30% | 1.11 |
+| Funds Management | 3.0 | 30% | 0.90 |
+| Liquidity Risk | 3.0 | 15% | 0.45 |
+| Operational Risk | 2.5 | 5% | 0.125 |
+| **Final Score** | | | **2.885** |
+
+**Final Score: 2.9**
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|------------|-----------|----------------|
+| **2.5-3.5** | **Medium Risk** | Approved with enhanced monitoring |
+
+**Final Risk Tier: Medium Risk**
+
+---
+
+RLP is a well-audited protocol with strong security practices but carries inherent structural risk as a **first-loss tranche** -- by design, RLP absorbs all losses from the delta-neutral strategy before USR is affected, meaning RLP price can decrease. A 3-of-5 Gnosis Safe multisig controls all contracts and a 3-day timelock gates proxy upgrades, but operational parameters remain untimelocked and no on-chain governance is live. In stress scenarios, RLP holders face both value impairment and potential liquidity lockout (110% CR gate). The RLP burn mechanism is epoch-based with no on-chain slippage protection, and pricing is entirely off-chain. These structural and centralization risks place RLP in the Medium Risk classification despite its strong audit and track record profile.
+
+**Key conditions for exposure:**
+- Enhanced monitoring of collateral pool composition and delta exposure via Apostro dashboard
+- Monitor for governance activation (stRESOLV voting)
+- Track RLP/USR coverage ratio; alert at <120%
+- Monitor multisig signer changes and timelock proposals
+
+---
+
+## Reassessment Triggers
+
+- **Time-based**: Reassess in 6 months (August 2026)
+- **Governance-based**: Reassess when on-chain governance is activated
+- **Incident-based**: Reassess after any exploit, governance change, CEX failure, or significant collateral modification

--- a/src/components/pages/curation/reports/resolv-wstusr.md
+++ b/src/components/pages/curation/reports/resolv-wstusr.md
@@ -1,0 +1,532 @@
+# Protocol Risk Assessment: Resolv wstUSR
+
+- **Assessment Date:** February 9, 2026
+- **Token:** wstUSR (Wrapped Staked USR)
+- **Chain:** Ethereum (primary), multi-chain (Arbitrum, Base)
+- **Token Address:** [`0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055`](https://etherscan.io/address/0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055)
+- **Final Score: 2.2/5.0**
+
+## Overview + Links
+
+Resolv is a protocol maintaining USR, a stablecoin pegged to the US Dollar, backed by a delta-neutral strategy using ETH, BTC, and stablecoins. The protocol hedges spot crypto holdings with short perpetual futures positions to create a market-neutral portfolio.
+
+**wstUSR (Wrapped Staked USR)** is the non-rebasing, DeFi-composable wrapper for stUSR (Staked USR). The token flow is:
+
+1. **USR** → User deposits USR into the **stUSR** contract → receives **stUSR** (a rebasing token whose balance grows as rewards accrue)
+2. **stUSR** → User wraps stUSR into the **wstUSR** contract → receives **wstUSR** (a non-rebasing ERC-4626 vault token whose price appreciates)
+3. Alternatively, users can deposit USR directly into **wstUSR** (which internally deposits into stUSR first)
+
+**wstUSR is analogous to Lido's wstETH**: it's a non-rebasing wrapper around a rebasing staked token. This makes it compatible with DeFi protocols (lending, AMMs) that don't support rebasing tokens natively.
+
+**Yield source**: The stUSR yield derives from the Resolv protocol's delta-neutral strategy profits. The **RewardDistributor** contract mints USR rewards and drips them into the stUSR contract, increasing the stUSR/USR exchange rate over time. Since wstUSR wraps stUSR, it captures the same yield through exchange rate appreciation.
+
+**Key metrics (Feb 9, 2026):**
+- wstUSR Price: ~$1.13 ([CoinGecko](https://www.coingecko.com/en/coins/resolv-wstusr))
+- wstUSR Market Cap: ~$344.8M
+- wstUSR Supply: ~305.1M tokens
+- wstUSR Exchange Rate: 1 wstUSR = ~1.1304 USR (on-chain `convertToAssets(1e18)`)
+- stUSR Total Supply: ~347.2M (rebased, in USR terms)
+- stUSR Staked in wstUSR: ~344.9M stUSR (99.3% of all stUSR is wrapped)
+- USR Backing stUSR: ~347.2M USR held by stUSR contract
+- USR Total Supply: ~350.7M
+- 24h Trading Volume: ~$2.6M
+- stUSR APY: ~7.36% (1-year price change of wstUSR per CoinGecko)
+- Total Protocol TVL: ~$447.8M (Ethereum, DeFiLlama)
+
+**Links:**
+
+- [Protocol Documentation](https://docs.resolv.xyz/litepaper/)
+- [Protocol App](https://app.resolv.xyz/)
+- [Collateral Pool Dashboard](https://app.resolv.xyz/collateral-pool)
+- [Apostro Proof of Reserves](https://info.apostro.xyz/resolv-reserves)
+- [GitHub](https://github.com/resolv-im/resolv-contracts-public)
+- [Security / Audits](https://docs.resolv.xyz/litepaper/resources/security)
+- [Immunefi Bug Bounty](https://immunefi.com/bug-bounty/resolv/information/)
+- [DeFiLlama](https://defillama.com/protocol/resolv)
+- [CoinGecko wstUSR](https://www.coingecko.com/en/coins/resolv-wstusr)
+
+## Contract Addresses
+
+### Core Token Contracts (Ethereum)
+
+| Contract | Address | Type |
+|----------|---------|------|
+| USR (Stablecoin) | [`0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110`](https://etherscan.io/address/0x66a1e37c9b0eaddca17d3662d6c05f4decf3e110) | ERC-20, Upgradeable Proxy |
+| stUSR (Staked USR) | [`0x6c8984bc7DBBeDAf4F6b2FD766f16eBB7d10AAb4`](https://etherscan.io/address/0x6c8984bc7DBBeDAf4F6b2FD766f16eBB7d10AAb4) | Rebasing ERC-20, Upgradeable Proxy |
+| wstUSR (Wrapped Staked USR) | [`0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055`](https://etherscan.io/address/0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055) | ERC-4626 Vault, Upgradeable Proxy |
+| RewardDistributor | [`0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9`](https://etherscan.io/address/0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9) | Non-proxy |
+
+### Proxy Implementation & Admin (Ethereum, verified on-chain)
+
+| Contract | Implementation | ProxyAdmin |
+|----------|---------------|------------|
+| stUSR | [`0xba1600735a039e2b3bf1d1d2f1a7f80f45973da7`](https://etherscan.io/address/0xba1600735a039e2b3bf1d1d2f1a7f80f45973da7) | [`0xeb88058615eaf3e4833af053484012c4d6cbfa37`](https://etherscan.io/address/0xeb88058615eaf3e4833af053484012c4d6cbfa37) |
+| wstUSR | [`0x6ed5485d079d7f0cfa8e395499b3c01a6c359cc0`](https://etherscan.io/address/0x6ed5485d079d7f0cfa8e395499b3c01a6c359cc0) | [`0xD89784610EefD4d11444788F7A85AaDfd57AF7E5`](https://etherscan.io/address/0xD89784610EefD4d11444788F7A85AaDfd57AF7E5) |
+
+### Cross-Chain Deployments
+
+| Chain | wstUSR Address |
+|-------|---------------|
+| Arbitrum | [`0x66cfbd79257dc5217903a36293120282548e2254`](https://arbiscan.io/address/0x66cfbd79257dc5217903a36293120282548e2254) |
+| Base | [`0xb67675158b412d53fe6b68946483ba920b135ba1`](https://basescan.org/address/0xb67675158b412d53fe6b68946483ba920b135ba1) |
+
+### Protocol Infrastructure (Ethereum)
+
+| Contract | Address |
+|----------|---------|
+| USR Requests Manager | [`0xAC85eF29192487E0a109b7f9E40C267a9ea95f2e`](https://etherscan.io/address/0xAC85eF29192487E0a109b7f9E40C267a9ea95f2e) |
+| USR Counter | [`0xa27a69Ae180e202fDe5D38189a3F24Fe24E55861`](https://etherscan.io/address/0xa27a69Ae180e202fDe5D38189a3F24Fe24E55861) |
+| Whitelist | [`0x5943026E21E3936538620ba27e01525bBA311255`](https://etherscan.io/address/0x5943026E21E3936538620ba27e01525bBA311255) |
+| Fee Collector | [`0x6E02e225329E32c854178d7c865cF70fE1617f02`](https://etherscan.io/address/0x6E02e225329E32c854178d7c865cF70fE1617f02) |
+| Gnosis Safe (3/5 multisig) | [`0xd6889f307be1b83bb355d5da7d4478fb0d2af547`](https://etherscan.io/address/0xd6889f307be1b83bb355d5da7d4478fb0d2af547) |
+| TimelockController (3-day) | [`0x290d9544669c9c7a64f6899a0a3b28d563f6ebee`](https://etherscan.io/address/0x290d9544669c9c7a64f6899a0a3b28d563f6ebee) |
+| Treasury | [`0xacb7027f271b03b502d65feba617a0d817d62b8e`](https://etherscan.io/address/0xacb7027f271b03b502d65feba617a0d817d62b8e) |
+
+## Audits and Due Diligence Disclosures
+
+Resolv has undergone extensive auditing with 4 audit firms across 14+ audit engagements since May 2024. **wstUSR and stUSR have been specifically audited** in dedicated engagements.
+
+### wstUSR/stUSR-Specific Audits
+
+| # | Date | Scope | Firm | Key Findings | Reports |
+|---|------|-------|------|-------------|---------|
+| 1 | May-Jun 2024 | USR, stUSR, Whitelist, Request Managers, RewardDistributor | MixBytes, Pessimistic | stUSR core design reviewed | [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/stUSR), [Pessimistic](https://github.com/pessimistic-io/audits/blob/main/Resolv%20Security%20Analysis%20by%20Pessimistic.pdf) |
+| 2 | Jul-Aug 2024 | **wstUSR** (dedicated) | Pashov, Pessimistic | 4 Medium + 3 Low (all resolved): rounding in unwrap, mintWithPermit wrong amount, previewWithdraw rounding, free withdraw via zero previewWithdraw, whale frontrunning rewards, EIP-4626 non-compliance, dust accumulation | [Pashov](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review.pdf), [Pessimistic](https://github.com/pessimistic-io/audits/blob/main/Resolv%20WstUSR%20Security%20Analysis%20by%20Pessimistic.pdf) |
+| 3 | Nov-Dec 2024 | **Full Core Protocol** (incl. wstUSR, stUSR) | Sherlock | 1 Medium: inflation attack on wstUSR deposits via stUSR share price manipulation (fixed via initial deposit mitigation + PR #222) | [Sherlock](https://github.com/sherlock-protocol/sherlock-reports/blob/main/audits/2024.12.02%20-%20Final%20-%20Resolv%20Core%20Audit%20Report.pdf) |
+| 4 | Apr-May 2025 | RewardDistributor with drip model (feeds stUSR) | Pashov | 1 Medium (withdraw bypass of claimEnabled), 2 Low (dripReward sandwiching, dust reward vesting) | [Pashov (Apr)](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review_2025-04-15.pdf), [Pashov (May)](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review_2025-05-14.pdf) |
+| 5 | Jul-Aug 2025 | ResolvStakingV2 | Pashov, MixBytes | 1 Critical (rewards stolen via self-transfer, resolved), 2 Low | [Pashov](https://github.com/pashov/audits/blob/master/team/pdf/Resolv-security-review_2025-07-25.pdf), [MixBytes](https://github.com/mixbytes/audits_public/tree/master/Resolv/Staking) |
+
+### Full Audit History
+
+The complete Resolv audit history covers 14+ engagements by MixBytes, Pashov Audit Group, Sherlock, and Pessimistic across all protocol contracts. See the [RLP risk assessment](rlp.md) for the complete audit table.
+
+### Bug Bounty
+
+- **Platform**: [Immunefi](https://immunefi.com/bug-bounty/resolv/information/)
+- **Maximum Bounty**: $500,000
+- **Critical Reward**: 10% of funds at risk, up to $500K (minimum $100K guaranteed)
+- **High Reward**: $50,000 - $100,000
+- **Medium Reward**: $5,000
+- **Program Type**: Primacy of Impact
+- **wstUSR/stUSR in scope**: Yes, both contracts are covered
+
+**Known acknowledged issues**:
+- Whale frontrunning of reward distribution (stUSR): A user can monitor the mempool for `dripReward` transactions, deposit USR into stUSR before rewards are distributed, and withdraw after to capture a portion. The team acknowledges this.
+- EIP-4626 partial non-compliance (wstUSR): `totalAssets()` returns `stUSR.totalSupply()` instead of USR managed specifically by wstUSR. Resolved in later versions.
+
+## Historical Track Record
+
+- **Production History**: stUSR and wstUSR launched alongside the core protocol in September 2024. In production for ~17 months.
+- **TVL Growth**: wstUSR market cap ~$344.8M. stUSR TVL ~$347M (DeFiLlama). The vast majority (99.3%) of stUSR is wrapped as wstUSR.
+- **Exchange Rate History**: wstUSR has appreciated from ~$1.00 (launch) to ~$1.13 (Feb 2026), representing ~13% cumulative yield. ATL was $0.59 (likely from low initial liquidity/launch pricing per CoinGecko). ATH is $1.13 (current).
+- **Incidents**: No reported security incidents, exploits, or hacks found for stUSR or wstUSR on Rekt News or DeFi Llama hacks database.
+- **Underlying Stability**: USR trading at ~$0.9998, maintaining close to $1 peg.
+- **Protocol TVL**: ~$447.8M total Resolv protocol TVL on Ethereum (DeFiLlama).
+
+## Funds Management
+
+### Token Mechanism (stUSR → wstUSR)
+
+**stUSR** is a **rebasing ERC-20 token** (similar to Lido's stETH):
+- Underlying token: USR
+- Users deposit USR to receive stUSR shares
+- stUSR uses an internal shares model: `balanceOf(user) = shares[user] * totalPooled / totalShares`
+- When the RewardDistributor drips USR rewards into the stUSR contract, the `totalPooled` USR increases, causing all stUSR balances to grow proportionally
+- On-chain state (verified Feb 9, 2026):
+  - `totalSupply()` (rebased): ~347.2M stUSR
+  - `totalShares()`: ~307.1B internal shares
+  - `underlyingToken()`: USR (`0x66a1e...`)
+  - USR held by stUSR contract: ~347.2M (1:1 backing verified)
+
+**wstUSR** is an **ERC-4626 vault** (similar to Lido's wstETH):
+- Underlying asset: USR (per `asset()` = `0x66a1e...`)
+- wstUSR wraps stUSR internally -- holds ~344.9M stUSR (99.3% of all stUSR)
+- Non-rebasing: wstUSR balance stays constant, but `convertToAssets()` increases over time
+- Exchange rate on-chain (verified Feb 9, 2026):
+  - `convertToAssets(1e18)` = 1.1304 USR per wstUSR
+  - `convertToShares(1e18)` = 0.8846 wstUSR per USR
+  - `totalAssets()` = ~344.9M USR
+  - `totalSupply()` = ~305.1M wstUSR
+- `maxDeposit()` = type(uint256).max (no deposit cap)
+
+### Reward Distribution
+
+The **RewardDistributor** contract ([`0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9`](https://etherscan.io/address/0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9)) is responsible for feeding yield to stUSR:
+- Mints USR rewards and transfers them to the stUSR contract
+- Uses a **drip model**: rewards are linearly vested over a `DRIP_DURATION` period
+- `dripReward()` is called to release accrued rewards
+- `allocateReward()` is called by a privileged role to set new reward amounts
+- Rewards are distributed approximately every 24 hours
+- Not a proxy contract (non-upgradeable)
+
+### Accessibility
+
+- **Wrapping/Unwrapping wstUSR**: Permissionless. Anyone can:
+  - `deposit(uint256 usrAmount)` → deposit USR, receive wstUSR
+  - `wrap(uint256 stUSRAmount)` → wrap stUSR, receive wstUSR
+  - `unwrap(uint256 wstUSRAmount)` → burn wstUSR, receive stUSR
+  - `redeem(uint256 wstUSRAmount)` → burn wstUSR, receive USR
+- **Staking USR to stUSR**: Permissionless. Anyone can deposit USR into stUSR.
+- **Minting/Redeeming USR**: Requires **allowlisted wallets** (whitelisted by Resolv Digital Assets Ltd). Uses `requestMint()`/`requestBurn()` flow on USR Requests Manager.
+- **Atomic operations**: Wrapping/unwrapping wstUSR and staking/unstaking stUSR are atomic single-transaction operations. Minting/redeeming USR is a multi-step backend process (1-24h).
+- **Fees**: No fees for wrap/unwrap or stake/unstake operations.
+
+### Collateralization
+
+- **wstUSR backing**: wstUSR is 100% backed by stUSR, which is 100% backed by USR. Verified on-chain: stUSR contract holds ~347.2M USR for ~347.2M stUSR supply.
+- **USR backing**: USR is >100% collateralized by the delta-neutral collateral pool (ETH, BTC, stETH, stablecoins, RWAs). Excess collateral above 100% backs RLP.
+- **No leverage**: wstUSR does not add leverage -- it is a direct wrapper around the staked stablecoin.
+- **Risk hierarchy**: Unlike RLP, wstUSR is in the **senior tranche** -- RLP absorbs all losses before any impact to USR/stUSR/wstUSR holders.
+
+### Provability
+
+- **wstUSR exchange rate**: Calculated **programmatically on-chain** via ERC-4626 `convertToAssets()`/`convertToShares()`. Based on `stUSR.totalSupply()` / `stUSR.totalShares()` ratio. Anyone can verify.
+- **stUSR backing**: USR held by stUSR contract is fully on-chain and verifiable. `USR.balanceOf(stUSR) == stUSR.totalSupply()` (verified).
+- **Reward distribution**: The RewardDistributor drip schedule is observable on-chain. The amount and frequency of reward allocations are controlled by a privileged role.
+- **Underlying USR collateral**: Verified via [Apostro dashboard](https://info.apostro.xyz/resolv-reserves) and [protocol collateral pool dashboard](https://app.resolv.xyz/collateral-pool).
+
+## Liquidity Risk
+
+### Primary Exit Mechanisms
+
+1. **Unwrap to stUSR → Unstake to USR**: Atomic operations. wstUSR → stUSR → USR, all permissionless and instant.
+2. **Redeem USR to USDC/USDT/ETH**: Uses USR Requests Manager. Requires whitelist. Processed within 1-24 hours by backend.
+3. **DEX swap**: Sell wstUSR directly on Curve, Fluid, Balancer, or other DEXes.
+
+### DEX Liquidity (Feb 9, 2026, via DeFiLlama & CoinGecko)
+
+| Protocol | Chain | Pool | TVL | 7d Volume |
+|----------|-------|------|-----|-----------|
+| Curve | Ethereum | DOLA-wstUSR | $37.3M | $3.8M |
+| Fluid DEX | Ethereum | wstUSR-USDC | $3.7M | $15.8M |
+| Fluid DEX | Arbitrum | wstUSR-USDC | $591K | $1.4M |
+| Fluid DEX | Base | USDC-wstUSR | $403K | $1.5M |
+| **Total DEX** | | | **~$42.2M** | **~$22.5M/7d** |
+
+### Lending Market Integrations (wstUSR as collateral)
+
+| Protocol | Chain | TVL | Notes |
+|----------|-------|-----|-------|
+| Fluid Lending | Ethereum | $65.5M + $34.3M + $333K | wstUSR/USDC, wstUSR/USDT, wstUSR/GHO pairs |
+| Fluid Lending | Arbitrum | $11.7M + $7.5M | wstUSR/USDT, wstUSR/USDC pairs |
+| Morpho | Arbitrum | $4.6M + $1.2M | wstUSR collateral vaults |
+| Morpho | Ethereum | $25K | wstUSR collateral vault |
+| **Total Lending** | | **~$125.1M** | |
+
+### Additional DeFi Integrations
+
+| Protocol | Chain | TVL | Notes |
+|----------|-------|-----|-------|
+| Convex | Ethereum | $37.2M | DOLA-wstUSR Curve LP |
+| Inverse Finance (FiRM) | Ethereum | $37.2M + $2.2M | DOLA-wstUSR lending + Yearn vault |
+| Pendle | Ethereum | $118K | wstUSR yield tokenization |
+| Rheo | Ethereum | $1.3M | PT-wstUSR-29JAN2026 |
+| StakeDAO | Ethereum | $20K | DOLA-wstUSR |
+| Yearn | Ethereum | $69K | DOLA-wstUSR vault |
+| **Total Additional** | | **~$78.1M** | |
+
+### Liquidity Summary
+
+- **Total wstUSR/stUSR DeFi TVL**: ~$593M across 25 pools (DeFiLlama)
+- **24h Trading Volume**: ~$2.6M (CoinGecko)
+- **Primary liquidity**: Fluid (lending + DEX), Curve DOLA-wstUSR pool
+- **Instant unwrap**: wstUSR → stUSR → USR is atomic and permissionless (no delay)
+- **USR redemption**: 1-24h via backend, requires whitelist
+- **Multi-chain**: Available on Ethereum (primary), Arbitrum, Base, Plasma via LayerZero OFT
+
+## Centralization & Control Risks
+
+### Governance
+
+- **Multisig**: All core contracts controlled by a **3-of-5 Gnosis Safe** at [`0xd6889f307be1b83bb355d5da7d4478fb0d2af547`](https://etherscan.io/address/0xd6889f307be1b83bb355d5da7d4478fb0d2af547). Controls `DEFAULT_ADMIN_ROLE` for stUSR, wstUSR, USR, RewardDistributor, and all infrastructure contracts.
+- **Timelock**: A 3-day OpenZeppelin `TimelockController` at [`0x290d9544669c9c7a64f6899a0a3b28d563f6ebee`](https://etherscan.io/address/0x290d9544669c9c7a64f6899a0a3b28d563f6ebee) owns all ProxyAdmin contracts. **Contract upgrades require a 3-day delay**.
+- **ProxyAdmins**: stUSR ProxyAdmin at [`0xeb88058615eaf3e4833af053484012c4d6cbfa37`](https://etherscan.io/address/0xeb88058615eaf3e4833af053484012c4d6cbfa37), wstUSR ProxyAdmin at [`0xD89784610EefD4d11444788F7A85AaDfd57AF7E5`](https://etherscan.io/address/0xD89784610EefD4d11444788F7A85AaDfd57AF7E5). Both owned by the timelock.
+- **Split architecture**: Multisig controls **operational parameters directly** (no delay) -- pausing, role grants, parameter changes. Timelock only gates **proxy upgrades**.
+- **On-chain governance not yet live**: stRESOLV token exists but Snapshot voting has not been initiated.
+- **All 5 signers are EOAs** (not publicly identified).
+
+### Programmability
+
+- **wstUSR exchange rate**: Fully programmatic. Calculated on-chain via ERC-4626 standard: `convertToAssets()` = stUSR totalSupply / totalShares. No admin input needed for exchange rate.
+- **stUSR rebasing**: Programmatic based on USR balance in the contract. When RewardDistributor drips USR, balances rebase automatically.
+- **Reward distribution**: Controlled by a **privileged role** on the RewardDistributor. The `allocateReward()` function is called by an admin to set reward amounts. The drip schedule is then programmatic.
+- **Wrapping/unwrapping**: Fully programmatic, no admin involvement.
+
+### External Dependencies
+
+- **USR stability**: wstUSR's value is fundamentally tied to USR maintaining its $1 peg. USR is backed by the delta-neutral collateral pool.
+- **RewardDistributor**: A single non-proxy contract controlled by the multisig. If it stops distributing rewards, wstUSR exchange rate stops growing (no loss of principal, just no yield).
+- **LayerZero**: Used for cross-chain bridging of wstUSR (OFT standard).
+- **Underlying collateral dependencies**: Same as the broader Resolv protocol -- CEX counterparty risk (Binance, Deribit, Bybit), DeFi integrations (Aave, Lido, EtherFi), oracle providers (Pyth, Chainlink, Chronicle, RedStone).
+
+## Operational Risk
+
+- **Team Transparency**: Team is **partially doxxed** via CoinGecko (Ivan Kozlov CEO, Tim Shekikhachev CPO, Fedor Chmilev CTO with LinkedIn/Twitter). Not prominently displayed on protocol website.
+- **Company founded**: 2023 (Resolv Labs).
+- **Legal Structure**: Two BVI entities: **Resolv Labs Ltd** (frontend/app) and **Resolv Digital Assets Ltd (RDAL)** (token issuance, collateral pool). A **Resolv Foundation** manages protocol revenue.
+- **Jurisdiction**: British Virgin Islands (BVI).
+- **Investors**: $10M seed round led by Cyber Fund and Maven 11. Other investors: Coinbase Ventures, Arrington Capital, Robot Ventures, Animoca Brands, Ether.fi.
+- **Documentation**: Comprehensive litepaper at [docs.resolv.xyz](https://docs.resolv.xyz/). Quarterly reports and parameter updates published.
+- **Incident Response**: No documented incident response plan found. Bug bounty and on-chain monitoring exist.
+
+## Monitoring
+
+### wstUSR Exchange Rate Monitoring
+
+- **wstUSR contract**: [`0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055`](https://etherscan.io/address/0x1202F5C7b4B9E47a1A484E8B270be34dbbC75055)
+  - Monitor `convertToAssets(1e18)` for exchange rate changes. Current: ~1.1304 USR/wstUSR.
+  - **Alert**: If exchange rate **decreases** (should only ever increase). Any decrease indicates a potential issue with the stUSR contract or reward distribution.
+  - **Alert**: If exchange rate growth **stops** for >48 hours (indicates RewardDistributor has stopped dripping rewards).
+  - Monitor `Deposit`, `Withdraw` events for large deposits/withdrawals (>$1M).
+  - **Threshold**: Alert on single deposits/withdrawals >$5M (potential whale activity or stress signals).
+
+### stUSR Backing Verification
+
+- **stUSR contract**: [`0x6c8984bc7DBBeDAf4F6b2FD766f16eBB7d10AAb4`](https://etherscan.io/address/0x6c8984bc7DBBeDAf4F6b2FD766f16eBB7d10AAb4)
+  - Monitor `USR.balanceOf(stUSR)` vs `stUSR.totalSupply()`. These should be approximately equal (1:1 backing).
+  - **Alert**: If `USR.balanceOf(stUSR) < stUSR.totalSupply() * 0.99` (under-collateralization by >1%).
+  - Monitor `totalShares()` and `totalSupply()` for the shares-to-tokens ratio.
+  - Monitor `Transfer` events for large movements (>$5M).
+
+### RewardDistributor Monitoring
+
+- **RewardDistributor**: [`0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9`](https://etherscan.io/address/0xbE23BB6D817C08E7EC4Cd0adB0E23156189c1bA9)
+  - Monitor `RewardDripped` events -- tracks when rewards are released to stUSR.
+  - **Alert**: If no `RewardDripped` event for >48 hours (rewards should drip approximately daily).
+  - Monitor `RewardAllocated` events -- tracks when new reward amounts are set.
+  - **Threshold**: Alert if allocated reward amount changes by >50% from previous allocation (significant yield change).
+  - Monitor USR balance of RewardDistributor -- this is the pending rewards to be dripped.
+
+### Governance & Proxy Monitoring
+
+- **Multisig**: [`0xd6889f307be1b83bb355d5da7d4478fb0d2af547`](https://etherscan.io/address/0xd6889f307be1b83bb355d5da7d4478fb0d2af547)
+  - Monitor for owner changes, threshold changes, module additions.
+  - **Alert**: Immediately on any signer replacement or threshold change.
+
+- **Timelock**: [`0x290d9544669c9c7a64f6899a0a3b28d563f6ebee`](https://etherscan.io/address/0x290d9544669c9c7a64f6899a0a3b28d563f6ebee)
+  - Monitor `CallScheduled`, `CallExecuted`, `Cancelled` events.
+  - **Alert**: Immediately on any `CallScheduled` event (3-day window to review proxy upgrades).
+  - Cross-reference scheduled calls against stUSR ProxyAdmin (`0xeb8805...`) and wstUSR ProxyAdmin (`0xD89784...`) addresses.
+
+- **stUSR ProxyAdmin**: [`0xeb88058615eaf3e4833af053484012c4d6cbfa37`](https://etherscan.io/address/0xeb88058615eaf3e4833af053484012c4d6cbfa37)
+  - Monitor for `Upgraded` events on stUSR proxy (implementation change).
+  - **Alert**: Immediately on any implementation change.
+
+- **wstUSR ProxyAdmin**: [`0xD89784610EefD4d11444788F7A85AaDfd57AF7E5`](https://etherscan.io/address/0xD89784610EefD4d11444788F7A85AaDfd57AF7E5)
+  - Monitor for `Upgraded` events on wstUSR proxy (implementation change).
+  - **Alert**: Immediately on any implementation change.
+
+### Liquidity Monitoring
+
+- **Curve DOLA-wstUSR pool**: Monitor TVL. Current: ~$37.3M.
+  - **Alert**: If pool TVL drops below $10M (liquidity deterioration).
+  - **Alert**: If pool imbalance exceeds 80/20 in either direction (potential depegging pressure).
+
+- **Fluid lending markets** (Ethereum):
+  - wstUSR/USDC: TVL $65.5M
+  - wstUSR/USDT: TVL $34.3M
+  - **Alert**: If utilization rate exceeds 98% (liquidity crunch risk).
+  - **Alert**: If wstUSR collateral liquidations occur (signals stress).
+
+- **CoinGecko wstUSR price**: Monitor for deviations from expected exchange rate.
+  - **Alert**: If CoinGecko price deviates >2% from on-chain `convertToAssets()` * USR_price (indicates market mispricing or DEX imbalance).
+
+### USR Collateral Pool Monitoring
+
+- **USR Collateralization Ratio**: Monitor via [Apostro dashboard](https://info.apostro.xyz/resolv-reserves).
+  - **Alert**: If CR drops below 120% (approaching stress levels for the entire Resolv system).
+  - **Alert**: If CR drops below 110% (RLP redemption gate triggers -- indirect impact on wstUSR if USR confidence is shaken).
+- **USR Peg**: Monitor USR price on DEXes.
+  - **Alert**: If USR deviates >0.5% from $1.00 peg (significant depegging).
+  - **Alert**: If USR deviates >2% from $1.00 peg (critical depegging -- wstUSR value directly impacted).
+
+### Monitoring Frequency
+
+| Category | Frequency | Priority |
+|----------|-----------|----------|
+| Timelock scheduled calls | Real-time | Critical |
+| Proxy upgrade events | Real-time | Critical |
+| Multisig signer changes | Real-time | Critical |
+| wstUSR exchange rate | Every 6 hours | High |
+| stUSR backing (USR balance) | Every 6 hours | High |
+| RewardDistributor drip events | Daily | High |
+| USR peg stability | Hourly | High |
+| DEX pool TVL/balance | Hourly | Medium |
+| Lending market utilization | Hourly | Medium |
+| USR Collateralization Ratio | Daily | Medium |
+
+## Risk Summary
+
+### Key Strengths
+
+- **Programmatic exchange rate**: Unlike RLP (where price is set off-chain), wstUSR exchange rate is computed on-chain via ERC-4626 standard. Anyone can verify.
+- **Senior tranche**: wstUSR/stUSR holders are protected by RLP, which absorbs all losses before USR is affected. wstUSR is fundamentally a yield-bearing wrapper around a USD-pegged stablecoin.
+- **Extensive audit coverage**: wstUSR specifically audited by Pashov, Pessimistic, and Sherlock. 14+ total protocol audits.
+- **Permissionless wrapping**: No whitelist needed to wrap/unwrap wstUSR/stUSR. Only minting/redeeming USR requires whitelist.
+- **Strong DeFi adoption**: ~$593M TVL across 25 pools. Integrated with Fluid, Curve, Morpho, Pendle, Balancer V3, Convex, Yearn.
+- **1:1 stUSR backing verified on-chain**: USR.balanceOf(stUSR) == stUSR.totalSupply() (verified Feb 9, 2026).
+
+### Key Risks
+
+- **Centralized reward distribution**: The RewardDistributor is controlled by the multisig. If rewards stop, wstUSR exchange rate stops growing.
+- **Upgradeable proxies**: Both stUSR and wstUSR are upgradeable (3-day timelock for implementation changes). A malicious upgrade could compromise funds.
+- **USR peg dependency**: wstUSR value is fundamentally tied to USR maintaining its $1 peg. Any USR depegging directly impacts wstUSR.
+- **Whale frontrunning acknowledged**: The known issue where MEV bots can frontrun reward distributions for stUSR has been acknowledged but not fixed.
+- **Underlying collateral risks**: wstUSR inherits all risks of the Resolv collateral pool (CEX counterparty, funding rate volatility, etc.), albeit protected by RLP as first-loss capital.
+
+### Critical Risks
+
+- **Proxy upgrade with 3-day timelock**: While the timelock provides a review window, the 3-of-5 anonymous signers could propose a malicious upgrade. The 3-day window is the only safeguard.
+- **RewardDistributor is not upgradeable** but is controlled by the multisig for allocating rewards. If the multisig is compromised, reward allocation could be manipulated (though this would affect yield, not principal).
+
+---
+
+## Risk Score Assessment
+
+**Scoring Guidelines:**
+- Be conservative: when uncertain between two scores, choose the higher (riskier) one
+- Use decimals (e.g., 2.5) when a subcategory falls between scores
+- Prioritize on-chain evidence over documentation claims
+
+### Critical Risk Gates
+
+- [x] **No audit** -- wstUSR specifically audited by 3 firms (Pashov, Pessimistic, Sherlock). Protocol has 14+ total audits. **PASS**
+- [x] **Unverifiable reserves** -- stUSR backing verified on-chain (USR.balanceOf(stUSR) == totalSupply). wstUSR exchange rate programmatic via ERC-4626. **PASS**
+- [x] **Total centralization** -- 3-of-5 Gnosis Safe multisig. 3-day timelock for upgrades. Not a single EOA. **PASS**
+
+**All gates pass.** Proceed to category scoring.
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+- **Audits**: 4 audit firms (MixBytes, Pashov, Sherlock, Pessimistic), 14+ engagements. wstUSR specifically audited in 3 separate engagements. Dedicated wstUSR audit found 7 issues (all resolved). Sherlock contest found inflation attack (fixed).
+- **Bug Bounty**: $500K max on Immunefi (Primacy of Impact). wstUSR/stUSR in scope.
+- **Time in Production**: ~17 months (Sep 2024 - Feb 2026).
+- **TVL**: ~$344.8M wstUSR market cap, ~$593M in DeFi integrations.
+- **Incidents**: None reported.
+
+**Score: 1.5/5** -- Exceptional audit coverage with wstUSR specifically reviewed by 3 firms. Strong bug bounty ($500K). >1 year production with >$100M TVL and no incidents. Known issues (frontrunning, ERC-4626 compliance) acknowledged and managed.
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+**Subcategory A: Governance**
+
+- **3-of-5 Gnosis Safe** multisig controls all contracts.
+- **3-day timelock** for proxy upgrades (stUSR and wstUSR are both upgradeable proxies).
+- Operational parameters (pause, role grants) controlled by multisig **directly without timelock**.
+- No on-chain governance live yet.
+- All 5 signers anonymous EOAs.
+
+**Governance Score: 3.5** -- Same governance structure as broader Resolv protocol. 3/5 multisig with 3-day upgrade timelock is adequate but operational parameters lack delay.
+
+**Subcategory B: Programmability**
+
+- **wstUSR exchange rate**: Fully on-chain, programmatic (ERC-4626). Significant improvement over RLP.
+- **stUSR rebase**: Programmatic based on USR in contract.
+- **Reward distribution**: Admin-controlled allocation, but drip schedule is programmatic.
+- **Wrapping/unwrapping**: Fully programmatic, no admin involvement.
+
+**Programmability Score: 2.5** -- wstUSR itself is highly programmatic (ERC-4626 on-chain exchange rate), but reward allocation is admin-controlled. Significantly better than RLP's fully off-chain pricing.
+
+**Subcategory C: External Dependencies**
+
+- USR stability depends on the delta-neutral collateral pool
+- 3 CEXes + 1 DEX for hedging (inherited from USR)
+- LayerZero for cross-chain bridging
+- DeFi integrations (Aave, Lido, EtherFi) for yield
+
+**Dependencies Score: 3.0** -- Inherits USR's dependency profile (CEX counterparty, multiple custodians). wstUSR itself adds no additional critical dependencies beyond the stUSR/USR contracts.
+
+**Centralization Score = (3.5 + 2.5 + 3.0) / 3 = 3.0**
+
+**Score: 3.0/5** -- Improved over RLP due to programmatic exchange rate. Still constrained by centralized reward distribution and multisig control without timelocked operational parameters.
+
+#### Category 3: Funds Management (Weight: 30%)
+
+**Subcategory A: Collateralization**
+
+- wstUSR → stUSR → USR: Each layer is 100% backed and verifiable on-chain.
+- stUSR holds exactly as much USR as its total supply (verified on-chain).
+- wstUSR is an ERC-4626 vault with no leverage.
+- **Senior tranche**: RLP absorbs losses before USR/stUSR/wstUSR are impacted.
+- Underlying USR collateral is a mix of on-chain (ETH, stETH, stablecoins) and off-chain (CEX margin ~15%).
+
+**Collateralization Score: 2.0** -- 100% on-chain verifiable backing for stUSR→USR. Senior tranche protection via RLP. Mixed quality underlying assets (including CEX margin), but wstUSR itself is purely on-chain.
+
+**Subcategory B: Provability**
+
+- wstUSR exchange rate: programmatic on-chain (ERC-4626).
+- stUSR backing: fully verifiable (USR.balanceOf(stUSR)).
+- Reward allocation: admin-controlled but drip is on-chain.
+- Underlying USR collateral: Apostro third-party dashboard + self-reporting.
+
+**Provability Score: 2.0** -- wstUSR and stUSR layers are fully on-chain verifiable. Underlying USR collateral has hybrid on-chain/off-chain provability (same as broader Resolv).
+
+**Funds Management Score = (2.0 + 2.0) / 2 = 2.0**
+
+**Score: 2.0/5** -- Significantly better than RLP. wstUSR/stUSR layers are fully on-chain and verifiable. Underlying USR has hybrid on-chain/off-chain backing but is senior tranche (protected by RLP).
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+- **Exit Mechanism**: wstUSR → stUSR → USR is atomic and permissionless (instant). USR → USDC/USDT requires whitelist and 1-24h.
+- **DEX Liquidity**: ~$42.2M in DEX pools, ~$22.5M/week trading volume. Curve DOLA-wstUSR is deepest at $37.3M.
+- **Lending Markets**: ~$125.1M in lending markets (Fluid, Morpho). Highly integrated.
+- **Multi-chain**: Available on Ethereum, Arbitrum, Base.
+- **Same-value redemption**: wstUSR redeems for USR (stablecoin) -- no variable pricing risk on exit.
+
+**Score: 2.0/5** -- Instant atomic unwrap to USR (stablecoin). Strong DEX liquidity ($42.2M) and lending market depth ($125.1M). Same-value asset (stablecoin-denominated). Minor friction for final USR→fiat step (whitelist, 1-24h delay). Excellent DeFi integration.
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+- **Team**: Partially doxxed (CoinGecko), strong investors ($10M seed).
+- **Documentation**: Comprehensive.
+- **Legal Structure**: Two BVI entities + Foundation.
+- **Incident Response**: No documented plan.
+
+**Score: 2.5/5** -- Same as broader Resolv protocol. Partially identifiable team, strong investors, good documentation. BVI jurisdiction, no documented incident response.
+
+### Final Score Calculation
+
+```
+Final Score = (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Audits × 0.20) + (Liquidity × 0.15) + (Operational × 0.05)
+```
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 1.5 | 20% | 0.30 |
+| Centralization & Control | 3.0 | 30% | 0.90 |
+| Funds Management | 2.0 | 30% | 0.60 |
+| Liquidity Risk | 2.0 | 15% | 0.30 |
+| Operational Risk | 2.5 | 5% | 0.125 |
+| **Final Score** | | | **2.225** |
+
+**Final Score: 2.2**
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|------------|-----------|----------------|
+| **1.5-2.5** | **Low Risk** | Approved with standard monitoring |
+
+**Final Risk Tier: Low Risk**
+
+---
+
+wstUSR is a well-audited, programmatically-priced ERC-4626 vault wrapping staked USR. Its exchange rate is fully on-chain and verifiable, significantly distinguishing it from RLP which relies on off-chain pricing. As a wrapper around the senior tranche of Resolv's protocol (USR/stUSR), wstUSR holders benefit from RLP's first-loss protection. The 1:1 stUSR→USR backing is verified on-chain. Strong DeFi adoption (~$593M across 25 pools) provides excellent exit liquidity. Key residual risks are the centralized reward distribution (admin-controlled), upgradeable proxy contracts (3-day timelock), and inherited dependency on USR peg stability and the underlying delta-neutral collateral pool.
+
+**Key conditions for exposure:**
+- Monitor wstUSR exchange rate for any decreases (should only increase)
+- Monitor stUSR backing ratio (USR.balanceOf(stUSR) vs totalSupply)
+- Monitor RewardDistributor for regular drip events (should occur ~daily)
+- Monitor timelock for any scheduled proxy upgrades (3-day review window)
+- Track USR peg stability and overall Resolv collateralization ratio
+
+---
+
+## Reassessment Triggers
+
+- **Time-based**: Reassess in 6 months (August 2026)
+- **Governance-based**: Reassess when on-chain governance is activated
+- **Incident-based**: Reassess after any exploit, governance change, or collateral modification
+- **Peg-based**: Reassess if USR deviates >2% from $1.00 peg

--- a/src/components/pages/curation/reports/stakedhype-sthype.md
+++ b/src/components/pages/curation/reports/stakedhype-sthype.md
@@ -1,0 +1,520 @@
+# Protocol Risk Assessment: StakedHYPE
+
+- **Assessment Date:** February 18, 2026
+- **Token:** stHYPE
+- **Chain:** HyperEVM (Hyperliquid L1 ecosystem)
+- **Token Address:** [`0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1`](https://hyperevmscan.io/address/0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1)
+- **Final Score: 3.03/5.0**
+
+## Overview + Links
+
+StakedHYPE issues `stHYPE`, a liquid staking token representing HYPE staked into Hyperliquid validators through Hyperliquid Stake Marketplace (HSM). Conceptually it is similar to stETH: users deposit native HYPE, receive an LST (`stHYPE`), and accumulate staking rewards in token exchange rate terms.
+
+StakedHYPE was originally built by **Thunderhead Labs**, a multi-LST provider (stFLIP, stELX, stMOVE, tPOKT, stHYPE) with shared modular infrastructure across products. In August 2025, stHYPE was **acquired by Valantis Labs**, which now maintains the protocol. The codebase benefits from components battle-tested across multiple Thunderhead LST deployments.
+
+The architecture has two layers:
+
+1. **LST layer (StakedHYPE)**
+- User-facing mint/redeem flow for stHYPE.
+- Maintains a withdrawal queue and reserve buffer.
+
+2. **Validator staking layer (HSM)**
+- HYPE is delegated into Hyperliquid validators via HSM infra.
+- Uses HSM voting and delegation controls to distribute stake and manage exits.
+
+**Links:**
+
+- [StakedHYPE docs](https://docs.stakedhype.fi/)
+- [HSM technical page](https://docs.stakedhype.fi/technical/hyperliquid-stake-marketplace-hsm)
+- [Stake Accounts & Architecture](https://docs.stakedhype.fi/technical/stake-accounts)
+- [stHYPE Integration (mint/burn/unstaking)](https://docs.stakedhype.fi/technical/integrate)
+- [Transparency & Risks](https://docs.stakedhype.fi/info/transparency-and-risks)
+- [Contract Addresses](https://docs.stakedhype.fi/technical/contract-addresses)
+- [Audits](https://docs.stakedhype.fi/technical/audits)
+- [StakedHYPE security page](https://docs.stakedhype.fi/technical/security)
+- [StakedHYPE governance page](https://docs.stakedhype.fi/governance)
+- [Hyperliquid staking docs](https://hyperliquid.gitbook.io/hyperliquid-docs/hype-staking)
+- [Hyperliquid validator docs](https://hyperliquid.gitbook.io/hyperliquid-docs/hype-staking/validators)
+
+## Contract Addresses
+
+All contracts are deployed on HyperEVM (Hyperliquid L1). Explorer: [HyperEVMScan](https://hyperevmscan.io).
+
+| Contract | Address | Type |
+|----------|---------|------|
+| stHYPE | [`0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1`](https://hyperevmscan.io/address/0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1) | Proxy (ERC-20 LST) |
+| stHYPE Impl | [`0xa2fdc8eca86e3cf2593ec20f42a777984927553c`](https://hyperevmscan.io/address/0xa2fdc8eca86e3cf2593ec20f42a777984927553c) | Implementation |
+| stHYPE ProxyAdmin | [`0xe7b0f26e8e20e109441f0ad1c885fffbb27125dc`](https://hyperevmscan.io/address/0xe7b0f26e8e20e109441f0ad1c885fffbb27125dc) | EIP-1967 Admin |
+| OverseerV1 | [`0xB96f07367e69e86d6e9C3F29215885104813eeAE`](https://hyperevmscan.io/address/0xB96f07367e69e86d6e9C3F29215885104813eeAE) | Proxy (mint/burn controller) |
+| OverseerV1 Impl | [`0xc9dcf086ee9f063bcd4c7d2ec4b82085142a8cee`](https://hyperevmscan.io/address/0xc9dcf086ee9f063bcd4c7d2ec4b82085142a8cee) | Implementation |
+| OverseerV1 ProxyAdmin | [`0x943a7e81373423f7bb0fb6a3e55553638264fd6b`](https://hyperevmscan.io/address/0x943a7e81373423f7bb0fb6a3e55553638264fd6b) | EIP-1967 Admin |
+| wstHYPE | [`0x94e8396e0869c9F2200760aF0621aFd240E1CF38`](https://hyperevmscan.io/address/0x94e8396e0869c9F2200760aF0621aFd240E1CF38) | Proxy (wrapped shares) |
+| wstHYPE Impl | [`0x2936b42d1bfa7298faa44644ddea665c7aa51ef8`](https://hyperevmscan.io/address/0x2936b42d1bfa7298faa44644ddea665c7aa51ef8) | Implementation |
+| wstHYPE ProxyAdmin | [`0xa29a2043b2fcbc9189beb9e6efcb2ba48bb3d586`](https://hyperevmscan.io/address/0xa29a2043b2fcbc9189beb9e6efcb2ba48bb3d586) | EIP-1967 Admin |
+| Governance Multisig | [`0x97dee0ea4ca10560f260a0f6f45bdc128a1d51f9`](https://hyperevmscan.io/address/0x97dee0ea4ca10560f260a0f6f45bdc128a1d51f9) | Gnosis Safe (3-of-5) |
+
+All contracts are **upgradeable** via EIP-1967 transparent proxy pattern. Each proxy has a separate ProxyAdmin contract. All three ProxyAdmin contracts are owned by the governance multisig (`0x97dee0ea...`, verified via `owner()` on each ProxyAdmin). This means the **3-of-5 multisig can upgrade all contract implementations** without timelock.
+
+Source: [docs.stakedhype.fi/technical/contract-addresses](https://docs.stakedhype.fi/technical/contract-addresses) + on-chain verification via `eth_getStorageAt` (EIP-1967 slots).
+
+## How Hyperliquid Staking Works (Context)
+
+Hyperliquid’s staking model is validator-based and epoch-driven.
+
+- Users stake HYPE and delegate to validators.
+- Rewards accrue through validator performance and protocol emissions/fees.
+- Validator set and stake movement are constrained by protocol rules (epoch timing and activation/deactivation semantics).
+- Hyperliquid docs describe validator/L1 operational risks; this is the core external risk inherited by any HYPE liquid staking protocol.
+
+### Slashing in Hyperliquid (Important for stHYPE)
+
+As of **February 18, 2026**, Hyperliquid docs state that core HYPE staking currently has:
+
+- **No automatic validator slashing mechanism** in live staking.
+- **Jailing** as the immediate validator penalty path for uptime/behavior issues.
+- A note that governance may introduce explicit validator slashing in the future.
+
+Practical interpretation for stHYPE:
+- **Today:** direct stake haircut from automatic validator slashing is low-probability because that mechanism is not yet active in base staking.
+- **Still material risk:** validator jailing, poor validator performance, or chain-level instability can still reduce effective yield and delay exits.
+- **Future risk step-up:** if governance enables validator slashing later, stHYPE loss profile can change meaningfully and requires immediate reassessment.
+
+Historical status:
+- No official Hyperliquid documentation found describing a past **validator slashing event** in HYPE staking as of February 18, 2026.
+- This is an inference from official docs and release/risk pages; absence of a documented event is not proof of impossibility.
+
+For stHYPE specifically, staking operations route through HSM abstractions and StakedHYPE’s queue/buffer logic, which adds additional smart-contract and operational layers on top of base protocol staking.
+
+## Audits and Due Diligence Disclosures
+
+StakedHYPE publicly lists 4 audits on its [audits page](https://docs.stakedhype.fi/technical/audits):
+
+| # | Date | Firm | Scope | Link |
+|---|---|---|---|---|
+| 1 | Feb 2025 | Three Sigma | StakedHYPE contracts | [Report](https://github.com/ValantisLabs/audits/blob/main/Three_Sigma_Feb_25.pdf) |
+| 2 | Oct 2025 | Pashov Audit Group | StakedHYPE contracts | [Report](https://github.com/ValantisLabs/audits/blob/main/pashov_oct_25.pdf) |
+| 3 | Nov 2025 | Pashov Audit Group | StakedHYPE updates | [Report](https://github.com/ValantisLabs/audits/blob/main/pashov_nov_2025.pdf) |
+| 4 | Nov 2025 | Guardian Audits | StakedHYPE updates | [Report](https://github.com/ValantisLabs/audits/blob/main/guardian_nov_2025.pdf) |
+
+StakedHYPE was originally built by **Thunderhead Labs** (multi-LST provider: stFLIP, stELX, stMOVE, tPOKT) and acquired by **Valantis Labs** in August 2025. Cross-LST audits with shared modular components are available in the [Thunderhead audits repo](https://github.com/thunderhead-labs/audits). The Three Sigma audit is mirrored in both repos (identical SHA: `4c39b756`).
+
+The governance system is based on a modified [FraxGovernorOmega](https://github.com/trailofbits/publications/blob/master/reviews/2023-05-fraxgov-securityreview.pdf) (audited by Trail of Bits), but is **not yet implemented** per the audits page.
+
+Additional disclosures:
+- HSM docs state code and technical docs are expected to be published in GitHub once finalized, indicating parts of stack/process may still be maturing.
+- No public formal verification disclosure was identified.
+
+### Bug Bounty
+
+No Immunefi/Sherlock/Cantina bug bounty link was identified in docs.
+
+Disclosed security contacts:
+- Email: audit@valantis.xyz (per [security page](https://docs.stakedhype.fi/technical/security))
+- Discord: [StakedHYPE Discord](https://t.co/zZB5aEVqCh)
+- Twitter: [@ValantisLabs](https://twitter.com/ValantisLabs)
+
+Assessment note:
+- Responsible disclosure channel exists, but absence of a public bounty with payout tiers weakens external adversarial testing incentives relative to peers.
+
+## Historical Track Record
+
+- StakedHYPE documentation indicates active production operation with stHYPE issuance and unstaking mechanisms live.
+- Listed on [DeFiLlama](https://defillama.com/protocol/stakedhype) since July 2025 (~8 months at assessment date).
+- **Current TVL**: ~$124M (February 18, 2026, per DeFiLlama).
+- **Peak TVL**: ~$544M (July 2025).
+- **TVL trend**: Significant decline from peak, currently at ~23% of ATH. Likely driven by broader market conditions and HYPE price movements rather than protocol-specific issues.
+- No major publicly disclosed exploit was identified in StakedHYPE docs at assessment time. Not listed on [Rekt News](https://rekt.news/) or [DeFiLlama Hacks](https://defillama.com/hacks).
+- Track record is materially shorter and less battle-tested than older LSTs like stETH (~8 months vs 3+ years).
+
+## Funds Management
+
+### Strategy and delegation model
+
+stHYPE deposits are managed via HSM-integrated staking operations:
+
+- User deposits -> mint stHYPE.
+- Capital is distributed across validator/delegation pathways using HSM.
+- A reserve buffer is kept to improve withdrawal responsiveness.
+- Redemptions rely on reserve and, when needed, unstake/rebalance processes.
+
+### Accessibility
+
+- stHYPE minting is permissionless at user level through protocol interface.
+- Unstaking uses a queue-based process and does not guarantee instant 1:1 native withdrawal.
+- Queue and buffer mechanics are key liquidity controls and must be actively monitored.
+
+### Collateralization
+
+On-chain state (verified February 18, 2026):
+- **stHYPE totalSupply**: 4,252,373.17 stHYPE
+- **Total HYPE backing** (`totalSupply × exchangeRate`): 4,338,882.91 HYPE
+- **OverseerV1 liquid reserve**: 261,728.59 HYPE (6.0% of total backing held as liquid HYPE)
+- **Exchange rate** (`balancePerShare`): 1.0203 (2.03% accumulated yield since launch)
+- **maxRedeemable**: 0 HYPE — no instant redemption buffer available at time of check, all burns go through 7-day unstaking queue
+- **burnCount**: 39,113 total burns processed
+
+Economic backing is staked HYPE plus liquid reserves. The remaining ~94.0% of HYPE is staked across validators via HyperCore Staking Modules.
+- Backing quality is primarily dependent on Hyperliquid validator set quality and slashing/operational outcomes.
+- This is not off-chain custodial collateral; risk is on-chain protocol + validator behavior.
+
+### Provability
+
+- Core staking and token accounting are on-chain by design.
+- Key on-chain readable functions verified: `totalSupply()`, `balancePerShare()`, `totalShares()`, `maxRedeemable()`, `burnCount()`, `getBurns(address)`, `redeemable(uint256)`.
+- Exchange rate (`balancePerShare`) is programmatically updated on-chain — not reliant on admin oracle updates.
+- Contracts use OpenZeppelin AccessControl with MINTER_ROLE, BURNER_ROLE, PAUSER_ROLE, DEFAULT_ADMIN_ROLE. OverseerV1 holds MINTER_ROLE and BURNER_ROLE on stHYPE. The 3-of-5 multisig holds DEFAULT_ADMIN_ROLE.
+- **Transparency gaps remain in several areas:**
+  - **Validator delegation breakdown**: No public dashboard or on-chain mechanism shows per-validator stake distribution. The [operators page](https://docs.stakedhype.fi/governance/operators) lists operator names (ASXN, B-harvest, HypurrCO, etc.) but publishes no addresses, delegation amounts, or performance metrics.
+  - **Queue monitoring**: The only user-facing tool is an estimated withdrawal time at `app.valantis.xyz/staking` ([stake accounts docs](https://docs.stakedhype.fi/technical/stake-accounts)). No real-time queue depth, position, or reserve utilization data is published.
+  - **HSM not yet deployed**: The [HSM specification](https://docs.stakedhype.fi/technical/hyperliquid-stake-marketplace-hsm) uses future tense throughout (*"HSM will be natively integrated"*, *"stHYPE will use a governance process"*), indicating the Hyperliquid Stake Marketplace is still a design document, not a live system.
+  - **Off-chain operational components**: Reserve management relies on *"active liquidity management from the Protocol Delegator"* and *"coordination with custodians / HIP-3 operators"* ([stake accounts docs](https://docs.stakedhype.fi/technical/stake-accounts)) — off-chain processes with no on-chain enforcement or public monitoring.
+  - **1:1 backing unverifiable end-to-end**: The [transparency page](https://docs.stakedhype.fi/info/transparency-and-risks) claims *"stHYPE is always backed 1:1 by native HYPE"*, but no independent verification tool is provided. Users can verify EVM-side state (`totalSupply`, `balancePerShare`) but cannot independently audit the full HyperCore validator delegation breakdown.
+
+## Liquidity Risk
+
+stHYPE exit risk is higher than a pure wrapper token:
+
+- There is an unstaking queue design (not instant native redemption in all conditions).
+- Docs disclose a reserve buffer with a [`maxRedeemable()`](https://docs.stakedhype.fi/technical/integrate) function for instant redemptions, a Managed Liquidity Buffer (1M HYPE early-exit threshold, 300k HYPE buffer), and up to a 90-day wind-down horizon for specialized stake accounts in extreme stress conditions.
+
+### DEX Liquidity (per DeFiLlama, February 18, 2026)
+
+**Total DEX liquidity: ~$380K** — extremely thin relative to $124M TVL (0.3% of TVL in DEX pools).
+
+**stHYPE pools:**
+
+| DEX | Pair | TVL | Fee | Vol 7D |
+|-----|------|-----|-----|--------|
+| HyperSwap V3 | WHYPE-STHYPE | $186,012 | 0.01% | $33,002 |
+| HyperSwap V3 | WHYPE-LSTHYPE | $54,172 | 0.3% | $57,978 |
+
+**wstHYPE pools:**
+
+| DEX | Pair | TVL | Fee | Vol 7D |
+|-----|------|-----|-----|--------|
+| Project X | WSTHYPE-KHYPE | $97,690 | 0.3% | $0 |
+| Project X | WHYPE-WSTHYPE | $39,857 | 0.01% | $7,749 |
+
+No stHYPE or wstHYPE pools found on Curve, Laminar, or KittenSwap despite these DEXes being deployed on HyperEVM. **No wstHYPE/USDC or wstHYPE/USDT pairs exist anywhere on HyperEVM** — there is no direct stablecoin exit path via DEX for either token.
+
+### wstHYPE as Lending Collateral
+
+Lending protocols accept **wstHYPE (wrapped stHYPE)**, not native stHYPE, as collateral for borrowing. This is the primary use case for staked HYPE derivatives and the key risk vector, since liquidation of undercollateralized positions depends on available on-chain liquidity.
+
+**Morpho V1** — isolated lending markets, **$44.0M wstHYPE collateral** across 10 active markets:
+
+| Loan Token | LLTV | wstHYPE Collateral | Borrowed | Utilization |
+|-----------|------|-------------------|----------|-------------|
+| USDC | 77.0% | $35.2M | $8.3M | 100% |
+| WHYPE | 86.0% | $5.95M | $4.07M | 90.4% |
+| USDH | 77.0% | $1.47M | $493K | 91.3% |
+| WHYPE | 86.0% | $744K | $499K | 69.9% |
+| USDT0 | 62.5% | $206K | $74K | 90.4% |
+| USDT0 | 77.0% | $185K | $120K | 88.0% |
+| USDHL | 62.5% | $127K | $45K | 11.4% |
+| Others | — | $71K | $47K | — |
+
+**HyperLend** — pooled lending (Aave-fork), **$30.1M wstHYPE** in pool. In pooled model, wstHYPE depositors can borrow any supported asset (WHYPE, USDC, USDT0, etc.). No native stHYPE market exists.
+
+**Felix CDP** — **$1.9M wstHYPE** collateral used to mint feUSD (synthetic dollar).
+
+| Protocol | Type | wstHYPE Collateral | Borrowable Assets | LLTV Range |
+|----------|------|-------------------|-------------------|------------|
+| Morpho | Isolated markets | $44.0M | USDC, WHYPE, USDH, USDT0, USDe | 62.5%–91.5% |
+| HyperLend | Pooled lending | $30.1M | Any pool asset | TBD |
+| Felix | CDP | $1.9M | feUSD | TBD |
+| **Total** | | **$76.0M** | | |
+
+~60% of stHYPE total supply ($127M) is wrapped and used as lending collateral.
+
+### Liquidation Risk
+
+**On-chain liquidation of wstHYPE collateral positions is effectively broken.** $76M of wstHYPE is used as borrowing collateral, but total wstHYPE DEX liquidity is only ~$138K with zero stablecoin pairs. When a borrower's position becomes undercollateralized, liquidators must acquire and sell wstHYPE — but there is no viable on-chain path to do so efficiently:
+
+1. **No stablecoin exit**: No wstHYPE/USDC or wstHYPE/USDT pools exist. Liquidators must route through HYPE derivatives (wstHYPE → WHYPE → USDC), adding hops and slippage. The largest Morpho market ($35.2M) is borrowing USDC against wstHYPE — liquidators need a wstHYPE-to-USDC path that doesn't exist on-chain.
+2. **Negligible DEX depth**: $138K total wstHYPE liquidity cannot absorb liquidations from $76M in collateral. Even a small liquidation event would exhaust available pool depth.
+3. **Unwrap delay**: Converting wstHYPE → stHYPE is instant at the contract level, but stHYPE → HYPE requires the 7-day unstaking queue (up to 90 days under stress). Liquidators cannot quickly realize value.
+4. **Correlated stress**: In a HYPE price drawdown, both the collateral value (wstHYPE) and exit liquidity (WHYPE pools) decline simultaneously, creating a liquidation spiral risk where falling prices trigger liquidations that cannot be efficiently executed.
+5. **High utilization**: Most Morpho wstHYPE markets show 88–100% utilization, meaning positions are heavily leveraged relative to available supply.
+
+This creates a structural fragility: $76M of wstHYPE borrowing collateral against ~$138K of DEX exit liquidity — a **550:1 collateral-to-liquidity ratio**.
+
+### Practical Implications
+
+- In normal conditions, protocol reserves/queue support predictable withdrawals (7-day unstaking).
+- **Secondary market exit is severely constrained**: the largest DEX pool is ~$186K with near-zero daily volume. Any meaningful position would need to rely on the protocol's native unstaking queue.
+- In stress conditions, exits can be delayed up to 90 days (specialized stake account wind-down) and/or become market-impact sensitive.
+- **Lending market liquidations are the primary systemic risk vector** due to the collateral-to-liquidity mismatch described above.
+
+## Centralization & Control Risks
+
+### Governance
+
+StakedHYPE docs describe a planned dual-governance model based on a modified [FraxGovernorOmega](https://github.com/trailofbits/publications/blob/master/reviews/2023-05-fraxgov-securityreview.pdf):
+- **Legislative branch**: Multisig composed of Thunderhead team, Valantis team, ecosystem partners, and community members. Proposals are optimistic (succeed by default unless vetoed).
+- **Executive branch**: stHYPE token holder veto power over governance proposals.
+
+**Current status: NOT YET IMPLEMENTED.** The [security page](https://docs.stakedhype.fi/technical/security) states: *"This system will go live post Hyperliquid pre-compiles."* The [audits page](https://docs.stakedhype.fi/technical/audits) labels this as *"Governance (not implemented)."*
+
+The current operational model is a **team-controlled multisig** without the documented veto mechanism.
+
+On-chain verified governance data:
+- **Multisig address**: [`0x97dee0ea4ca10560f260a0f6f45bdc128a1d51f9`](https://hyperevmscan.io/address/0x97dee0ea4ca10560f260a0f6f45bdc128a1d51f9) (Gnosis Safe on HyperEVM)
+- **Threshold**: **3-of-5** (verified via `getThreshold()`)
+- **Nonce**: 20 transactions executed
+- **Timelock**: No timelock mechanism documented or found on-chain.
+- **Signer identities**: Not individually disclosed. Described only as "Thunderhead team, Valantis Team, ecosystem partners."
+
+Risk implications:
+- Governance is operationally centralized in current phase with no public timelock or threshold disclosure.
+- The planned dual-governance with stHYPE holder veto would be a meaningful improvement, but is not yet live.
+- Governance and parameter controls need explicit monitor coverage for role changes and critical parameter updates.
+
+### Programmability
+
+- Hybrid system: smart-contract based staking + operational policy layer for delegation, reserves, and queue management.
+- More complex than simple wrappers (WHYPE/WETH).
+- Potential sensitivity to off-chain operator execution quality and policy correctness.
+
+### External Dependencies
+
+Critical dependencies include:
+1. Hyperliquid L1 consensus/liveness.
+2. Hyperliquid validator performance and staking/slashing rules.
+3. HSM mechanism assumptions and stake-market behavior.
+4. DEX liquidity conditions for stHYPE/HYPE exits.
+
+Dependency concentration on Hyperliquid ecosystem is structurally high.
+
+## Operational Risk
+
+- Docs quality is good and technically detailed.
+- Security page and audit disclosures are positive. One co-founder found a [$6M white-hat vulnerability in Curve](https://docs.stakedhype.fi/technical/security), demonstrating security expertise.
+- Public bounty program absent. Not listed on Immunefi, Sherlock, Code4rena, or Cantina.
+- Team operates as "known anons" via Valantis Labs. Key GitHub contributors identified: Ankit Parashar (0xparashar), Ed (happenwah). Twitter: [@ValantisLabs](https://twitter.com/ValantisLabs).
+- Thunderhead Labs (original builder) has operational track record across multiple LST deployments (stFLIP, stELX, stMOVE, tPOKT). The Valantis acquisition adds the AMM/DEX expertise of the Valantis team.
+- Team/governance transparency is improving but appears earlier-stage than mature LST incumbents.
+
+## Monitoring
+
+Key contracts to monitor:
+- stHYPE Proxy: [`0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1`](https://hyperevmscan.io/address/0xfFaa4a3D97fE9107Cef8a3F48c069F577Ff76cC1)
+- OverseerV1 Proxy: [`0xB96f07367e69e86d6e9C3F29215885104813eeAE`](https://hyperevmscan.io/address/0xB96f07367e69e86d6e9C3F29215885104813eeAE)
+- wstHYPE Proxy: [`0x94e8396e0869c9F2200760aF0621aFd240E1CF38`](https://hyperevmscan.io/address/0x94e8396e0869c9F2200760aF0621aFd240E1CF38)
+- Governance Multisig: [`0x97dee0ea4ca10560f260a0f6f45bdc128a1d51f9`](https://hyperevmscan.io/address/0x97dee0ea4ca10560f260a0f6f45bdc128a1d51f9) (Gnosis Safe 3-of-5)
+
+### 1. Governance Monitoring (MANDATORY)
+
+Monitor all privileged role actions and parameter changes for:
+- RoleGranted / RoleRevoked events on stHYPE and OverseerV1 (AccessControl)
+- queue limits and withdrawal controls
+- reserve/buffer parameters
+- delegation strategy controls
+- Upgraded events on proxy contracts (implementation changes)
+
+Alert immediately on:
+- ownership/multisig signer changes (AddedOwner/RemovedOwner on Safe)
+- threshold changes (ChangedThreshold on Safe)
+- implementation upgrades (Upgraded event on proxy)
+- emergency pause activations
+
+### 2. Backing & Solvency Monitoring (MANDATORY)
+
+Track:
+- total stHYPE supply
+- estimated total managed HYPE (staked + liquid reserve)
+- backing ratio trend
+- validator concentration and large delegation shifts
+
+Alert thresholds:
+- backing ratio deterioration >1% in 24h (without expected event)
+- single validator concentration >25%
+
+### 3. Queue & Exit Monitoring (MANDATORY)
+
+Track:
+- queue size and age distribution
+- realized withdrawal times
+- reserve utilization rate
+
+Alert thresholds:
+- median queue delay > target SLA for 24h+
+- reserve buffer utilization >80% sustained
+- abrupt increase in queued exits (>20% day-over-day)
+
+### 4. Market Liquidity Monitoring
+
+Track:
+- stHYPE/HYPE and stHYPE/stable pool depth
+- slippage for representative sizes
+- depeg vs implied fair value
+
+Alert thresholds:
+- >2% sustained discount vs implied NAV proxy
+- pool depth drop >40% day-over-day
+
+### 5. Hyperliquid Base Risk Monitoring
+
+Track official Hyperliquid staking/validator announcements for:
+- validator jailing incidents
+- any governance activation of validator slashing
+- validator instability
+- staking parameter changes
+- chain liveness incidents
+
+## Risk Summary
+
+### Key Strengths
+
+1. Clear product-market fit: native HYPE liquid staking primitive.
+2. Public audit trail with multiple firms and multiple rounds.
+3. Detailed technical docs for HSM and unstaking mechanics.
+4. On-chain staking economics rather than off-chain custodial backing.
+
+### Key Risks
+
+1. Queue-based exits and stress-path wind-down mechanics introduce liquidity delay risk.
+2. Meaningful governance/parameter control centralization in current phase.
+3. Strong dependency on Hyperliquid validator and chain-level risk.
+4. Slashing regime may change via governance (currently no automatic validator slashing in base staking).
+5. No public bug bounty program identified.
+
+### Critical Risks
+
+- No immediate critical gate failure found from available public docs.
+- Highest tail risk is correlated Hyperliquid chain/validator stress causing both backing and liquidity pressure simultaneously.
+
+---
+
+## Risk Score Assessment
+
+### Critical Risk Gates
+
+- [x] **No audit** -- PASS (4 audits disclosed)
+- [x] **Unverifiable reserves** -- PASS (on-chain staking model, though monitoring visibility still maturing)
+- [x] **Total centralization** -- PASS (not single-EOA only, but governance remains relatively concentrated)
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+- 4 disclosed audits across Feb 2025-Nov 2025 (Three Sigma, Pashov x2, Guardian). Governance audit via Trail of Bits (inherited FraxGov).
+- No bug bounty program on any major platform.
+- ~8 months in production, TVL ~$124M (peaked ~$544M).
+- Per rubric: 3+ audits -> score 1-2 range for audits, but no bug bounty -> cannot reach score 1. Production time 6-12 months with TVL >$100M fits score 3 for track record.
+
+**Score: 2.5/5**
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+Subscores:
+- Governance: **4.0** — 3-of-5 multisig (verified on-chain), no timelock, signer identities undisclosed, planned governance system not yet implemented. Per rubric: "Multisig 3/5 or low threshold" + "No timelock" + "Powerful admin roles with limited constraints" = score 4.
+- Programmability: **3.0** — Hybrid on-chain/off-chain. Exchange rate is on-chain (`balancePerShare`), but validator delegation strategy requires off-chain operational decisions. OverseerV1 has MINTER_ROLE and BURNER_ROLE over stHYPE.
+- External dependencies: **4.0** — Critical single-ecosystem dependency on Hyperliquid L1 (consensus, validator performance, staking rules). Failure of Hyperliquid would break the entire protocol.
+
+Centralization score = (4.0 + 3.0 + 4.0) / 3 = **3.67**
+
+**Score: 3.67/5**
+
+#### Category 3: Funds Management (Weight: 30%)
+
+Subscores:
+- Collateralization: **2.5** — 100% on-chain collateral (staked HYPE), but not over-collateralized. Liquid reserve only 6.0% of total backing. Collateral quality = single-asset (HYPE), not blue-chip.
+- Provability: **2.0** — Key state readable on-chain (`totalSupply`, `balancePerShare`, `maxRedeemable`, `totalShares`). Exchange rate updated programmatically. AccessControl roles verified. Some off-chain complexity around validator delegation not fully transparent.
+
+Funds management score = (2.5 + 2.0) / 2 = **2.25**
+
+**Score: 2.25/5**
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+- Queue-based withdrawals: 7-day standard unstaking, up to 90-day for specialized stake account wind-down.
+- DEX liquidity is extremely thin: ~$380K total across all stHYPE/wstHYPE pools (0.3% of $124M TVL). Largest single pool ~$186K with near-zero daily volume.
+- `maxRedeemable()` returned 0 at time of check — no instant redemption buffer available.
+- Protocol unstaking queue is the primary exit mechanism, not secondary market trading.
+- ~$77M of wstHYPE used as lending collateral (HyperLend, Morpho, Felix) against only ~$138K wstHYPE DEX liquidity and zero stablecoin pairs. Liquidations are effectively unexecutable on-chain.
+- Per rubric: "Withdrawal queues or restrictions" + "<$1M DEX liquidity" + ">1 week potential exit time" = score 4. Current DEX liquidity ($380K) with near-zero daily trading volume ($13/day avg) means secondary market exits are effectively unavailable for any meaningful position size. The protocol unstaking queue (7+ days, up to 90 days under stress) is the only realistic exit path.
+
+**Score: 4.0/5**
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+- Good docs and audits.
+- No public bounty; governance and transparency still maturing.
+
+**Score: 3.0/5**
+
+### Final Score Calculation
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 2.5 | 20% | 0.50 |
+| Centralization & Control | 3.67 | 30% | 1.10 |
+| Funds Management | 2.25 | 30% | 0.68 |
+| Liquidity Risk | 4.0 | 15% | 0.60 |
+| Operational Risk | 3.0 | 5% | 0.15 |
+| **Final Score** | | | **3.03 / 5.0** |
+
+## Overall Risk Score: **3.0 / 5.0**
+
+### Risk Tier: **MEDIUM RISK**
+
+Rationale:
+- stHYPE is materially more complex/risk-bearing than WHYPE due to delegated staking, queue exits, and governance parameter controls.
+- Audit coverage is decent (4 audits from reputable firms), but no bug bounty.
+- Governance is centralized: 3-of-5 multisig with no timelock, planned dual-governance not yet implemented.
+- DEX liquidity is extremely thin ($380K vs $124M TVL); primary exit is via protocol unstaking queue (7+ days). ~$77M wstHYPE lending collateral with no stablecoin DEX pairs creates structural liquidation risk.
+- Strong single-ecosystem dependency on Hyperliquid L1.
+- Partially offset by: on-chain verifiable backing, programmatic exchange rate, Thunderhead's multi-LST track record, no incidents to date.
+
+## Reassessment Triggers
+
+1. Any governance architecture upgrade (SAFE/timelock/token governance rollout).
+2. Material changes to unstake queue logic, reserve policy, or `maxRedeemable()` buffer parameters.
+3. Any Hyperliquid validator jailing wave or governance rollout of validator slashing.
+4. Any stHYPE discount >3% sustained for >24h.
+5. Any incident disclosure by StakedHYPE or Hyperliquid affecting staking settlement.
+6. Release of new audits or public bug bounty program.
+
+## Sources
+
+- StakedHYPE docs home: https://docs.stakedhype.fi/
+- HSM technical docs: https://docs.stakedhype.fi/technical/hyperliquid-stake-marketplace-hsm
+- Stake Accounts & Architecture: https://docs.stakedhype.fi/technical/stake-accounts
+- Integration (mint/burn/unstaking): https://docs.stakedhype.fi/technical/integrate
+- Transparency & Risks: https://docs.stakedhype.fi/info/transparency-and-risks
+- Contract Addresses: https://docs.stakedhype.fi/technical/contract-addresses
+- Audits page: https://docs.stakedhype.fi/technical/audits
+- StakedHYPE governance: https://docs.stakedhype.fi/governance
+- StakedHYPE operators: https://docs.stakedhype.fi/governance/operators
+- StakedHYPE security: https://docs.stakedhype.fi/technical/security
+- wstHYPE docs: https://docs.stakedhype.fi/technical/wsthype
+- ValantisLabs audit repo: https://github.com/ValantisLabs/audits
+- Thunderhead Labs audit repo: https://github.com/thunderhead-labs/audits
+- Three Sigma Feb 2025 audit: https://github.com/ValantisLabs/audits/blob/main/Three_Sigma_Feb_25.pdf
+- Pashov Oct 2025 audit: https://github.com/ValantisLabs/audits/blob/main/pashov_oct_25.pdf
+- Pashov Nov 2025 audit: https://github.com/ValantisLabs/audits/blob/main/pashov_nov_2025.pdf
+- Guardian Nov 2025 audit: https://github.com/ValantisLabs/audits/blob/main/guardian_nov_2025.pdf
+- Trail of Bits FraxGov audit (governance basis): https://github.com/trailofbits/publications/blob/master/reviews/2023-05-fraxgov-securityreview.pdf
+- DeFiLlama StakedHYPE: https://defillama.com/protocol/stakedhype
+- Hyperliquid staking docs: https://hyperliquid.gitbook.io/hyperliquid-docs/hype-staking
+- Hyperliquid validators docs: https://hyperliquid.gitbook.io/hyperliquid-docs/hype-staking/validators
+- Hyperliquid risks docs: https://hyperliquid.gitbook.io/hyperliquid-docs/risks
+- ASXN HyperScreener (LST data): https://hyperscreener.asxn.xyz/liquid-staking
+
+## Appendix: HyperEVM Liquid Staking Market Share
+
+Source: [ASXN HyperScreener](https://hyperscreener.asxn.xyz/liquid-staking) — February 18, 2026
+
+| Token | Supply | Supply USD | Market Share |
+|-------|--------|-----------|-------------|
+| kHYPE | 21.79M | $661.46M | 77.67% |
+| stHYPE | 4.19M | $127.20M | 14.94% |
+| vHYPE | 1.04M | $31.72M | 3.72% |
+| iHYPE | 499.68K | $15.17M | 1.78% |
+| beHYPE | 484.88K | $14.72M | 1.73% |
+| mHYPE | 37.06K | $1.13M | 0.13% |
+| HYPED | 6.52K | $197.91K | 0.02% |
+| sHYPE | 2.03K | $61.67K | 0.01% |
+
+**Total LST market: ~$851M.** stHYPE is the second-largest LST on HyperEVM at 14.94% market share, behind kHYPE (77.67%). Notably, ~61% of stHYPE supply ($77.9M) is deposited in lending protocols as wstHYPE collateral, indicating high utilization concentration in a single use case.

--- a/src/components/pages/curation/reports/strata-srusde.md
+++ b/src/components/pages/curation/reports/strata-srusde.md
@@ -1,0 +1,540 @@
+# Protocol Risk Assessment: Strata
+
+- **Assessment Date:** February 18, 2026
+- **Token:** srUSDe (Senior Tranche USDe)
+- **Chain:** Ethereum
+- **Token Address:** [`0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003`](https://etherscan.io/address/0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003)
+- **Final Score: 2.8/5.0**
+
+## Overview + Links
+
+Strata is a generalized risk-tranching protocol that splits yield from underlying strategies into two tokenized tranches with distinct risk-reward profiles:
+
+- **Senior Tranche (srUSDe)**: Over-collateralized, yield-bearing synthetic dollar. Designed for capital preservation with a stable yield floored at a benchmark rate, uncapped upside participation in underlying yield, and first-loss protection from the junior tranche.
+- **Junior Tranche (jrUSDe)**: Provides leveraged upside to the underlying yield, absorbing yield volatility and associated risks in exchange for potentially higher returns.
+
+**srUSDe** is an ERC-4626 Meta Vault that accepts deposits of USDe, sUSDe, USDT, USDC, and DAI. All deposited assets are routed through the StrataCDO orchestrator into Ethena's sUSDe vault via the sUSDeStrategy. Yield is distributed between senior and junior tranches using a Dynamic Yield Split (DYS) mechanism that references:
+- The underlying sUSDe APY
+- A benchmark rate (supply-weighted average of USDC/USDT lending rates on Aave v3 Core)
+- The relative TVL distribution between the two tranches
+- Risk-premium parameters set by the team (planned to transition to independent risk managers)
+
+The senior tranche always earns at minimum the benchmark rate (floored), with upside participation. In extreme scenarios where junior liquidity is depleted and the underlying APY is below the benchmark rate, the senior tranche simply earns the underlying APY. If the junior tranche is fully depleted, **senior tranche may incur principal losses**.
+
+**Yield source**: Ethena's sUSDe yield (delta-neutral basis trade on ETH/BTC), redistributed via Strata's DYS mechanism.
+
+**Key metrics (Feb 18, 2026):**
+- Protocol TVL: ~$153.6M (DeFiLlama)
+- Peak TVL: ~$326M (December 2025)
+- Chain: Ethereum only
+
+**Yearn use cases per issue #47:**
+1. Deposit into senior vault srUSDe as part of a strategy
+2. Use srUSDe as collateral on Morpho for srUSDe/USDC markets where srUSDe is collateral and USDC is the loan token (minimal price change exposure)
+
+**Links:**
+
+- [Protocol Documentation](https://docs.strata.markets/)
+- [Protocol App](https://app.strata.money)
+- [Mechanism Overview](https://docs.strata.markets/protocol-mechanism/mechanism-overview)
+- [Technical Overview](https://docs.strata.markets/technical-documentation/protocol-overview)
+- [Contract Details](https://docs.strata.markets/technical-documentation/contracts-details)
+- [Roles & Permissions](https://docs.strata.markets/technical-documentation/roles-and-permissions)
+- [Audits](https://docs.strata.markets/technical-documentation/audits)
+- [Risks & Mitigations](https://docs.strata.markets/protocol-mechanism/risks-and-mitigations)
+- [DeFiLlama](https://defillama.com/protocol/strata)
+- [GitHub](https://github.com/Strata-Money/contracts-tranches)
+- [Twitter/X](https://twitter.com/strata_markets)
+
+## Contract Addresses
+
+### Core Ethena USDe Market Contracts (Ethereum)
+
+| Contract | Address | Type |
+|----------|---------|------|
+| srUSDe (Senior Tranche) | [`0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003`](https://etherscan.io/address/0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003) | ERC-4626 Meta Vault, Upgradeable Proxy |
+| jrUSDe (Junior Tranche) | [`0xC58D044404d8B14e953C115E67823784dEA53d8F`](https://etherscan.io/address/0xC58D044404d8B14e953C115E67823784dEA53d8F) | ERC-4626 Vault, Upgradeable Proxy |
+| StrataCDO | [`0x908B3921aaE4fC17191D382BB61020f2Ee6C0e20`](https://etherscan.io/address/0x908B3921aaE4fC17191D382BB61020f2Ee6C0e20) | Core Orchestrator, Upgradeable Proxy |
+| Accounting | [`0xa436c5Dd1Ba62c55D112C10cd10E988bb3355102`](https://etherscan.io/address/0xa436c5Dd1Ba62c55D112C10cd10E988bb3355102) | TVL calculations, fee accrual |
+| sUSDeStrategy | [`0xdbf4FB6C310C1C85D0b41B5DbCA06096F2E7099F`](https://etherscan.io/address/0xdbf4FB6C310C1C85D0b41B5DbCA06096F2E7099F) | Deposits into Ethena sUSDe Vault |
+| ERC20Cooldown | [`0xd6dAD17d025cDdDEd27305aEbAB8b277996A6fAF`](https://etherscan.io/address/0xd6dAD17d025cDdDEd27305aEbAB8b277996A6fAF) | Token lockup for cooldown period |
+| UnstakeCooldown | [`0x735edDF50Ca2371aa48466469C742e684c610F74`](https://etherscan.io/address/0x735edDF50Ca2371aa48466469C742e684c610F74) | sUSDe unstaking cooldown |
+| SUSDeCooldownRequestImpl | [`0x00A96056c30A22b684fF7a09F4A0AfEaE426dde2`](https://etherscan.io/address/0x00A96056c30A22b684fF7a09F4A0AfEaE426dde2) | Cooldown workflow for sUSDe |
+| TrancheDepositor | [`0x50E850641F43F65BF8fB3a7d0CF082a1D252F47e`](https://etherscan.io/address/0x50E850641F43F65BF8fB3a7d0CF082a1D252F47e) | Routes deposits into tranches |
+| AprPairFeed | [`0x2bb416614D740E5313aA64A0E3e419B39e800EC2`](https://etherscan.io/address/0x2bb416614D740E5313aA64A0E3e419B39e800EC2) | Benchmark & Collateral APY inputs |
+| AaveAprPairProvider | [`0x1c137776e04803F807616c382AbBA12d9BF0AF73`](https://etherscan.io/address/0x1c137776e04803F807616c382AbBA12d9BF0AF73) | Fetches APR values from Aave |
+| AccessControlManager | [`0x1d19E18ECaC4ef332a0d5d6Aa3a0f0f772605f60`](https://etherscan.io/address/0x1d19E18ECaC4ef332a0d5d6Aa3a0f0f772605f60) | Role-based access control |
+| TwoStepConfigManager | [`0x0f93bAC77c3dDD1341d3Ecc388c5F8A180818994`](https://etherscan.io/address/0x0f93bAC77c3dDD1341d3Ecc388c5F8A180818994) | Two-step exit-fee governance |
+
+### Governance & Multisig Contracts
+
+| Contract | Address | Configuration |
+|----------|---------|---------------|
+| Admin Multisig | [`0xA27cA9292268ee0f0258B749f1D5740c9Bb68B50`](https://etherscan.io/address/0xA27cA9292268ee0f0258B749f1D5740c9Bb68B50) | 3-of-4 Gnosis Safe, cold wallets, internal team + founding contributors |
+| Operational Multisig | [`0x4be3749a0F6557b8fd98F3967e859DbD7C694eF4`](https://etherscan.io/address/0x4be3749a0F6557b8fd98F3967e859DbD7C694eF4) | 2-of-3 Gnosis Safe, internal team |
+| Timelock (48h) | [`0xb2A3CF69C97AFD4dE7882E5fEE120e4efC77B706`](https://etherscan.io/address/0xb2A3CF69C97AFD4dE7882E5fEE120e4efC77B706) | Proposer: Admin Multisig. Canceller: Guardian |
+| Timelock (24h) | [`0x4f2682b78F37910704fB1AFF29358A1da07E022d`](https://etherscan.io/address/0x4f2682b78F37910704fB1AFF29358A1da07E022d) | Strategy config changes |
+| Guardian | [`0x277D26a45Add5775F21256159F089769892CEa5B`](https://etherscan.io/address/0x277D26a45Add5775F21256159F089769892CEa5B) | Patrick Collins (Cyfrin CEO) -- can cancel timelock transactions |
+
+### Proxy Infrastructure
+
+| Contract | ProxyAdmin |
+|----------|-----------|
+| StrataCDO | [`0xcAb791D0D44eBaC17378fF2AF6356c012F15c9e6`](https://etherscan.io/address/0xcAb791D0D44eBaC17378fF2AF6356c012F15c9e6) |
+| ERC20Cooldown | [`0xeD6c7b379F73DF0618406d263b13b2386E398166`](https://etherscan.io/address/0xeD6c7b379F73DF0618406d263b13b2386E398166) |
+
+### On-Chain Verification (Etherscan, Feb 18, 2026)
+
+All core contracts are **verified on Etherscan**:
+
+| Contract | Etherscan Name | Verified | Proxy |
+|----------|---------------|----------|-------|
+| srUSDe | TransparentUpgradeableProxy → Tranche (impl) | Yes | Yes |
+| jrUSDe | TransparentUpgradeableProxy | Yes | Yes |
+| StrataCDO | TransparentUpgradeableProxy → StrataCDO (impl) | Yes | Yes |
+| sUSDeStrategy | TransparentUpgradeableProxy | Yes | Yes |
+| Accounting | TransparentUpgradeableProxy | Yes | Yes |
+| AccessControlManager | AccessControlManager | Yes | No |
+| Admin Multisig | GnosisSafeProxy | Yes | Yes |
+| Operational Multisig | SafeProxy | Yes | Yes |
+| 48h Timelock | StrataMasterChef (OZ TimelockController) | Yes | No |
+| 24h Timelock | StrataMasterChef (OZ TimelockController) | Yes | No |
+| Guardian | EOA (not a contract) | N/A | N/A |
+
+**Note**: Both timelocks are registered on Etherscan as `StrataMasterChef` but contain standard OpenZeppelin TimelockController functions (`schedule`, `execute`, `cancel`, `getMinDelay`). Delays verified on-chain: 48h = 172,800 seconds, 24h = 86,400 seconds.
+
+## Audits and Due Diligence Disclosures
+
+Strata has completed an extensive, multi-phased audit process with 3 reputable firms across at least 7 distinct audit engagements:
+
+### Audit History
+
+| # | Firm | Date | Scope | C | H | M | L | Info | Report |
+|---|------|------|-------|---|---|---|---|------|--------|
+| 1 | **Cyfrin** | Oct 8, 2025 | Protocol v1 (Tranches) | 1 | 2 | 6 | 5 | 12 | [PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-10-08-cyfrin-strata-tranches-v2.0.pdf) |
+| 2 | **Guardian Audits** | Oct 10, 2025 | Protocol v1 (Tranches) | 1 | 5 | 14 | 5 | 8 | [PDF](https://github.com/GuardianAudits/Audits/blob/main/Strata/Strata_Tranches_report.pdf) |
+| 3 | **Quantstamp** | ~Q4 2025 | Protocol v1 (Tranches) | - | - | - | - | - | [Certificate](https://certificate.quantstamp.com/full/strata-tranches/3c3a4037-2a92-468c-a4f3-5ea498e7b539/index.html) |
+| 4 | **Quantstamp** | ~Q4 2025 | Redemption Fee (Update to Tranches) | - | - | - | - | - | [Certificate](https://certificate.quantstamp.com/full/strata-update-to-tranches/d7a903b7-80cf-42db-8433-79186fdd8be2/index.html) |
+| 5 | **Cyfrin** | Jan 23, 2026 | Shares Cooldown mechanism | 0 | 0 | 6 | 3 | 10 | [PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2026-01-23-cyfrin-strata-shares-cooldown-v2.0.pdf) |
+| 6 | **Cyfrin** | Jun 11, 2025 | Pre-Deposit Vaults | 1 | 1 | 3 | 16 | 9 | [PDF](https://github.com/Cyfrin/cyfrin-audit-reports/blob/main/reports/2025-06-11-cyfrin-strata-predeposit-v2.1.pdf) |
+| 7 | **Quantstamp** | ~2025 | Pre-Deposit Vaults | - | - | - | - | - | [Papermark](https://www.papermark.com/view/cmgm9op9b0003l404g395i6a5) |
+
+*Quantstamp reports hosted on JS-rendered platforms; finding counts require browser access. Dashes indicate data not programmatically extractable.*
+
+**Total findings across Cyfrin + Guardian reports: 3 Critical, 8 High, 29 Medium, 29 Low (all resolved).**
+
+Notable Critical/High findings (all resolved):
+- **C: Withdrawers of sUSDe always incur a loss** (Cyfrin #1) -- Inverted parameters in `Tranche::_withdraw` caused users to receive significantly less than entitled
+- **C: Reserve withdrawal unit mismatch** (Guardian #2) -- `StrataCDO.reduceReserve` forwarded incorrect amounts, breaking internal accounting
+- **C: Attacker can drain entire protocol sUSDe balance** (Cyfrin #6) -- Incorrect redemption accounting in pre-deposit vault could drain funds
+- **H: Withdrawal active requests DoS** (Cyfrin #1, Guardian #2) -- Spam tiny withdrawal requests on behalf of another user causing out-of-gas during finalization
+- **H: MEV APR front-run** (Guardian #2) -- Front-running of APR changes via `onAprChanged`
+- **H: JR tranche bankrun susceptibility** (Cyfrin #5) -- SharesCooldown finalization bypassed `minimumJrtSrtRatio`
+
+Guardian Audits recommended an independent follow-up review after finding 1 Critical + 5 High issues, which was conducted by Quantstamp.
+
+### On-Chain Complexity
+
+The architecture is moderately complex:
+- **CDO Pattern**: Core orchestrator (StrataCDO) connects tranches, accounting, and strategy contracts
+- **Multiple Proxy Contracts**: Most core contracts use OpenZeppelin TransparentUpgradeableProxy
+- **Cooldown Mechanisms**: Two-stage withdrawal with ERC20Cooldown and UnstakeCooldown contracts
+- **APR Feed System**: On-chain APR calculation using Aave data feeds
+- **Multi-token deposits**: The srUSDe Meta Vault accepts USDe, sUSDe, USDT, USDC, and DAI
+
+### Bug Bounty
+
+**No active bug bounty program found.** Exhaustive search across Immunefi, Code4rena, Sherlock, HackerOne, Safe Harbor, and the protocol's own documentation and GitHub yielded no bug bounty listing, responsible disclosure policy, or security contact for vulnerability reporting. The [security documentation](https://docs.strata.markets/technical-documentation/security) covers audits, multisigs, and monitoring but does not mention a bug bounty. This is a notable gap for a protocol with >$150M TVL.
+
+## Historical Track Record
+
+- **Time in Production**: srUSDe proxy deployed October 2, 2025 (block [23492392](https://etherscan.io/tx/0x857c511cb166160e9b9acdb8ef47d9306ad5bcef1a311e845b4a2d4b90ea1f6b)). In production for **~4.5 months** as of February 2026. Pre-deposit vaults with TVL existed from July 2025 (~7 months with TVL).
+- **GitHub Repository**: Created September 16, 2025. Public, Solidity-based, actively maintained (last update Feb 17, 2026).
+- **TVL History**:
+
+| Period | TVL | Notes |
+|--------|-----|-------|
+| Jul 2025 | ~$18M | Pre-deposit vaults / soft launch |
+| Aug 2025 | $18M - $53M | Steady growth |
+| Sep 2025 | $53M - $105M | Rapid growth |
+| Oct 13, 2025 | ~$110M | Official launch on Ethena USDe |
+| Nov 2025 | $110M - $258M | Strong growth phase |
+| Dec 5-8, 2025 | **~$326M** | **Peak TVL** |
+| Dec 20-31, 2025 | $326M → $262M | Moderate decline |
+| Jan 8-14, 2026 | $230M → $147M | **Sharp drop** (~$83M outflow in ~1 week) |
+| Jan 17, 2026 | **~$122M** | **Deepest drawdown** (62.6% below peak) |
+| Feb 1-10, 2026 | $152M → $233M | Recovery |
+| Feb 18, 2026 | ~$153M | Current (53% below ATH) |
+
+- **TVL Volatility**: The protocol has experienced significant TVL swings. The sharp January drop (from ~$262M to ~$147M in one week) suggests **large depositor concentration risk**. The TVL remains volatile with multiple >20% swings.
+- **Incidents**: No reported security incidents, exploits, or hacks found.
+- **Exchange Rate (on-chain verified Feb 18, 2026)**:
+  - `convertToAssets(1e18)` = 1.013728 USDe per srUSDe
+  - `totalAssets()` = 113,838,466 USDe
+  - `totalSupply()` = 112,296,907 srUSDe
+  - As an ERC-4626 vault, the exchange rate should only increase (denominated in underlying). The current 1.37% appreciation over ~4.5 months implies ~3.7% annualized yield to the senior tranche.
+
+## Funds Management
+
+### Deposit/Withdrawal Flow
+
+**Deposit**: Users deposit USDe (or sUSDe, USDT, USDC, DAI) into the srUSDe Meta Vault. Deposited assets are exchanged for shares proportional to the current exchange rate and passed to the sUSDeStrategy, which stakes them into Ethena's sUSDe vault.
+
+**Withdrawal**: Uses a multi-stage cooldown mechanism:
+1. **ERC20Cooldown**: Strategy locks tokens in a cooldown contract for a specified period
+2. **UnstakeCooldown**: For sUSDe, triggers Ethena's own sUSDe cooldown (currently 7 days)
+3. Each withdrawal request is handled independently per user; new requests do not extend or affect earlier requests
+4. After the cooldown period, tokens can be finalized/withdrawn
+
+### Accessibility
+
+- **Deposits**: Permissionless. Anyone can deposit USDe, sUSDe, USDT, USDC, or DAI
+- **Redemptions**: Permissionless but subject to cooldown periods tied to Ethena's sUSDe unstaking
+- **Atomic operations**: Deposits are single-transaction. Withdrawals require initiation + cooldown + finalization
+- **Fees**: Performance fees and redemption fees apply (transparent, visible on the app). Exit-fee changes governed by a two-step process via TwoStepConfigManager
+
+### Collateralization
+
+- **Backing**: srUSDe is backed by the underlying USDe/sUSDe staked in Ethena's vault, with additional over-collateralization from the junior tranche (jrUSDe) which serves as first-loss capital
+- **Senior coverage ratio**: When it falls below **105%**, the protocol may temporarily halt senior minting and junior redemptions to protect the senior tranche
+- **Underlying collateral**: USDe is Ethena's synthetic dollar backed by a delta-neutral strategy (ETH/BTC spot + short perpetual futures). Ethena maintains proof of reserves via third-party verification
+- **Risk hierarchy**: Senior tranche (srUSDe) is principal-protected in the base asset and paid first. The junior tranche absorbs losses before any impact to senior holders. However, if the junior tranche is **fully depleted**, the senior tranche **may incur principal losses**
+- **Reserve mechanism**: Part of strategy gains can be allocated to a protocol reserve (configurable via `setReserveBps`), which can be redistributed to tranche TVL or withdrawn to treasury
+
+### Provability
+
+- **Exchange rate**: Calculated on-chain via ERC-4626 standard (`convertToAssets()`/`convertToShares()`). Anyone can verify
+- **Underlying sUSDe balance**: Verifiable on-chain by checking the strategy's sUSDe holdings
+- **Yield calculation**: DYS mechanism computes yields on-chain using the AprPairFeed contract. Benchmark rate sourced from Aave v3 Core. However, risk-premium parameters (x, y, k) are set by the team
+- **Accounting**: On-chain Accounting contract tracks raw TVL, balances, inflows/outflows, fees, and reward distribution for both tranches
+
+## Liquidity Risk
+
+### Primary Exit Mechanisms
+
+1. **Redeem from srUSDe vault**: Initiate withdrawal → cooldown period (tied to Ethena's sUSDe cooldown, currently ~7 days) → finalize. Permissionless but not instant
+2. **DEX swap**: Extremely thin on-chain DEX liquidity. Total across all Uniswap V4 pools: ~$135K. Largest pool is srUSDe/USDe at ~$81K with only $425 in 24h volume. **No Curve or Balancer pools exist.** CoinGecko does not list srUSDe
+3. **Pendle markets**: PT-srUSDe-02APR2026 pool holds ~$21.9M TVL with ~$128K weekly volume. Primary venue for srUSDe trading, but these are fixed-yield PT tokens, not raw srUSDe
+4. **Morpho markets**: PT-srUSDe-2APR2026/USDC market has ~$14.6M supply and 82.4% utilization. A raw srUSDe/USDe market exists on Morpho but is empty ($0 supply/$0 borrow)
+
+### Withdrawal Restrictions
+
+- **Cooldown period**: Withdrawals require a cooldown period linked to Ethena's sUSDe unstaking (~7 days). Not instant
+- **Coverage protection**: When senior coverage ratio falls below 105%, senior minting and junior redemptions are suspended. This protects senior tranche but could trap capital in extreme scenarios
+- **Self-balancing**: The coverage mechanism is designed to be self-balancing -- thinner junior coverage attracts more liquidity via higher junior yields
+
+### Liquidity Assessment
+
+- **Primary liquidity**: The main exit path is through the cooldown-based redemption mechanism (not instant)
+- **Secondary market**: DEX liquidity is negligible (~$135K total across Uniswap V4 pools). Pendle PT-srUSDe markets (~$21.9M) are the most liquid venue but trade fixed-yield PTs, not raw srUSDe. Morpho lending markets hold ~$14.6M in PT-srUSDe collateral
+- **Large holder impact**: Given the TVL volatility (62.6% drawdown from peak), large holders can exit but it takes time due to cooldowns
+- **Same-value redemption**: srUSDe redeems for USDe (stablecoin-denominated), so price impact risk is minimal for the Morpho use case
+
+## Centralization & Control Risks
+
+### Governance
+
+Strata uses a layered Role-Based Access Control (RBAC) system with clear separation between operational, administrative, and owner functions:
+
+| Role | Callable By | Description | Key Functions |
+|------|-------------|-------------|---------------|
+| PAUSER_ROLE | Admin Multisig (3/4) | Pause/resume deposits and redemptions | `setActionStates`, `setJrtShortfallPausePrice` |
+| UPDATER_FEED_ROLE | Operational Multisig (2/3) | Trigger APR refresh and recalculation | `onAprChanged`, `updateRoundData` |
+| UPDATER_STRAT_CONFIG_ROLE | 24h Timelock | Update strategy risk parameters and cooldowns | `setRiskParameters`, `setCooldowns` |
+| RESERVE_MANAGER_ROLE | Admin Multisig (3/4) | Redistribute reserves or withdraw to treasury | `reduceReserve`, `distributeReserve`, `setReserveTreasury` |
+| PROPOSER_CONFIG_ROLE | Admin Multisig (3/4) | Propose exit-fee configuration changes | `scheduleExitFeeChange` |
+| OWNER_ROLE | 48h Timelock | High-level protocol configuration | `setAprPairFeed`, `setReserveBps`, `setFeeRetentionBps`, `setMinimumJrtSrtRatio`, `setImplementations`, `setProvider` |
+
+**Multisig Details:**
+- **Admin Multisig**: 3-of-4 Gnosis Safe. All signers use cold wallets. Keys held by internal team members and founding core contributors. At least 3 signers must validate transaction hashes match
+- **Operational Multisig**: 2-of-3 Gnosis Safe. All keys held by internal team members
+- **Timelocks**: 48h for owner-level changes (proxy upgrades, core config), 24h for strategy config changes
+- **Guardian**: Patrick Collins (Co-Founder & CEO of Cyfrin, well-known security researcher). Can cancel timelock transactions before execution. Monitors queued transactions using Hypernative and custom tools
+
+**Key concerns:**
+- Admin Multisig is only 3-of-4 (relatively low threshold)
+- Operational Multisig is only 2-of-3 (low threshold)
+- All multisig keys held by internal team -- no external/independent signers
+- Admin Multisig can pause the protocol immediately (no timelock on pause)
+- RESERVE_MANAGER_ROLE (Admin Multisig) can transfer reserves to treasury -- potential extraction vector if compromised
+- No on-chain governance yet (planned for future)
+
+### Programmability
+
+- **srUSDe exchange rate**: Calculated on-chain via ERC-4626 standard. Programmatic, no admin input needed
+- **Yield distribution (DYS)**: Mostly programmatic. AprPairFeed fetches benchmark rate from Aave on-chain. However, risk-premium parameters (x, y, k) are set by the team initially
+- **APR updates**: Triggered by Operational Multisig via `updateRoundData`. This is a manual trigger for an on-chain computation
+- **Accounting**: Fully on-chain. TVL, balances, fees, and reward distribution tracked programmatically
+- **Withdrawals**: Programmatic cooldown mechanism. No manual intervention needed after initiation
+
+### External Dependencies
+
+| Dependency | Type | Criticality | Impact of Failure |
+|------------|------|-------------|-------------------|
+| **Ethena (sUSDe/USDe)** | Yield source & collateral | **Critical** | All deposited assets staked in Ethena's sUSDe vault. Ethena insolvency, USDe depegging, or sUSDe exploit would directly impact srUSDe. Senior tranche principal at risk if junior tranche is depleted |
+| **Aave v3 Core** | Benchmark rate oracle | **High** | Supply-weighted average of USDC/USDT lending rates used for benchmark. Failure could distort yield calculations and tranche distributions |
+| **Gnosis Safe** | Multisig infrastructure | **High** | All governance actions flow through Safe multisigs |
+| **Hypernative** | Monitoring & alerting | **Medium** | 24/7 contract monitoring. Not critical for operations but important for security |
+| **Ethereum L1** | Settlement layer | **High** | All contracts deployed on Ethereum mainnet only |
+
+**Key dependency risk**: Strata has a **single critical yield source dependency** on Ethena/sUSDe. The benchmark rate relies on a **single data source** (Aave v3 Core). No documented fallback mechanisms if Ethena or Aave dependencies fail. The AprPairFeed has a `setRoundStaleAfter` parameter suggesting some staleness detection.
+
+## Operational Risk
+
+- **Team Transparency**: Founding team is **not publicly named** in documentation. Operational team members are not publicly identified. The only publicly named individual is **Patrick Collins** (Cyfrin CEO), who serves as Guardian (security oversight role, not management). Team is classified as **partially anonymous** -- known anons at best
+- **Documentation**: Good quality. Comprehensive docs at docs.strata.markets covering mechanism, technical architecture, contracts, roles, and risks. Actively maintained (last updated Feb 14, 2026)
+- **Legal Structure**: **Frontera Labs, Inc.**, a Delaware (USA) corporation, operates the Interface (front-end) only. The company explicitly disclaims ownership or control of the protocol smart contracts. Protocol contracts are licensed under BUSL-1.1. A planned transition to a **Cayman Islands foundation** is referenced in the [Terms of Service](https://docs.strata.markets/resources/terms-of-service) (last updated Nov 28, 2025). US users are geo-blocked. Contact: legal@strata.markets
+- **Incident Response**: Not formally documented, but the protocol has multiple layers of defense:
+  - 24/7 monitoring via Hypernative
+  - Guardian (Patrick Collins) can cancel timelock transactions
+  - Admin Multisig can pause the protocol immediately
+- **Open Source**: Contracts are public on [GitHub](https://github.com/Strata-Money/contracts-tranches)
+- **Points Program**: Strata runs a "Strata Points Program" (likely incentive/airdrop mechanism). The TVL volatility may be partially explained by points farming behavior
+
+## Monitoring
+
+### srUSDe Vault Monitoring
+
+- **srUSDe contract**: [`0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003`](https://etherscan.io/address/0x3d7d6fdf07EE548B939A80edbc9B2256d0cdc003)
+  - Monitor `convertToAssets(1e18)` for exchange rate changes (should only increase)
+  - **Alert**: If exchange rate **decreases** -- indicates potential issue with yield distribution or losses
+  - Monitor `Deposit`, `Withdraw` events for large deposits/withdrawals (>$1M)
+  - **Alert**: Single deposits/withdrawals >$5M (potential whale activity)
+
+### StrataCDO Monitoring
+
+- **StrataCDO**: [`0x908B3921aaE4fC17191D382BB61020f2Ee6C0e20`](https://etherscan.io/address/0x908B3921aaE4fC17191D382BB61020f2Ee6C0e20)
+  - Monitor senior coverage ratio (should stay above 105%)
+  - **Alert**: Coverage ratio below 105% (triggers protective measures -- junior redemptions halted)
+  - Monitor for any pausing events (`setActionStates`)
+
+### Strategy Monitoring
+
+- **sUSDeStrategy**: [`0xdbf4FB6C310C1C85D0b41B5DbCA06096F2E7099F`](https://etherscan.io/address/0xdbf4FB6C310C1C85D0b41B5DbCA06096F2E7099F)
+  - Monitor sUSDe balance held by strategy
+  - **Alert**: If strategy balance drops significantly relative to total deposits
+
+### Governance Monitoring
+
+- **Admin Multisig**: [`0xA27cA9292268ee0f0258B749f1D5740c9Bb68B50`](https://etherscan.io/address/0xA27cA9292268ee0f0258B749f1D5740c9Bb68B50)
+  - Monitor for owner/signer changes and threshold modifications
+  - **Alert**: Immediately on any signer replacement or threshold change
+
+- **48h Timelock**: [`0xb2A3CF69C97AFD4dE7882E5fEE120e4efC77B706`](https://etherscan.io/address/0xb2A3CF69C97AFD4dE7882E5fEE120e4efC77B706)
+  - Monitor `CallScheduled`, `CallExecuted`, `Cancelled` events
+  - **Alert**: Immediately on any `CallScheduled` event (48h window to review changes)
+
+- **24h Timelock**: [`0x4f2682b78F37910704fB1AFF29358A1da07E022d`](https://etherscan.io/address/0x4f2682b78F37910704fB1AFF29358A1da07E022d)
+  - Monitor `CallScheduled`, `CallExecuted`, `Cancelled` events
+  - **Alert**: On any `CallScheduled` event (24h window for strategy config changes)
+
+### Ethena Dependency Monitoring
+
+- **USDe peg**: Monitor USDe price on DEXes
+  - **Alert**: If USDe deviates >0.5% from $1.00 peg
+  - **Alert**: If USDe deviates >2% from $1.00 peg (critical -- srUSDe value directly impacted)
+- **sUSDe vault**: Monitor Ethena's sUSDe vault for any anomalies, cooldown period changes
+
+### Monitoring Frequency
+
+| Category | Frequency | Priority |
+|----------|-----------|----------|
+| Timelock scheduled calls (both 48h and 24h) | Real-time | Critical |
+| Proxy upgrade events | Real-time | Critical |
+| Multisig signer/threshold changes | Real-time | Critical |
+| srUSDe exchange rate | Every 6 hours | High |
+| Senior coverage ratio | Every 6 hours | High |
+| USDe peg stability | Hourly | High |
+| Strategy sUSDe balance | Daily | Medium |
+| Protocol TVL changes | Daily | Medium |
+
+## Risk Summary
+
+### Key Strengths
+
+- **Structured risk tranching**: srUSDe benefits from junior tranche (jrUSDe) first-loss protection, providing additional security beyond just the underlying yield source
+- **Multi-layered governance**: 48h timelock for owner changes, 24h timelock for strategy config, two-step exit-fee changes, independent Guardian (Patrick Collins/Cyfrin) with veto power
+- **On-chain transparency**: Exchange rate is programmatic (ERC-4626), accounting is fully on-chain, and the codebase is open-source
+- **Multiple reputable audits**: 7+ audit engagements across Cyfrin, Quantstamp, and Guardian Audits
+- **Active monitoring**: 24/7 monitoring via Hypernative with Guardian oversight
+
+### Key Risks
+
+- **Short track record**: Only ~4 months in production since official launch (October 2025). Very young protocol
+- **Single critical dependency on Ethena**: All funds flow into Ethena's sUSDe. An Ethena exploit or USDe depeg would directly impact srUSDe holders
+- **Significant TVL volatility**: 62.6% drawdown from peak ($326M → $122M), suggesting large depositor concentration and/or points farming instability
+- **Low multisig thresholds**: Admin Multisig is 3-of-4 with all internal signers (no independent/external signers). Operational Multisig is 2-of-3
+- **No bug bounty program found**: Notable absence for a protocol managing >$150M TVL
+- **Withdrawal delays**: Redemptions subject to cooldown periods tied to Ethena's sUSDe unstaking (~7 days)
+- **Anonymous team**: Founding team not publicly identified. Patrick Collins (Guardian) is the only doxxed individual, in a security oversight role
+
+### Critical Risks
+
+- **Junior tranche depletion**: If the junior tranche is fully depleted (e.g., prolonged negative yield or extreme outflows), senior tranche **may incur principal losses**. The 105% coverage circuit breaker provides some protection but is not a guarantee
+- **Reserve extraction risk**: The Admin Multisig (3/4, internal team only) holds RESERVE_MANAGER_ROLE and can transfer reserves to treasury. If compromised, this could be an extraction vector
+- **Proxy upgrade risk**: Core contracts are upgradeable with 48h timelock. While the Guardian can cancel, this requires active monitoring
+
+---
+
+## Risk Score Assessment
+
+**Scoring Guidelines:**
+- Be conservative: when uncertain between two scores, choose the higher (riskier) one
+- Use decimals (e.g., 2.5) when a subcategory falls between scores
+- Prioritize on-chain evidence over documentation claims
+
+### Critical Risk Gates
+
+- [x] **No audit** -- Protocol audited by 3 reputable firms (Cyfrin, Quantstamp, Guardian) across 7+ engagements. **PASS**
+- [x] **Unverifiable reserves** -- srUSDe exchange rate is programmatic on-chain (ERC-4626). Underlying sUSDe holdings verifiable on-chain. **PASS**
+- [x] **Total centralization** -- 3-of-4 Gnosis Safe multisig with 48h timelock and independent Guardian. Not a single EOA. **PASS**
+
+**All gates pass.** Proceed to category scoring.
+
+### Category Scores
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+- **Audits**: 3 audit firms (Cyfrin, Quantstamp, Guardian) across 7+ engagements covering core contracts, redemption mechanism, and pre-deposit vaults. Good coverage.
+- **Bug Bounty**: No active bug bounty program found. Significant gap.
+- **Time in Production**: ~4 months since official launch (October 2025). Very young.
+- **TVL**: ~$153M current, peaked at ~$326M. Has shown significant volatility (62.6% drawdown).
+- **Incidents**: None reported.
+
+**Score: 3.0/5** -- Strong audit coverage from reputable firms across multiple phases. However, the very short production history (~4 months), absence of a bug bounty program, and significant TVL volatility weigh heavily. Between score 2 (2+ audits, 1-2 years, TVL >$50M) and score 3 (1 audit, 6-12 months) -- the strong audit suite is offset by the very short track record. Conservative assessment leans toward 3.
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+**Subcategory A: Governance**
+
+- 3-of-4 Admin Multisig with cold wallets, all internal team signers
+- 2-of-3 Operational Multisig, all internal team signers
+- 48h timelock for owner-level changes (proxy upgrades, core config)
+- 24h timelock for strategy config changes
+- Independent Guardian (Patrick Collins/Cyfrin) can cancel timelock transactions
+- Pause function available immediately via Admin Multisig (no timelock)
+- No external/independent signers on either multisig
+
+**Governance Score: 3.0** -- The timelocked governance with Guardian veto is a good design. However, the 3/4 admin threshold is low, operational multisig is only 2/3, and all signers are internal team only. The Guardian adds meaningful independent oversight but cannot initiate changes, only cancel.
+
+**Subcategory B: Programmability**
+
+- srUSDe exchange rate: fully on-chain ERC-4626
+- Yield distribution (DYS): mostly programmatic using AprPairFeed from Aave
+- Risk-premium parameters (x, y, k): set by team initially, planned transition to independent risk managers
+- APR updates: triggered manually by Operational Multisig (but computation is on-chain)
+- Accounting: fully on-chain
+
+**Programmability Score: 2.5** -- Most critical functions are on-chain and programmatic. The APR update trigger and risk-premium parameter setting introduce some manual dependency. The planned transition to independent risk managers is positive but not yet implemented.
+
+**Subcategory C: External Dependencies**
+
+- **Critical**: Ethena sUSDe (single yield source, all funds deposited there)
+- **High**: Aave v3 Core (single benchmark rate source)
+- **High**: Gnosis Safe (multisig infrastructure)
+- No documented fallback mechanisms if critical dependencies fail
+
+**Dependencies Score: 4.0** -- Single critical dependency on Ethena with no fallback. Aave as single benchmark rate source. Failure of Ethena would break core functionality and potentially result in principal losses.
+
+**Centralization Score = (3.0 + 2.5 + 4.0) / 3 = 3.17**
+
+**Score: 3.2/5** -- Reasonable governance structure with timelocks and Guardian oversight, but constrained by low multisig thresholds, internal-only signers, critical Ethena dependency, and team-controlled risk parameters.
+
+#### Category 3: Funds Management (Weight: 30%)
+
+**Subcategory A: Collateralization**
+
+- srUSDe backed by sUSDe staked in Ethena's vault (on-chain verifiable)
+- Over-collateralized by junior tranche (first-loss capital)
+- 105% coverage circuit breaker provides protection
+- Underlying collateral is USDe (Ethena's synthetic dollar -- backed by delta-neutral ETH/BTC strategy with CEX counterparty exposure)
+- Reserve mechanism exists (configurable by admin, can be withdrawn to treasury)
+
+**Collateralization Score: 2.5** -- On-chain backing verifiable through ERC-4626 and strategy. Junior tranche first-loss protection is a strength. But the underlying asset is Ethena's USDe (itself a synthetic dollar with CEX counterparty risk), and the reserve extraction vector is a concern.
+
+**Subcategory B: Provability**
+
+- Exchange rate: programmatic on-chain (ERC-4626)
+- Strategy holdings: verifiable on-chain (sUSDe balance in strategy contract)
+- Accounting: fully on-chain with transparent TVL tracking
+- Underlying USDe collateral: relies on Ethena's proof of reserves (third-party verified)
+- Risk-premium parameters: set by team, visible on-chain once set
+
+**Provability Score: 2.0** -- srUSDe layer is fully on-chain verifiable. Underlying USDe/sUSDe provability depends on Ethena (which has third-party verification). Good transparency overall.
+
+**Funds Management Score = (2.5 + 2.0) / 2 = 2.25**
+
+**Score: 2.25/5** -- Good on-chain provability and transparency. Senior tranche benefits from junior first-loss protection. Underlying Ethena dependency and reserve extraction risk prevent a lower score.
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+- **Exit mechanism**: Cooldown-based redemption (~7 days via Ethena sUSDe unstaking). Not instant
+- **DEX liquidity**: Negligible -- ~$135K total across Uniswap V4 pools with <$500/day volume. No Curve or Balancer pools. Pendle PT markets (~$21.9M) are the most liquid but trade PTs, not raw srUSDe
+- **Withdrawal restrictions**: 105% coverage circuit breaker can temporarily halt operations
+- **Same-value redemption**: srUSDe redeems for USDe (stablecoin-denominated), minimal price change risk
+- **Use case context**: For the Morpho use case (srUSDe as collateral for USDC loans), the collateral/loan price change should be minimal
+
+**Score: 3.0/5** -- Redemptions are available but not instant (~7 day cooldown). Limited or no DEX liquidity for secondary market exits. The same-value (stablecoin-denominated) redemption is a plus, and the Morpho collateral use case has minimal price impact risk. Between score 2 (direct redemption with minor delays) and score 4 (withdrawal queues/restrictions) -- the 7-day cooldown and limited secondary market push this toward 3.
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+- **Team**: Partially anonymous. Founding team not publicly identified. Patrick Collins (Guardian) is the only doxxed individual, in a security oversight role
+- **Documentation**: Good quality, comprehensive, actively maintained
+- **Legal Structure**: Frontera Labs, Inc. (Delaware) operates the front-end. Protocol contracts are autonomous and licensed under BUSL-1.1. Planned transition to Cayman Islands foundation. US users geo-blocked
+- **Incident Response**: Not formally documented. 24/7 Hypernative monitoring + Guardian veto capability provide de facto incident response
+
+**Score: 2.5/5** -- Adequate documentation, clear legal entity (Delaware corporation), and US compliance via geo-blocking. Anonymous team and no formal incident response plan are concerns, but Patrick Collins's involvement adds credibility.
+
+### Final Score Calculation
+
+```
+Final Score = (Centralization × 0.30) + (Funds Mgmt × 0.30) + (Audits × 0.20) + (Liquidity × 0.15) + (Operational × 0.05)
+```
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 3.0 | 20% | 0.60 |
+| Centralization & Control | 3.2 | 30% | 0.96 |
+| Funds Management | 2.25 | 30% | 0.675 |
+| Liquidity Risk | 3.0 | 15% | 0.45 |
+| Operational Risk | 2.5 | 5% | 0.125 |
+| **Final Score** | | | **2.81** |
+
+**Final Score: 2.8**
+
+### Risk Tier
+
+| Final Score | Risk Tier | Recommendation |
+|------------|-----------|----------------|
+| **2.5-3.5** | **Medium Risk** | Approved with enhanced monitoring |
+
+**Final Risk Tier: Medium Risk**
+
+---
+
+Strata's srUSDe is a well-designed risk-tranching product with good audit coverage from reputable firms, multi-layered governance with independent Guardian oversight, and fully on-chain accounting and exchange rate computation. The junior tranche first-loss protection adds meaningful risk mitigation beyond the underlying yield source.
+
+However, the protocol is very young (~4 months), has a critical single dependency on Ethena's sUSDe, exhibited significant TVL volatility (62.6% drawdown), has no bug bounty program, an anonymous team, and withdrawal delays tied to Ethena's cooldown period.
+
+**For the intended Yearn use cases:**
+1. **Direct srUSDe deposit**: Medium risk. The 7-day withdrawal cooldown and Ethena dependency are the primary concerns.
+2. **srUSDe as Morpho collateral (srUSDe/USDC)**: Lower effective risk for the specific use case since srUSDe is stablecoin-denominated and price changes should be minimal, but liquidation could be slow due to cooldown periods.
+
+**Key conditions for exposure:**
+- Monitor srUSDe exchange rate for any decreases (should only increase)
+- Monitor senior coverage ratio (alert below 105%)
+- Monitor 48h and 24h timelocks for any scheduled changes
+- Monitor USDe peg stability
+- Track TVL for concentration risk signals (large outflows)
+- Verify bug bounty program status with the team
+
+---
+
+## Reassessment Triggers
+
+- **Time-based**: Reassess in 3 months (May 2026) given the protocol's youth
+- **TVL-based**: Reassess if TVL changes by more than 50%
+- **Incident-based**: Reassess after any exploit, governance change, collateral modification, or Ethena incident
+- **Dependency-based**: Reassess if Ethena modifies sUSDe mechanics, cooldown periods, or undergoes significant changes
+- **Bug bounty**: Reassess if/when a bug bounty program is launched (should improve Audits score)
+- **Governance-based**: Reassess when on-chain governance is activated or when risk-premium parameters transition to independent managers

--- a/src/components/pages/curation/reports/unit-ubtc.md
+++ b/src/components/pages/curation/reports/unit-ubtc.md
@@ -1,0 +1,494 @@
+# Protocol Risk Assessment: Unit Bitcoin (UBTC)
+
+- **Assessment Date:** February 19, 2026
+- **Token:** UBTC
+- **Chain:** HyperEVM (Hyperliquid L1 ecosystem)
+- **Token Address:** [`0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463`](https://hyperevmscan.io/address/0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463)
+- **HyperCore Token ID:** [`0x8f254b963e8468305d409b33aa137c67`](https://app.hyperliquid.xyz/explorer/token/0x8f254b963e8468305d409b33aa137c67)
+- **Final Score: 5.0/5.0**
+
+## Overview + Links
+
+Unit is the asset tokenization layer on Hyperliquid, enabling deposits and withdrawals for major crypto assets (BTC, ETH, SOL, etc.) between their native blockchains and Hyperliquid. Unit Bitcoin (UBTC) is the protocol's wrapped Bitcoin token — users deposit BTC on the Bitcoin network and receive UBTC on Hyperliquid (both HyperCore and HyperEVM).
+
+The protocol uses a **Guardian Network** — a distributed leader-verifier network of 3 independent operators that collectively manage cross-chain transfers via a **2-of-3 MPC threshold signature scheme (TSS)**. Guardians independently monitor blockchain state, verify transactions, and co-sign operations. No single Guardian can unilaterally perform operations.
+
+UBTC is a **1:1 BTC-backed token** with no yield component. It represents a custodial claim on Bitcoin held in Unit's treasury addresses on the Bitcoin network.
+
+**Context:** UBTC is being evaluated as collateral on Morpho on HyperEVM, specifically the [UBTC-USDC market](https://app.morpho.org/hyperevm/market/0x45af9c72aa97978e143a646498c8922058b7c6f18b6f7b05d7316c8cf7ab942f/ubtc-usdc).
+
+**Links:**
+
+- [Unit app](https://hyperunit.xyz/)
+- [Unit docs](https://docs.hyperunit.xyz/)
+- [Unit explorer](https://explorer.hyperunit.xyz)
+- [Supported assets](https://docs.hyperunit.xyz/unit/about-unit/supported-assets)
+- [Architecture docs](https://docs.hyperunit.xyz/architecture/components)
+- [Security docs](https://docs.hyperunit.xyz/architecture/security)
+- [Key addresses](https://docs.hyperunit.xyz/developers/key-addresses/mainnet)
+- [Token metadata](https://docs.hyperunit.xyz/developers/key-addresses/mainnet/token-metadata)
+- [DeFiLlama Unit](https://defillama.com/protocol/unit)
+- [CoinGecko UBTC](https://www.coingecko.com/en/coins/unit-bitcoin)
+- [Regulatory compliance](https://docs.hyperunit.xyz/legal/regulatory-compliance)
+
+## Contract Addresses
+
+### HyperEVM Contracts
+
+| Contract | Address | Type |
+|----------|---------|------|
+| UBTC Token | [`0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463`](https://hyperevmscan.io/address/0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463) | UUPS Proxy (ERC-20) |
+| UBTC Implementation | [`0x1a7689c3b783eb37550efbb9c81e7f468f7034fc`](https://hyperevmscan.io/address/0x1a7689c3b783eb37550efbb9c81e7f468f7034fc) | Implementation |
+| HyperEVM Deployer (Owner) | [`0xB4FC973924a91362D301E583E839Cdaf4f19cdF8`](https://hyperevmscan.io/address/0xB4FC973924a91362D301E583E839Cdaf4f19cdF8) | EOA (MPC-controlled per docs) |
+
+### Treasury Addresses
+
+| Native Chain | Treasury Address | HyperCore Treasury |
+|-------------|-----------------|-------------------|
+| Bitcoin | `bc1pdwu79dady576y3fupmm82m3g7p2p9f6hgyeqy0tdg7ztxg7xrayqlkl8j9` | [`0x574bAFCe69d9411f662a433896e74e4F153096FA`](https://hyperevmscan.io/address/0x574bAFCe69d9411f662a433896e74e4F153096FA) |
+
+### HyperCore Token Deployer
+
+The HyperCore deployer is a multi-sig user at address [`0xF036a5261406a394bd63Eb4dF49C464634a66155`](https://hyperevmscan.io/address/0xF036a5261406a394bd63Eb4dF49C464634a66155) (per docs, deployed via HIP-1 native token standard).
+
+## How Unit Protocol Works (Context)
+
+Unit is a **bridge/asset tokenization protocol** — not a lending, staking, or yield protocol.
+
+**Deposit flow:**
+1. User connects Hyperliquid wallet and selects BTC
+2. Unit's Guardian Network generates a unique Bitcoin deposit address (MPC-derived, permanently tied to user's Hyperliquid address)
+3. User sends BTC to this address
+4. After 2 block confirmations on Bitcoin, Guardians verify and co-sign a transaction to credit UBTC on Hyperliquid
+
+**Withdrawal flow:**
+1. User enters destination Bitcoin address and amount
+2. Unit generates a unique withdrawal address on Hyperliquid
+3. User signs the transaction
+4. Upon Hyperliquid finalization (~10 seconds), Guardians process the Bitcoin transfer
+5. Withdrawals are batched — BTC withdrawals process every ~3 Bitcoin blocks, ETH every ~21 slots
+
+**Fees:** Unit does not collect revenue from deposits or withdrawals. The only fees are native network transaction fees.
+
+**Required confirmations:**
+| Chain | Confirmations | Time |
+|-------|--------------|------|
+| Bitcoin | 2+ | ≥20 minutes |
+| Hyperliquid | 2,000 | ~3.5 minutes |
+| Ethereum | 14 | ~3 minutes |
+
+## Audits and Due Diligence Disclosures
+
+**No smart contract audits are publicly disclosed or listed.**
+
+- DeFiLlama lists **0 audits** for the Unit protocol.
+- No audit reports or links are found in the Unit documentation.
+- No audit page exists on the Unit website or docs.
+- The Unit docs do not mention any audit firm engagement.
+- HyperEVMScan explicitly shows **"No contract security audit submitted"** for the UBTC token contract.
+- Multiple independent third-party analyses ([ASXN](https://newsletter.asxn.xyz/p/unit-protocol), [Impossible Finance](https://blog.impossible.finance/hyperunit-cross-chain-asset-infrastructure-for-hyperliquid/), [blocmates](https://www.blocmates.com/articles/unit-the-asset-tokenization-layer-on-hyperliquid), [ChainCatcher](https://www.chaincatcher.com/en/article/2168910)) confirm no audits exist.
+
+### Bug Bounty
+
+- **No bug bounty program found** on Immunefi, Sherlock, or Cantina.
+- Unit Protocol is **not registered** on Safe Harbor (SEAL).
+
+### Source Code
+
+- **Proxy contract** ([`0x9FDB...3463`](https://hyperevmscan.io/address/0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463#code)) **is source-code verified** on HyperEVMScan — it is a standard OpenZeppelin `ERC1967Proxy` (Solidity v0.8.24, MIT license, 200 optimization runs, Cancun EVM).
+- **Implementation contract** ([`0x1a76...34fc`](https://hyperevmscan.io/address/0x1a7689c3b783eb37550efbb9c81e7f468f7034fc)) **is NOT source-code verified** — the actual token logic is opaque. HyperEVMScan shows "Are you the contract creator? Verify and Publish your contract source code today!"
+- Bytecode analysis of the implementation suggests it contains **allowlist/blacklist mechanisms** for sender restrictions (per HyperEVMScan), in addition to standard ERC-20 functionality.
+- No public GitHub repository found for Unit Protocol smart contracts.
+- Implementation bytecode is 11,660 bytes. Proxy bytecode is 163 bytes (minimal ERC-1967 proxy).
+
+## Historical Track Record
+
+- **DeFiLlama listing date:** February 14, 2025 (~12 months at assessment date).
+- **Current protocol TVL:** ~$447M (February 19, 2026).
+- **Peak TVL:** ~$1.48B (October 8, 2025).
+- **TVL trend:** Declined ~70% from peak; currently at ~30% of ATH.
+
+**CoinGecko market data (UBTC):**
+
+| Metric | Value |
+|--------|-------|
+| Price | ~$66,628 |
+| Market Cap | ~$218M |
+| 24h Volume | ~$34M |
+| Circulating Supply | ~3,273 UBTC |
+| Total Supply | 21,000,000 UBTC |
+| ATH | $126,087 (Oct 6, 2025) |
+| ATL | $60,537 (Feb 6, 2026) |
+| 30-day Price Change | -25.67% |
+
+**On-chain supply (verified):**
+- `totalSupply()` = 21,000,000 UBTC (8 decimals, matching Bitcoin's hard cap)
+- Circulating supply per CoinGecko is only ~3,273 UBTC — the vast majority of the 21M max supply is not in circulation.
+
+**Peg stability (30-day per CoinGecko):**
+- Current UBTC/BTC ratio: ~0.9962 (0.38% below peg)
+- 30-day minimum: 0.9858 (1.42% below peg)
+- 30-day maximum: 1.0169 (1.69% above peg)
+- Peg has been relatively stable, with deviations up to ~1.7% in both directions.
+
+**Incidents:**
+- No Unit/UBTC exploits found in DeFiLlama hacks database or Rekt News.
+- **Guardian offline incident (April 15, 2025):** A Guardian went offline, causing delays in Bitcoin withdrawals and deposit address generation. This exposed fault tolerance gaps in the 2-of-3 Guardian Network. Community feedback called for permissionless Guardian participation to improve decentralization ([source](https://blog.impossible.finance/hyperunit-cross-chain-asset-infrastructure-for-hyperliquid/)).
+
+## Funds Management
+
+### Accessibility
+
+- **Deposits:** Permissionless — anyone can deposit BTC to receive UBTC.
+- **Withdrawals:** Queue-based — withdrawal batches process every ~3 Bitcoin blocks for BTC, ~21 Ethereum slots for ETH.
+- **Current withdrawal queue:** Bitcoin: 0, Ethereum: 1, Solana: 4, Plasma: 0, Monad: 0 (from Unit API, February 19, 2026).
+- **Fees:** No protocol fee; only native network gas fees.
+- **Minimum deposit:** 0.0003 BTC.
+- **Revert mechanism:** Failed deposits can be reverted after sufficient confirmations (20 blocks for BTC = ~3+ hours). Not all failed deposits are revertible.
+
+### Collateralization
+
+UBTC is a **1:1 BTC-backed bridged asset**. For every UBTC in circulation, the protocol claims to hold an equivalent amount of BTC in the Bitcoin treasury address.
+
+- **Bitcoin treasury:** `bc1pdwu79dady576y3fupmm82m3g7p2p9f6hgyeqy0tdg7ztxg7xrayqlkl8j9`
+- Reserves can be verified on any Bitcoin block explorer (e.g., mempool.space).
+- No off-chain collateral or lending activity is disclosed.
+- Collateral is entirely **native BTC** — the highest quality collateral for a BTC wrapper.
+
+### Provability
+
+- **Bitcoin reserves** are verifiable on-chain via the Bitcoin treasury address.
+- **UBTC supply** on HyperCore/HyperEVM is verifiable via `totalSupply()`.
+- **The backing ratio requires comparing two chains** (Bitcoin balance vs Hyperliquid UBTC supply), which complicates real-time verification but is deterministic.
+- No Chainlink Proof of Reserve (PoR) or equivalent third-party attestation mechanism is in place.
+- Unit operates an [explorer](https://explorer.hyperunit.xyz) for transaction tracking.
+- The protocol does not have a public dashboard showing real-time reserve status.
+
+## Liquidity Risk
+
+### HyperCore Spot Orderbook (Primary Liquidity)
+
+UBTC trades on Hyperliquid's native spot CLOB (Central Limit Order Book). Per CoinGecko:
+
+| Venue | Pair | 24h Volume |
+|-------|------|-----------|
+| Hyperliquid | UBTC/USDC | ~$28.6M |
+| Hyperliquid | UBTC/USDH | ~$979K |
+
+This is the primary exit liquidity for UBTC — the spot orderbook provides market-based exit at BTC spot prices.
+
+### HyperEVM DEX Liquidity
+
+Per DeFiLlama, 27 UBTC pools on Hyperliquid L1 with ~$35M total TVL:
+
+| DEX | Pair | TVL | 24h Volume |
+|-----|------|-----|-----------|
+| Project X | WHYPE-UBTC | $5,495,037 | - |
+| Project X | UBTC-USDT0 | $1,157,720 | - |
+| Project X | UBTC-KHYPE | $838,225 | - |
+| Project X | UBTC-UETH | $452,481 | - |
+| HyperSwap V3 | WHYPE-UBTC | $403,719 | - |
+| Ramses HL | UBTC-UETH | $251,943 | - |
+| Nest V1 | WHYPE-UBTC | $205,647 | - |
+
+**DEX-only liquidity:** ~$9.4M across 18 pools.
+
+### Lending Protocol Deposits
+
+| Protocol | TVL |
+|----------|-----|
+| HyperLend | ~$14.0M |
+| Morpho (14 markets) | ~$7.6M supply |
+| Other (Nabla, etc.) | ~$33K |
+
+### Morpho Markets (UBTC as Collateral)
+
+14 Morpho markets use UBTC as collateral with total supply of ~$7.6M and total borrows of ~$6.4M.
+
+**The specific market from the issue (UBTC-USDC):**
+
+| Metric | Value |
+|--------|-------|
+| Market ID | [`0x45af9c72aa97978e143a646498c8922058b7c6f18b6f7b05d7316c8cf7ab942f`](https://app.morpho.org/hyperevm/market/0x45af9c72aa97978e143a646498c8922058b7c6f18b6f7b05d7316c8cf7ab942f/ubtc-usdc) |
+| Loan Asset | USDC |
+| LLTV | 77.0% |
+| Supply | ~$2.72M |
+| Borrow | ~$2.45M |
+| Utilization | 90.0% |
+
+### Liquidity Assessment
+
+- **Primary exit:** Hyperliquid spot CLOB with ~$29M daily volume — adequate for most position sizes.
+- **Secondary exit:** Protocol withdrawal back to native BTC (queue-based, ~3 Bitcoin block batches).
+- **DEX liquidity on HyperEVM:** ~$9.4M — moderate for DEX-based exits.
+- **All liquidity is within the Hyperliquid ecosystem** — no CEX listings.
+
+## Centralization & Control Risks
+
+### Governance
+
+**UBTC HyperEVM token contract:**
+- **Owner:** [`0xB4FC973924a91362D301E583E839Cdaf4f19cdF8`](https://hyperevmscan.io/address/0xB4FC973924a91362D301E583E839Cdaf4f19cdF8)
+- **On-chain code-size: 0** — this is an **EOA** (Externally Owned Account).
+- **Per Unit docs:** The HyperEVM deployer is "controlled via multi-party computation (MPC), requiring key-shares from multiple signers to construct and perform transactions." However, this is **not verifiable on-chain** — it appears as a regular EOA.
+- **Contract type:** UUPS upgradeable proxy — the owner can upgrade the implementation without timelock.
+- **No timelock** detected on-chain.
+- **No multisig** on-chain — the MPC claim is off-chain only.
+
+**Guardian Network (bridge operations):**
+- 2-of-3 MPC threshold signature scheme.
+- 3 Guardians: **Unit**, **Hyperliquid**, and **Infinite Field**.
+  - **Infinite Field** self-identifies as "a proprietary HFT market making firm" running on Hyperliquid since February 2024 ([source](https://x.com/infinitefieldx/status/1890437991224520799)).
+- Each Guardian runs independent blockchain indexers, verifiers, and secure enclaves (e.g., AWS Nitro).
+- Guardian keys are generated via distributed key generation (DKG), encrypted at rest via KMS, combined only at runtime in secure enclaves.
+- The relay server only forwards ciphertext — no key material.
+- **Leader centralization:** Currently a single pre-determined leader coordinates proposals. The protocol plans to implement a leader election process in the future, but this creates interim centralization risk.
+
+**Key concern:** While the bridge operations use 2-of-3 MPC, the HyperEVM token contract ownership is an EOA. A compromise of the MPC key (or the off-chain signers controlling it) could allow an attacker to upgrade the UBTC implementation to a malicious contract.
+
+### Programmability
+
+- The UBTC token contract is a **simple ERC-20 with Ownable + UUPS**. No complex vault logic, exchange rates, or admin parameters detected.
+- No `paused()`, `blacklister()`, `cap()`, `MINTER_ROLE()`, `DEFAULT_ADMIN_ROLE()`, or `DOMAIN_SEPARATOR()` functions exposed via the proxy interface.
+- However, bytecode analysis of the unverified implementation suggests **allowlist/blacklist mechanisms** exist for sender restrictions — these are not callable from the proxy but may be accessible to the owner.
+- The bridge operations (deposit/withdrawal) are handled entirely off-chain by the Guardian Network — the on-chain token contract is just a standard ERC-20.
+- The deterministic state machine underlying all protocol actions guarantees strict, verifiable workflows per the security docs.
+
+### External Dependencies
+
+Critical dependencies:
+1. **Bitcoin network** — for BTC custody and transfer verification.
+2. **Hyperliquid L1** — HyperCore consensus/liveness and HyperEVM execution.
+3. **Guardian Network infrastructure** — AWS Nitro enclaves, relay servers, indexers.
+4. **KMS services** — for Guardian key encryption at rest.
+
+**Hyperliquid chain risk:**
+- Hyperliquid is a highly centralized chain — Hyper Foundation controls 56.4% of validator stake via 5 validators, exceeding the 1/3 BFT blocking minority (per kHYPE assessment).
+- HyperEVM shares the same HyperBFT consensus as HyperCore — no separate bridge risk between the two, but full L1 dependency.
+
+## Operational Risk
+
+- **Team:** Unit describes itself as "a research and development collective dedicated to advancing the Hyperliquid ecosystem." Core team members claim expertise from **HRT** (Hudson River Trading), **Jump** (Jump Crypto), **Fortress**, and **IDF cyber units** (per docs). The team is reportedly self-funded.
+- **Team transparency:** No individual team members are named or publicly doxxed. No "Team" page with identifiable individuals. Multiple third-party analyses ([ChainCatcher](https://www.chaincatcher.com/en/article/2168910), [Impossible Finance](https://blog.impossible.finance/hyperunit-cross-chain-asset-infrastructure-for-hyperliquid/)) note "founders and investors are unknown" and flag this as a transparency concern.
+- **Entity:** "Unit Labs" — referenced in regulatory compliance docs.
+- **Legal:** Unit Labs utilizes blockchain analytics to screen wallets (OFAC SDN List compliance). Frontend implements IP-based geofencing for prohibited jurisdictions. Legal inquiries to `legal@hyperunit.xyz`.
+- **Twitter:** [@hyperunit](https://x.com/hyperunit) (primary, per CoinGecko) / [@unitxyz](https://twitter.com/unitxyz) (per DeFiLlama).
+- **Token:** The team secured the $UNIT ticker for ~$350K in January 2025, strongly suggesting plans for a future token launch. No official airdrop confirmed.
+- **Documentation:** Adequate — hosted on GitBook, covers architecture, security, API, key addresses. Some pages are JS-rendered only.
+- **Compliance:** Guardians independently implement compliance screening. Unit Labs uses blockchain analytics software. Maintains transaction records for law enforcement disclosure.
+- **Incident handling:** Guardian offline incident (April 15, 2025) was resolved, but no formal public incident response plan is documented.
+
+## Monitoring
+
+Key addresses and data to monitor:
+
+### 1. Bitcoin Treasury Monitoring (MANDATORY)
+
+- **Bitcoin treasury:** `bc1pdwu79dady576y3fupmm82m3g7p2p9f6hgyeqy0tdg7ztxg7xrayqlkl8j9`
+- Compare BTC held vs UBTC circulating supply on Hyperliquid
+- Alert: If BTC balance falls below circulating UBTC supply
+
+### 2. Token Supply Monitoring (MANDATORY)
+
+- `UBTC.totalSupply()` on HyperEVM: [`0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463`](https://hyperevmscan.io/address/0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463)
+- HyperCore token supply via Hyperliquid explorer
+- Alert: Sudden supply changes >10% in 24h
+
+### 3. Contract Upgrade Monitoring (MANDATORY)
+
+- Monitor `Upgraded` events on UBTC proxy contract
+- Monitor ownership transfers on UBTC contract (`OwnershipTransferred` event)
+- Alert: Any implementation upgrade or ownership change (immediate)
+
+### 4. Peg Monitoring
+
+- UBTC/BTC price ratio (CoinGecko, Hyperliquid spot)
+- Alert: Discount >3% sustained for >1h
+
+### 5. Withdrawal Queue Monitoring
+
+- Unit API endpoint: `GET https://api.hyperunit.xyz/withdrawal-queue`
+- Alert: Bitcoin withdrawal queue >10 pending operations
+
+### 6. Guardian Network Health
+
+- Monitor for any Guardian downtime or signing failures
+- TODO: No public endpoint for Guardian health status identified
+
+## Risk Summary
+
+### Key Strengths
+
+1. **Simple architecture** — UBTC is a straightforward 1:1 BTC wrapper with minimal on-chain complexity.
+2. **Significant protocol TVL** (~$447M) and meaningful trading volume (~$34M/day) demonstrating product-market fit.
+3. **Bitcoin reserves are verifiable** on-chain via the Bitcoin treasury address.
+4. **No protocol fees** — reduces attack surface and misalignment incentives.
+5. **Regulatory compliance measures** — OFAC screening, geofencing, law enforcement cooperation.
+
+### Key Risks
+
+1. **No public smart contract audits** — no audit reports found anywhere, confirmed by multiple independent sources. This is a critical concern for a bridge holding ~$447M.
+2. **No bug bounty program** — no Immunefi, Sherlock, or Cantina listing found.
+3. **Implementation source code unverified** — the proxy is verified (standard OpenZeppelin ERC1967Proxy), but the actual token implementation at [`0x1a7689c3b783eb37550efbb9c81e7f468f7034fc`](https://hyperevmscan.io/address/0x1a7689c3b783eb37550efbb9c81e7f468f7034fc) is **not verified**. Bytecode analysis suggests undisclosed allowlist/blacklist features.
+4. **EOA ownership on HyperEVM** — the MPC claim is not verifiable on-chain. The contract owner (`Unit: Deployer`) appears as a single EOA that can upgrade the implementation instantly.
+5. **No timelock** on contract upgrades — implementation can be swapped instantly.
+7. **2-of-3 MPC** is a relatively low threshold — compromise of any 2 Guardians (one of which is Unit itself) could compromise the system.
+8. **Hyperliquid chain centralization** — Hyper Foundation controls 56.4% of validator stake.
+
+### Critical Risks
+
+- **No audit combined with unverified implementation source code and EOA upgradeability** — the UBTC implementation could contain vulnerabilities or be upgraded to a malicious contract. Bytecode hints at undisclosed allowlist/blacklist mechanisms.
+- **2-of-3 MPC with only 3 Guardians** — a coordinated compromise of Unit + one other Guardian (Hyperliquid or Infinite Field) gives full control over bridge funds.
+
+---
+
+## Risk Score Assessment
+
+### Critical Risk Gates
+
+- [ ] **No audit** -> **TRIGGERED** — Protocol has no publicly disclosed audits by any firm.
+- [x] **Unverifiable reserves** -> **PASS** — Bitcoin reserves are verifiable on-chain.
+- [ ] **Total centralization** -> **BORDERLINE** — EOA owner on HyperEVM (claimed MPC), 2-of-3 Guardian Network. Not a single EOA in the traditional sense, but on-chain evidence shows EOA ownership.
+
+**Critical gate "No audit" is triggered.** Per the scoring guidelines, this automatically results in a score of **5** (High Risk).
+
+However, given that:
+1. The protocol has been operational for ~12 months with ~$447M TVL
+2. The on-chain token contract interface is relatively simple (standard ERC-20 + UUPS)
+3. The 2-of-3 MPC Guardian architecture provides some multi-party security
+4. Bitcoin reserves are transparently verifiable
+
+We assess whether the automatic 5 should be applied strictly or with contextual modifiers. **Given the framework's explicit instruction ("If ANY gate is triggered, the protocol automatically receives a score of 5"), we apply the automatic score.**
+
+### Category Scores (For Reference)
+
+Even though the critical gate is triggered, we provide category scores for reference if audits are conducted in the future.
+
+#### Category 1: Audits & Historical Track Record (Weight: 20%)
+
+- **No audits** from any firm (confirmed by DeFiLlama, HyperEVMScan, and multiple third-party analyses).
+- No bug bounty program.
+- Implementation source code unverified (proxy verified as standard OpenZeppelin ERC1967Proxy).
+- ~12 months in production, TVL ~$447M (peaked ~$1.48B).
+- One operational incident: Guardian offline (April 15, 2025) causing BTC withdrawal delays.
+
+**Score: 5.0/5** — No audit (critical gate triggered).
+
+#### Category 2: Centralization & Control Risks (Weight: 30%)
+
+Subscores:
+- **Governance: 4.5** — EOA owner (on-chain) claimed to be MPC-controlled (off-chain). No timelock. UUPS upgradeable. 2-of-3 Guardian Network for bridge operations, but not for contract governance.
+- **Programmability: 2.0** — Simple ERC-20 token; bridge operations handled by deterministic state machine. No complex vault logic or admin parameters.
+- **External dependencies: 3.5** — Depends on Bitcoin network, Hyperliquid L1 (centralized validator set), Guardian infrastructure (AWS Nitro, KMS). Hyperliquid Foundation controls 56.4% of validator stake.
+
+Centralization score = (4.5 + 2.0 + 3.5) / 3 = **3.33**
+
+**Score: 3.3/5**
+
+#### Category 3: Funds Management (Weight: 30%)
+
+Subscores:
+- **Collateralization: 2.0** — 1:1 BTC-backed on-chain. Collateral is native BTC (highest quality). No off-chain or mixed collateral.
+- **Provability: 2.5** — Bitcoin reserves verifiable on-chain. UBTC supply verifiable on Hyperliquid. Requires cross-chain comparison. No Proof of Reserve oracle or third-party attestation. No public reserve dashboard.
+
+Funds management score = (2.0 + 2.5) / 2 = **2.25**
+
+**Score: 2.25/5**
+
+#### Category 4: Liquidity Risk (Weight: 15%)
+
+- Primary exit via Hyperliquid CLOB: ~$29M daily volume — adequate.
+- Secondary exit via native BTC withdrawal: queue-based, currently 0 pending BTC withdrawals.
+- DEX liquidity: ~$9.4M across 18 pools.
+- All within Hyperliquid ecosystem — no CEX listings.
+- Peg deviations up to ~1.7% observed in last 30 days.
+
+**Score: 2.5/5**
+
+#### Category 5: Operational Risk (Weight: 5%)
+
+- Team from reputable backgrounds (HRT, Jump, Fortress) but not individually doxxed.
+- Documentation adequate but some pages JS-rendered only.
+- Regulatory compliance measures in place (OFAC, geofencing).
+- No public incident response plan.
+
+**Score: 3.0/5**
+
+### Final Score Calculation
+
+**Due to the critical gate trigger (no audit), the final score is automatically set to 5.0/5.**
+
+For reference, the weighted score without the critical gate would be:
+
+| Category | Score | Weight | Weighted |
+|----------|-------|--------|----------|
+| Audits & Historical | 5.0 | 20% | 1.00 |
+| Centralization & Control | 3.3 | 30% | 0.99 |
+| Funds Management | 2.25 | 30% | 0.675 |
+| Liquidity Risk | 2.5 | 15% | 0.375 |
+| Operational Risk | 3.0 | 5% | 0.15 |
+| **Weighted Score** | | | **3.19 / 5.0** |
+
+**But critical gate applies → Final Score: 5.0 / 5.0**
+
+## Overall Risk Score: **5.0 / 5.0**
+
+### Risk Tier: **HIGH RISK**
+
+Rationale:
+- **The critical gate "No audit" is triggered.** Unit Protocol has no publicly disclosed audits despite managing ~$447M in TVL.
+- Implementation source code is unverified.
+- No bug bounty program exists.
+- HyperEVM contract owner is an EOA (MPC claim not verifiable on-chain) with UUPS upgradeability and no timelock.
+- Without the critical gate, the weighted score would be 3.19/5.0 (Medium Risk), primarily elevated by the audit gap and centralization concerns.
+- If audits are conducted and code is verified, the score could improve significantly to the Low-Medium range.
+
+## Reassessment Triggers
+
+- **Time-based**: Reassess in 3 months or upon completion of an audit
+- **TVL-based**: Reassess if TVL changes by more than 50%
+1. Publication of any smart contract audit for Unit Protocol / UBTC
+2. Source code verification on block explorers
+3. Launch of a bug bounty program
+4. Contract implementation upgrade on HyperEVM
+5. Ownership transfer of the UBTC contract
+6. Change in Guardian Network composition (addition/removal of Guardians)
+7. Introduction of timelock governance (positive trigger — would improve score)
+
+## Appendix: What Would Improve the Score
+
+If the following were addressed, the score could improve from 5.0 to approximately **2.5-3.0** (Low-Medium Risk):
+
+1. **Audit by 1-2 reputable firms** → Would remove critical gate trigger
+2. **Implementation source code verification** on HyperEVMScan → Would improve transparency (proxy is already verified)
+3. **Bug bounty program** → Would reduce audit category score
+4. **On-chain multisig** for contract ownership (replacing EOA) → Would improve governance score
+5. **Timelock** on contract upgrades → Would improve governance score
+
+## Sources
+
+- Unit docs: https://docs.hyperunit.xyz/
+- Unit app: https://hyperunit.xyz/
+- Unit explorer: https://explorer.hyperunit.xyz
+- Unit architecture: https://docs.hyperunit.xyz/architecture/components
+- Unit security: https://docs.hyperunit.xyz/architecture/security
+- Unit key addresses: https://docs.hyperunit.xyz/developers/key-addresses/mainnet
+- Unit token metadata: https://docs.hyperunit.xyz/developers/key-addresses/mainnet/token-metadata
+- Unit team: https://docs.hyperunit.xyz/unit/about-unit/team
+- Unit regulatory compliance: https://docs.hyperunit.xyz/legal/regulatory-compliance
+- Unit withdrawal queue API: https://api.hyperunit.xyz/withdrawal-queue
+- DeFiLlama Unit: https://defillama.com/protocol/unit
+- CoinGecko UBTC: https://www.coingecko.com/en/coins/unit-bitcoin
+- Morpho UBTC markets: https://app.morpho.org/hyperevm/market/0x45af9c72aa97978e143a646498c8922058b7c6f18b6f7b05d7316c8cf7ab942f
+- HyperEVMScan UBTC proxy (verified): https://hyperevmscan.io/address/0x9FDBdA0A5e284c32744D2f17Ee5c74B284993463#code
+- HyperEVMScan UBTC implementation (unverified): https://hyperevmscan.io/address/0x1a7689c3b783eb37550efbb9c81e7f468f7034fc
+- On-chain verification via `cast` against HyperEVM RPC (`rpc.hyperliquid.xyz/evm`)
+- Morpho Blue API: https://blue-api.morpho.org/graphql
+- DeFiLlama Yields API: https://yields.llama.fi/pools
+- DeFiLlama Hacks: https://api.llama.fi/hacks
+- Infinite Field Guardian announcement: https://x.com/infinitefieldx/status/1890437991224520799
+- ASXN Unit Protocol analysis: https://newsletter.asxn.xyz/p/unit-protocol
+- Impossible Finance HyperUnit analysis: https://blog.impossible.finance/hyperunit-cross-chain-asset-infrastructure-for-hyperliquid/
+- blocmates Unit overview: https://www.blocmates.com/articles/unit-the-asset-tokenization-layer-on-hyperliquid
+- ChainCatcher Unit analysis: https://www.chaincatcher.com/en/article/2168910
+- Delphi Digital HyperUnit analysis: https://members.delphidigital.io/feed/hyperunit-the-infrastructure-powering-native-spot-on-hyperliquid

--- a/src/components/pages/curation/test-1.tsx
+++ b/src/components/pages/curation/test-1.tsx
@@ -1,0 +1,120 @@
+import Link from '@components/Link'
+import { ScoreBadge } from '@pages/curation/components/ScoreBadge'
+import { scoreTier } from '@pages/curation/lib/colors'
+import type { TReportData } from '@pages/curation/lib/parseReport'
+import { getAllReports } from '@pages/curation/lib/reports'
+import type { ReactElement } from 'react'
+import { useEffect, useState } from 'react'
+import '@pages/curation/curation.css'
+
+function CurationTestLayoutOne(): ReactElement {
+  const [reports, setReports] = useState<TReportData[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    const lifecycle = { isCancelled: false }
+
+    void getAllReports()
+      .then((loadedReports) => {
+        if (lifecycle.isCancelled) {
+          return
+        }
+        setReports(loadedReports)
+        setError(undefined)
+      })
+      .catch((caughtError: unknown) => {
+        if (lifecycle.isCancelled) {
+          return
+        }
+        const message = caughtError instanceof Error ? caughtError.message : 'Failed to load curation reports.'
+        setError(message)
+      })
+      .finally(() => {
+        if (lifecycle.isCancelled) {
+          return
+        }
+        setIsLoading(false)
+      })
+
+    return () => {
+      lifecycle.isCancelled = true
+    }
+  }, [])
+
+  return (
+    <div className={'curation-page'}>
+      <main className={'curation-container'}>
+        <div className={'curation-heading-row'}>
+          <h1 className={'curation-heading'}>{'Risk Assessment Reports'}</h1>
+          <Link href={'/curation'} className={'curation-layout-toggle'}>
+            {'Back to table layout'}
+          </Link>
+        </div>
+
+        {isLoading && <p className={'text-text-secondary'}>{'Loading reports...'}</p>}
+        {!isLoading && error && <p className={'text-red'}>{error}</p>}
+
+        {!isLoading && !error && (
+          <div className={'curation-card-grid'}>
+            {reports.map((report) => {
+              const reportPath = `/curation/report/${report.slug}`
+
+              return (
+                <Link key={report.slug} href={reportPath} className={'curation-report-card'}>
+                  <article className={'curation-report-card-content'}>
+                    <div className={'curation-report-card-header'}>
+                      <div className={'curation-icon-stack'}>
+                        {report.iconUrl ? (
+                          <img
+                            src={report.iconUrl}
+                            alt={''}
+                            width={24}
+                            height={24}
+                            className={'curation-protocol-icon'}
+                            loading={'lazy'}
+                          />
+                        ) : (
+                          <div className={'curation-icon-placeholder'} />
+                        )}
+                        {report.chainIconUrl && (
+                          <img
+                            src={report.chainIconUrl}
+                            alt={''}
+                            width={14}
+                            height={14}
+                            className={'curation-chain-icon'}
+                            loading={'lazy'}
+                          />
+                        )}
+                      </div>
+                      <h2 className={'curation-report-card-title'}>{report.name}</h2>
+                    </div>
+
+                    <div className={'curation-report-card-row'}>
+                      <span className={'curation-report-card-label'}>{'Token'}</span>
+                      <span className={'curation-mono'}>{report.token}</span>
+                    </div>
+
+                    <div className={'curation-report-card-footer'}>
+                      <div className={'curation-report-card-risk'}>
+                        <span className={'curation-report-card-label'}>{'Risk Tier'}</span>
+                        <span>{scoreTier(report.finalScore)}</span>
+                      </div>
+                      <div className={'curation-report-card-score'}>
+                        <span className={'curation-report-card-label'}>{'Final Score'}</span>
+                        <ScoreBadge score={report.finalScore} />
+                      </div>
+                    </div>
+                  </article>
+                </Link>
+              )
+            })}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}
+
+export default CurationTestLayoutOne

--- a/src/components/shared/components/Header.tsx
+++ b/src/components/shared/components/Header.tsx
@@ -108,7 +108,10 @@ function AppHeader(): ReactElement {
   const themePreference = useThemePreference()
   const isDarkTheme = themePreference !== 'light'
 
-  const isHomePage = normalizePathname(pathname) === '/'
+  const normalizedPathname = normalizePathname(pathname)
+  const isHomePage = normalizedPathname === '/'
+  const isCurationPage = normalizedPathname.startsWith('/curation') || normalizedPathname.startsWith('/curation-test')
+  const usesLandingHeaderShell = isHomePage || isCurationPage
 
   const walletIdentity = useMemo((): string | undefined => {
     if (ens) return ens
@@ -120,7 +123,10 @@ function AppHeader(): ReactElement {
   return (
     <div
       id={'head'}
-      className={cl('sticky inset-x-0 top-0 z-50 w-full backdrop-blur-md', isHomePage ? 'bg-transparent' : 'bg-app')}
+      className={cl(
+        'sticky inset-x-0 top-0 z-50 w-full backdrop-blur-md',
+        usesLandingHeaderShell ? 'bg-transparent' : 'bg-app'
+      )}
     >
       <div className={'mx-auto w-full max-w-[1232px] px-4'}>
         <header className={'flex h-[var(--header-height)] w-full items-center justify-between px-0'}>
@@ -133,7 +139,19 @@ function AppHeader(): ReactElement {
             </div>
           </div>
           <div className={'flex items-center justify-end gap-2'}>
-            {!isHomePage && (
+            {isCurationPage && (
+              <button
+                className={
+                  'min-h-[44px] min-w-[44px] rounded-full p-2.5 text-text-secondary transition-colors hover:text-text-primary'
+                }
+                onClick={() => setThemePreference(isDarkTheme ? 'light' : 'soft-dark')}
+                title={isDarkTheme ? 'Switch to light mode' : 'Switch to dark mode'}
+              >
+                {isDarkTheme ? <IconSun className={'size-5'} /> : <IconMoon className={'size-5'} />}
+              </button>
+            )}
+
+            {!isHomePage && !isCurationPage && (
               <>
                 <div className={'hidden items-center justify-end md:flex gap-2'} data-tour="vaults-header-user">
                   <Link href={'/portfolio'}>

--- a/src/components/shared/components/HeaderNavMenu.tsx
+++ b/src/components/shared/components/HeaderNavMenu.tsx
@@ -88,7 +88,7 @@ export function HeaderNavMenu({ isHomePage, isDarkTheme }: THeaderNavMenuProps):
     },
     {
       name: 'Curation',
-      href: 'https://app.morpho.org/ethereum/earn?v2=false&curators=yearn',
+      href: '/curation',
       description: 'Lending Market Curation',
       icon: <LogoCuration className={'size-11'} back={'text-transparent'} front={'text-primary'} />
     },

--- a/src/components/shared/data/curation-manifest.json
+++ b/src/components/shared/data/curation-manifest.json
@@ -1,0 +1,35 @@
+{
+  "name": "Yearn Curation",
+  "short_name": "Curation",
+  "description": "Risk assessment reports maintained by Yearn Curation.",
+  "iconPath": "./favicons/favicon.svg",
+  "locale": "en-US",
+  "uri": "https://yearn.fi/curation/",
+  "og": "https://yearn.fi/apps/vaults-og.png",
+  "twitter": "@yearnfi",
+  "github": "https://github.com/yearn/risk-score",
+  "icons": [
+    {
+      "src": "./favicons/android-icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "./favicons/android-icon-144x144.png",
+      "sizes": "144x144",
+      "type": "image/png"
+    },
+    {
+      "src": "./favicons/android-icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#000000",
+  "background_color": "#000000",
+  "title_color": "#ffffff",
+  "start_url": "/curation",
+  "display": "standalone",
+  "orientation": "portrait"
+}

--- a/src/components/shared/hooks/useCurrentApp.tsx
+++ b/src/components/shared/hooks/useCurrentApp.tsx
@@ -1,3 +1,4 @@
+import curationManifest from '@shared/data/curation-manifest.json'
 import landingManifest from '@shared/data/landing-manifest.json'
 import vaultsManifest from '@shared/data/vaults-manifest.json'
 import type { TDict } from '@shared/types'
@@ -5,7 +6,7 @@ import { useMemo } from 'react'
 import { useLocation } from 'react-router'
 
 type TCurrentApp = {
-  name: 'Home' | 'Vaults' | string
+  name: 'Home' | 'Vaults' | 'Curation' | string
   manifest: TManifest
 }
 
@@ -37,6 +38,14 @@ export function useCurrentApp(): TCurrentApp {
       '/vaults': {
         name: 'Vaults',
         manifest: vaultsManifest
+      },
+      '/curation': {
+        name: 'Curation',
+        manifest: curationManifest
+      },
+      '/curation-test-1': {
+        name: 'Curation',
+        manifest: curationManifest
       },
       '/landing': {
         name: 'Home',

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react'
 import { lazy, Suspense } from 'react'
-import { Navigate, Route, Routes as RouterRoutes } from 'react-router'
+import { Navigate, Route, Routes as RouterRoutes, useParams } from 'react-router'
 
 // Lazy load all page components
 const HomePage = lazy(() => import('@pages/landing'))
@@ -8,6 +8,9 @@ const PortfolioPage = lazy(() => import('@pages/portfolio/index'))
 const VaultsPage = lazy(() => import('@pages/vaults/index'))
 const VaultsDetailPage = lazy(() => import('@pages/vaults/[chainID]/[address]'))
 const IconListPage = lazy(() => import('@pages/icon-list/index'))
+const CurationPage = lazy(() => import('@pages/curation/index'))
+const CurationReportPage = lazy(() => import('@pages/curation/report/[slug]'))
+const CurationTestPage = lazy(() => import('@pages/curation/test-1'))
 
 // Loading component
 const PageLoader = (): ReactElement => (
@@ -24,6 +27,14 @@ const ExternalRedirect = ({ to }: { to: string }): ReactElement => {
   return <PageLoader />
 }
 
+const CurationReportRedirect = (): ReactElement => {
+  const { slug } = useParams()
+  if (!slug) {
+    return <Navigate to="/curation" replace />
+  }
+  return <Navigate to={`/curation/report/${slug}`} replace />
+}
+
 // Main routes component
 export function Routes(): ReactElement {
   return (
@@ -38,6 +49,13 @@ export function Routes(): ReactElement {
         {/* Icon inventory page */}
         <Route path="/icon-list" element={<IconListPage />} />
 
+        {/* Curation pages */}
+        <Route path="/curation">
+          <Route index element={<CurationPage />} />
+          <Route path="report/:slug" element={<CurationReportPage />} />
+        </Route>
+        <Route path="/curation-test-1" element={<CurationTestPage />} />
+
         {/* Unified Vaults routes */}
         <Route path="/vaults">
           <Route index element={<VaultsPage />} />
@@ -51,6 +69,9 @@ export function Routes(): ReactElement {
         {/* Legacy v3 vault detail alias */}
         <Route path="/v3/:chainID/:address" element={<VaultsDetailPage />} />
         <Route path="/v3/*" element={<Navigate to="/vaults" replace />} />
+
+        {/* Legacy risk-score path */}
+        <Route path="/report/:slug" element={<CurationReportRedirect />} />
 
         {/* External redirects */}
         <Route path="/ybribe/*" element={<ExternalRedirect to="https://ybribe.yearn.fi" />} />


### PR DESCRIPTION
## Description

ports the curation page to the yearn.fi site at yearn.fi/curation. This is a test, as we may not want to host the actual reports and will need to find a nice way to read them from the risk-scores github instead of having to manually update. Maybe a script to look at that repo and sync?

The main page shows the vault in a list like spalen's version, and also a table of cards. I want to discuss more with the curation guys about how we should best show their work.