### PR TITLE
Fix portfolio vault suggestion ranking

### DIFF
--- a/src/components/pages/portfolio/hooks/buildVaultSuggestions.test.ts
+++ b/src/components/pages/portfolio/hooks/buildVaultSuggestions.test.ts
@@ -1,0 +1,138 @@
+import type { TExternalToken } from '@pages/portfolio/constants/externalTokens'
+import { buildVaultSuggestions } from '@pages/portfolio/hooks/buildVaultSuggestions'
+import type { TKongVault } from '@pages/vaults/domain/kongVaultSelectors'
+import { describe, expect, it } from 'vitest'
+
+const buildVault = ({
+  address,
+  assetSymbol,
+  tvl,
+  apr
+}: {
+  address: string
+  assetSymbol: string
+  tvl: number
+  apr: number
+}): TKongVault =>
+  ({
+    chainId: 1,
+    address,
+    name: `${assetSymbol} Vault`,
+    symbol: `yv${assetSymbol}`,
+    apiVersion: '3.0.0',
+    decimals: 18,
+    asset: {
+      address:
+        assetSymbol === 'USDC'
+          ? '0x0000000000000000000000000000000000000010'
+          : assetSymbol === 'DAI'
+            ? '0x0000000000000000000000000000000000000011'
+            : '0x0000000000000000000000000000000000000012',
+      name: assetSymbol,
+      symbol: assetSymbol,
+      decimals: 18
+    },
+    tvl,
+    performance: {
+      oracle: { apr, apy: apr },
+      estimated: {
+        apr,
+        apy: apr,
+        type: 'estimated',
+        components: {}
+      },
+      historical: {
+        net: apr,
+        weeklyNet: apr,
+        monthlyNet: apr,
+        inceptionNet: apr
+      }
+    },
+    fees: {
+      managementFee: 0.0025,
+      performanceFee: 0.1
+    },
+    category: 'Stablecoin',
+    type: 'Standard',
+    kind: 'Multi Strategy',
+    v3: true,
+    yearn: true,
+    isRetired: false,
+    isHidden: false,
+    isBoosted: false,
+    isHighlighted: true,
+    strategiesCount: 1,
+    riskLevel: 1,
+    staking: {
+      address: null,
+      available: false
+    }
+  }) as unknown as TKongVault
+
+describe('buildVaultSuggestions', () => {
+  it('dedupes repeated vault matches before applying the two-item cap', () => {
+    const usdcVault = buildVault({
+      address: '0x0000000000000000000000000000000000000001',
+      assetSymbol: 'USDC',
+      tvl: 2_000_000,
+      apr: 0.06
+    })
+    const daiVault = buildVault({
+      address: '0x0000000000000000000000000000000000000002',
+      assetSymbol: 'DAI',
+      tvl: 1_500_000,
+      apr: 0.05
+    })
+    const wethVault = buildVault({
+      address: '0x0000000000000000000000000000000000000003',
+      assetSymbol: 'WETH',
+      tvl: 1_250_000,
+      apr: 0.05
+    })
+
+    const detectedTokens: TExternalToken[] = [
+      {
+        address: '0x0000000000000000000000000000000000000101',
+        chainId: 1,
+        protocol: 'Aave V3',
+        underlyingSymbol: 'USDC',
+        underlyingAddress: '0x0000000000000000000000000000000000000010'
+      },
+      {
+        address: '0x0000000000000000000000000000000000000102',
+        chainId: 1,
+        protocol: 'Compound V3',
+        underlyingSymbol: 'USDC',
+        underlyingAddress: '0x0000000000000000000000000000000000000010'
+      },
+      {
+        address: '0x0000000000000000000000000000000000000103',
+        chainId: 1,
+        protocol: 'Spark',
+        underlyingSymbol: 'DAI',
+        underlyingAddress: '0x0000000000000000000000000000000000000011'
+      },
+      {
+        address: '0x0000000000000000000000000000000000000104',
+        chainId: 1,
+        protocol: 'Morpho',
+        underlyingSymbol: 'WETH',
+        underlyingAddress: '0x0000000000000000000000000000000000000012'
+      }
+    ]
+
+    const suggestions = buildVaultSuggestions(
+      detectedTokens,
+      {
+        [usdcVault.address]: usdcVault,
+        [daiVault.address]: daiVault,
+        [wethVault.address]: wethVault
+      },
+      new Set()
+    )
+
+    expect(suggestions).toHaveLength(2)
+    expect(suggestions[0]?.vault).toBe(usdcVault)
+    expect(suggestions[1]?.vault).toBe(daiVault)
+  })
+})

