### PR TITLE
Add vault docs links and yvUSD API row to More Info

### DIFF
--- a/src/components/pages/vaults/components/detail/VaultInfoSection.test.ts
+++ b/src/components/pages/vaults/components/detail/VaultInfoSection.test.ts
@@ -1,8 +1,63 @@
+import { YBOLD_VAULT_ADDRESS } from '@pages/vaults/domain/normalizeVault'
+import { YVUSD_LOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { describe, expect, it } from 'vitest'
-import { extractCurvePools, resolveCurveDepositUrl } from './VaultInfoSection'
+import { extractCurvePools, getVaultDocsLinks, resolveCurveDepositUrl } from './VaultInfoSection'
 
 const TOKEN_ADDRESS = '0x1111111111111111111111111111111111111111'
 const POOL_ADDRESS = '0x2222222222222222222222222222222222222222'
+const DEFAULT_VAULT_ADDRESS = '0x3333333333333333333333333333333333333333'
+
+function createVaultTokenAddress(address = DEFAULT_VAULT_ADDRESS): `0x${string}` {
+  return address as `0x${string}`
+}
+
+describe('getVaultDocsLinks', () => {
+  it('returns yvUSD docs by address', () => {
+    expect(getVaultDocsLinks(YVUSD_LOCKED_ADDRESS, 'yvUSD', '2')).toStrictEqual({
+      developerDocumentationUrl: 'https://docs.yearn.fi/developers/yvusd/',
+      userDocumentationUrl: 'https://docs.yearn.fi/getting-started/products/yvaults/yvusd'
+    })
+  })
+
+  it('returns yBOLD docs by address', () => {
+    expect(getVaultDocsLinks(YBOLD_VAULT_ADDRESS, 'yBOLD', '2')).toStrictEqual({
+      developerDocumentationUrl: 'https://docs.yearn.fi/developers/v3/overview',
+      userDocumentationUrl: 'https://docs.yearn.fi/getting-started/products/yvaults/yBold'
+    })
+  })
+
+  it('returns yCRV docs by symbol', () => {
+    expect(
+      getVaultDocsLinks(createVaultTokenAddress('0x1111111111111111111111111111111111111111'), 'ycrv', '2')
+    ).toStrictEqual({
+      developerDocumentationUrl: 'https://docs.yearn.fi/developers/building-on-yearn',
+      userDocumentationUrl: 'https://docs.yearn.fi/getting-started/products/ylockers/ycrv/overview'
+    })
+  })
+
+  it('returns yYB docs by symbol', () => {
+    expect(
+      getVaultDocsLinks(createVaultTokenAddress('0x1111111111111111111111111111111111111112'), 'yyb', '2')
+    ).toStrictEqual({
+      developerDocumentationUrl: 'https://docs.yearn.fi/developers/building-on-yearn',
+      userDocumentationUrl: 'https://docs.yearn.fi/getting-started/products/ylockers/yyb/overview'
+    })
+  })
+
+  it('returns v3 docs by version fallback', () => {
+    expect(getVaultDocsLinks(DEFAULT_VAULT_ADDRESS as `0x${string}`, 'some-symbol', '3')).toStrictEqual({
+      developerDocumentationUrl: 'https://docs.yearn.fi/developers/v3/overview',
+      userDocumentationUrl: 'https://docs.yearn.fi/getting-started/products/yvaults/v3'
+    })
+  })
+
+  it('returns v2 docs by version fallback', () => {
+    expect(getVaultDocsLinks(DEFAULT_VAULT_ADDRESS as `0x${string}`, 'some-symbol', '2')).toStrictEqual({
+      developerDocumentationUrl: 'https://docs.yearn.fi/developers/building-on-yearn',
+      userDocumentationUrl: 'https://docs.yearn.fi/getting-started/products/yvaults/v2'
+    })
+  })
+})
 
 describe('extractCurvePools', () => {
   it('extracts pools from canonical data.poolData shape', () => {

--- a/src/components/pages/vaults/components/detail/VaultInfoSection.tsx
+++ b/src/components/pages/vaults/components/detail/VaultInfoSection.tsx
@@ -6,9 +6,11 @@ import {
   getVaultInfo,
   getVaultStaking,
   getVaultToken,
+  getVaultVersion,
   isAutomatedVault,
   type TKongVaultInput
 } from '@pages/vaults/domain/kongVaultSelectors'
+import { YBOLD_VAULT_ADDRESS } from '@pages/vaults/domain/normalizeVault'
 import { useYvUsdVaults } from '@pages/vaults/hooks/useYvUsdVaults'
 import { KONG_REST_BASE } from '@pages/vaults/utils/kongRest'
 import { isYvUsdAddress, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
@@ -36,7 +38,70 @@ const CURVE_POOLS_CACHE_TTL_MS = 30 * 60 * 1000
 const CURVE_POOLS_CACHE_GC_MS = 60 * 60 * 1000
 const CURVE_POOLS_ENDPOINT = 'https://api.curve.finance/v1/getPools/all'
 const YVUSD_API_URL = 'https://yvusd-api.yearn.fi/api/aprs'
+const USER_DOCS_V2_URL = 'https://docs.yearn.fi/getting-started/products/yvaults/v2'
+const USER_DOCS_V3_URL = 'https://docs.yearn.fi/getting-started/products/yvaults/v3'
+const DEVELOPER_DOCS_V2_URL = 'https://docs.yearn.fi/developers/building-on-yearn'
+const DEVELOPER_DOCS_V3_URL = 'https://docs.yearn.fi/developers/v3/overview'
+const USER_DOCS_YVUSD_URL = 'https://docs.yearn.fi/getting-started/products/yvaults/yvusd'
+const DEVELOPER_DOCS_YVUSD_URL = 'https://docs.yearn.fi/developers/yvusd/'
+const USER_DOCS_YBOLD_URL = 'https://docs.yearn.fi/getting-started/products/yvaults/yBold'
+const DEVELOPER_DOCS_YBOLD_URL = DEVELOPER_DOCS_V3_URL
+const USER_DOCS_YCRV_URL = 'https://docs.yearn.fi/getting-started/products/ylockers/ycrv/overview'
+const DEVELOPER_DOCS_YCRV_URL = DEVELOPER_DOCS_V2_URL
+const USER_DOCS_YYB_URL = 'https://docs.yearn.fi/getting-started/products/ylockers/yyb/overview'
+const DEVELOPER_DOCS_YYB_URL = DEVELOPER_DOCS_V2_URL
 const INFO_LABEL_CLASS = 'w-full text-sm text-text-secondary md:w-auto md:pr-4'
+
+export function getVaultDocsLinks(
+  vaultAddress: `0x${string}`,
+  tokenSymbol: string,
+  version: string
+): {
+  userDocumentationUrl: string
+  developerDocumentationUrl: string
+} {
+  const normalizedSymbol = tokenSymbol.toLowerCase()
+
+  if (isYvUsdAddress(vaultAddress)) {
+    return {
+      developerDocumentationUrl: DEVELOPER_DOCS_YVUSD_URL,
+      userDocumentationUrl: USER_DOCS_YVUSD_URL
+    }
+  }
+
+  if (vaultAddress === YBOLD_VAULT_ADDRESS) {
+    return {
+      developerDocumentationUrl: DEVELOPER_DOCS_YBOLD_URL,
+      userDocumentationUrl: USER_DOCS_YBOLD_URL
+    }
+  }
+
+  if (normalizedSymbol === 'ycrv') {
+    return {
+      developerDocumentationUrl: DEVELOPER_DOCS_YCRV_URL,
+      userDocumentationUrl: USER_DOCS_YCRV_URL
+    }
+  }
+
+  if (normalizedSymbol === 'yyb') {
+    return {
+      developerDocumentationUrl: DEVELOPER_DOCS_YYB_URL,
+      userDocumentationUrl: USER_DOCS_YYB_URL
+    }
+  }
+
+  if (version.startsWith('3') || version.startsWith('~3')) {
+    return {
+      developerDocumentationUrl: DEVELOPER_DOCS_V3_URL,
+      userDocumentationUrl: USER_DOCS_V3_URL
+    }
+  }
+
+  return {
+    developerDocumentationUrl: DEVELOPER_DOCS_V2_URL,
+    userDocumentationUrl: USER_DOCS_V2_URL
+  }
+}
 
 export function extractCurvePools(payload: unknown): TCurvePoolEntry[] {
   const poolData = (payload as TCurvePoolsApiResponse | null)?.data?.poolData
@@ -204,6 +269,12 @@ export function VaultInfoSection({
   const liquidityUrl = getLiquidityUrl({ isVelodrome, isAerodrome, tokenAddress: token.address })
   const powergloveUrl = `https://powerglove.yearn.fi/vaults/${chainID}/${vaultAddress}`
   const deployedLabel = getDeployedLabel(inceptTime)
+  const vaultVersion = getVaultVersion(currentVault)
+  const { developerDocumentationUrl, userDocumentationUrl } = getVaultDocsLinks(
+    vaultAddress,
+    token.symbol,
+    vaultVersion
+  )
 
   return (
     <div className={'grid w-full grid-cols-1 gap-10 p-4 md:p-6 md:pt-0'}>
@@ -308,6 +379,42 @@ export function VaultInfoSection({
             </p>
           </div>
         ) : null}
+
+        <div className={'flex flex-col items-start md:flex-row md:items-center'}>
+          <p className={INFO_LABEL_CLASS}>{'User Documentation'}</p>
+          <div className={'flex items-center gap-1 md:flex-1 md:justify-end'}>
+            <a
+              href={userDocumentationUrl}
+              target={'_blank'}
+              rel={'noopener noreferrer'}
+              className={
+                'flex items-center gap-1 md:text-sm text-text-primary transition-colors hover:text-text-secondary'
+              }
+              suppressHydrationWarning
+            >
+              {'View Documentation'}
+              <IconLinkOut className={'size-3'} />
+            </a>
+          </div>
+        </div>
+
+        <div className={'flex flex-col items-start md:flex-row md:items-center'}>
+          <p className={INFO_LABEL_CLASS}>{'Developer Documentation'}</p>
+          <div className={'flex items-center gap-1 md:flex-1 md:justify-end'}>
+            <a
+              href={developerDocumentationUrl}
+              target={'_blank'}
+              rel={'noopener noreferrer'}
+              className={
+                'flex items-center gap-1 md:text-sm text-text-primary transition-colors hover:text-text-secondary'
+              }
+              suppressHydrationWarning
+            >
+              {'View Documentation'}
+              <IconLinkOut className={'size-3'} />
+            </a>
+          </div>
+        </div>
 
         <div className={'flex flex-col items-start md:flex-row md:items-center'}>
           <p className={INFO_LABEL_CLASS}>{'Powerglove Analytics Page'}</p>


### PR DESCRIPTION
## Summary
- Add vault-specific User Docs and Developer Docs links to the Vault Detail `More Info` section.
- Keep the docs links above Powerglove Analytics.
- Add a dedicated `yvUSD API` row sourced from `https://yvusd-api.yearn.fi/api/aprs`.
- Keep the `yvUSD API` row above Kong snapshot data.

## Vault docs mapping
| Vault type | User docs | Developer docs |
| --- | --- | --- |
| v2 vaults | [v2 vault docs](https://docs.yearn.fi/getting-started/products/yvaults/v2) | [Building on Yearn](https://docs.yearn.fi/developers/building-on-yearn) |
| v3 vaults | [v3 vault docs](https://docs.yearn.fi/getting-started/products/yvaults/v3) | [v3 overview](https://docs.yearn.fi/developers/v3/overview) |
| yvUSD | [yvUSD docs](https://docs.yearn.fi/getting-started/products/yvaults/yvusd) | [yvUSD developer docs](https://docs.yearn.fi/developers/yvusd/) |
| yBOLD | [yBOLD docs](https://docs.yearn.fi/getting-started/products/yvaults/yBold) | [v3 overview](https://docs.yearn.fi/developers/v3/overview) |
| yCRV | [yCRV docs](https://docs.yearn.fi/getting-started/products/ylockers/ycrv/overview) | [Building on Yearn](https://docs.yearn.fi/developers/building-on-yearn) |
| yYB | [yYB docs](https://docs.yearn.fi/getting-started/products/ylockers/yyb/overview) | [Building on Yearn](https://docs.yearn.fi/developers/building-on-yearn) |

## How to test
### Manual
1. Start the app locally with `bun run dev`.
2. Open any vault detail page and scroll to the `More Info` section.
3. Verify `User Documentation` and `Developer Documentation` rows are present and appear above `Powerglove Analytics Page`.
4. Verify the docs links open the expected destinations for representative vault types:
   - `v2` vault: v2 user docs + Building on Yearn developer docs
   - `v3` vault: v3 user docs + v3 overview developer docs
   - `yvUSD`: yvUSD user docs + yvUSD developer docs
   - `yBOLD`: yBOLD user docs + v3 overview developer docs
   - `yCRV` / `yYB`: locker-specific user docs + Building on Yearn developer docs
5. Open a `yvUSD` vault detail page and verify a `yvUSD API` row is shown above `Vault Snapshot Data` and links to `https://yvusd-api.yearn.fi/api/aprs`.
6. Open a non-`yvUSD` vault detail page and verify the `yvUSD API` row is not shown.

### Automated
- `bun run tslint`
- `bun run lint:fix`
- `bunx vitest run src/components/pages/vaults/components/detail/VaultInfoSection.test.ts`
