### PR TITLE
Reduce deposit success UI lag

### DIFF
--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -70,6 +70,7 @@ interface Props {
   hideContainerBorder?: boolean
   headerActions?: ReactNode
   tokenSelectorExtraTokens?: TToken[]
+  deferSuccessEffectsUntilClose?: boolean
 }
 
 type DepositActionCopy = {
@@ -142,7 +143,8 @@ export function WidgetDeposit({
   hideActionButton = false,
   hideContainerBorder = false,
   headerActions,
-  tokenSelectorExtraTokens
+  tokenSelectorExtraTokens,
+  deferSuccessEffectsUntilClose = true
 }: Props): ReactElement {
   const { address: account } = useAccount()
   const { openLoginModal } = useWeb3()
@@ -774,7 +776,7 @@ export function WidgetDeposit({
         onClose={() => setShowTransactionOverlay(false)}
         step={currentStep}
         isLastStep={!needsApproval}
-        deferOnAllCompleteUntilClose={routeType === 'ENSO'}
+        deferOnAllCompleteUntilClose={routeType === 'ENSO' || deferSuccessEffectsUntilClose}
         autoContinueToNextStep
         autoContinueStepLabels={['Approve', 'Sign Permit']}
         onAllComplete={handleDepositSuccess}

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -71,6 +71,7 @@ interface Props {
   headerActions?: ReactNode
   tokenSelectorExtraTokens?: TToken[]
   deferSuccessEffectsUntilClose?: boolean
+  deferSuccessEffectsUntilConfettiEnd?: boolean
 }
 
 type DepositActionCopy = {
@@ -144,7 +145,8 @@ export function WidgetDeposit({
   hideContainerBorder = false,
   headerActions,
   tokenSelectorExtraTokens,
-  deferSuccessEffectsUntilClose = true
+  deferSuccessEffectsUntilClose = false,
+  deferSuccessEffectsUntilConfettiEnd = true
 }: Props): ReactElement {
   const { address: account } = useAccount()
   const { openLoginModal } = useWeb3()
@@ -776,7 +778,8 @@ export function WidgetDeposit({
         onClose={() => setShowTransactionOverlay(false)}
         step={currentStep}
         isLastStep={!needsApproval}
-        deferOnAllCompleteUntilClose={routeType === 'ENSO' || deferSuccessEffectsUntilClose}
+        deferOnAllCompleteUntilClose={deferSuccessEffectsUntilClose}
+        deferOnAllCompleteUntilConfettiEnd={deferSuccessEffectsUntilConfettiEnd}
         autoContinueToNextStep
         autoContinueStepLabels={['Approve', 'Sign Permit']}
         onAllComplete={handleDepositSuccess}

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shouldAutoContinuePermitSuccess } from './transactionOverlay.helpers'
+import { resolveCompletionDeferral, shouldAutoContinuePermitSuccess } from './transactionOverlay.helpers'
 
 describe('shouldAutoContinuePermitSuccess', () => {
   it('continues permit steps once the next step is ready', () => {
@@ -48,5 +48,51 @@ describe('shouldAutoContinuePermitSuccess', () => {
         hasAutoContinuedFromStep: null
       })
     ).toBe(false)
+  })
+})
+
+describe('resolveCompletionDeferral', () => {
+  it('does not run completion callbacks for non-terminal success states', () => {
+    expect(
+      resolveCompletionDeferral({
+        completedAllSteps: false,
+        deferOnAllCompleteUntilClose: false,
+        deferOnAllCompleteUntilConfettiEnd: true,
+        stepShowsConfetti: true
+      })
+    ).toBe('none')
+  })
+
+  it('prefers close deferral when explicitly requested', () => {
+    expect(
+      resolveCompletionDeferral({
+        completedAllSteps: true,
+        deferOnAllCompleteUntilClose: true,
+        deferOnAllCompleteUntilConfettiEnd: true,
+        stepShowsConfetti: true
+      })
+    ).toBe('after-close')
+  })
+
+  it('defers terminal completion until confetti ends when configured', () => {
+    expect(
+      resolveCompletionDeferral({
+        completedAllSteps: true,
+        deferOnAllCompleteUntilClose: false,
+        deferOnAllCompleteUntilConfettiEnd: true,
+        stepShowsConfetti: true
+      })
+    ).toBe('after-confetti')
+  })
+
+  it('falls back to immediate completion when no confetti is shown', () => {
+    expect(
+      resolveCompletionDeferral({
+        completedAllSteps: true,
+        deferOnAllCompleteUntilClose: false,
+        deferOnAllCompleteUntilConfettiEnd: true,
+        stepShowsConfetti: false
+      })
+    ).toBe('immediate')
   })
 })

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -17,7 +17,11 @@ import {
   useWriteContract
 } from 'wagmi'
 import { AnimatedCheckmark, ErrorIcon, Spinner } from './TransactionStateIndicators'
-import { type OverlayState, shouldAutoContinuePermitSuccess } from './transactionOverlay.helpers'
+import {
+  type OverlayState,
+  resolveCompletionDeferral,
+  shouldAutoContinuePermitSuccess
+} from './transactionOverlay.helpers'
 
 export type PermitDataDirect = {
   domain: TypedDataDomain
@@ -135,6 +139,7 @@ type TransactionOverlayProps = {
   isLastStep?: boolean
   onAllComplete?: () => void
   deferOnAllCompleteUntilClose?: boolean
+  deferOnAllCompleteUntilConfettiEnd?: boolean
   onStepSuccess?: (label: string) => void
   topOffset?: string
   contentAlign?: 'center' | 'start'
@@ -149,6 +154,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   isLastStep = true,
   onAllComplete,
   deferOnAllCompleteUntilClose = false,
+  deferOnAllCompleteUntilConfettiEnd = false,
   onStepSuccess,
   contentAlign = 'center',
   autoContinueToNextStep = false,
@@ -196,16 +202,6 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       (autoContinueStepLabels.length === 0 || autoContinueStepLabels.includes(executedStepLabel))
   )
 
-  const confettiId = useId()
-  const { reward } = useReward(confettiId, 'confetti', {
-    spread: 80,
-    elementCount: 80,
-    startVelocity: 35,
-    decay: 0.91,
-    lifetime: 200,
-    colors: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899']
-  })
-
   // Track if we've started execution to prevent re-triggering
   const hasStartedRef = useRef(false)
   const hasAutoContinuedFromStepRef = useRef<string | null>(null)
@@ -226,6 +222,17 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     onAllComplete?.()
   }, [onAllComplete])
 
+  const confettiId = useId()
+  const { reward } = useReward(confettiId, 'confetti', {
+    spread: 80,
+    elementCount: 80,
+    startVelocity: 35,
+    decay: 0.91,
+    lifetime: 200,
+    colors: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'],
+    onAnimationComplete: runAllCompleteIfPending
+  })
+
   const finalizeSuccessState = useCallback(
     (completedAllSteps: boolean, completedStep?: TransactionStep | null) => {
       setOverlayState('success')
@@ -237,7 +244,14 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
         return
       }
 
-      if (deferOnAllCompleteUntilClose) {
+      const completionDeferral = resolveCompletionDeferral({
+        completedAllSteps,
+        deferOnAllCompleteUntilClose,
+        deferOnAllCompleteUntilConfettiEnd,
+        stepShowsConfetti: Boolean((completedStep ?? executedStepRef.current)?.showConfetti)
+      })
+
+      if (completionDeferral === 'after-close' || completionDeferral === 'after-confetti') {
         hasPendingCompletionRef.current = true
         return
       }
@@ -245,7 +259,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       hasPendingCompletionRef.current = false
       onAllComplete?.()
     },
-    [deferOnAllCompleteUntilClose, onAllComplete]
+    [deferOnAllCompleteUntilClose, deferOnAllCompleteUntilConfettiEnd, onAllComplete]
   )
 
   const setStepExecutionContext = useCallback((nextStep: TransactionStep, nextIsLastStep: boolean) => {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,4 +1,5 @@
 export type OverlayState = 'idle' | 'confirming' | 'pending' | 'success' | 'error'
+export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
 
 export function shouldAutoContinuePermitSuccess(params: {
   overlayState: OverlayState
@@ -33,4 +34,19 @@ export function shouldAutoContinuePermitSuccess(params: {
   if (hasAutoContinuedFromStep === executedStepLabel) return false
 
   return true
+}
+
+export function resolveCompletionDeferral(params: {
+  completedAllSteps: boolean
+  deferOnAllCompleteUntilClose: boolean
+  deferOnAllCompleteUntilConfettiEnd: boolean
+  stepShowsConfetti: boolean
+}): CompletionDeferral {
+  const { completedAllSteps, deferOnAllCompleteUntilClose, deferOnAllCompleteUntilConfettiEnd, stepShowsConfetti } =
+    params
+
+  if (!completedAllSteps) return 'none'
+  if (deferOnAllCompleteUntilClose) return 'after-close'
+  if (deferOnAllCompleteUntilConfettiEnd && stepShowsConfetti) return 'after-confetti'
+  return 'immediate'
 }

--- a/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.helpers.ts
+++ b/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.helpers.ts
@@ -1,6 +1,6 @@
 import type { TYvUsdVariant } from '@pages/vaults/utils/yvUsd'
 
-export function shouldDeferYvUsdDepositSuccessUntilClose(variant: TYvUsdVariant | null): boolean {
+export function shouldRefetchUnlockedAfterYvUsdDeposit(variant: TYvUsdVariant | null): boolean {
   return variant === 'locked'
 }
 
@@ -8,7 +8,7 @@ export function scheduleAdditionalYvUsdDepositRefetch(
   variant: TYvUsdVariant | null,
   refetchUnlocked: () => void
 ): void {
-  if (!shouldDeferYvUsdDepositSuccessUntilClose(variant)) {
+  if (!shouldRefetchUnlockedAfterYvUsdDeposit(variant)) {
     return
   }
 

--- a/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.helpers.ts
+++ b/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.helpers.ts
@@ -1,0 +1,14 @@
+import type { TYvUsdVariant } from '@pages/vaults/utils/yvUsd'
+
+export function scheduleAdditionalYvUsdDepositRefetch(
+  variant: TYvUsdVariant | null,
+  refetchUnlocked: () => void
+): void {
+  if (variant !== 'locked') {
+    return
+  }
+
+  globalThis.setTimeout(() => {
+    refetchUnlocked()
+  }, 0)
+}

--- a/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.helpers.ts
+++ b/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.helpers.ts
@@ -1,10 +1,14 @@
 import type { TYvUsdVariant } from '@pages/vaults/utils/yvUsd'
 
+export function shouldDeferYvUsdDepositSuccessUntilClose(variant: TYvUsdVariant | null): boolean {
+  return variant === 'locked'
+}
+
 export function scheduleAdditionalYvUsdDepositRefetch(
   variant: TYvUsdVariant | null,
   refetchUnlocked: () => void
 ): void {
-  if (variant !== 'locked') {
+  if (!shouldDeferYvUsdDepositSuccessUntilClose(variant)) {
     return
   }
 

--- a/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.test.tsx
+++ b/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.test.tsx
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { scheduleAdditionalYvUsdDepositRefetch } from './YvUsdDeposit.helpers'
+import {
+  scheduleAdditionalYvUsdDepositRefetch,
+  shouldDeferYvUsdDepositSuccessUntilClose
+} from './YvUsdDeposit.helpers'
 
 describe('YvUsdDeposit', () => {
   beforeEach(() => {
@@ -26,5 +29,11 @@ describe('YvUsdDeposit', () => {
     vi.runAllTimers()
 
     expect(unlockedRefetch).not.toHaveBeenCalled()
+  })
+
+  it('only defers success effects for locked deposits', () => {
+    expect(shouldDeferYvUsdDepositSuccessUntilClose('locked')).toBe(true)
+    expect(shouldDeferYvUsdDepositSuccessUntilClose('unlocked')).toBe(false)
+    expect(shouldDeferYvUsdDepositSuccessUntilClose(null)).toBe(false)
   })
 })

--- a/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.test.tsx
+++ b/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.test.tsx
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  scheduleAdditionalYvUsdDepositRefetch,
-  shouldDeferYvUsdDepositSuccessUntilClose
-} from './YvUsdDeposit.helpers'
+import { scheduleAdditionalYvUsdDepositRefetch, shouldRefetchUnlockedAfterYvUsdDeposit } from './YvUsdDeposit.helpers'
 
 describe('YvUsdDeposit', () => {
   beforeEach(() => {
@@ -31,9 +28,9 @@ describe('YvUsdDeposit', () => {
     expect(unlockedRefetch).not.toHaveBeenCalled()
   })
 
-  it('only defers success effects for locked deposits', () => {
-    expect(shouldDeferYvUsdDepositSuccessUntilClose('locked')).toBe(true)
-    expect(shouldDeferYvUsdDepositSuccessUntilClose('unlocked')).toBe(false)
-    expect(shouldDeferYvUsdDepositSuccessUntilClose(null)).toBe(false)
+  it('only schedules the extra unlocked refetch for locked deposits', () => {
+    expect(shouldRefetchUnlockedAfterYvUsdDeposit('locked')).toBe(true)
+    expect(shouldRefetchUnlockedAfterYvUsdDeposit('unlocked')).toBe(false)
+    expect(shouldRefetchUnlockedAfterYvUsdDeposit(null)).toBe(false)
   })
 })

--- a/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.test.tsx
+++ b/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.test.tsx
@@ -1,138 +1,30 @@
-import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { YvUsdDeposit } from './YvUsdDeposit'
-
-const USDC_ADDRESS = '0x0000000000000000000000000000000000000001' as const
-const UNLOCKED_VAULT_ADDRESS = '0x0000000000000000000000000000000000000010' as const
-const LOCKED_VAULT_ADDRESS = '0x0000000000000000000000000000000000000020' as const
-const YVUSD_TOKEN_ADDRESS = '0x696d02Db93291651ED510704c9b286841d506987' as const
-
-const { mockUseYvUsdVaults, mockUseVaultUserData, mockWidgetDeposit } = vi.hoisted(() => ({
-  mockUseYvUsdVaults: vi.fn(),
-  mockUseVaultUserData: vi.fn(),
-  mockWidgetDeposit: vi.fn()
-}))
-
-vi.mock('wagmi', () => ({
-  useAccount: () => ({
-    address: '0x0000000000000000000000000000000000000003'
-  })
-}))
-
-vi.mock('@pages/vaults/hooks/useYvUsdVaults', () => ({
-  useYvUsdVaults: mockUseYvUsdVaults
-}))
-
-vi.mock('@pages/vaults/hooks/useVaultUserData', () => ({
-  useVaultUserData: mockUseVaultUserData
-}))
-
-vi.mock('../deposit', () => ({
-  WidgetDeposit: (props: unknown) => {
-    mockWidgetDeposit(props)
-    return <div>{'WidgetDeposit'}</div>
-  }
-}))
+import { scheduleAdditionalYvUsdDepositRefetch } from './YvUsdDeposit.helpers'
 
 describe('YvUsdDeposit', () => {
   beforeEach(() => {
-    mockWidgetDeposit.mockReset()
-    mockUseYvUsdVaults.mockReturnValue({
-      isLoading: false,
-      metrics: {
-        unlocked: { apy: 0.05 },
-        locked: { apy: 0.08 }
-      },
-      unlockedVault: {
-        address: UNLOCKED_VAULT_ADDRESS,
-        decimals: 18,
-        token: {
-          address: USDC_ADDRESS,
-          name: 'USD Coin',
-          symbol: 'USDC',
-          decimals: 6
-        },
-        apr: { netAPR: 0.05 }
-      },
-      lockedVault: {
-        address: LOCKED_VAULT_ADDRESS,
-        decimals: 18,
-        token: {
-          address: YVUSD_TOKEN_ADDRESS,
-          name: 'yvUSD',
-          symbol: 'yvUSD',
-          decimals: 18
-        },
-        apr: { netAPR: 0.08 }
-      }
-    })
+    vi.useRealTimers()
   })
 
-  it('refetches both yvUSD user-data branches after deposit success', () => {
+  it('defers the unlocked branch refetch after a locked deposit success', () => {
+    vi.useFakeTimers()
     const unlockedRefetch = vi.fn()
-    const lockedRefetch = vi.fn()
-    mockUseVaultUserData
-      .mockReturnValueOnce({
-        assetToken: {
-          address: USDC_ADDRESS,
-          name: 'USD Coin',
-          symbol: 'USDC',
-          decimals: 6,
-          chainID: 1,
-          balance: { raw: 5n, normalized: 5, display: '5', decimals: 6 }
-        },
-        vaultToken: {
-          address: YVUSD_TOKEN_ADDRESS,
-          name: 'yvUSD',
-          symbol: 'yvUSD',
-          decimals: 18,
-          chainID: 1,
-          balance: { raw: 0n, normalized: 0, display: '0', decimals: 18 }
-        },
-        pricePerShare: 1_000_000n,
-        availableToDeposit: 0n,
-        depositedShares: 0n,
-        depositedValue: 0n,
-        stakingWithdrawableAssets: 0n,
-        stakingRedeemableShares: 0n,
-        isLoading: false,
-        refetch: unlockedRefetch
-      })
-      .mockReturnValueOnce({
-        assetToken: {
-          address: YVUSD_TOKEN_ADDRESS,
-          name: 'yvUSD',
-          symbol: 'yvUSD',
-          decimals: 18,
-          chainID: 1,
-          balance: { raw: 2n, normalized: 2, display: '2', decimals: 18 }
-        },
-        vaultToken: {
-          address: LOCKED_VAULT_ADDRESS,
-          name: 'Locked yvUSD',
-          symbol: 'Locked yvUSD',
-          decimals: 18,
-          chainID: 1,
-          balance: { raw: 0n, normalized: 0, display: '0', decimals: 18 }
-        },
-        pricePerShare: 1_000_000_000_000_000_000n,
-        availableToDeposit: 0n,
-        depositedShares: 0n,
-        depositedValue: 0n,
-        stakingWithdrawableAssets: 0n,
-        stakingRedeemableShares: 0n,
-        isLoading: false,
-        refetch: lockedRefetch
-      })
+    scheduleAdditionalYvUsdDepositRefetch('locked', unlockedRefetch)
 
-    const onDepositSuccess = vi.fn()
-    renderToStaticMarkup(<YvUsdDeposit chainId={1} assetAddress={USDC_ADDRESS} onDepositSuccess={onDepositSuccess} />)
+    expect(unlockedRefetch).not.toHaveBeenCalled()
 
-    const props = mockWidgetDeposit.mock.calls.at(-1)?.[0] as { handleDepositSuccess?: () => void }
-    props.handleDepositSuccess?.()
+    vi.runAllTimers()
 
     expect(unlockedRefetch).toHaveBeenCalledTimes(1)
-    expect(lockedRefetch).toHaveBeenCalledTimes(1)
-    expect(onDepositSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not schedule an extra refetch after an unlocked deposit success', () => {
+    vi.useFakeTimers()
+    const unlockedRefetch = vi.fn()
+    scheduleAdditionalYvUsdDepositRefetch('unlocked', unlockedRefetch)
+
+    vi.runAllTimers()
+
+    expect(unlockedRefetch).not.toHaveBeenCalled()
   })
 })

--- a/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.tsx
+++ b/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.tsx
@@ -18,6 +18,7 @@ import { useState } from 'react'
 import { useAccount } from 'wagmi'
 import { WidgetDeposit } from '../deposit'
 import { getDefaultTokenLogoSrc } from '../tokenLogo.utils'
+import { scheduleAdditionalYvUsdDepositRefetch } from './YvUsdDeposit.helpers'
 import { YvUsdVariantToggle } from './YvUsdVariantToggle'
 
 type Props = {
@@ -228,8 +229,7 @@ export function YvUsdDeposit({
     onVariantChange?.(nextVariant)
   }
   const handleDepositSuccess = (): void => {
-    unlockedUserData.refetch()
-    lockedUserData.refetch()
+    scheduleAdditionalYvUsdDepositRefetch(variant, unlockedUserData.refetch)
     onDepositSuccess?.()
   }
   const depositPrefill = getDepositPrefill(variant, unlockedAssetAddress, chainId, pendingPrefillAmount)

--- a/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.tsx
+++ b/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.tsx
@@ -18,7 +18,7 @@ import { useState } from 'react'
 import { useAccount } from 'wagmi'
 import { WidgetDeposit } from '../deposit'
 import { getDefaultTokenLogoSrc } from '../tokenLogo.utils'
-import { scheduleAdditionalYvUsdDepositRefetch, shouldDeferYvUsdDepositSuccessUntilClose } from './YvUsdDeposit.helpers'
+import { scheduleAdditionalYvUsdDepositRefetch } from './YvUsdDeposit.helpers'
 import { YvUsdVariantToggle } from './YvUsdVariantToggle'
 
 type Props = {
@@ -299,7 +299,6 @@ export function YvUsdDeposit({
         onPrefillApplied={() => setPendingPrefillAmount(undefined)}
         tokenSelectorExtraTokens={lockedDepositExtraTokens}
         vaultSharesLabel={getVaultSharesLabel(variant)}
-        deferSuccessEffectsUntilClose={shouldDeferYvUsdDepositSuccessUntilClose(variant)}
       />
     </div>
   )

--- a/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.tsx
+++ b/src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.tsx
@@ -18,7 +18,7 @@ import { useState } from 'react'
 import { useAccount } from 'wagmi'
 import { WidgetDeposit } from '../deposit'
 import { getDefaultTokenLogoSrc } from '../tokenLogo.utils'
-import { scheduleAdditionalYvUsdDepositRefetch } from './YvUsdDeposit.helpers'
+import { scheduleAdditionalYvUsdDepositRefetch, shouldDeferYvUsdDepositSuccessUntilClose } from './YvUsdDeposit.helpers'
 import { YvUsdVariantToggle } from './YvUsdVariantToggle'
 
 type Props = {
@@ -299,6 +299,7 @@ export function YvUsdDeposit({
         onPrefillApplied={() => setPendingPrefillAmount(undefined)}
         tokenSelectorExtraTokens={lockedDepositExtraTokens}
         vaultSharesLabel={getVaultSharesLabel(variant)}
+        deferSuccessEffectsUntilClose={shouldDeferYvUsdDepositSuccessUntilClose(variant)}
       />
     </div>
   )

--- a/src/components/shared/contexts/useNotifications.helpers.test.ts
+++ b/src/components/shared/contexts/useNotifications.helpers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { appendCachedNotification, mergeCachedNotificationEntry } from './useNotifications.helpers'
+
+describe('useNotifications.helpers', () => {
+  it('appends new notifications without reloading the existing list', () => {
+    const first = {
+      id: 1,
+      type: 'deposit' as const,
+      address: '0x111' as const,
+      chainId: 1,
+      amount: '1',
+      status: 'pending' as const
+    }
+    const second = {
+      id: 2,
+      type: 'withdraw' as const,
+      address: '0x222' as const,
+      chainId: 1,
+      amount: '2',
+      status: 'pending' as const
+    }
+
+    expect(appendCachedNotification([first], second)).toEqual([first, second])
+  })
+
+  it('merges notification updates in place', () => {
+    const original = {
+      id: 7,
+      type: 'deposit' as const,
+      address: '0x111' as const,
+      chainId: 1,
+      amount: '1',
+      status: 'pending' as const
+    }
+
+    expect(mergeCachedNotificationEntry([original], 7, { status: 'success', txHash: '0xabc' })).toEqual([
+      {
+        ...original,
+        status: 'success',
+        txHash: '0xabc'
+      }
+    ])
+  })
+
+  it('adds the updated notification if the cache does not contain it yet', () => {
+    expect(
+      mergeCachedNotificationEntry([], 3, {
+        type: 'deposit',
+        address: '0x333',
+        chainId: 1,
+        amount: '3',
+        status: 'success'
+      })
+    ).toEqual([
+      {
+        id: 3,
+        type: 'deposit',
+        address: '0x333',
+        chainId: 1,
+        amount: '3',
+        status: 'success'
+      }
+    ])
+  })
+})

--- a/src/components/shared/contexts/useNotifications.helpers.ts
+++ b/src/components/shared/contexts/useNotifications.helpers.ts
@@ -1,0 +1,30 @@
+import type { TNotification } from '@shared/types/notifications'
+
+export function appendCachedNotification(
+  cachedEntries: TNotification[],
+  notification: TNotification
+): TNotification[] {
+  return [...cachedEntries, notification]
+}
+
+export function mergeCachedNotificationEntry(
+  cachedEntries: TNotification[],
+  id: number,
+  entry: Partial<TNotification>
+): TNotification[] {
+  let found = false
+  const updatedEntries = cachedEntries.map((notification) => {
+    if (notification.id !== id) {
+      return notification
+    }
+
+    found = true
+    return { ...notification, ...entry }
+  })
+
+  if (found) {
+    return updatedEntries
+  }
+
+  return [...updatedEntries, { ...entry, id } as TNotification]
+}

--- a/src/components/shared/contexts/useNotifications.helpers.ts
+++ b/src/components/shared/contexts/useNotifications.helpers.ts
@@ -1,9 +1,6 @@
 import type { TNotification } from '@shared/types/notifications'
 
-export function appendCachedNotification(
-  cachedEntries: TNotification[],
-  notification: TNotification
-): TNotification[] {
+export function appendCachedNotification(cachedEntries: TNotification[], notification: TNotification): TNotification[] {
   return [...cachedEntries, notification]
 }
 

--- a/src/components/shared/contexts/useNotifications.tsx
+++ b/src/components/shared/contexts/useNotifications.tsx
@@ -1,8 +1,9 @@
 import { useAsyncTrigger } from '@shared/hooks/useAsyncTrigger'
 import type { TNotification, TNotificationStatus, TNotificationsContext } from '@shared/types/notifications'
 import type React from 'react'
-import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import { createContext, startTransition, useCallback, useContext, useMemo, useState } from 'react'
 import { useIndexedDBStore } from 'use-indexeddb'
+import { appendCachedNotification, mergeCachedNotificationEntry } from './useNotifications.helpers'
 
 const defaultProps: TNotificationsContext = {
   cachedEntries: [],
@@ -72,9 +73,12 @@ export const WithNotifications = ({ children }: { children: React.ReactElement }
         const notification = await getByID(id)
 
         if (notification) {
-          await update({ ...notification, ...entry })
-          setEntryNonce((nonce) => nonce + 1)
-          setNotificationStatus(entry?.status || null)
+          const updatedNotification = { ...notification, ...entry }
+          await update(updatedNotification)
+          startTransition(() => {
+            setCachedEntries((currentEntries) => mergeCachedNotificationEntry(currentEntries, id, updatedNotification))
+            setNotificationStatus(entry?.status || null)
+          })
         } else {
           console.warn(`Notification with id ${id} not found`)
         }
@@ -89,8 +93,10 @@ export const WithNotifications = ({ children }: { children: React.ReactElement }
     async (notification: TNotification): Promise<number> => {
       try {
         const id = await add(notification)
-        setEntryNonce((nonce) => nonce + 1)
-        setNotificationStatus(notification.status)
+        startTransition(() => {
+          setCachedEntries((currentEntries) => appendCachedNotification(currentEntries, { ...notification, id }))
+          setNotificationStatus(notification.status)
+        })
         return id
       } catch (error) {
         console.error('Failed to add notification:', error)

--- a/src/components/shared/contexts/useWallet.helpers.test.ts
+++ b/src/components/shared/contexts/useWallet.helpers.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { zeroNormalizedBN } from '../utils'
+import { hasWalletBalanceSnapshot, shouldExposeWalletLoading } from './useWallet.helpers'
+
+describe('useWallet.helpers', () => {
+  it('detects when the wallet has a settled balance snapshot', () => {
+    expect(hasWalletBalanceSnapshot({})).toBe(false)
+    expect(hasWalletBalanceSnapshot({ 1: {} })).toBe(false)
+    expect(
+      hasWalletBalanceSnapshot({
+        1: {
+          '0x123': {
+            address: '0x123',
+            name: 'Token',
+            symbol: 'TOK',
+            decimals: 18,
+            chainID: 1,
+            value: 0,
+            balance: zeroNormalizedBN
+          }
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('exposes loading only for cold wallet loads', () => {
+    expect(
+      shouldExposeWalletLoading({
+        userAddress: undefined,
+        hasVisibleBalances: false,
+        isLoading: true,
+        isBalancesPending: true
+      })
+    ).toBe(false)
+
+    expect(
+      shouldExposeWalletLoading({
+        userAddress: '0x123',
+        hasVisibleBalances: false,
+        isLoading: true,
+        isBalancesPending: false
+      })
+    ).toBe(true)
+
+    expect(
+      shouldExposeWalletLoading({
+        userAddress: '0x123',
+        hasVisibleBalances: false,
+        isLoading: false,
+        isBalancesPending: true
+      })
+    ).toBe(true)
+  })
+
+  it('keeps background refreshes visually quiet once balances are visible', () => {
+    expect(
+      shouldExposeWalletLoading({
+        userAddress: '0x123',
+        hasVisibleBalances: true,
+        isLoading: true,
+        isBalancesPending: false
+      })
+    ).toBe(false)
+
+    expect(
+      shouldExposeWalletLoading({
+        userAddress: '0x123',
+        hasVisibleBalances: true,
+        isLoading: false,
+        isBalancesPending: true
+      })
+    ).toBe(false)
+  })
+})

--- a/src/components/shared/contexts/useWallet.helpers.ts
+++ b/src/components/shared/contexts/useWallet.helpers.ts
@@ -1,0 +1,25 @@
+import type { TChainTokens } from '../types'
+
+type TShouldExposeWalletLoadingParams = {
+  userAddress?: string
+  hasVisibleBalances: boolean
+  isLoading: boolean
+  isBalancesPending: boolean
+}
+
+export function hasWalletBalanceSnapshot(balances: TChainTokens): boolean {
+  return Object.values(balances).some((tokensByChain) => Object.keys(tokensByChain || {}).length > 0)
+}
+
+export function shouldExposeWalletLoading({
+  userAddress,
+  hasVisibleBalances,
+  isLoading,
+  isBalancesPending
+}: TShouldExposeWalletLoadingParams): boolean {
+  if (!userAddress) {
+    return false
+  }
+
+  return !hasVisibleBalances && (isLoading || isBalancesPending)
+}

--- a/src/components/shared/contexts/useWallet.tsx
+++ b/src/components/shared/contexts/useWallet.tsx
@@ -20,6 +20,7 @@ import { useStakingAssetConversions } from '../hooks/useStakingAssetConversions'
 import { getVaultHoldingsUsdValue } from '../hooks/useVaultFilterUtils'
 import type { TAddress, TChainTokens, TDict, TNDict, TNormalizedBN, TToken, TYChainTokens } from '../types'
 import { DEFAULT_ERC20, isZeroAddress, toAddress, zeroNormalizedBN } from '../utils'
+import { hasWalletBalanceSnapshot, shouldExposeWalletLoading } from './useWallet.helpers'
 import { useWeb3 } from './useWeb3'
 import { useYearn } from './useYearn'
 import { useYearnTokens } from './useYearn.helper'
@@ -146,6 +147,13 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
     return _tokens as TYChainTokens
   }, [deferredTokensRaw])
   const isBalancesPending = deferredTokensRaw !== visibleTokensRaw
+  const hasVisibleBalances = hasWalletBalanceSnapshot(visibleTokensRaw)
+  const isWalletLoading = shouldExposeWalletLoading({
+    userAddress,
+    hasVisibleBalances,
+    isLoading,
+    isBalancesPending
+  })
 
   const onRefresh = useCallback(
     async (tokenToUpdate?: TUseBalancesTokens[]): Promise<TYChainTokens> => {
@@ -278,7 +286,7 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
       getBalance,
       getVaultHoldingsUsd,
       balances,
-      isLoading: isLoading || isBalancesPending,
+      isLoading: isWalletLoading,
       onRefresh,
       cumulatedValueInV2Vaults,
       cumulatedValueInV3Vaults
@@ -288,8 +296,7 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
       getBalance,
       getVaultHoldingsUsd,
       balances,
-      isLoading,
-      isBalancesPending,
+      isWalletLoading,
       onRefresh,
       cumulatedValueInV2Vaults,
       cumulatedValueInV3Vaults


### PR DESCRIPTION
## Summary
- trim the yvUSD-specific success path so locked deposits only schedule the extra unlocked-side refetch they actually need
- stop background wallet and notification refreshes from surfacing as foreground loading during the success state
- defer shared deposit completion work until confetti finishes, with panel close as the fallback if the overlay is dismissed early

## What Was Happening
- deposit success was kicking off a cluster of work in the same success window: deposit completion callbacks, wallet refreshes, vault user-data refetches, and notification updates
- those updates overlapped the success screen and confetti animation, which made the success state visibly stutter across deposit flows
- the lag was initially noticed on locked yvUSD deposits, but the remaining issue turned out to live in the shared deposit success pipeline rather than the yvUSD flow itself

## Fixes
- yvUSD deposit success no longer does duplicate post-success refetch work; locked deposits only queue the additional unlocked-vault refresh they actually need
- wallet loading now stays tied to true cold-load states, so background balance refreshes do not light up the header spinner during success
- notification status updates now update the in-memory cache directly instead of forcing a full notifications reload on each transaction status transition
- `WidgetDeposit` and `TransactionOverlay` now let the success state and confetti render first, then run deposit cleanup after confetti completes; closing the overlay early still flushes the pending completion work

## Testing
- bunx vitest run src/components/pages/vaults/components/widget/shared/TransactionOverlay.test.ts src/components/pages/vaults/components/widget/yvUSD/YvUsdDeposit.test.tsx src/components/shared/contexts/useNotifications.helpers.test.ts src/components/shared/contexts/useWallet.helpers.test.ts
- bun run tslint
- bun run build