--- a/src/components/pages/portfolio/hooks/buildVaultSuggestions.ts
+++ b/src/components/pages/portfolio/hooks/buildVaultSuggestions.ts
@@ -1,0 +1,51 @@
+import type { TExternalToken } from '@pages/portfolio/constants/externalTokens'
+import { getEligibleVaults, normalizeSymbol, selectPreferredVault } from '@pages/portfolio/hooks/getEligibleVaults'
+import { getVaultToken, type TKongVault } from '@pages/vaults/domain/kongVaultSelectors'
+import { getVaultKey } from '@shared/hooks/useVaultFilterUtils'
+
+export type TVaultSuggestion = {
+  vault: TKongVault
+  externalProtocol: string
+  underlyingSymbol: string
+}
+
+export function buildVaultSuggestions(
+  detectedTokens: TExternalToken[],
+  vaults: Record<string, TKongVault>,
+  holdingsKeySet: Set<string>
+): TVaultSuggestion[] {
+  if (detectedTokens.length === 0) return []
+
+  const eligible = getEligibleVaults(vaults, holdingsKeySet)
+
+  const vaultsBySymbol = eligible.reduce((acc, vault) => {
+    const normalized = normalizeSymbol(getVaultToken(vault).symbol ?? '')
+    return acc.set(normalized, [...(acc.get(normalized) ?? []), vault])
+  }, new Map<string, TKongVault[]>())
+
+  const bestVaultByUnderlying = new Map<string, TKongVault>(
+    [...vaultsBySymbol.entries()]
+      .map(([symbol, candidates]) => [symbol, selectPreferredVault(candidates)] as const)
+      .filter((entry): entry is [string, TKongVault] => entry[1] !== undefined)
+  )
+
+  const seenVaults = new Set<string>()
+
+  return detectedTokens
+    .flatMap((token) => {
+      const normalized = normalizeSymbol(token.underlyingSymbol)
+      const bestVault = bestVaultByUnderlying.get(normalized)
+      if (!bestVault) return []
+
+      return [{ vault: bestVault, externalProtocol: token.protocol, underlyingSymbol: token.underlyingSymbol }]
+    })
+    .filter((suggestion) => {
+      const vaultKey = getVaultKey(suggestion.vault)
+      if (seenVaults.has(vaultKey)) {
+        return false
+      }
+      seenVaults.add(vaultKey)
+      return true
+    })
+    .slice(0, 2)
+}

--- a/src/components/pages/portfolio/hooks/getEligibleVaults.test.ts
+++ b/src/components/pages/portfolio/hooks/getEligibleVaults.test.ts
@@ -1,0 +1,85 @@
+import type { TKongVault } from '@pages/vaults/domain/kongVaultSelectors'
+import { describe, expect, it } from 'vitest'
+import { selectPreferredVault } from './getEligibleVaults'
+
+const buildVault = ({
+  address,
+  assetSymbol,
+  tvl,
+  apr,
+  version = '3.0.0'
+}: {
+  address: string
+  assetSymbol: string
+  tvl: number
+  apr: number
+  version?: string
+}): TKongVault =>
+  ({
+    chainId: 1,
+    address,
+    name: `${assetSymbol} Vault`,
+    symbol: `yv${assetSymbol}`,
+    apiVersion: version,
+    decimals: 18,
+    asset: {
+      address: '0x0000000000000000000000000000000000000010',
+      name: assetSymbol,
+      symbol: assetSymbol,
+      decimals: 18
+    },
+    tvl,
+    performance: {
+      oracle: { apr, apy: apr },
+      estimated: {
+        apr,
+        apy: apr,
+        type: 'estimated',
+        components: {}
+      },
+      historical: {
+        net: apr,
+        weeklyNet: apr,
+        monthlyNet: apr,
+        inceptionNet: apr
+      }
+    },
+    fees: {
+      managementFee: 0.0025,
+      performanceFee: 0.1
+    },
+    category: 'Stablecoin',
+    type: 'Standard',
+    kind: 'Single Strategy',
+    v3: true,
+    yearn: true,
+    isRetired: false,
+    isHidden: false,
+    isBoosted: false,
+    isHighlighted: true,
+    strategiesCount: 1,
+    riskLevel: 1,
+    staking: {
+      address: null,
+      available: false
+    }
+  }) as unknown as TKongVault
+
+describe('selectPreferredVault', () => {
+  it('prefers the highest-TVL qualifying vault', () => {
+    const smaller = buildVault({
+      address: '0x0000000000000000000000000000000000000001',
+      assetSymbol: 'USDC',
+      tvl: 900_000,
+      apr: 0.06
+    })
+    const larger = buildVault({
+      address: '0x0000000000000000000000000000000000000002',
+      assetSymbol: 'USDC',
+      tvl: 2_500_000,
+      apr: 0.05
+    })
+
+    expect(selectPreferredVault([smaller, larger])).toBe(larger)
+  })
+})

