### PR TITLE
update strategy card text and number styling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "yearnfi",

--- a/src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
+++ b/src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
@@ -16,9 +16,10 @@ import { DARK_MODE_COLORS, LIGHT_MODE_COLORS, useDarkMode } from '@shared/compon
 import { useYearn } from '@shared/contexts/useYearn'
 import { useYearnTokenPrice } from '@shared/hooks/useYearnTokenPrice'
 import type { TSortDirection } from '@shared/types'
-import { cl, formatPercent, formatTvlDisplay, toAddress, toBigInt, toNormalizedBN } from '@shared/utils'
+import { cl, formatTvlDisplay, toAddress, toBigInt, toNormalizedBN } from '@shared/utils'
 import type { ReactElement } from 'react'
 import { lazy, Suspense, useCallback, useMemo } from 'react'
+import { formatStrategiesPercent } from './strategiesPercentFormat'
 import { VaultsListHead } from './VaultsListHead'
 import { VaultsListStrategy } from './VaultsListStrategy'
 
@@ -248,7 +249,7 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
             {unallocatedPercentage > 0 && unallocatedValue > 0n ? (
               <div className={'w-full rounded-lg text-text-primary opacity-50'}>
                 <div className={'grid w-full grid-cols-1 items-center gap-4 px-4 py-3 md:grid-cols-24 md:px-8'}>
-                  <div className={'flex w-full items-center gap-2 md:col-span-9 md:w-auto'}>
+                  <div className={'flex w-full items-center gap-2 md:col-span-11 md:w-auto'}>
                     <div className={'flex size-6 items-center justify-center'}>
                       <div className={'size-2 rounded-full bg-text-secondary'} />
                     </div>
@@ -256,12 +257,12 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
                       Unallocated
                     </strong>
                   </div>
-                  <div className={'grid w-full grid-cols-3 gap-2 md:col-span-14 md:grid-cols-15 md:gap-4'}>
-                    <div className={'flex flex-col items-center md:items-end md:col-span-5'} datatype={'number'}>
+                  <div className={'grid w-full grid-cols-3 gap-2 md:col-span-12 md:grid-cols-12 md:gap-2'}>
+                    <div className={'flex flex-col items-center md:items-end md:col-span-4'} datatype={'number'}>
                       <p className={'mb-1 text-xs text-text-primary/60 md:hidden'}>Allocation %</p>
-                      <p className={'font-semibold'}>{formatPercent(unallocatedPercentage / 100)}</p>
+                      <p className={'font-semibold'}>{formatStrategiesPercent(unallocatedPercentage / 100)}</p>
                     </div>
-                    <div className={'flex flex-col items-center md:items-end md:col-span-5'} datatype={'number'}>
+                    <div className={'flex flex-col items-center md:items-end md:col-span-4'} datatype={'number'}>
                       <p className={'mb-1 text-xs text-text-primary/60 md:hidden'}>Amount</p>
                       <p className={'font-semibold'}>
                         {formatTvlDisplay(
@@ -269,7 +270,7 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
                         )}
                       </p>
                     </div>
-                    <div className={'flex flex-col items-center md:items-end md:col-span-5'} datatype={'number'}>
+                    <div className={'flex flex-col items-center md:items-end md:col-span-4'} datatype={'number'}>
                       <p className={'mb-1 text-xs text-text-primary/60 md:hidden'}>APY</p>
                       <p className={'font-semibold'}>-</p>
                     </div>

--- a/src/components/pages/vaults/components/detail/VaultsListHead.test.ts
+++ b/src/components/pages/vaults/components/detail/VaultsListHead.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+
+import { STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT } from './strategiesLayout'
+
+describe('VaultsListHead desktop layout', () => {
+  it('uses tightened strategy panel desktop column classes', () => {
+    expect(STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT.nameColumnSpanClass).toBe('col-span-11')
+    expect(STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT.valuesColumnSpanClass).toBe('col-span-12')
+    expect(STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT.valuesGridClass).toBe('md:grid-cols-12 md:gap-2')
+    expect(STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT.valueColumnSpanClass).toBe('md:col-span-4')
+  })
+})

--- a/src/components/pages/vaults/components/detail/VaultsListHead.tsx
+++ b/src/components/pages/vaults/components/detail/VaultsListHead.tsx
@@ -6,6 +6,7 @@ import { cl } from '@shared/utils'
 
 import type { ReactElement } from 'react'
 import { useCallback, useMemo } from 'react'
+import { STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT } from './strategiesLayout'
 
 type TSortableListHeadItem = {
   type?: 'sort'
@@ -178,7 +179,7 @@ export function VaultsListHead({
       >
         <div
           className={cl(
-            'col-span-9',
+            STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT.nameColumnSpanClass,
             'flex flex-row items-center justify-start!',
             'mb-2 py-4 md:mb-0 md:py-0',
             token.className
@@ -187,10 +188,16 @@ export function VaultsListHead({
           {renderItem(token, !isToggleItem(token) && sortBy === token.value, false)}
         </div>
 
-        <div className={cl('col-span-14 z-10', 'grid grid-cols-1 md:grid-cols-15 md:gap-4', 'mt-4 md:mt-0')}>
+        <div
+          className={cl(
+            `${STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT.valuesColumnSpanClass} z-10`,
+            `grid grid-cols-1 ${STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT.valuesGridClass}`,
+            'mt-4 md:mt-0'
+          )}
+        >
           {rest.map(
             (item): ReactElement => (
-              <div key={item.value} className="md:col-span-5">
+              <div key={item.value} className={STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT.valueColumnSpanClass}>
                 {renderItem(item, !isToggleItem(item) && sortBy === item.value, true)}
               </div>
             )

--- a/src/components/pages/vaults/components/detail/VaultsListStrategy.test.ts
+++ b/src/components/pages/vaults/components/detail/VaultsListStrategy.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { STRATEGY_PANEL_ROW_DESKTOP_LAYOUT } from './strategiesLayout'
+
+describe('VaultsListStrategy desktop layout', () => {
+  it('uses tightened strategy row desktop column classes with balanced desktop title wrapping', () => {
+    expect(STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.nameColumnSpanClass).toBe('md:col-span-11')
+    expect(STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.valuesColumnSpanClass).toBe('md:col-span-12')
+    expect(STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.valuesGridClass).toBe('md:grid-cols-12 md:gap-2')
+    expect(STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.valueColumnSpanClass).toBe('md:col-span-4')
+    expect(STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.nameLabelDesktopWrapClass).toBe(
+      'md:[display:-webkit-box] md:[-webkit-box-orient:vertical] md:[-webkit-line-clamp:2] md:[text-wrap:balance] md:whitespace-normal'
+    )
+  })
+})

--- a/src/components/pages/vaults/components/detail/VaultsListStrategy.tsx
+++ b/src/components/pages/vaults/components/detail/VaultsListStrategy.tsx
@@ -4,13 +4,15 @@ import { IconChevron } from '@shared/icons/IconChevron'
 import { IconCopy } from '@shared/icons/IconCopy'
 import { IconLinkOut } from '@shared/icons/IconLinkOut'
 import type { TAddress } from '@shared/types'
-import { cl, formatApyDisplay, formatPercent, toAddress, truncateHex } from '@shared/utils'
+import { cl, toAddress, truncateHex } from '@shared/utils'
 import { formatDuration } from '@shared/utils/format.time'
 import { copyToClipboard } from '@shared/utils/helpers'
 import { getNetwork } from '@shared/utils/wagmi/utils'
 import type { ReactElement } from 'react'
 import { useState } from 'react'
 import Link from '/src/components/Link'
+import { STRATEGY_PANEL_ROW_DESKTOP_LAYOUT } from './strategiesLayout'
+import { formatStrategiesApy, formatStrategiesPercent } from './strategiesPercentFormat'
 
 export function VaultsListStrategy({
   details,
@@ -52,10 +54,10 @@ export function VaultsListStrategy({
   if (shouldShowPlaceholders) {
     apyContent = '-'
   } else {
-    apyContent = formatApyDisplay(displayApr)
+    apyContent = formatStrategiesApy(displayApr)
   }
 
-  const allocationContent = isInactive ? '-' : isUnallocated ? '-' : formatPercent((details?.debtRatio || 0) / 100)
+  const allocationContent = isInactive || isUnallocated ? '-' : formatStrategiesPercent((details?.debtRatio || 0) / 100)
 
   const amountContent = isInactive ? '-' : isUnallocated ? '-' : allocation
 
@@ -64,13 +66,15 @@ export function VaultsListStrategy({
       {/* Collapsible header - always visible */}
       <div
         className={cl(
-          'flex flex-col md:grid md:grid-cols-24 items-start md:items-center w-full gap-3 md:gap-4 py-3 px-4 md:px-8 cursor-pointer',
+          'flex flex-col md:grid md:grid-cols-24 items-start md:items-center w-full gap-3 md:gap-3 py-3 px-4 md:px-8 cursor-pointer',
           'transition-colors duration-200 hover:bg-surface-secondary/50'
         )}
         onClick={() => setIsExpanded(!isExpanded)}
       >
         {/* Top row on mobile: Name + Chevron */}
-        <div className={'flex w-full items-center justify-between md:col-span-9 md:w-auto'}>
+        <div
+          className={`flex w-full items-center justify-between ${STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.nameColumnSpanClass} md:w-auto`}
+        >
           <div className={'flex min-w-0 flex-1 items-center gap-2'}>
             <div className={'flex items-center justify-center size-6 shrink-0'}>
               <div className={cl('size-2 rounded-full', totalValueUsd > 0.01 ? 'bg-green-500' : 'bg-text-secondary')} />
@@ -99,9 +103,17 @@ export function VaultsListStrategy({
                 className="rounded-full"
               />
             </div>
-            <strong title={name} className={'block truncate font-bold min-w-0'}>
-              {name}
-            </strong>
+            <div className={'min-w-0 flex-1'}>
+              <strong
+                title={name}
+                className={cl(
+                  'block min-w-0 truncate font-bold',
+                  STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.nameLabelDesktopWrapClass
+                )}
+              >
+                {name}
+              </strong>
+            </div>
           </div>
           <div className={'ml-2 flex md:hidden'}>
             <IconChevron
@@ -112,18 +124,26 @@ export function VaultsListStrategy({
         </div>
 
         {/* Stats row - 3 columns on mobile */}
-        <div className={'grid w-full grid-cols-3 gap-2 md:col-span-14 md:grid-cols-15 md:gap-4'}>
-          <div className={'flex flex-col items-center md:items-end md:col-span-5'}>
+        <div
+          className={`grid w-full grid-cols-3 gap-2 ${STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.valuesColumnSpanClass} ${STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.valuesGridClass}`}
+        >
+          <div
+            className={`flex flex-col items-center md:items-end ${STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.valueColumnSpanClass}`}
+          >
             <p className={'text-xs text-text-primary/60 mb-1 md:hidden'}>{'Allocation %'}</p>
             <p className={'font-semibold'}>{allocationContent}</p>
           </div>
-          <div className={'flex flex-col items-center md:items-end md:col-span-5'}>
+          <div
+            className={`flex flex-col items-center md:items-end ${STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.valueColumnSpanClass}`}
+          >
             <p className={'text-xs text-text-primary/60 mb-1 md:hidden'}>{'Amount'}</p>
             <p className={'font-semibold truncate'} title={allocation}>
               {amountContent}
             </p>
           </div>
-          <div className={'flex flex-col items-center md:items-end md:col-span-5'}>
+          <div
+            className={`flex flex-col items-center md:items-end ${STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.valueColumnSpanClass}`}
+          >
             <p className={'text-xs text-text-primary/60 mb-1 md:hidden'}>{'APY'}</p>
             <p className={'font-semibold'}>{apyContent}</p>
           </div>
@@ -144,11 +164,11 @@ export function VaultsListStrategy({
           <div className={'flex flex-col gap-1 text-sm pt-2'}>
             <div className={'flex flex-col items-start gap-1 md:flex-row md:items-center md:gap-3'}>
               <span className={'w-full text-text-secondary md:w-36'}>Management Fee:</span>
-              <span>{formatPercent((fees?.management || 0) * 100, 0)}</span>
+              <span>{formatStrategiesPercent((fees?.management || 0) * 100)}</span>
             </div>
             <div className={'flex flex-col items-start gap-1 md:flex-row md:items-center md:gap-3'}>
               <span className={'w-full text-text-secondary md:w-36'}>Performance Fee:</span>
-              <span>{formatPercent((details?.performanceFee || 0) / 100, 0)}</span>
+              <span>{formatStrategiesPercent((details?.performanceFee || 0) / 100)}</span>
             </div>
             <div className={'flex flex-col items-start gap-1 md:flex-row md:items-center md:gap-3'}>
               <span className={'w-full text-text-secondary md:w-36'}>Last Report:</span>

--- a/src/components/pages/vaults/components/detail/strategiesLayout.ts
+++ b/src/components/pages/vaults/components/detail/strategiesLayout.ts
@@ -1,0 +1,15 @@
+export const STRATEGY_PANEL_HEAD_DESKTOP_LAYOUT = {
+  nameColumnSpanClass: 'col-span-11',
+  valuesColumnSpanClass: 'col-span-12',
+  valuesGridClass: 'md:grid-cols-12 md:gap-2',
+  valueColumnSpanClass: 'md:col-span-4'
+} as const
+
+export const STRATEGY_PANEL_ROW_DESKTOP_LAYOUT = {
+  nameColumnSpanClass: 'md:col-span-11',
+  valuesColumnSpanClass: 'md:col-span-12',
+  valuesGridClass: 'md:grid-cols-12 md:gap-2',
+  valueColumnSpanClass: 'md:col-span-4',
+  nameLabelDesktopWrapClass:
+    'md:[display:-webkit-box] md:[-webkit-box-orient:vertical] md:[-webkit-line-clamp:2] md:[text-wrap:balance] md:whitespace-normal'
+} as const

--- a/src/components/pages/vaults/components/detail/strategiesPercentFormat.test.ts
+++ b/src/components/pages/vaults/components/detail/strategiesPercentFormat.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatStrategiesApy, formatStrategiesPercent } from './strategiesPercentFormat'
+
+describe('strategiesPercentFormat', () => {
+  it('pads percentages to the strategy card precision rules', () => {
+    expect(formatStrategiesPercent(12.34)).toBe('12.3%')
+    expect(formatStrategiesPercent(13)).toBe('13.0%')
+    expect(formatStrategiesPercent(5.2)).toBe('5.20%')
+    expect(formatStrategiesPercent(0)).toBe('0.00%')
+  })
+
+  it('limits sub-1 percentages and apy to two decimal places', () => {
+    expect(formatStrategiesPercent(0.9876)).toBe('0.99%')
+    expect(formatStrategiesApy(0.00262)).toBe('0.26%')
+  })
+
+  it('applies upper-limit formatting for percentages at or above threshold', () => {
+    expect(formatStrategiesPercent(501)).toBe('≥ 500%')
+  })
+
+  it('formats infinity values for percentage and APY', () => {
+    expect(formatStrategiesPercent(Infinity)).toBe('∞%')
+    expect(formatStrategiesApy(Infinity)).toBe('∞%')
+  })
+})

--- a/src/components/pages/vaults/components/detail/strategiesPercentFormat.ts
+++ b/src/components/pages/vaults/components/detail/strategiesPercentFormat.ts
@@ -1,0 +1,60 @@
+type TStrategiesPercentFormatOptions = {
+  locales?: string[]
+  upperLimit?: number
+}
+
+function resolveLocales(options?: TStrategiesPercentFormatOptions): string[] {
+  const locales: string[] = []
+  if (options?.locales) {
+    locales.push(...options.locales)
+  }
+  if (typeof navigator !== 'undefined') {
+    locales.push(navigator.language || 'en-US')
+  }
+  locales.push('en-US')
+  return locales
+}
+
+function resolveFractionDigits(value: number): number {
+  const absoluteValue = Math.abs(value)
+  if (absoluteValue >= 100) {
+    return 0
+  }
+  if (absoluteValue >= 10) {
+    return 1
+  }
+  return 2
+}
+
+function formatWithPaddedFractionDigits(value: number, options?: TStrategiesPercentFormatOptions): string {
+  const fractionDigits = resolveFractionDigits(value)
+  return new Intl.NumberFormat(resolveLocales(options), {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits
+  }).format(value)
+}
+
+export function formatStrategiesPercent(value: number, options?: TStrategiesPercentFormatOptions): string {
+  if (value === Infinity || value === -Infinity) {
+    return '∞%'
+  }
+
+  const safeValue = Number.isFinite(value) ? value : 0
+  const upperLimit = options?.upperLimit ?? 500
+  if (safeValue >= upperLimit) {
+    return `≥ ${formatWithPaddedFractionDigits(upperLimit, options)}%`
+  }
+  return `${formatWithPaddedFractionDigits(safeValue, options)}%`
+}
+
+export function formatStrategiesApy(
+  value: number | null | undefined,
+  options?: TStrategiesPercentFormatOptions
+): string {
+  if (value === Infinity || value === -Infinity) {
+    return '∞%'
+  }
+  const numericValue = typeof value === 'number' ? value : 0
+  const safeValue = Number.isFinite(numericValue) ? numericValue : 0
+  return formatStrategiesPercent(safeValue * 100, options)
+}


### PR DESCRIPTION
## Summary

  This updates the vault strategy card presentation so numeric values use consistent padded precision and long strategy
  names wrap more gracefully without crowding adjacent columns.

  ## What changed

  - Added strategy-specific percent/APY formatting for the strategy card
    - Pads values to fixed visible precision instead of collapsing trailing zeroes
    - Examples: `13.0%`, `5.20%`, `0.00%`, `0.26%`
    - Keeps the existing special handling for `∞%` and `≥ 500%`
  - Tightened the strategy card column layout
    - Rebalanced the desktop name/value column spans
    - Applied the same spacing to the unallocated row
  - Improved long strategy-name handling
    - Allows names to wrap to two lines on desktop
    - Uses balanced wrapping so line breaks are more even before ellipsis is applied
  - Extracted shared strategy-card layout constants
  - Added focused tests for:
    - strategy card layout constants
    - padded percent/APY formatting
    - balanced multi-line title wrapping

  ## Files of interest

  - `src/components/pages/vaults/components/detail/VaultsListStrategy.tsx`
  - `src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx`
  - `src/components/pages/vaults/components/detail/VaultsListHead.tsx`
  - `src/components/pages/vaults/components/detail/strategiesLayout.ts`
  - `src/components/pages/vaults/components/detail/strategiesPercentFormat.ts`

  ## Testing

  - `bunx vitest run src/components/pages/vaults/components/detail/VaultsListHead.test.ts src/components/pages/vaults/
  components/detail/VaultsListStrategy.test.ts src/components/pages/vaults/components/detail/
  strategiesPercentFormat.test.ts`
  - `bun run tslint`
  - `bun run lint:fix`

## Human Review
- Make sure you like how it looks.
<img width="789" height="605" alt="image" src="https://github.com/user-attachments/assets/ae0b09e5-017f-4d1b-a1c8-24f51c6dd3b2" />
