### PR TITLE
chore: update scpectra markets

### DIFF
--- a/src/components/pages/vaults/constants/addresses.ts
+++ b/src/components/pages/vaults/constants/addresses.ts
@@ -5,9 +5,7 @@ export const KATANA_CHAIN_ID = 747474
  *************************************************************************************************/
 export const SPECTRA_MARKET_VAULT_ADDRESSES = [
   '0x80c34BD3A3569E126e7055831036aa7b212cB159', //vbUSDC
-  '0xE007CA01894c863d7898045ed5A3B4Abf0b18f37', //vbETH
-  '0x9A6bd7B6Fd5C4F87eb66356441502fc7dCdd185B', //vbUSDT
-  '0x93Fec6639717b6215A48E5a72a162C50DCC40d68' //AUSD
+  '0x9A6bd7B6Fd5C4F87eb66356441502fc7dCdd185B' //vbUSDT
 ].map((addr) => addr.toLowerCase())
 
 export const PENDLE_MARKET_VAULT_ADDRESSES = [


### PR DESCRIPTION
## Description

Spectra fixed rate markets for WETH and AUSD are no longer available. This PR removes them from the hardcoded list.

## Screenshots (if appropriate):

before: 
<img width="2470" height="1318" alt="image" src="https://github.com/user-attachments/assets/36c4cd8d-a56f-43b1-ba60-7458dcf3d7de" />

after: 
<img width="2490" height="1316" alt="image" src="https://github.com/user-attachments/assets/0b4ff54b-9ee0-4480-b947-b5fcff2a38c6" />