--- a/src/components/pages/portfolio/hooks/getEligibleVaults.ts
+++ b/src/components/pages/portfolio/hooks/getEligibleVaults.ts
@@ -32,7 +32,7 @@ export function selectPreferredVault(candidates: TKongVault[]): TKongVault | und
 
   if (qualifying.length > 0) {
     return qualifying.reduce((best, vault) =>
-      (getVaultTVL(vault).tvl ?? 0) < (getVaultTVL(best).tvl ?? 0) ? vault : best
+      (getVaultTVL(vault).tvl ?? 0) > (getVaultTVL(best).tvl ?? 0) ? vault : best
     )
   }
 

--- a/src/components/pages/portfolio/hooks/useVaultSuggestions.ts
+++ b/src/components/pages/portfolio/hooks/useVaultSuggestions.ts
@@ -1,17 +1,10 @@
 import { EXTERNAL_TOKENS } from '@pages/portfolio/constants/externalTokens'
-import { getEligibleVaults, normalizeSymbol, selectPreferredVault } from '@pages/portfolio/hooks/getEligibleVaults'
-import { getVaultToken, type TKongVault } from '@pages/vaults/domain/kongVaultSelectors'
+import { buildVaultSuggestions, type TVaultSuggestion } from '@pages/portfolio/hooks/buildVaultSuggestions'
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { useYearn } from '@shared/contexts/useYearn'
 import { useEnsoBalances } from '@shared/hooks/useEnsoBalances'
 import { toAddress } from '@shared/utils'
 import { useMemo } from 'react'
-
-export type TVaultSuggestion = {
-  vault: TKongVault
-  externalProtocol: string
-  underlyingSymbol: string
-}
 
 export function useVaultSuggestions(holdingsKeySet: Set<string>): {
   suggestions: TVaultSuggestion[]
@@ -30,30 +23,7 @@ export function useVaultSuggestions(holdingsKeySet: Set<string>): {
   )
 
   const suggestions = useMemo(() => {
-    if (detectedTokens.length === 0) return []
-
-    const eligible = getEligibleVaults(vaults, holdingsKeySet)
-
-    const vaultsBySymbol = eligible.reduce((acc, vault) => {
-      const normalized = normalizeSymbol(getVaultToken(vault).symbol ?? '')
-      return acc.set(normalized, [...(acc.get(normalized) ?? []), vault])
-    }, new Map<string, TKongVault[]>())
-
-    const bestVaultByUnderlying = new Map<string, TKongVault>(
-      [...vaultsBySymbol.entries()]
-        .map(([symbol, candidates]) => [symbol, selectPreferredVault(candidates)] as const)
-        .filter((entry): entry is [string, TKongVault] => entry[1] !== undefined)
-    )
-
-    return detectedTokens
-      .flatMap((token) => {
-        const normalized = normalizeSymbol(token.underlyingSymbol)
-        const bestVault = bestVaultByUnderlying.get(normalized)
-        if (!bestVault) return []
-
-        return [{ vault: bestVault, externalProtocol: token.protocol, underlyingSymbol: token.underlyingSymbol }]
-      })
-      .slice(0, 2)
+    return buildVaultSuggestions(detectedTokens, vaults, holdingsKeySet)
   }, [detectedTokens, vaults, holdingsKeySet])
 
   return { suggestions }


### PR DESCRIPTION
## Description

Fix the remaining portfolio suggestion regressions on top of `release/03-16-26`.

related to this: https://github.com/yearn/yearn.fi/pull/1093#issuecomment-4039676720

## Related Issue

- [P2] Select the largest qualifying vault, not the smallest
- [P3] Deduplicate external matches before truncating to two items

## Motivation and Context

Two confirmed regressions remained on `release/03-16-26`:
- `selectPreferredVault()` used `<` in the qualifying path, so it preferred the smallest qualifying TVL instead of the most liquid option.
- `useVaultSuggestions()` truncated external suggestions before deduping, so multiple wrappers of the same underlying could consume both external slots and hide distinct matches.

This branch fixes both by:
- choosing the highest-TVL vault among qualifying candidates
- deduping vault suggestions before applying the two-item external cap
- extracting the suggestion builder into a pure helper so the behavior is covered by focused tests

The separate token RPC failure report was revalidated on this release branch and was already addressed here, so it is intentionally not part of this PR.

## How Has This Been Tested?

- `bun run lint:fix`
- `bun run tslint`
- `bunx vitest run src/components/pages/portfolio/hooks/getEligibleVaults.test.ts src/components/pages/portfolio/hooks/buildVaultSuggestions.test.ts`

## Screenshots (if appropriate):

N/A
