### PR TITLE
Fix font fallbacks to prevent horrible font rendering on some computers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "yearnfi",
@@ -46,7 +45,6 @@
         "tailwindcss": "4.1.18",
         "typescript": "5.9.3",
         "vite": "7.3.1",
-        "vite-plugin-webfont-dl": "3.12.0",
         "vitest": "1.6.1",
       },
     },
@@ -117,10 +115,6 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-g47s+V+OqsGxbSZN3lpav6WYOk0PIc3aCBAq+p6dwSynL3K5MA6Cg6nkzDOlu28GEHwbakW+BllzHCJCxnfK5Q=="],
 
     "@bytecodealliance/preview2-shim": ["@bytecodealliance/preview2-shim@0.17.6", "", {}, "sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw=="],
-
-    "@cacheable/memory": ["@cacheable/memory@2.0.7", "", { "dependencies": { "@cacheable/utils": "^2.3.3", "@keyv/bigmap": "^1.3.0", "hookified": "^1.14.0", "keyv": "^5.5.5" } }, "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A=="],
-
-    "@cacheable/utils": ["@cacheable/utils@2.3.4", "", { "dependencies": { "hashery": "^1.3.0", "keyv": "^5.6.0" } }, "sha512-knwKUJEYgIfwShABS1BX6JyJJTglAFcEU7EXqzTdiGCXur4voqkiJkdgZIQtWNFhynzDWERcTYv/sETMu3uJWA=="],
 
     "@coinbase/wallet-sdk": ["@coinbase/wallet-sdk@4.3.6", "", { "dependencies": { "@noble/hashes": "1.4.0", "clsx": "1.2.1", "eventemitter3": "5.0.1", "idb-keyval": "6.2.1", "ox": "0.6.9", "preact": "10.24.2", "viem": "^2.27.2", "zustand": "5.0.3" } }, "sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA=="],
 
@@ -291,10 +285,6 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
-    "@keyv/bigmap": ["@keyv/bigmap@1.3.1", "", { "dependencies": { "hashery": "^1.4.0", "hookified": "^1.15.0" }, "peerDependencies": { "keyv": "^5.6.0" } }, "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ=="],
-
-    "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
 
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.5.1", "", {}, "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA=="],
 
@@ -712,13 +702,9 @@
 
     "async-sema": ["async-sema@3.1.1", "", {}, "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg=="],
 
-    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
-
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
-
-    "axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
@@ -758,8 +744,6 @@
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
-    "cacheable": ["cacheable@2.3.2", "", { "dependencies": { "@cacheable/memory": "^2.0.7", "@cacheable/utils": "^2.3.3", "hookified": "^1.15.0", "keyv": "^5.5.5", "qified": "^0.6.0" } }, "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA=="],
-
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -794,8 +778,6 @@
 
     "cjs-module-lexer": ["cjs-module-lexer@1.2.3", "", {}, "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="],
 
-    "clean-css": ["clean-css@5.3.3", "", { "dependencies": { "source-map": "~0.6.0" } }, "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg=="],
-
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
     "cli-truncate": ["cli-truncate@5.1.1", "", { "dependencies": { "slice-ansi": "^7.1.0", "string-width": "^8.0.0" } }, "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A=="],
