### PR TITLE
Fix quote impact consent resets

### DIFF
--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -253,10 +253,29 @@ export const WidgetDeposit: FC<Props> = ({
     }
   }, [depositAmount.bn, inputToken?.decimals, inputTokenPrice, vaultShareValue.usdRaw])
 
-  // Reset price impact acceptance when amount changes
+  const priceImpactAcceptanceKey = useMemo(() => {
+    return [
+      depositAmount.bn.toString(),
+      routeType,
+      sourceChainId,
+      depositToken,
+      destinationToken,
+      activeFlow.periphery.routerAddress ?? '',
+      activeFlow.periphery.expectedOut.toString()
+    ].join(':')
+  }, [
+    depositAmount.bn,
+    routeType,
+    sourceChainId,
+    depositToken,
+    destinationToken,
+    activeFlow.periphery.routerAddress,
+    activeFlow.periphery.expectedOut
+  ])
+
   useEffect(() => {
     setHasAcceptedPriceImpact(false)
-  }, [depositAmount.bn])
+  }, [priceImpactAcceptanceKey])
 
   const formattedDepositAmount = formatTAmount({ value: depositAmount.bn, decimals: inputToken?.decimals ?? 18 })
   const needsApproval = !isNativeToken && !activeFlow.periphery.isAllowanceSufficient

--- a/src/components/pages/vaults/components/widget/withdraw/index.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/index.tsx
@@ -265,10 +265,33 @@ export const WidgetWithdraw: FC<
     outputTokenPrice
   ])
 
-  // Reset price impact acceptance when amount changes
+  const priceImpactAcceptanceKey = useMemo(() => {
+    return [
+      withdrawAmount.bn.toString(),
+      requiredShares.toString(),
+      routeType,
+      withdrawalSource ?? '',
+      sourceToken,
+      withdrawToken,
+      destinationChainId,
+      activeFlow.periphery.routerAddress ?? '',
+      activeFlow.periphery.expectedOut.toString()
+    ].join(':')
+  }, [
+    withdrawAmount.bn,
+    requiredShares,
+    routeType,
+    withdrawalSource,
+    sourceToken,
+    withdrawToken,
+    destinationChainId,
+    activeFlow.periphery.routerAddress,
+    activeFlow.periphery.expectedOut
+  ])
+
   useEffect(() => {
     setHasAcceptedPriceImpact(false)
-  }, [withdrawAmount.bn])
+  }, [priceImpactAcceptanceKey])
 
   const zapToken = useMemo(() => {
     if (withdrawToken === assetAddress) return undefined


### PR DESCRIPTION
## Summary
- reset deposit high-price-impact consent when the active quote changes, not only when the typed amount changes
- reset withdraw high-price-impact consent when the active quote changes, not only when the typed amount changes
- keep the staked-share quote handling issue out of scope for this PR

## Review Issues Addressed
This PR fixes the first two review findings from the latest widget safety pass:

1. Deposit consent could persist across quote changes.
If a user accepted a high-price-impact deposit quote and then changed the route for the same amount, the prior acceptance was preserved. A concrete example is toggling `Stake Automatically`, which can switch the flow from a direct deposit to an auto-stake quote without changing `depositAmount.bn`.

2. Withdraw consent could persist across route changes.
If a user accepted a high-price-impact withdraw quote and then switched `withdrawalSource` for the same amount, the prior acceptance was preserved even though the route and quoted output changed.

## Fix Details
The deposit widget now invalidates the high-price-impact acknowledgement from a quote signature composed from the current amount plus the active route identity and quote output:
- amount
- route type
- source chain / selected route destination
- router address when present
- quoted `expectedOut`

The withdraw widget now does the same for its current route context:
- amount
- required shares
- route type
- withdrawal source
- source/destination token context
- destination chain
- router address when present
- quoted `expectedOut`

That keeps the confirmation tied to the currently displayed quote, so changing routes for the same amount requires a fresh acknowledgement before submit is enabled again.

## Out of Scope
This PR does not change the separate review finding about staked-share quotes being misclassified by the deposit price-impact calculation.

## Verification
- `bun run tslint`
- `bun run lint:fix`