@@ -811,8 +793,6 @@
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
-
-    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
@@ -900,8 +880,6 @@
 
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
-    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
-
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "derive-valtio": ["derive-valtio@0.1.0", "", { "peerDependencies": { "valtio": "*" } }, "sha512-OCg2UsLbXK7GmmpzMXhYkdO64vhJ1ROUUGaTFyHjVwEdMEcTTRj7W1TxLbSBxdY8QLBPCcp66MTyaSy0RpO17A=="],
@@ -957,8 +935,6 @@
     "es-module-lexer": ["es-module-lexer@1.4.1", "", {}, "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
-
-    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-toolkit": ["es-toolkit@1.33.0", "", {}, "sha512-X13Q/ZSc+vsO1q600bvNK4bxgXMkHcf//RxCmYDaRY5DAcT+eoXjY5hoAPGMdRnWQjvyLEcyauG3b6hz76LNqg=="],
 
@@ -1018,15 +994,7 @@
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
-    "flat-cache": ["flat-cache@6.1.20", "", { "dependencies": { "cacheable": "^2.3.2", "flatted": "^3.3.3", "hookified": "^1.15.0" } }, "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ=="],
-
-    "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
-
-    "follow-redirects": ["follow-redirects@1.15.11", "", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
-
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
-
-    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "framer-motion": ["framer-motion@12.34.0", "", { "dependencies": { "motion-dom": "^12.34.0", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-+/H49owhzkzQyxtn7nZeF4kdH++I2FWrESQ184Zbcw5cEqNHYkE5yxWxcTLSj5lNx3NWdbIRy5FHqUvetD8FWg=="],
 
@@ -1080,8 +1048,6 @@
 
     "hash.js": ["hash.js@1.1.7", "", { "dependencies": { "inherits": "^2.0.3", "minimalistic-assert": "^1.0.1" } }, "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA=="],
 
-    "hashery": ["hashery@1.5.0", "", { "dependencies": { "hookified": "^1.14.0" } }, "sha512-nhQ6ExaOIqti2FDWoEMWARUqIKyjr2VcZzXShrI+A3zpeiuPWzx6iPftt44LhP74E5sW36B75N6VHbvRtpvO6Q=="],
-
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
@@ -1091,8 +1057,6 @@
     "hmac-drbg": ["hmac-drbg@1.0.1", "", { "dependencies": { "hash.js": "^1.0.3", "minimalistic-assert": "^1.0.0", "minimalistic-crypto-utils": "^1.0.1" } }, "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg=="],
 
     "hono": ["hono@4.12.3", "", {}, "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg=="],
-
-    "hookified": ["hookified@1.15.1", "", {}, "sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
@@ -1173,8 +1137,6 @@
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
     "keccak": ["keccak@3.0.4", "", { "dependencies": { "node-addon-api": "^2.0.0", "node-gyp-build": "^4.2.0", "readable-stream": "^3.6.0" } }, "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q=="],
-
-    "keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 
     "keyvaluestorage-interface": ["keyvaluestorage-interface@1.0.0", "", {}, "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="],
 
@@ -1450,13 +1412,9 @@
 
     "proxy-compare": ["proxy-compare@2.6.0", "", {}, "sha512-8xuCeM3l8yqdmbPoYeLbrAXCBWu19XEYc5/F28f5qOaoAIMyfmBUkl5axiK+x9olUvRlcekvnm98AP9RDngOIw=="],
 
-    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
-
     "pump": ["pump@3.0.3", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
-
-    "qified": ["qified@0.6.0", "", { "dependencies": { "hookified": "^1.14.0" } }, "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA=="],
 
     "qr": ["qr@0.5.4", "", {}, "sha512-gjVMHOt7CX+BQd7JLQ9fnS4kJK4Lj4u+Conq52tcCbW7YH3mATTtBbTMA+7cQ1rKOkDo61olFHJReawe+XFxIA=="],
 
@@ -1571,8 +1529,6 @@
     "socket.io-parser": ["socket.io-parser@4.2.5", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1" } }, "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ=="],
 
     "sonic-boom": ["sonic-boom@2.8.0", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg=="],
-
-    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -1723,8 +1679,6 @@
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "vite-node": ["vite-node@1.6.1", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.4", "pathe": "^1.1.1", "picocolors": "^1.0.0", "vite": "^5.0.0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA=="],
-
-    "vite-plugin-webfont-dl": ["vite-plugin-webfont-dl@3.12.0", "", { "dependencies": { "axios": "^1", "clean-css": "^5", "flat-cache": "^6", "picocolors": "^1" }, "peerDependencies": { "vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-0jxsr8ycuoK/uV5Y3ytttTRhgvfZo8v3O4JZBlVc4C7QWIws/vCLVR4B3ag+TGVkLNQya6hXfY3UnZge3M8vmA=="],
 
     "vitest": ["vitest@1.6.1", "", { "dependencies": { "@vitest/expect": "1.6.1", "@vitest/runner": "1.6.1", "@vitest/snapshot": "1.6.1", "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "acorn-walk": "^8.3.2", "chai": "^4.3.10", "debug": "^4.3.4", "execa": "^8.0.1", "local-pkg": "^0.5.0", "magic-string": "^0.30.5", "pathe": "^1.1.1", "picocolors": "^1.0.0", "std-env": "^3.5.0", "strip-literal": "^2.0.0", "tinybench": "^2.5.1", "tinypool": "^0.8.3", "vite": "^5.0.0", "vite-node": "1.6.1", "why-is-node-running": "^2.2.2" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "1.6.1", "@vitest/ui": "1.6.1", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag=="],
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "tailwindcss": "4.1.18",
     "typescript": "5.9.3",
     "vite": "7.3.1",
-    "vite-plugin-webfont-dl": "3.12.0",
     "vitest": "1.6.1"
   }
 }

--- a/public/fonts/fonts.css
+++ b/public/fonts/fonts.css
@@ -1,7 +1,10 @@
 /* Aeonik Font Family */
 @font-face {
   font-family: "Aeonik";
-  src: url("./Aeonik-Light.ttf") format("truetype");
+  src:
+    local("Aeonik Light"),
+    local("Aeonik-Light"),
+    url("./Aeonik-Light.ttf") format("truetype");
   font-weight: 300;
   font-style: normal;
   font-display: swap;
@@ -10,6 +13,9 @@
 @font-face {
   font-family: "Aeonik";
   src:
+    local("Aeonik"),
+    local("Aeonik Regular"),
+    local("Aeonik-Regular"),
     url("./Aeonik-Regular.woff2") format("woff2"),
     url("./Aeonik-Regular.woff") format("woff"),
     url("./Aeonik-Regular.ttf") format("truetype");
@@ -21,6 +27,8 @@
 @font-face {
   font-family: "Aeonik";
   src:
+    local("Aeonik Bold"),
+    local("Aeonik-Bold"),
     url("./Aeonik-Bold.woff2") format("woff2"),
     url("./Aeonik-Bold.woff") format("woff"),
     url("./Aeonik-Bold.ttf") format("truetype");
@@ -31,8 +39,22 @@
 
 @font-face {
   font-family: "Aeonik";
-  src: url("./Aeonik-Black.ttf") format("truetype");
+  src:
+    local("Aeonik Black"),
+    local("Aeonik-Black"),
+    url("./Aeonik-Black.ttf") format("truetype");
   font-weight: 900;
+  font-style: normal;
+  font-display: swap;
+}
+
+/* Explicit sans fallback used when Aeonik cannot be resolved */
+@font-face {
+  font-family: "Aeonik Fallback";
+  src:
+    local("SF Pro Text"), local("SF Pro Display"), local("Helvetica Neue"), local("Helvetica"), local("Arial"),
+    local("Segoe UI"), local("Roboto");
+  font-weight: 300 900;
   font-style: normal;
   font-display: swap;
 }
@@ -58,6 +80,9 @@
 @font-face {
   font-family: "Aeonik Mono";
   src:
+    local("Aeonik Mono"),
+    local("AeonikMono Regular"),
+    local("AeonikMono-Regular"),
     url("./AeonikMono-Regular.woff2") format("woff2"),
     url("./AeonikMono-Regular.woff") format("woff"),
     url("./AeonikMono-Regular.ttf") format("truetype");
@@ -69,6 +94,9 @@
 @font-face {
   font-family: "Aeonik Mono";
   src:
+    local("Aeonik Mono Bold"),
+    local("AeonikMono Bold"),
+    local("AeonikMono-Bold"),
     url("./AeonikMono-Bold.woff2") format("woff2"),
     url("./AeonikMono-Bold.woff") format("woff"),
     url("./AeonikMono-Bold.ttf") format("truetype");
@@ -77,10 +105,21 @@
   font-display: swap;
 }
 
+/* Explicit monospace fallback used when Aeonik Mono cannot be resolved */
+@font-face {
+  font-family: "Aeonik Mono Fallback";
+  src:
+    local("SF Mono"), local("SFMono-Regular"), local("Menlo"), local("Monaco"), local("Consolas"), local("Courier New");
+  font-weight: 400 700;
+  font-style: normal;
+  font-display: swap;
+}
+
 /* CSS Variables for Fonts */
 :root {
-  --font-aeonik: "Aeonik", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-aeonik:
+    "Aeonik", "Aeonik Fallback", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --font-aeonik-fono:
-    "Aeonik Fono", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --scp-font: "Source Code Pro", "Aeonik Mono", Consolas, "Courier New", monospace;
+    "Aeonik Fono", "Aeonik Fallback", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
 }

--- a/public/fonts/fonts.css
+++ b/public/fonts/fonts.css
@@ -51,9 +51,7 @@
 /* Explicit sans fallback used when Aeonik cannot be resolved */
 @font-face {
   font-family: "Aeonik Fallback";
-  src:
-    local("SF Pro Text"), local("SF Pro Display"), local("Helvetica Neue"), local("Helvetica"), local("Arial"),
-    local("Segoe UI"), local("Roboto");
+  src: local("SF Pro Text"), local("SF Pro Display"), local("Arial"), local("Segoe UI"), local("Roboto");
   font-weight: 300 900;
   font-style: normal;
   font-display: swap;
@@ -117,6 +115,6 @@
 
 /* CSS Variables for Fonts */
 :root {
-  --font-aeonik: "Aeonik", "Aeonik Fallback", system-ui, sans-serif;
-  --font-aeonik-fono: "Aeonik Fono", "Aeonik Fallback", system-ui, sans-serif;
+  --font-aeonik: "Aeonik", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-aeonik-fono: "Aeonik Fono", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }

--- a/public/fonts/fonts.css
+++ b/public/fonts/fonts.css
@@ -117,9 +117,6 @@
 
 /* CSS Variables for Fonts */
 :root {
-  --font-aeonik:
-    "Aeonik", "Aeonik Fallback", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --font-aeonik-fono:
-    "Aeonik Fono", "Aeonik Fallback", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
-    sans-serif;
+  --font-aeonik: "Aeonik", "Aeonik Fallback", system-ui, sans-serif;
+  --font-aeonik-fono: "Aeonik Fono", "Aeonik Fallback", system-ui, sans-serif;
 }

--- a/public/fonts/fonts.css
+++ b/public/fonts/fonts.css
@@ -105,6 +105,6 @@
 
 /* CSS Variables for Fonts */
 :root {
-  --font-aeonik: "Aeonik", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --font-aeonik-fono: "Aeonik Fono", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-aeonik: "Aeonik", Helvetica, Arial, system-ui, sans-serif;
+  --font-aeonik-fono: "Aeonik Fono", Helvetica, Arial, system-ui, sans-serif;
 }

--- a/public/fonts/fonts.css
+++ b/public/fonts/fonts.css
@@ -103,16 +103,6 @@
   font-display: swap;
 }
 
-/* Explicit monospace fallback used when Aeonik Mono cannot be resolved */
-@font-face {
-  font-family: "Aeonik Mono Fallback";
-  src:
-    local("SF Mono"), local("SFMono-Regular"), local("Menlo"), local("Monaco"), local("Consolas"), local("Courier New");
-  font-weight: 400 700;
-  font-style: normal;
-  font-display: swap;
-}
-
 /* CSS Variables for Fonts */
 :root {
   --font-aeonik: "Aeonik", system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/src/components/pages/font-fallbacks/index.tsx
+++ b/src/components/pages/font-fallbacks/index.tsx
@@ -14,15 +14,14 @@ type TFontStatus = 'available' | 'missing' | 'system' | 'generic' | 'unknown'
 
 const SANS_STACK: TFontCandidate[] = [
   { family: '"Aeonik"', kind: 'named', label: 'Aeonik', note: 'Primary self-hosted UI sans.' },
+  { family: 'Helvetica', kind: 'named', label: 'Helvetica', note: 'Primary Apple-compatible sans fallback.' },
+  { family: 'Arial', kind: 'named', label: 'Arial', note: 'Cross-platform safety-net sans.' },
   {
     family: 'system-ui',
     kind: 'system',
     label: 'system-ui',
-    note: 'Cross-platform system UI sans keyword.'
+    note: 'Late cross-platform system UI fallback keyword.'
   },
-  { family: '"Helvetica Neue"', kind: 'named', label: 'Helvetica Neue', note: 'Primary macOS legacy sans fallback.' },
-  { family: 'Helvetica', kind: 'named', label: 'Helvetica', note: 'Broader Apple-compatible sans fallback.' },
-  { family: 'Arial', kind: 'named', label: 'Arial', note: 'Cross-platform safety-net sans.' },
   { family: 'sans-serif', kind: 'generic', label: 'sans-serif', note: 'Browser generic sans fallback.' }
 ]
 
@@ -31,12 +30,6 @@ const MONO_STACK: TFontCandidate[] = [
   { family: 'Menlo', kind: 'named', label: 'Menlo', note: 'Preferred macOS mono fallback.' },
   { family: 'Consolas', kind: 'named', label: 'Consolas', note: 'Preferred Windows mono fallback.' },
   { family: '"Liberation Mono"', kind: 'named', label: 'Liberation Mono', note: 'Common Linux mono fallback.' },
-  {
-    family: '"Courier New"',
-    kind: 'named',
-    label: 'Courier New',
-    note: 'Bottom named mono fallback across platforms.'
-  },
   { family: 'monospace', kind: 'generic', label: 'monospace', note: 'Browser generic mono fallback.' }
 ]
 

--- a/src/components/pages/font-fallbacks/index.tsx
+++ b/src/components/pages/font-fallbacks/index.tsx
@@ -28,19 +28,15 @@ const SANS_STACK: TFontCandidate[] = [
 
 const MONO_STACK: TFontCandidate[] = [
   { family: '"Aeonik Mono"', kind: 'named', label: 'Aeonik Mono', note: 'Primary mono for numeric UI samples.' },
-  {
-    family: '"Aeonik Mono Fallback"',
-    kind: 'named',
-    label: 'Aeonik Mono Fallback',
-    note: 'Explicit local alias for system mono fonts.'
-  },
-  { family: 'ui-monospace', kind: 'system', label: 'ui-monospace', note: 'Browser system mono keyword.' },
-  { family: 'SFMono-Regular', kind: 'named', label: 'SFMono-Regular', note: 'macOS system mono face.' },
-  { family: 'Menlo', kind: 'named', label: 'Menlo', note: 'Modern macOS fallback mono.' },
-  { family: 'Monaco', kind: 'named', label: 'Monaco', note: 'Older macOS mono fallback.' },
-  { family: 'Consolas', kind: 'named', label: 'Consolas', note: 'Primary Windows mono.' },
+  { family: 'Menlo', kind: 'named', label: 'Menlo', note: 'Preferred macOS mono fallback.' },
+  { family: 'Consolas', kind: 'named', label: 'Consolas', note: 'Preferred Windows mono fallback.' },
   { family: '"Liberation Mono"', kind: 'named', label: 'Liberation Mono', note: 'Common Linux mono fallback.' },
-  { family: '"Courier New"', kind: 'named', label: 'Courier New', note: 'Last explicit named mono fallback.' },
+  {
+    family: '"Courier New"',
+    kind: 'named',
+    label: 'Courier New',
+    note: 'Bottom named mono fallback across platforms.'
+  },
   { family: 'monospace', kind: 'generic', label: 'monospace', note: 'Browser generic mono fallback.' }
 ]
 

--- a/src/components/pages/font-fallbacks/index.tsx
+++ b/src/components/pages/font-fallbacks/index.tsx
@@ -1,5 +1,4 @@
 import { Meta } from '@shared/components/Meta'
-import { cl } from '@shared/utils'
 import type { ReactElement, ReactNode } from 'react'
 import { useEffect, useState } from 'react'
 
@@ -10,7 +9,20 @@ type TFontCandidate = {
   note: string
 }
 
-type TFontStatus = 'available' | 'missing' | 'system' | 'generic' | 'unknown'
+type TFontIdentityCandidate = Pick<TFontCandidate, 'family' | 'kind' | 'label'>
+type TFontProbe = {
+  fontSizePx: number
+  fontStyle: 'normal' | 'italic'
+  fontWeight: number
+  label: string
+  sampleText: string
+}
+
+type TRenderedFontMatch = {
+  aliases: string[]
+  label: string
+  primaryLabel: string | null
+}
 
 const SANS_STACK: TFontCandidate[] = [
   { family: '"Aeonik"', kind: 'named', label: 'Aeonik', note: 'Primary self-hosted UI sans.' },
@@ -31,6 +43,45 @@ const MONO_STACK: TFontCandidate[] = [
   { family: 'Consolas', kind: 'named', label: 'Consolas', note: 'Preferred Windows mono fallback.' },
   { family: '"Liberation Mono"', kind: 'named', label: 'Liberation Mono', note: 'Common Linux mono fallback.' },
   { family: 'monospace', kind: 'generic', label: 'monospace', note: 'Browser generic mono fallback.' }
+]
+
+const SANS_RENDER_CANDIDATES: TFontIdentityCandidate[] = [
+  { family: '"Aeonik"', kind: 'named', label: 'Aeonik' },
+  { family: '"SF Pro Text"', kind: 'named', label: 'SF Pro Text' },
+  { family: '"SF Pro Display"', kind: 'named', label: 'SF Pro Display' },
+  { family: 'Helvetica', kind: 'named', label: 'Helvetica' },
+  { family: 'Arial', kind: 'named', label: 'Arial' },
+  { family: '"Segoe UI"', kind: 'named', label: 'Segoe UI' },
+  { family: 'Roboto', kind: 'named', label: 'Roboto' },
+  { family: 'system-ui', kind: 'system', label: 'system-ui' },
+  { family: 'sans-serif', kind: 'generic', label: 'sans-serif' }
+]
+
+const MONO_RENDER_CANDIDATES: TFontIdentityCandidate[] = [
+  { family: '"Aeonik Mono"', kind: 'named', label: 'Aeonik Mono' },
+  { family: '"SFMono-Regular"', kind: 'named', label: 'SFMono-Regular' },
+  { family: 'Menlo', kind: 'named', label: 'Menlo' },
+  { family: 'Consolas', kind: 'named', label: 'Consolas' },
+  { family: '"Liberation Mono"', kind: 'named', label: 'Liberation Mono' },
+  { family: 'monospace', kind: 'generic', label: 'monospace' }
+]
+
+const SANS_RENDER_PROBES: TFontProbe[] = [
+  { label: 'Regular', fontSizePx: 14, fontStyle: 'normal', fontWeight: 400, sampleText: 'Yearn BOLD Stability Pool' },
+  { label: 'Bold', fontSizePx: 18, fontStyle: 'normal', fontWeight: 900, sampleText: 'Yearn BOLD 2.74%' },
+  { label: 'Italic', fontSizePx: 14, fontStyle: 'italic', fontWeight: 400, sampleText: 'Italic stress sample' }
+]
+
+const MONO_RENDER_PROBES: TFontProbe[] = [
+  { label: 'Regular', fontSizePx: 16, fontStyle: 'normal', fontWeight: 400, sampleText: '2.74% 3.00% $4.54M' },
+  { label: 'Bold', fontSizePx: 14, fontStyle: 'normal', fontWeight: 700, sampleText: '9,430 BOLD ($9,480)' },
+  {
+    label: 'Italic',
+    fontSizePx: 12,
+    fontStyle: 'italic',
+    fontWeight: 400,
+    sampleText: 'Projected settlement 03/26/26 14:08'
+  }
 ]
 
 const BODY_STACK = SANS_STACK.map((entry) => entry.family).join(', ')
@@ -55,39 +106,145 @@ function buildFallbackStack(candidates: TFontCandidate[], startIndex: number): s
     .join(', ')
 }
 
-function getNamedFontStatus(candidate: TFontCandidate): TFontStatus {
-  if (candidate.kind === 'system') {
-    return 'system'
-  }
-  if (candidate.kind === 'generic') {
-    return 'generic'
+function buildCanvasFont(probe: TFontProbe, fontFamily: string): string {
+  return `${probe.fontStyle} ${probe.fontWeight} ${probe.fontSizePx}px ${fontFamily}`
+}
+
+function buildFontFingerprint(fontFamily: string, probe: TFontProbe): string | null {
+  const canvas = document.createElement('canvas')
+  const context = canvas.getContext('2d', { willReadFrequently: true })
+
+  if (!context) {
+    return null
   }
 
-  try {
-    return document.fonts.check(`16px ${candidate.family}`) ? 'available' : 'missing'
-  } catch {
-    return 'unknown'
+  context.font = buildCanvasFont(probe, fontFamily)
+  context.textBaseline = 'top'
+
+  const width = Math.max(1, Math.ceil(context.measureText(probe.sampleText).width + 32))
+  const height = Math.max(1, Math.ceil(probe.fontSizePx * 3))
+
+  canvas.width = width
+  canvas.height = height
+
+  const renderContext = canvas.getContext('2d', { willReadFrequently: true })
+
+  if (!renderContext) {
+    return null
+  }
+
+  renderContext.fillStyle = '#ffffff'
+  renderContext.fillRect(0, 0, width, height)
+  renderContext.fillStyle = '#000000'
+  renderContext.font = buildCanvasFont(probe, fontFamily)
+  renderContext.textBaseline = 'top'
+  renderContext.fontKerning = 'normal'
+  renderContext.fillText(probe.sampleText, 16, 12)
+
+  const imageData = renderContext.getImageData(0, 0, width, height).data
+  let hash = 2166136261
+
+  for (let index = 0; index < imageData.length; index += 4) {
+    hash = Math.imul(hash ^ imageData[index + 3], 16777619)
+  }
+
+  return `${width}:${height}:${hash >>> 0}`
+}
+
+function rankRenderedMatches(matches: TFontIdentityCandidate[]): TFontIdentityCandidate[] {
+  const priority = {
+    named: 0,
+    system: 1,
+    generic: 2
+  }
+
+  return [...matches].sort((candidateA, candidateB) => priority[candidateA.kind] - priority[candidateB.kind])
+}
+
+function inferRenderedFontMatch(
+  stack: string,
+  candidates: TFontIdentityCandidate[],
+  probe: TFontProbe
+): TRenderedFontMatch {
+  const stackFingerprint = buildFontFingerprint(stack, probe)
+
+  if (!stackFingerprint) {
+    return { label: probe.label, primaryLabel: null, aliases: [] }
+  }
+
+  const matches = candidates.filter((candidate) => buildFontFingerprint(candidate.family, probe) === stackFingerprint)
+
+  if (!matches.length) {
+    return { label: probe.label, primaryLabel: null, aliases: [] }
+  }
+
+  const rankedMatches = rankRenderedMatches(matches)
+
+  return {
+    label: probe.label,
+    primaryLabel: rankedMatches[0]?.label || null,
+    aliases: rankedMatches.slice(1).map((candidate) => candidate.label)
   }
 }
 
-function statusClassName(status: TFontStatus): string {
-  return {
-    available: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-    missing: 'border-red-200 bg-red-50 text-red-700',
-    system: 'border-blue-200 bg-blue-50 text-blue-700',
-    generic: 'border-neutral-300 bg-neutral-100 text-neutral-700',
-    unknown: 'border-neutral-300 bg-neutral-100 text-neutral-700'
-  }[status]
+function inferRenderedFontMatches(
+  stack: string,
+  candidates: TFontIdentityCandidate[],
+  probes: TFontProbe[]
+): TRenderedFontMatch[] {
+  return probes.map((probe) => inferRenderedFontMatch(stack, candidates, probe))
 }
 
-function statusLabel(status: TFontStatus): string {
-  return {
-    available: 'Available',
-    missing: 'Missing',
-    system: 'System keyword',
-    generic: 'Generic family',
-    unknown: 'Unknown'
-  }[status]
+function formatRenderedFontMatches(matches: TRenderedFontMatch[]): string {
+  const primaryLabels = [
+    ...new Set(matches.map((match) => match.primaryLabel).filter((label): label is string => Boolean(label)))
+  ]
+
+  if (!primaryLabels.length) {
+    return 'No exact match in known candidates'
+  }
+
+  if (primaryLabels.length === 1) {
+    return primaryLabels[0]
+  }
+
+  return matches.map((match) => `${match.label} ${match.primaryLabel || 'Unknown'}`).join(' · ')
+}
+
+function RenderedFontHeader({
+  isolatedStack,
+  fallbackStack,
+  candidates,
+  probes
+}: {
+  candidates: TFontIdentityCandidate[]
+  fallbackStack: string
+  isolatedStack: string
+  probes: TFontProbe[]
+}): ReactElement {
+  const [isolatedMatches, setIsolatedMatches] = useState<TRenderedFontMatch[]>([])
+  const [fallbackMatches, setFallbackMatches] = useState<TRenderedFontMatch[]>([])
+
+  useEffect(() => {
+    setIsolatedMatches(inferRenderedFontMatches(isolatedStack, candidates, probes))
+    setFallbackMatches(inferRenderedFontMatches(fallbackStack, candidates, probes))
+  }, [candidates, fallbackStack, isolatedStack, probes])
+
+  return (
+    <div className={'min-w-0 rounded-lg border border-border bg-surface-secondary px-3 py-2'}>
+      <p className={'font-number text-[10px] uppercase tracking-wide text-text-tertiary'}>{'Likely Rendered'}</p>
+      <div className={'mt-2 grid gap-1 text-xs text-text-secondary'}>
+        <p>
+          <span className={'font-medium text-text-primary'}>{'Isolated: '}</span>
+          {formatRenderedFontMatches(isolatedMatches)}
+        </p>
+        <p>
+          <span className={'font-medium text-text-primary'}>{'Fallback: '}</span>
+          {formatRenderedFontMatches(fallbackMatches)}
+        </p>
+      </div>
+    </div>
+  )
 }
 
 function PreviewShell({ children, fontFamily }: { children: ReactNode; fontFamily: string }): ReactElement {
@@ -98,7 +255,7 @@ function PreviewShell({ children, fontFamily }: { children: ReactNode; fontFamil
   )
 }
 
-function PreviewPanel({ label, stack, preview }: { label: string; stack: string; preview: ReactNode }): ReactElement {
+function PreviewPanel({ label, stack, preview }: { label: string; preview: ReactNode; stack: string }): ReactElement {
   return (
     <div className={'flex flex-col gap-2'}>
       <div className={'flex flex-col gap-1'}>
@@ -186,7 +343,8 @@ function FontCard({
   fallbackStack,
   isolatedPreview,
   fallbackPreview,
-  status,
+  probeCandidates,
+  probes,
   order
 }: {
   candidate: TFontCandidate
@@ -194,7 +352,8 @@ function FontCard({
   fallbackStack: string
   isolatedPreview: ReactNode
   order: number
-  status: TFontStatus
+  probeCandidates: TFontIdentityCandidate[]
+  probes: TFontProbe[]
 }): ReactElement {
   return (
     <article className={'flex h-full flex-col gap-4 border border-border bg-surface p-4'}>
@@ -203,9 +362,12 @@ function FontCard({
           <p className={'font-number text-xs text-text-tertiary'}>{`${order}. ${candidate.label}`}</p>
           <h2 className={'text-base font-semibold text-text-primary'}>{candidate.note}</h2>
         </div>
-        <span className={cl('rounded-full border px-2 py-1 text-xs font-medium', statusClassName(status))}>
-          {statusLabel(status)}
-        </span>
+        <RenderedFontHeader
+          isolatedStack={candidate.family}
+          fallbackStack={fallbackStack}
+          candidates={probeCandidates}
+          probes={probes}
+        />
       </div>
       <PreviewPanel label={'Isolated family'} stack={candidate.family} preview={isolatedPreview} />
       <PreviewPanel label={'Fallback from here'} stack={fallbackStack} preview={fallbackPreview} />
@@ -237,7 +399,6 @@ function StackPreview({
 }
 
 function Index(): ReactElement {
-  const [statuses, setStatuses] = useState<Record<string, TFontStatus>>({})
   const [platform, setPlatform] = useState('Unknown platform')
 
   useEffect(() => {
@@ -246,15 +407,6 @@ function Index(): ReactElement {
     }
 
     setPlatform(navigatorWithUserAgentData.userAgentData?.platform || navigator.platform || 'Unknown platform')
-
-    const updateStatuses = () =>
-      setStatuses(
-        Object.fromEntries(
-          [...SANS_STACK, ...MONO_STACK].map((candidate) => [candidate.label, getNamedFontStatus(candidate)])
-        )
-      )
-
-    void document.fonts.ready.then(updateStatuses).catch(updateStatuses)
   }, [])
 
   return (
@@ -279,7 +431,8 @@ function Index(): ReactElement {
                 Use this page to compare the live body stack and number stack against each individual fallback
                 candidate. Each card shows the isolated family first, then the actual remaining fallback chain from that
                 point in the stack. The bold weights mirror the vault detail route, and the italic lines are included as
-                a deliberate stress test.
+                a deliberate stress test. The rendered-face readout is inferred by matching canvas output against known
+                families on this machine.
               </p>
             </div>
             <div className={'grid gap-2 text-sm text-text-secondary'}>
@@ -318,7 +471,8 @@ function Index(): ReactElement {
                 fallbackStack={buildFallbackStack(SANS_STACK, index)}
                 isolatedPreview={<VaultSansPreview fontFamily={candidate.family} />}
                 order={index + 1}
-                status={statuses[candidate.label] || 'unknown'}
+                probeCandidates={SANS_RENDER_CANDIDATES}
+                probes={SANS_RENDER_PROBES}
               />
             ))}
           </div>
@@ -340,7 +494,8 @@ function Index(): ReactElement {
                 fallbackStack={buildFallbackStack(MONO_STACK, index)}
                 isolatedPreview={<VaultMonoPreview fontFamily={candidate.family} />}
                 order={index + 1}
-                status={statuses[candidate.label] || 'unknown'}
+                probeCandidates={MONO_RENDER_CANDIDATES}
+                probes={MONO_RENDER_PROBES}
               />
             ))}
           </div>

--- a/src/components/pages/font-fallbacks/index.tsx
+++ b/src/components/pages/font-fallbacks/index.tsx
@@ -1,0 +1,367 @@
+import { Meta } from '@shared/components/Meta'
+import { cl } from '@shared/utils'
+import type { ReactElement, ReactNode } from 'react'
+import { useEffect, useState } from 'react'
+
+type TFontCandidate = {
+  family: string
+  kind: 'named' | 'system' | 'generic'
+  label: string
+  note: string
+}
+
+type TFontStatus = 'available' | 'missing' | 'system' | 'generic' | 'unknown'
+
+const SANS_STACK: TFontCandidate[] = [
+  { family: '"Aeonik"', kind: 'named', label: 'Aeonik', note: 'Primary self-hosted UI sans.' },
+  {
+    family: '"Aeonik Fallback"',
+    kind: 'named',
+    label: 'Aeonik Fallback',
+    note: 'Explicit local alias for sane system sans.'
+  },
+  {
+    family: 'system-ui',
+    kind: 'system',
+    label: 'system-ui',
+    note: 'Cross-platform system UI sans keyword.'
+  },
+  { family: 'sans-serif', kind: 'generic', label: 'sans-serif', note: 'Browser generic sans fallback.' }
+]
+
+const MONO_STACK: TFontCandidate[] = [
+  { family: '"Aeonik Mono"', kind: 'named', label: 'Aeonik Mono', note: 'Primary mono for numeric UI samples.' },
+  {
+    family: '"Aeonik Mono Fallback"',
+    kind: 'named',
+    label: 'Aeonik Mono Fallback',
+    note: 'Explicit local alias for system mono fonts.'
+  },
+  { family: 'ui-monospace', kind: 'system', label: 'ui-monospace', note: 'Browser system mono keyword.' },
+  { family: 'SFMono-Regular', kind: 'named', label: 'SFMono-Regular', note: 'macOS system mono face.' },
+  { family: 'Menlo', kind: 'named', label: 'Menlo', note: 'Modern macOS fallback mono.' },
+  { family: 'Monaco', kind: 'named', label: 'Monaco', note: 'Older macOS mono fallback.' },
+  { family: 'Consolas', kind: 'named', label: 'Consolas', note: 'Primary Windows mono.' },
+  { family: '"Liberation Mono"', kind: 'named', label: 'Liberation Mono', note: 'Common Linux mono fallback.' },
+  { family: '"Courier New"', kind: 'named', label: 'Courier New', note: 'Last explicit named mono fallback.' },
+  { family: 'monospace', kind: 'generic', label: 'monospace', note: 'Browser generic mono fallback.' }
+]
+
+const BODY_STACK = SANS_STACK.map((entry) => entry.family).join(', ')
+const NUMBER_STACK = MONO_STACK.map((entry) => entry.family).join(', ')
+
+const DETAIL_STATS = [
+  { label: 'Est. APY', value: '2.74%' },
+  { label: 'TVL', value: '$4.54M' },
+  { label: 'Your deposits', value: '$0.00' }
+]
+
+const NUMBER_ROWS = [
+  { label: 'Vault share value', value: '9,430 BOLD ($9,480)' },
+  { label: 'Expected out', value: '10.0K BOLD' },
+  { label: 'Price impact', value: '-5.66%' }
+]
+
+function buildFallbackStack(candidates: TFontCandidate[], startIndex: number): string {
+  return candidates
+    .slice(startIndex)
+    .map((entry) => entry.family)
+    .join(', ')
+}
+
+function getNamedFontStatus(candidate: TFontCandidate): TFontStatus {
+  if (candidate.kind === 'system') {
+    return 'system'
+  }
+  if (candidate.kind === 'generic') {
+    return 'generic'
+  }
+
+  try {
+    return document.fonts.check(`16px ${candidate.family}`) ? 'available' : 'missing'
+  } catch {
+    return 'unknown'
+  }
+}
+
+function statusClassName(status: TFontStatus): string {
+  return {
+    available: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    missing: 'border-red-200 bg-red-50 text-red-700',
+    system: 'border-blue-200 bg-blue-50 text-blue-700',
+    generic: 'border-neutral-300 bg-neutral-100 text-neutral-700',
+    unknown: 'border-neutral-300 bg-neutral-100 text-neutral-700'
+  }[status]
+}
+
+function statusLabel(status: TFontStatus): string {
+  return {
+    available: 'Available',
+    missing: 'Missing',
+    system: 'System keyword',
+    generic: 'Generic family',
+    unknown: 'Unknown'
+  }[status]
+}
+
+function PreviewShell({ children, fontFamily }: { children: ReactNode; fontFamily: string }): ReactElement {
+  return (
+    <div className={'flex flex-col gap-4 border border-border bg-surface-secondary p-4'} style={{ fontFamily }}>
+      {children}
+    </div>
+  )
+}
+
+function PreviewPanel({ label, stack, preview }: { label: string; stack: string; preview: ReactNode }): ReactElement {
+  return (
+    <div className={'flex flex-col gap-2'}>
+      <div className={'flex flex-col gap-1'}>
+        <p className={'font-number text-xs text-text-tertiary'}>{label}</p>
+        <code className={'font-number break-all text-xs text-text-secondary'}>{stack}</code>
+      </div>
+      {preview}
+    </div>
+  )
+}
+
+function VaultSansPreview({ fontFamily }: { fontFamily: string }): ReactElement {
+  return (
+    <PreviewShell fontFamily={fontFamily}>
+      <div className={'flex flex-col gap-1'}>
+        <p className={'text-xs uppercase tracking-wide text-text-secondary'}>{'Vault Header'}</p>
+        <h3 className={'truncate-safe text-lg font-black leading-tight text-text-primary'}>{'Yearn BOLD'}</h3>
+        <p className={'text-sm text-text-secondary'}>{'Ethereum · Stablecoin · Single Asset'}</p>
+      </div>
+
+      <div className={'grid gap-3 md:grid-cols-3'}>
+        {DETAIL_STATS.map((item) => (
+          <div key={item.label} className={'rounded-lg border border-border bg-surface p-3'}>
+            <p className={'text-[10px] uppercase tracking-wide text-text-secondary'}>{item.label}</p>
+            <p className={'mt-1 text-base font-semibold text-text-primary'}>{item.value}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className={'rounded-lg border border-border bg-surface p-4'}>
+        <p className={'text-sm leading-relaxed text-text-primary'}>
+          {
+            "yBOLD is Yearn's BOLD tokenized Stability Pool product. It is designed to tokenize the benefits of a BOLD-in-stability-pool position."
+          }
+        </p>
+        <p className={'mt-2 text-sm italic text-text-secondary'}>
+          {
+            'Italic stress sample: explanatory copy and warning notes should still read cleanly if Aeonik is unavailable.'
+          }
+        </p>
+      </div>
+
+      <div
+        className={
+          'inline-flex w-fit items-center rounded-lg border border-border bg-surface px-4 py-2 text-sm font-semibold text-text-primary'
+        }
+      >
+        {'Approve & Deposit'}
+      </div>
+    </PreviewShell>
+  )
+}
+
+function VaultMonoPreview({ fontFamily }: { fontFamily: string }): ReactElement {
+  return (
+    <PreviewShell fontFamily={fontFamily}>
+      <div className={'flex flex-col gap-1'}>
+        <p className={'text-xs uppercase tracking-wide text-text-secondary'}>{'Metric Samples'}</p>
+        <p className={'text-lg font-semibold text-text-primary'}>{'2.74%   3.00%   $4.54M'}</p>
+      </div>
+
+      <div className={'rounded-lg border border-border bg-surface p-4'}>
+        <div className={'grid gap-2'}>
+          {NUMBER_ROWS.map((item) => (
+            <div key={item.label} className={'flex items-baseline justify-between gap-4'}>
+              <span className={'text-xs text-text-secondary'}>{item.label}</span>
+              <span className={'text-sm font-semibold text-text-primary'}>{item.value}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className={'rounded-lg border border-border bg-surface p-4'}>
+        <p className={'break-all text-sm font-medium text-text-primary'}>
+          {'0x9f4330700a36b29952869fac9b33f45eedd8a3d8'}
+        </p>
+        <p className={'mt-2 text-xs italic text-text-secondary'}>{'Projected settlement 03/26/26 14:08'}</p>
+      </div>
+    </PreviewShell>
+  )
+}
+
+function FontCard({
+  candidate,
+  fallbackStack,
+  isolatedPreview,
+  fallbackPreview,
+  status,
+  order
+}: {
+  candidate: TFontCandidate
+  fallbackPreview: ReactNode
+  fallbackStack: string
+  isolatedPreview: ReactNode
+  order: number
+  status: TFontStatus
+}): ReactElement {
+  return (
+    <article className={'flex h-full flex-col gap-4 border border-border bg-surface p-4'}>
+      <div className={'flex items-start justify-between gap-3'}>
+        <div className={'flex flex-col gap-1'}>
+          <p className={'font-number text-xs text-text-tertiary'}>{`${order}. ${candidate.label}`}</p>
+          <h2 className={'text-base font-semibold text-text-primary'}>{candidate.note}</h2>
+        </div>
+        <span className={cl('rounded-full border px-2 py-1 text-xs font-medium', statusClassName(status))}>
+          {statusLabel(status)}
+        </span>
+      </div>
+      <PreviewPanel label={'Isolated family'} stack={candidate.family} preview={isolatedPreview} />
+      <PreviewPanel label={'Fallback from here'} stack={fallbackStack} preview={fallbackPreview} />
+    </article>
+  )
+}
+
+function StackPreview({
+  title,
+  description,
+  stack,
+  preview
+}: {
+  title: string
+  description: string
+  stack: string
+  preview: ReactNode
+}): ReactElement {
+  return (
+    <section className={'flex flex-col gap-4 border border-border bg-surface p-5'}>
+      <div className={'flex flex-col gap-1'}>
+        <p className={'font-number text-xs text-text-tertiary'}>{title}</p>
+        <h2 className={'text-xl font-semibold text-text-primary'}>{description}</h2>
+      </div>
+      <code className={'font-number break-all text-xs text-text-secondary'}>{stack}</code>
+      {preview}
+    </section>
+  )
+}
+
+function Index(): ReactElement {
+  const [statuses, setStatuses] = useState<Record<string, TFontStatus>>({})
+  const [platform, setPlatform] = useState('Unknown platform')
+
+  useEffect(() => {
+    const navigatorWithUserAgentData = navigator as Navigator & {
+      userAgentData?: { platform?: string }
+    }
+
+    setPlatform(navigatorWithUserAgentData.userAgentData?.platform || navigator.platform || 'Unknown platform')
+
+    const updateStatuses = () =>
+      setStatuses(
+        Object.fromEntries(
+          [...SANS_STACK, ...MONO_STACK].map((candidate) => [candidate.label, getNamedFontStatus(candidate)])
+        )
+      )
+
+    void document.fonts.ready.then(updateStatuses).catch(updateStatuses)
+  }, [])
+
+  return (
+    <div className={'min-h-[calc(100vh-var(--header-height))] bg-app'}>
+      <Meta
+        title={'Yearn Font Fallbacks'}
+        description={'Inspect Yearn sans and mono fallback order on the current system.'}
+        titleColor={'#ffffff'}
+        themeColor={'#000000'}
+        og={'https://yearn.fi/og.png'}
+        uri={'https://yearn.fi/font-fallbacks'}
+      />
+      <main className={'mx-auto flex w-full max-w-7xl flex-col gap-8 px-4 py-6 md:px-6 xl:px-8'}>
+        <section className={'flex flex-col gap-4 border border-border bg-surface p-6'}>
+          <p className={'font-number text-xs text-text-tertiary'}>Font Fallback Debug</p>
+          <div className={'flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between'}>
+            <div className={'max-w-3xl space-y-3'}>
+              <h1 className={'text-3xl font-semibold text-text-primary'}>
+                Compare the exact sans and mono fallback order on this machine.
+              </h1>
+              <p className={'max-w-2xl text-sm text-text-secondary'}>
+                Use this page to compare the live body stack and number stack against each individual fallback
+                candidate. Each card shows the isolated family first, then the actual remaining fallback chain from that
+                point in the stack. The bold weights mirror the vault detail route, and the italic lines are included as
+                a deliberate stress test.
+              </p>
+            </div>
+            <div className={'grid gap-2 text-sm text-text-secondary'}>
+              <span>{`Platform: ${platform}`}</span>
+              <span>{`Route: /font-fallbacks`}</span>
+            </div>
+          </div>
+        </section>
+
+        <section className={'grid gap-6 lg:grid-cols-2'}>
+          <StackPreview
+            title={'Current Sans Stack'}
+            description={'This is the full body stack the app now requests.'}
+            stack={BODY_STACK}
+            preview={<VaultSansPreview fontFamily={BODY_STACK} />}
+          />
+          <StackPreview
+            title={'Current Mono Stack'}
+            description={'This is the number and metrics stack the app now requests.'}
+            stack={NUMBER_STACK}
+            preview={<VaultMonoPreview fontFamily={NUMBER_STACK} />}
+          />
+        </section>
+
+        <section className={'flex flex-col gap-4'}>
+          <div className={'flex flex-col gap-2'}>
+            <p className={'font-number text-xs text-text-tertiary'}>Sans Candidates</p>
+            <h2 className={'text-2xl font-semibold text-text-primary'}>Body fallback order, one family at a time.</h2>
+          </div>
+          <div className={'grid gap-4 lg:grid-cols-2 xl:grid-cols-3'}>
+            {SANS_STACK.map((candidate, index) => (
+              <FontCard
+                key={candidate.label}
+                candidate={candidate}
+                fallbackPreview={<VaultSansPreview fontFamily={buildFallbackStack(SANS_STACK, index)} />}
+                fallbackStack={buildFallbackStack(SANS_STACK, index)}
+                isolatedPreview={<VaultSansPreview fontFamily={candidate.family} />}
+                order={index + 1}
+                status={statuses[candidate.label] || 'unknown'}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className={'flex flex-col gap-4 pb-10'}>
+          <div className={'flex flex-col gap-2'}>
+            <p className={'font-number text-xs text-text-tertiary'}>Mono Candidates</p>
+            <h2 className={'text-2xl font-semibold text-text-primary'}>
+              Numeric and code-style fallback order, one family at a time.
+            </h2>
+          </div>
+          <div className={'grid gap-4 lg:grid-cols-2 xl:grid-cols-3'}>
+            {MONO_STACK.map((candidate, index) => (
+              <FontCard
+                key={candidate.label}
+                candidate={candidate}
+                fallbackPreview={<VaultMonoPreview fontFamily={buildFallbackStack(MONO_STACK, index)} />}
+                fallbackStack={buildFallbackStack(MONO_STACK, index)}
+                isolatedPreview={<VaultMonoPreview fontFamily={candidate.family} />}
+                order={index + 1}
+                status={statuses[candidate.label] || 'unknown'}
+              />
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}
+
+export default Index

--- a/src/components/pages/font-fallbacks/index.tsx
+++ b/src/components/pages/font-fallbacks/index.tsx
@@ -142,11 +142,7 @@ function buildFontFingerprint(fontFamily: string, probe: TFontProbe): string | n
   renderContext.fillText(probe.sampleText, 16, 12)
 
   const imageData = renderContext.getImageData(0, 0, width, height).data
-  let hash = 2166136261
-
-  for (let index = 0; index < imageData.length; index += 4) {
-    hash = Math.imul(hash ^ imageData[index + 3], 16777619)
-  }
+  const hash = imageData.reduce((currentHash, channel) => Math.imul(currentHash ^ channel, 16777619), 2166136261)
 
   return `${width}:${height}:${hash >>> 0}`
 }
@@ -226,8 +222,33 @@ function RenderedFontHeader({
   const [fallbackMatches, setFallbackMatches] = useState<TRenderedFontMatch[]>([])
 
   useEffect(() => {
-    setIsolatedMatches(inferRenderedFontMatches(isolatedStack, candidates, probes))
-    setFallbackMatches(inferRenderedFontMatches(fallbackStack, candidates, probes))
+    let isActive = true
+
+    const syncMatches = (): void => {
+      if (!isActive) {
+        return
+      }
+
+      setIsolatedMatches(inferRenderedFontMatches(isolatedStack, candidates, probes))
+      setFallbackMatches(inferRenderedFontMatches(fallbackStack, candidates, probes))
+    }
+
+    syncMatches()
+
+    const fontSet = document.fonts
+
+    void fontSet.ready.then(() => {
+      syncMatches()
+    })
+
+    fontSet.addEventListener('loadingdone', syncMatches)
+    fontSet.addEventListener('loadingerror', syncMatches)
+
+    return () => {
+      isActive = false
+      fontSet.removeEventListener('loadingdone', syncMatches)
+      fontSet.removeEventListener('loadingerror', syncMatches)
+    }
   }, [candidates, fallbackStack, isolatedStack, probes])
 
   return (

--- a/src/components/pages/font-fallbacks/index.tsx
+++ b/src/components/pages/font-fallbacks/index.tsx
@@ -15,17 +15,14 @@ type TFontStatus = 'available' | 'missing' | 'system' | 'generic' | 'unknown'
 const SANS_STACK: TFontCandidate[] = [
   { family: '"Aeonik"', kind: 'named', label: 'Aeonik', note: 'Primary self-hosted UI sans.' },
   {
-    family: '"Aeonik Fallback"',
-    kind: 'named',
-    label: 'Aeonik Fallback',
-    note: 'Explicit local alias for sane system sans.'
-  },
-  {
     family: 'system-ui',
     kind: 'system',
     label: 'system-ui',
     note: 'Cross-platform system UI sans keyword.'
   },
+  { family: '"Helvetica Neue"', kind: 'named', label: 'Helvetica Neue', note: 'Primary macOS legacy sans fallback.' },
+  { family: 'Helvetica', kind: 'named', label: 'Helvetica', note: 'Broader Apple-compatible sans fallback.' },
+  { family: 'Arial', kind: 'named', label: 'Arial', note: 'Cross-platform safety-net sans.' },
   { family: 'sans-serif', kind: 'generic', label: 'sans-serif', note: 'Browser generic sans fallback.' }
 ]
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,6 +8,7 @@ const PortfolioPage = lazy(() => import('@pages/portfolio/index'))
 const VaultsPage = lazy(() => import('@pages/vaults/index'))
 const VaultsDetailPage = lazy(() => import('@pages/vaults/[chainID]/[address]'))
 const IconListPage = lazy(() => import('@pages/icon-list/index'))
+const FontFallbacksPage = lazy(() => import('@pages/font-fallbacks/index'))
 
 // Loading component
 const PageLoader = (): ReactElement => (
@@ -37,6 +38,9 @@ export function Routes(): ReactElement {
 
         {/* Icon inventory page */}
         <Route path="/icon-list" element={<IconListPage />} />
+
+        {/* Font fallback debug page */}
+        <Route path="/font-fallbacks" element={<FontFallbacksPage />} />
 
         {/* Unified Vaults routes */}
         <Route path="/vaults">

--- a/style.css
+++ b/style.css
@@ -10,9 +10,9 @@
 @theme {
   /* Font families */
   --font-family-aeonik:
-    'Aeonik', 'Aeonik Fallback', system-ui, sans-serif;
+    'Aeonik', system-ui, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --font-family-aeonik-fono:
-    'Aeonik Fono', 'Aeonik Fallback', system-ui, sans-serif;
+    'Aeonik Fono', system-ui, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --font-family-aeonik-mono:
     'Aeonik Mono', 'Aeonik Mono Fallback', ui-monospace, SFMono-Regular,
     Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
@@ -164,7 +164,7 @@ html {
 body {
   background-color: var(--color-app);
   color: var(--color-text-primary);
-  font-family: 'Aeonik', 'Aeonik Fallback', system-ui, sans-serif;
+  font-family: 'Aeonik', system-ui, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   /* Mobile-optimized line height for readability */
   line-height: 1.5;
 }

--- a/style.css
+++ b/style.css
@@ -10,11 +10,11 @@
 @theme {
   /* Font families */
   --font-family-aeonik:
-    'Aeonik', system-ui, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    'Aeonik', Helvetica, Arial, system-ui, sans-serif;
   --font-family-aeonik-fono:
-    'Aeonik Fono', system-ui, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    'Aeonik Fono', Helvetica, Arial, system-ui, sans-serif;
   --font-family-aeonik-mono:
-    'Aeonik Mono', Menlo, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    'Aeonik Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
   --color-black: hsl(0 0% 0%);
   --color-white: hsl(0 0% 100%);
@@ -163,7 +163,7 @@ html {
 body {
   background-color: var(--color-app);
   color: var(--color-text-primary);
-  font-family: 'Aeonik', system-ui, 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-family: 'Aeonik', Helvetica, Arial, system-ui, sans-serif;
   /* Mobile-optimized line height for readability */
   line-height: 1.5;
 }
@@ -176,7 +176,7 @@ body {
 @layer utilities {
   .font-number {
     font-family:
-      'Aeonik Mono', Menlo, Consolas, 'Liberation Mono', 'Courier New', monospace;
+      'Aeonik Mono', Menlo, Consolas, 'Liberation Mono', monospace;
   }
 
   .scrollbar-none {

--- a/style.css
+++ b/style.css
@@ -14,8 +14,7 @@
   --font-family-aeonik-fono:
     'Aeonik Fono', system-ui, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   --font-family-aeonik-mono:
-    'Aeonik Mono', 'Aeonik Mono Fallback', ui-monospace, SFMono-Regular,
-    Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    'Aeonik Mono', Menlo, Consolas, 'Liberation Mono', 'Courier New', monospace;
 
   --color-black: hsl(0 0% 0%);
   --color-white: hsl(0 0% 100%);
@@ -177,8 +176,7 @@ body {
 @layer utilities {
   .font-number {
     font-family:
-      'Aeonik Mono', 'Aeonik Mono Fallback', ui-monospace, SFMono-Regular,
-      Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+      'Aeonik Mono', Menlo, Consolas, 'Liberation Mono', 'Courier New', monospace;
   }
 
   .scrollbar-none {

--- a/style.css
+++ b/style.css
@@ -10,14 +10,14 @@
 @theme {
   /* Font families */
   --font-family-aeonik:
-    Aeonik, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
-    Arial, sans-serif;
+    'Aeonik', 'Aeonik Fallback', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Helvetica, Arial, sans-serif;
   --font-family-aeonik-fono:
-    'Aeonik Fono', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    Helvetica, Arial, sans-serif;
-  --font-family-aeonik-mono: 'Aeonik Mono', Consolas, 'Courier New', monospace;
-  --font-family-source-code-pro:
-    'Source Code Pro', 'Aeonik Mono', Consolas, 'Courier New', monospace;
+    'Aeonik Fono', 'Aeonik Fallback', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-family-aeonik-mono:
+    'Aeonik Mono', 'Aeonik Mono Fallback', ui-monospace, SFMono-Regular,
+    Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 
   --color-black: hsl(0 0% 0%);
   --color-white: hsl(0 0% 100%);
@@ -166,9 +166,8 @@ html {
 body {
   background-color: var(--color-app);
   color: var(--color-text-primary);
-  font-family:
-    aeonik, 'aeonik Fallback', 'Source Code Pro', 'Source Code Pro Fallback',
-    sans-serif;
+  font-family: 'Aeonik', 'Aeonik Fallback', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   /* Mobile-optimized line height for readability */
   line-height: 1.5;
 }
@@ -181,8 +180,8 @@ body {
 @layer utilities {
   .font-number {
     font-family:
-      'Aeonik Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-      'Liberation Mono', 'Courier New', monospace;
+      'Aeonik Mono', 'Aeonik Mono Fallback', ui-monospace, SFMono-Regular,
+      Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   }
 
   .scrollbar-none {

--- a/style.css
+++ b/style.css
@@ -10,11 +10,9 @@
 @theme {
   /* Font families */
   --font-family-aeonik:
-    'Aeonik', 'Aeonik Fallback', -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    Roboto, Helvetica, Arial, sans-serif;
+    'Aeonik', 'Aeonik Fallback', system-ui, sans-serif;
   --font-family-aeonik-fono:
-    'Aeonik Fono', 'Aeonik Fallback', -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    'Aeonik Fono', 'Aeonik Fallback', system-ui, sans-serif;
   --font-family-aeonik-mono:
     'Aeonik Mono', 'Aeonik Mono Fallback', ui-monospace, SFMono-Regular,
     Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
@@ -166,8 +164,7 @@ html {
 body {
   background-color: var(--color-app);
   color: var(--color-text-primary);
-  font-family: 'Aeonik', 'Aeonik Fallback', -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  font-family: 'Aeonik', 'Aeonik Fallback', system-ui, sans-serif;
   /* Mobile-optimized line height for readability */
   line-height: 1.5;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,6 @@
 import react from '@vitejs/plugin-react'
 import path from 'path'
 import { defineConfig } from 'vite'
-import webfontDownload from 'vite-plugin-webfont-dl'
 
 const API_PROXY_TARGET = 'http://localhost:3001'
 const API_HEALTHCHECK_PATH = '/api/enso/balances'
@@ -64,17 +63,7 @@ function previewApiGuard() {
 }
 
 export default defineConfig({
-  plugins: [
-    react(),
-    previewApiGuard(),
-    webfontDownload(['https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400;500;600;700&display=swap'], {
-      injectAsStyleTag: true,
-      minifyCss: true,
-      async: true,
-      cache: true,
-      proxy: false
-    })
-  ],
+  plugins: [react(), previewApiGuard()],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

Some users have posted screenshots of the Yearn website with fonts that are wildly different from the expected Aeonik fonts. This PR attempts to prevent that by setting better fallback options for font choices by browser

What it looked like on some computers: 
<img width="1280" height="808" alt="image" src="https://github.com/user-attachments/assets/dcbe1bda-4c3b-489d-8e08-3675425029b4" />

This was downloading and using `source-code-pro` and the font fallbacks were also behaving poorly.

This change should improve this and provide reasonable sans serif fallbacks when users have disabled font downloads.

## To Test:

  This PR includes a new route at `/font-fallbacks` that shows the possible fonts for you to review.

  To simulate users who have font downloads disabled, block font file requests and then reload the page:

  ### Chrome / Brave / other Chromium browsers
  1. Open DevTools.
  2. Open `More tools` -> `Request blocking`.
  3. Enable request blocking and add these patterns:
     - `*.woff`
     - `*.woff2`
     - `*.ttf`
     - `*.otf`
  4. Hard refresh `/font-fallbacks`.

  ### Firefox
  1. Open `about:config`.
  2. Set `browser.display.use_document_fonts` to `0`.
  3. Reload `/font-fallbacks`.

  ### What to verify
  - The page should still render with reasonable sans-serif fallbacks for body/UI text.
  - Numeric/mono samples should fall back to a normal monospace font.
  - The `Likely Rendered` labels on the page should show expected fallback families instead of something unexpected.
  - The app should no longer fall through to `Source Code Pro` for normal UI text when Aeonik is unavailable.