### PR TITLE
update tenderly scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,19 @@ VITE_TENDERLY_RPC_URI_FOR_1=
 TENDERLY_ADMIN_RPC_URI_FOR_1=
 VITE_TENDERLY_EXPLORER_URI_FOR_1=
 
+WEBOPS_TENDERLY_API_KEY=
+WEBOPS_ACCOUNT_SLUG=
+WEBOPS_PROJECT_SLUG=
+# Optional owner suffix override for derived stable RPC names like yearn-fi-webops-vnet-10-ross.
+# If unset, the bootstrap script falls back to TENDERLY_RPC_OWNER or the local shell user.
+WEBOPS_TENDERLY_RPC_OWNER=
+WEBOPS_TENDERLY_RPC_NAME=
+
 PERSONAL_TENDERLY_API_KEY=
 PERSONAL_ACCOUNT_SLUG=
 PERSONAL_PROJECT_SLUG=
+# Optional owner suffix override for derived stable RPC names.
+PERSONAL_TENDERLY_RPC_OWNER=
 PERSONAL_TENDERLY_RPC_NAME=
 
 VITE_ALCHEMY_KEY=

--- a/scripts/tenderly-vnet-status.test.ts
+++ b/scripts/tenderly-vnet-status.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildTenderlyStatusJson,
+  buildTenderlyStatusMarkdown,
+  classifyPublicRpcMode,
+  normalizeTenderlyTransactionListResponse,
+  normalizeTenderlyVnetListResponse,
+  resolveStableNamedPublicRpcName,
+  resolveTenderlyStatusIdentity,
+  selectMatchingTenderlyVnet
+} from './tenderly-vnet-status'
+
+describe('tenderly-vnet-status', () => {
+  it('defaults to the webops profile', () => {
+    expect(
+      resolveTenderlyStatusIdentity(
+        {},
+        {
+          WEBOPS_ACCOUNT_SLUG: 'yearn',
+          WEBOPS_PROJECT_SLUG: 'frontend'
+        }
+      )
+    ).toMatchObject({
+      profile: 'webops',
+      accountSlug: 'yearn',
+      projectSlug: 'frontend'
+    })
+  })
+
+  it('supports explicit personal profile overrides', () => {
+    expect(
+      resolveTenderlyStatusIdentity(
+        { profile: 'personal' },
+        {
+          PERSONAL_ACCOUNT_SLUG: 'me',
+          PERSONAL_PROJECT_SLUG: 'sandbox'
+        }
+      )
+    ).toMatchObject({
+      profile: 'personal',
+      accountSlug: 'me',
+      projectSlug: 'sandbox'
+    })
+  })
+
+  it('normalizes array and wrapped vnet list responses', () => {
+    expect(normalizeTenderlyVnetListResponse([{ slug: 'vnet-a' }])).toHaveLength(1)
+    expect(normalizeTenderlyVnetListResponse({ vnets: [{ slug: 'vnet-b' }] })).toHaveLength(1)
+    expect(normalizeTenderlyVnetListResponse({ virtual_networks: [{ slug: 'vnet-c' }] })).toHaveLength(1)
+  })
+
+  it('normalizes array and wrapped transaction list responses', () => {
+    expect(normalizeTenderlyTransactionListResponse([{ tx_hash: '0xabc' }])).toHaveLength(1)
+    expect(normalizeTenderlyTransactionListResponse({ transactions: [{ tx_hash: '0xdef' }] })).toHaveLength(1)
+    expect(normalizeTenderlyTransactionListResponse({ data: [{ tx_hash: '0xghi' }] })).toHaveLength(1)
+  })
+
+  it('matches the active vnet by admin rpc before any weaker fallback', () => {
+    expect(
+      selectMatchingTenderlyVnet({
+        vnets: [
+          {
+            slug: 'first',
+            rpcs: [{ name: 'Admin RPC', url: 'https://admin-a' }]
+          },
+          {
+            slug: 'second',
+            rpcs: [{ name: 'Admin RPC', url: 'https://admin-b' }]
+          }
+        ],
+        adminRpcUri: 'https://admin-b',
+        publicRpcUri: 'https://public-miss',
+        executionChainId: 694201
+      })
+    ).toMatchObject({
+      reason: 'admin-rpc',
+      record: { slug: 'second' }
+    })
+  })
+
+  it('classifies stable named public rpcs correctly without relying on a single profile rpc name', () => {
+    expect(
+      classifyPublicRpcMode({
+        accountSlug: 'yearn',
+        projectSlug: 'frontend',
+        publicRpcUri: 'https://virtual.rpc.tenderly.co/yearn/frontend/public/yearn-fi-webops-vnet-42161'
+      })
+    ).toBe('stable named endpoint')
+
+    expect(
+      resolveStableNamedPublicRpcName({
+        accountSlug: 'yearn',
+        projectSlug: 'frontend',
+        publicRpcUri: 'https://virtual.rpc.tenderly.co/yearn/frontend/public/yearn-fi-webops-vnet-42161'
+      })
+    ).toBe('yearn-fi-webops-vnet-42161')
+
+    expect(
+      classifyPublicRpcMode({
+        accountSlug: 'yearn',
+        projectSlug: 'frontend',
+        rpcName: 'yearn-fi-webops-vnet',
+        publicRpcUri: 'https://virtual.mainnet.eu.rpc.tenderly.co/ephemeral-id'
+      })
+    ).toBe('dynamic endpoint')
+  })
+
+  it('builds sanitized markdown and json reports without admin rpc leakage', () => {
+    const report = {
+      profile: 'webops' as const,
+      accountSlug: 'yearn',
+      projectSlug: 'frontend',
+      restMetadataAvailable: true,
+      recentTransactionCount: 5,
+      chainReports: [
+        {
+          canonicalChainId: 1,
+          canonicalChainName: 'Ethereum',
+          configuredExecutionChainId: 694201,
+          liveExecutionChainId: 694201,
+          currentBlockNumber: 24_735_515,
+          latestBlockTimestampSeconds: 1_742_000_000,
+          latestBlockTimestampLabel: '2025-03-25 17:46:40 UTC',
+          latestBlockAgeLabel: '8s',
+          publicRpcUri: 'https://virtual.rpc.tenderly.co/yearn/frontend/public/yearn-fi-webops-vnet-1',
+          publicRpcMode: 'stable named endpoint' as const,
+          publicRpcName: 'yearn-fi-webops-vnet-1',
+          hasAdminRpc: true,
+          explorerEnabled: false,
+          totalTransactionsAvailable: true,
+          totalTransactionsCount: 12,
+          recentTransactionsAvailable: true,
+          recentTransactions: [
+            {
+              status: 'success',
+              functionName: 'deposit',
+              createdAtAgeLabel: '8s',
+              blockNumber: 24_735_515,
+              txHash: '0xb00dc057e50c8926896495cb31717bfa7ab47608673789b4b7b478ec114080cb',
+              from: '0x5b0d3243c78fb9d4ac035fb2384ffdf7a9ef6396',
+              to: '0xc56413869c6cdf96496f2b1ef801fedbdfa7ddb0'
+            }
+          ],
+          matchedVnet: {
+            slug: 'vnet-123',
+            displayName: 'Webops VNet 123',
+            forkNetworkId: 1,
+            forkBlockNumber: 24_735_515
+          },
+          matchReason: 'admin-rpc' as const
+        }
+      ]
+    }
+
+    const markdown = buildTenderlyStatusMarkdown(report)
+    const json = JSON.stringify(buildTenderlyStatusJson(report))
+
+    expect(markdown).toContain('# Tenderly VNet Status')
+    expect(markdown).toContain('Profile: webops')
+    expect(markdown).toContain('## Ethereum (1)')
+    expect(markdown).toContain('ID: vnet-123')
+    expect(markdown).toContain('Chain ID: 694201')
+    expect(markdown).toContain(
+      'Public RPC: https://virtual.rpc.tenderly.co/yearn/frontend/public/yearn-fi-webops-vnet-1'
+    )
+    expect(markdown).toContain('Public RPC Mode: stable named endpoint (yearn-fi-webops-vnet-1)')
+    expect(markdown).toContain('Total Transactions: 12')
+    expect(markdown).toContain('Admin RPC: configured')
+    expect(markdown).toContain('Most Recent Transactions (1 shown):')
+    expect(markdown).toContain('| Age | Status | Block | Method | From | To | Tx Hash |')
+    expect(markdown).toContain('deposit')
+    expect(markdown).not.toContain('https://admin')
+    expect(json).toContain('"slug":"vnet-123"')
+    expect(json).toContain('"recentTransactions"')
+    expect(json).toContain(
+      '"publicRpcUri":"https://virtual.rpc.tenderly.co/yearn/frontend/public/yearn-fi-webops-vnet-1"'
+    )
+    expect(json).toContain('"totalTransactionsCount":12')
+    expect(json).toContain('"publicRpcName":"yearn-fi-webops-vnet-1"')
+    expect(json).not.toContain('adminRpc')
+  })
+})

--- a/scripts/tenderly-vnet-status.ts
+++ b/scripts/tenderly-vnet-status.ts
@@ -1,0 +1,930 @@
+/// <reference types="node" />
+
+import { resolve as resolvePath } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { parseTenderlyServerChains, type TTenderlyServerChainConfig } from '../api/tenderly.helpers'
+import { buildPredictablePublicRpcUrl, readEnvFile, sanitizeConsoleText } from './tenderly-vnet'
+
+type TParsedCliArgs = {
+  flags: Record<string, string>
+  positionals: string[]
+}
+
+type TTenderlyProfile = 'webops' | 'personal'
+
+type TTenderlyStatusIdentity = {
+  profile: TTenderlyProfile
+  accountSlug: string
+  projectSlug: string
+  apiKey?: string
+  rpcName?: string
+}
+
+type TTenderlyVnetRpc = {
+  name?: string
+  url?: string
+}
+
+type TTenderlyVnetRecord = {
+  id?: string
+  slug?: string
+  display_name?: string
+  status?: string
+  fork_config?: {
+    network_id?: number | string
+    block_number?: number | string
+  }
+  virtual_network_config?: {
+    chain_config?: {
+      chain_id?: number | string
+    }
+  }
+  explorer_page_config?: {
+    enabled?: boolean
+  }
+  rpcs?: TTenderlyVnetRpc[]
+}
+
+type TTenderlyStatusMatchReason = 'admin-rpc' | 'public-rpc' | 'execution-chain-id' | 'single-vnet-fallback'
+
+type TTenderlyMatchedVnet = {
+  record: TTenderlyVnetRecord
+  reason: TTenderlyStatusMatchReason
+}
+
+type TTenderlyChainLiveState = {
+  liveExecutionChainId: number
+  currentBlockNumber: number
+  latestBlockTimestampSeconds: number
+}
+
+type TTenderlyVnetTransactionRecord = {
+  id?: string
+  vnet_id?: string
+  origin?: string
+  category?: string
+  kind?: string
+  status?: string
+  rpc_method?: string
+  created_at?: string
+  block_number?: number | string
+  block_hash?: string
+  tx_hash?: string
+  tx_index?: number | string
+  from?: string
+  to?: string
+  function_name?: string
+  dashboard_url?: string
+}
+
+type TTenderlyRecentTransaction = {
+  id?: string
+  status: string
+  category?: string
+  kind?: string
+  rpcMethod?: string
+  functionName?: string
+  createdAt?: string
+  createdAtAgeLabel?: string
+  blockNumber?: number
+  txHash?: string
+  from?: string
+  to?: string
+}
+
+type TTenderlyStatusChainReport = {
+  canonicalChainId: number
+  canonicalChainName: string
+  configuredExecutionChainId: number
+  liveExecutionChainId: number
+  currentBlockNumber: number
+  latestBlockTimestampSeconds: number
+  latestBlockTimestampLabel: string
+  latestBlockAgeLabel: string
+  publicRpcUri: string
+  publicRpcMode: 'stable named endpoint' | 'dynamic endpoint'
+  publicRpcName?: string
+  hasAdminRpc: boolean
+  explorerEnabled: boolean
+  explorerUri?: string
+  totalTransactionsAvailable: boolean
+  totalTransactionsCount?: number
+  totalTransactionsNote?: string
+  recentTransactionsAvailable: boolean
+  recentTransactionsNote?: string
+  recentTransactions: TTenderlyRecentTransaction[]
+  matchedVnet?: {
+    id?: string
+    slug?: string
+    displayName?: string
+    status?: string
+    forkNetworkId?: number
+    forkBlockNumber?: number
+  }
+  matchReason?: TTenderlyStatusMatchReason
+}
+
+type TTenderlyStatusReport = {
+  profile: TTenderlyProfile
+  accountSlug: string
+  projectSlug: string
+  restMetadataAvailable: boolean
+  restMetadataNote?: string
+  recentTransactionCount: number
+  chainReports: TTenderlyStatusChainReport[]
+}
+
+const DEFAULT_ACCOUNT_SLUG = 'me'
+const DEFAULT_RECENT_TRANSACTION_COUNT = 5
+const TENDERLY_TRANSACTION_PAGE_SIZE = 100
+const TENDERLY_TRANSACTION_MAX_PAGES = 100
+const TENDERLY_API_URL = 'https://api.tenderly.co/api/v1/account'
+const PROFILE_DEFAULTS = {
+  personal: {
+    apiKeyEnv: 'PERSONAL_TENDERLY_API_KEY',
+    accountEnvKeys: ['PERSONAL_ACCOUNT_SLUG', 'ACCOUNT_SLUG'],
+    projectEnvKeys: ['PERSONAL_PROJECT_SLUG', 'PROJECT_SLUG'],
+    rpcNameEnv: 'PERSONAL_TENDERLY_RPC_NAME'
+  },
+  webops: {
+    apiKeyEnv: 'WEBOPS_TENDERLY_API_KEY',
+    accountEnvKeys: ['WEBOPS_ACCOUNT_SLUG', 'TENDERLY_ACCOUNT_SLUG'],
+    projectEnvKeys: ['WEBOPS_PROJECT_SLUG', 'TENDERLY_PROJECT_SLUG'],
+    rpcNameEnv: 'WEBOPS_TENDERLY_RPC_NAME'
+  }
+} as const
+
+const HELP_TEXT = `Tenderly Virtual TestNet status
+
+Usage:
+  bun scripts/tenderly-vnet-status.ts [options]
+
+Options:
+  --profile <name>      Credential profile: webops or personal (default: webops)
+  --chain <id>          Canonical chain id to inspect (default: all configured Tenderly chains)
+  --account <slug>      Tenderly account slug override
+  --project <slug>      Tenderly project slug override
+  --api-key <key>       Tenderly API key override for metadata lookup
+  --api-key-env <name>  Env var name to read the API key from
+  --account-env <name>  Env var name to read the account slug from
+  --project-env <name>  Env var name to read the project slug from
+  --rpc-name <name>     Stable public RPC name override
+  --recent-tx-count <n> Number of recent transactions to include per chain (default: 5)
+  --json                Print a sanitized JSON report instead of Markdown
+  --help                Show this help text
+
+Notes:
+  - Reads the active Tenderly mapping from repo .env and process.env.
+  - Uses Admin RPC for live chain state.
+  - Uses the Tenderly REST API for VNet metadata when credentials are available.
+  - Never prints API keys or admin RPC URLs.
+`
+
+function parseCliArgs(argv: readonly string[]): TParsedCliArgs {
+  const recurse = (index: number, accumulator: TParsedCliArgs): TParsedCliArgs => {
+    if (index >= argv.length) {
+      return accumulator
+    }
+
+    const token = argv[index]
+    if (!token.startsWith('--')) {
+      return recurse(index + 1, {
+        flags: accumulator.flags,
+        positionals: [...accumulator.positionals, token]
+      })
+    }
+
+    const key = token.slice(2)
+    const nextToken = argv[index + 1]
+    const value = nextToken && !nextToken.startsWith('--') ? nextToken : 'true'
+    const nextIndex = value === 'true' ? index + 1 : index + 2
+
+    return recurse(nextIndex, {
+      positionals: accumulator.positionals,
+      flags: {
+        ...accumulator.flags,
+        [key]: value
+      }
+    })
+  }
+
+  return recurse(0, { flags: {}, positionals: [] })
+}
+
+function getArg(flags: Record<string, string>, ...keys: string[]): string | undefined {
+  return keys.map((key) => flags[key]?.trim()).find(Boolean)
+}
+
+function getEnvValue(env: Record<string, string | undefined>, key?: string): string | undefined {
+  if (!key) {
+    return undefined
+  }
+  return env[key]?.trim()
+}
+
+function getFirstEnvValue(env: Record<string, string | undefined>, keys: string[]): string | undefined {
+  return keys.map((key) => getEnvValue(env, key)).find(Boolean)
+}
+
+function parseProfile(value: string | undefined): TTenderlyProfile {
+  const normalizedValue = value?.trim().toLowerCase()
+
+  if (!normalizedValue) {
+    return 'webops'
+  }
+
+  if (normalizedValue === 'webops' || normalizedValue === 'personal') {
+    return normalizedValue
+  }
+
+  throw new Error(`Unsupported profile: ${value}. Expected "webops" or "personal".`)
+}
+
+function parseOptionalInteger(value: string | undefined, label: string): number | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const parsedValue = Number(value)
+  if (!Number.isInteger(parsedValue) || parsedValue <= 0) {
+    throw new Error(`Invalid ${label}: ${value}`)
+  }
+
+  return parsedValue
+}
+
+function parseRecentTransactionCount(flags: Record<string, string>): number {
+  const parsedValue =
+    parseOptionalInteger(getArg(flags, 'recent-tx-count', 'recent-transactions'), 'recent transaction count') ||
+    DEFAULT_RECENT_TRANSACTION_COUNT
+
+  return Math.min(Math.max(parsedValue, 1), 20)
+}
+
+export function resolveTenderlyStatusIdentity(
+  flags: Record<string, string>,
+  env: Record<string, string | undefined>
+): TTenderlyStatusIdentity {
+  const profile = parseProfile(getArg(flags, 'profile'))
+  const defaults = PROFILE_DEFAULTS[profile]
+  const accountEnv = getArg(flags, 'account-env')
+  const projectEnv = getArg(flags, 'project-env')
+  const apiKeyEnv = getArg(flags, 'api-key-env')
+
+  return {
+    profile,
+    accountSlug:
+      getArg(flags, 'account') ||
+      getEnvValue(env, accountEnv) ||
+      getFirstEnvValue(env, [...defaults.accountEnvKeys]) ||
+      DEFAULT_ACCOUNT_SLUG,
+    projectSlug:
+      getArg(flags, 'project') ||
+      getEnvValue(env, projectEnv) ||
+      getFirstEnvValue(env, [...defaults.projectEnvKeys]) ||
+      '',
+    apiKey:
+      getArg(flags, 'api-key') ||
+      getEnvValue(env, apiKeyEnv) ||
+      getEnvValue(env, defaults.apiKeyEnv) ||
+      env.TENDERLY_ACCESS_KEY?.trim() ||
+      env.TENDERLY_API_KEY?.trim(),
+    rpcName: getArg(flags, 'rpc-name') || getEnvValue(env, defaults.rpcNameEnv) || env.TENDERLY_RPC_NAME?.trim()
+  }
+}
+
+export function normalizeTenderlyVnetListResponse(payload: unknown): TTenderlyVnetRecord[] {
+  if (Array.isArray(payload)) {
+    return payload as TTenderlyVnetRecord[]
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return []
+  }
+
+  const record = payload as Record<string, unknown>
+  return (
+    [record.virtual_networks, record.vnets]
+      .find(Array.isArray)
+      ?.filter(Boolean)
+      .map((item) => item as TTenderlyVnetRecord) || []
+  )
+}
+
+export function normalizeTenderlyTransactionListResponse(payload: unknown): TTenderlyVnetTransactionRecord[] {
+  if (Array.isArray(payload)) {
+    return payload as TTenderlyVnetTransactionRecord[]
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return []
+  }
+
+  const record = payload as Record<string, unknown>
+  return (
+    [record.transactions, record.results, record.data]
+      .find(Array.isArray)
+      ?.filter(Boolean)
+      .map((item) => item as TTenderlyVnetTransactionRecord) || []
+  )
+}
+
+function resolveVnetRpcUrl(vnet: TTenderlyVnetRecord, rpcName: string): string | undefined {
+  return vnet.rpcs?.find((rpc) => rpc.name === rpcName)?.url
+}
+
+function parseNumericString(value: number | string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : undefined
+  }
+
+  const normalizedValue = value.trim()
+  if (!normalizedValue) {
+    return undefined
+  }
+
+  return normalizedValue.startsWith('0x') ? Number(BigInt(normalizedValue)) : Number(normalizedValue)
+}
+
+export function selectMatchingTenderlyVnet(params: {
+  vnets: TTenderlyVnetRecord[]
+  adminRpcUri?: string
+  publicRpcUri?: string
+  executionChainId: number
+}): TTenderlyMatchedVnet | undefined {
+  const adminRpcMatch = params.adminRpcUri
+    ? params.vnets.find((vnet) => resolveVnetRpcUrl(vnet, 'Admin RPC') === params.adminRpcUri)
+    : undefined
+
+  if (adminRpcMatch) {
+    return { record: adminRpcMatch, reason: 'admin-rpc' }
+  }
+
+  const publicRpcMatch = params.publicRpcUri
+    ? params.vnets.find((vnet) => resolveVnetRpcUrl(vnet, 'Public RPC') === params.publicRpcUri)
+    : undefined
+
+  if (publicRpcMatch) {
+    return { record: publicRpcMatch, reason: 'public-rpc' }
+  }
+
+  const executionChainMatch = params.vnets.find(
+    (vnet) => parseNumericString(vnet.virtual_network_config?.chain_config?.chain_id) === params.executionChainId
+  )
+
+  if (executionChainMatch) {
+    return { record: executionChainMatch, reason: 'execution-chain-id' }
+  }
+
+  return params.vnets.length === 1 ? { record: params.vnets[0], reason: 'single-vnet-fallback' } : undefined
+}
+
+export function classifyPublicRpcMode(params: {
+  accountSlug: string
+  projectSlug: string
+  rpcName?: string
+  publicRpcUri: string
+}): 'stable named endpoint' | 'dynamic endpoint' {
+  if (resolveStableNamedPublicRpcName(params)) {
+    return 'stable named endpoint'
+  }
+
+  if (!params.rpcName) {
+    return 'dynamic endpoint'
+  }
+
+  const predictablePublicRpc = buildPredictablePublicRpcUrl(params.accountSlug, params.projectSlug, params.rpcName)
+  return predictablePublicRpc === params.publicRpcUri ? 'stable named endpoint' : 'dynamic endpoint'
+}
+
+export function resolveStableNamedPublicRpcName(params: {
+  accountSlug: string
+  projectSlug: string
+  rpcName?: string
+  publicRpcUri: string
+}): string | undefined {
+  try {
+    const parsedUrl = new URL(params.publicRpcUri)
+    if (parsedUrl.hostname !== 'virtual.rpc.tenderly.co') {
+      return undefined
+    }
+
+    const pathSegments = parsedUrl.pathname.split('/').filter(Boolean)
+    if (pathSegments.length !== 4) {
+      return undefined
+    }
+
+    const [accountSlug, projectSlug, visibility, rpcName] = pathSegments
+    if (
+      accountSlug !== params.accountSlug ||
+      projectSlug !== params.projectSlug ||
+      visibility !== 'public' ||
+      !rpcName
+    ) {
+      return undefined
+    }
+
+    return rpcName
+  } catch {
+    return undefined
+  }
+}
+
+function formatTimestampUtc(timestampSeconds: number): string {
+  return new Date(timestampSeconds * 1000)
+    .toISOString()
+    .replace('T', ' ')
+    .replace(/\.\d{3}Z$/, ' UTC')
+}
+
+function formatRelativeAgeLabel(timestampSeconds: number): string {
+  const elapsedSeconds = Math.max(0, Math.round(Date.now() / 1000 - timestampSeconds))
+
+  if (elapsedSeconds < 60) {
+    return `${elapsedSeconds}s`
+  }
+
+  if (elapsedSeconds < 3_600) {
+    return `${Math.round(elapsedSeconds / 60)}m`
+  }
+
+  if (elapsedSeconds < 86_400) {
+    return `${Math.round(elapsedSeconds / 3_600)}h`
+  }
+
+  return `${Math.round(elapsedSeconds / 86_400)}d`
+}
+
+function formatIsoAgeLabel(isoTimestamp: string | undefined): string | undefined {
+  if (!isoTimestamp) {
+    return undefined
+  }
+
+  const timestampMs = Date.parse(isoTimestamp)
+  if (!Number.isFinite(timestampMs)) {
+    return undefined
+  }
+
+  return formatRelativeAgeLabel(Math.round(timestampMs / 1000))
+}
+
+function shortenHex(value: string | undefined, prefixLength: number, suffixLength: number): string {
+  if (!value) {
+    return 'n/a'
+  }
+
+  const normalizedValue = value.trim()
+  if (normalizedValue.length <= prefixLength + suffixLength + 1) {
+    return normalizedValue
+  }
+
+  return `${normalizedValue.slice(0, prefixLength)}…${normalizedValue.slice(-suffixLength)}`
+}
+
+function formatTransactionLabel(transaction: TTenderlyRecentTransaction): string {
+  return transaction.functionName || transaction.rpcMethod || transaction.kind || transaction.category || 'unknown'
+}
+
+function formatRecentTransactionRow(transaction: TTenderlyRecentTransaction): string {
+  return `| ${transaction.createdAtAgeLabel || 'n/a'} | ${transaction.status} | ${
+    transaction.blockNumber?.toLocaleString('en-US') || 'n/a'
+  } | ${formatTransactionLabel(transaction)} | ${shortenHex(transaction.from, 8, 4)} | ${shortenHex(
+    transaction.to,
+    8,
+    4
+  )} | ${shortenHex(transaction.txHash, 10, 6)} |`
+}
+
+async function fetchJsonRpcResult<T>(adminRpcUri: string, method: string, params: unknown[]): Promise<T> {
+  const response = await fetch(adminRpcUri, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: 1,
+      jsonrpc: '2.0',
+      method,
+      params
+    })
+  })
+
+  if (!response.ok) {
+    throw new Error(`Tenderly Admin RPC request failed (${response.status})`)
+  }
+
+  const payload = (await response.json()) as { result?: T; error?: { code: number; message: string } } | undefined
+
+  if (payload?.error) {
+    throw new Error(sanitizeConsoleText(`${payload.error.message} (code ${payload.error.code})`))
+  }
+
+  return payload?.result as T
+}
+
+async function fetchTenderlyVnets(identity: TTenderlyStatusIdentity): Promise<TTenderlyVnetRecord[]> {
+  if (!identity.apiKey || !identity.projectSlug) {
+    return []
+  }
+
+  const response = await fetch(
+    `${TENDERLY_API_URL}/${encodeURIComponent(identity.accountSlug)}/project/${encodeURIComponent(identity.projectSlug)}/vnets`,
+    {
+      headers: {
+        Accept: 'application/json',
+        'X-Access-Key': identity.apiKey
+      }
+    }
+  )
+
+  if (!response.ok) {
+    throw new Error(`Tenderly REST API request failed (${response.status})`)
+  }
+
+  return normalizeTenderlyVnetListResponse(await response.json())
+}
+
+async function fetchTenderlyRecentTransactions(params: {
+  identity: TTenderlyStatusIdentity
+  vnetId?: string
+  recentCount: number
+}): Promise<{
+  recentTransactions: TTenderlyRecentTransaction[]
+  totalTransactionsCount: number
+  totalTransactionsNote?: string
+}> {
+  if (!params.identity.apiKey || !params.identity.projectSlug || !params.vnetId) {
+    return {
+      recentTransactions: [],
+      totalTransactionsCount: 0
+    }
+  }
+
+  const recentTransactions: TTenderlyRecentTransaction[] = []
+  let totalTransactionsCount = 0
+
+  for (let page = 1; page <= TENDERLY_TRANSACTION_MAX_PAGES; page += 1) {
+    const response = await fetch(
+      `${TENDERLY_API_URL}/${encodeURIComponent(params.identity.accountSlug)}/project/${encodeURIComponent(
+        params.identity.projectSlug
+      )}/vnets/${encodeURIComponent(params.vnetId)}/transactions?page=${page}&per_page=${TENDERLY_TRANSACTION_PAGE_SIZE}`,
+      {
+        headers: {
+          Accept: 'application/json',
+          'X-Access-Key': params.identity.apiKey
+        }
+      }
+    )
+
+    if (!response.ok) {
+      throw new Error(`Tenderly recent transactions request failed (${response.status})`)
+    }
+
+    const pageTransactions = normalizeTenderlyTransactionListResponse(await response.json()).map((transaction) => ({
+      id: transaction.id,
+      status: transaction.status || 'unknown',
+      category: transaction.category,
+      kind: transaction.kind,
+      rpcMethod: transaction.rpc_method,
+      functionName: transaction.function_name,
+      createdAt: transaction.created_at,
+      createdAtAgeLabel: formatIsoAgeLabel(transaction.created_at),
+      blockNumber: parseNumericString(transaction.block_number),
+      txHash: transaction.tx_hash,
+      from: transaction.from,
+      to: transaction.to
+    }))
+
+    totalTransactionsCount += pageTransactions.length
+
+    if (page === 1) {
+      recentTransactions.push(...pageTransactions.slice(0, params.recentCount))
+    }
+
+    if (pageTransactions.length < TENDERLY_TRANSACTION_PAGE_SIZE) {
+      return {
+        recentTransactions,
+        totalTransactionsCount
+      }
+    }
+  }
+
+  const totalTransactionsNote = `count truncated after ${(
+    TENDERLY_TRANSACTION_MAX_PAGES * TENDERLY_TRANSACTION_PAGE_SIZE
+  ).toLocaleString('en-US')} transactions`
+
+  return {
+    recentTransactions,
+    totalTransactionsCount,
+    totalTransactionsNote
+  }
+}
+
+async function fetchTenderlyChainLiveState(chain: TTenderlyServerChainConfig): Promise<TTenderlyChainLiveState> {
+  const [chainIdHex, blockNumberHex, latestBlock] = await Promise.all([
+    fetchJsonRpcResult<string>(chain.adminRpcUri || '', 'eth_chainId', []),
+    fetchJsonRpcResult<string>(chain.adminRpcUri || '', 'eth_blockNumber', []),
+    fetchJsonRpcResult<{ timestamp?: string }>(chain.adminRpcUri || '', 'eth_getBlockByNumber', ['latest', false])
+  ])
+
+  const liveExecutionChainId = Number(BigInt(chainIdHex))
+  const currentBlockNumber = Number(BigInt(blockNumberHex))
+  const latestBlockTimestampSeconds = Number(BigInt(latestBlock.timestamp || '0x0'))
+
+  return {
+    liveExecutionChainId,
+    currentBlockNumber,
+    latestBlockTimestampSeconds
+  }
+}
+
+function buildChainReport(params: {
+  identity: TTenderlyStatusIdentity
+  chain: TTenderlyServerChainConfig
+  liveState: TTenderlyChainLiveState
+  matchedVnet?: TTenderlyMatchedVnet
+  recentTransactionsResult:
+    | {
+        recentTransactionsAvailable: true
+        totalTransactionsCount: number
+        totalTransactionsNote?: string
+        recentTransactions: TTenderlyRecentTransaction[]
+        recentTransactionsNote?: string
+      }
+    | {
+        recentTransactionsAvailable: false
+        totalTransactionsCount?: number
+        totalTransactionsNote?: string
+        recentTransactions: TTenderlyRecentTransaction[]
+        recentTransactionsNote?: string
+      }
+  env: Record<string, string | undefined>
+}): TTenderlyStatusChainReport {
+  const explorerUri = params.env[`VITE_TENDERLY_EXPLORER_URI_FOR_${params.chain.canonicalChainId}`]?.trim() || undefined
+  const forkNetworkId = parseNumericString(params.matchedVnet?.record.fork_config?.network_id)
+  const forkBlockNumber = parseNumericString(params.matchedVnet?.record.fork_config?.block_number)
+
+  return {
+    canonicalChainId: params.chain.canonicalChainId,
+    canonicalChainName: params.chain.canonicalChainName,
+    configuredExecutionChainId: params.chain.executionChainId,
+    liveExecutionChainId: params.liveState.liveExecutionChainId,
+    currentBlockNumber: params.liveState.currentBlockNumber,
+    latestBlockTimestampSeconds: params.liveState.latestBlockTimestampSeconds,
+    latestBlockTimestampLabel: formatTimestampUtc(params.liveState.latestBlockTimestampSeconds),
+    latestBlockAgeLabel: formatRelativeAgeLabel(params.liveState.latestBlockTimestampSeconds),
+    publicRpcUri: params.chain.rpcUri,
+    publicRpcName: resolveStableNamedPublicRpcName({
+      accountSlug: params.identity.accountSlug,
+      projectSlug: params.identity.projectSlug,
+      rpcName: params.identity.rpcName,
+      publicRpcUri: params.chain.rpcUri
+    }),
+    publicRpcMode: classifyPublicRpcMode({
+      accountSlug: params.identity.accountSlug,
+      projectSlug: params.identity.projectSlug,
+      rpcName: params.identity.rpcName,
+      publicRpcUri: params.chain.rpcUri
+    }),
+    hasAdminRpc: Boolean(params.chain.adminRpcUri),
+    explorerEnabled: Boolean(params.matchedVnet?.record.explorer_page_config?.enabled || explorerUri),
+    explorerUri,
+    totalTransactionsAvailable: params.recentTransactionsResult.recentTransactionsAvailable,
+    totalTransactionsCount: params.recentTransactionsResult.totalTransactionsCount,
+    totalTransactionsNote: params.recentTransactionsResult.totalTransactionsNote,
+    recentTransactionsAvailable: params.recentTransactionsResult.recentTransactionsAvailable,
+    recentTransactionsNote: params.recentTransactionsResult.recentTransactionsNote,
+    recentTransactions: params.recentTransactionsResult.recentTransactions,
+    matchedVnet: params.matchedVnet
+      ? {
+          id: params.matchedVnet.record.id,
+          slug: params.matchedVnet.record.slug,
+          displayName: params.matchedVnet.record.display_name,
+          status: params.matchedVnet.record.status,
+          forkNetworkId,
+          forkBlockNumber
+        }
+      : undefined,
+    matchReason: params.matchedVnet?.reason
+  }
+}
+
+export function buildTenderlyStatusMarkdown(report: TTenderlyStatusReport): string {
+  const headerLines = [
+    '# Tenderly VNet Status',
+    '',
+    `Profile: ${report.profile}`,
+    `Account / Project: ${report.accountSlug} / ${report.projectSlug || '[unset]'}`,
+    `Metadata: ${report.restMetadataAvailable ? 'available' : report.restMetadataNote || 'unavailable'}`
+  ]
+
+  const chainSections = report.chainReports.flatMap((chainReport) => {
+    const transactionSection =
+      chainReport.recentTransactions.length > 0
+        ? [
+            '',
+            `Most Recent Transactions (${Math.min(chainReport.recentTransactions.length, report.recentTransactionCount)} shown):`,
+            '',
+            '| Age | Status | Block | Method | From | To | Tx Hash |',
+            '| --- | --- | ---: | --- | --- | --- | --- |',
+            ...chainReport.recentTransactions.map(formatRecentTransactionRow)
+          ]
+        : [
+            '',
+            `Most Recent Transactions: ${
+              chainReport.recentTransactionsAvailable
+                ? chainReport.recentTransactionsNote || 'none'
+                : chainReport.recentTransactionsNote || 'unavailable'
+            }`
+          ]
+
+    return [
+      '',
+      `## ${chainReport.canonicalChainName} (${chainReport.canonicalChainId})`,
+      `ID: ${chainReport.matchedVnet?.slug || 'metadata unavailable'}`,
+      `UUID: ${chainReport.matchedVnet?.id || 'metadata unavailable'}`,
+      `Display Name: ${chainReport.matchedVnet?.displayName || 'metadata unavailable'}`,
+      `Chain ID: ${chainReport.liveExecutionChainId}`,
+      `Configured Chain ID: ${chainReport.configuredExecutionChainId}`,
+      `Public RPC: ${chainReport.publicRpcUri}`,
+      `Public RPC Mode: ${
+        chainReport.publicRpcName
+          ? `${chainReport.publicRpcMode} (${chainReport.publicRpcName})`
+          : chainReport.publicRpcMode
+      }`,
+      `Current Block: ${chainReport.currentBlockNumber.toLocaleString('en-US')}`,
+      `Total Transactions: ${
+        chainReport.totalTransactionsAvailable
+          ? `${chainReport.totalTransactionsCount?.toLocaleString('en-US') || 0}${
+              chainReport.totalTransactionsNote ? ` (${chainReport.totalTransactionsNote})` : ''
+            }`
+          : chainReport.totalTransactionsNote || 'unavailable'
+      }`,
+      `Latest Block Time: ${chainReport.latestBlockTimestampLabel}`,
+      `Block Age: ~${chainReport.latestBlockAgeLabel}`,
+      `Fork: ${
+        chainReport.matchedVnet?.forkNetworkId && chainReport.matchedVnet?.forkBlockNumber
+          ? `${chainReport.matchedVnet.forkNetworkId} @ ${chainReport.matchedVnet.forkBlockNumber.toLocaleString('en-US')}`
+          : 'metadata unavailable'
+      }`,
+      `Admin RPC: ${chainReport.hasAdminRpc ? 'configured' : 'missing'}`,
+      `Explorer: ${chainReport.explorerEnabled ? chainReport.explorerUri || 'enabled' : 'disabled'}`,
+      `Repo Mapping: ${chainReport.matchReason ? `matched via ${chainReport.matchReason}` : 'configured'}`,
+      ...transactionSection
+    ]
+  })
+
+  return [...headerLines, ...chainSections].join('\n')
+}
+
+export function buildTenderlyStatusJson(report: TTenderlyStatusReport): Record<string, unknown> {
+  return {
+    profile: report.profile,
+    accountSlug: report.accountSlug,
+    projectSlug: report.projectSlug,
+    restMetadataAvailable: report.restMetadataAvailable,
+    restMetadataNote: report.restMetadataNote || null,
+    recentTransactionCount: report.recentTransactionCount,
+    chains: report.chainReports.map((chainReport) => ({
+      canonicalChainId: chainReport.canonicalChainId,
+      canonicalChainName: chainReport.canonicalChainName,
+      configuredExecutionChainId: chainReport.configuredExecutionChainId,
+      liveExecutionChainId: chainReport.liveExecutionChainId,
+      currentBlockNumber: chainReport.currentBlockNumber,
+      latestBlockTimestampSeconds: chainReport.latestBlockTimestampSeconds,
+      latestBlockTimestampLabel: chainReport.latestBlockTimestampLabel,
+      latestBlockAgeLabel: chainReport.latestBlockAgeLabel,
+      publicRpcUri: chainReport.publicRpcUri,
+      publicRpcMode: chainReport.publicRpcMode,
+      publicRpcName: chainReport.publicRpcName || null,
+      hasAdminRpc: chainReport.hasAdminRpc,
+      explorerEnabled: chainReport.explorerEnabled,
+      explorerUri: chainReport.explorerUri || null,
+      totalTransactionsAvailable: chainReport.totalTransactionsAvailable,
+      totalTransactionsCount: chainReport.totalTransactionsCount ?? null,
+      totalTransactionsNote: chainReport.totalTransactionsNote || null,
+      recentTransactionsAvailable: chainReport.recentTransactionsAvailable,
+      recentTransactionsNote: chainReport.recentTransactionsNote || null,
+      recentTransactions: chainReport.recentTransactions,
+      matchedVnet: chainReport.matchedVnet || null,
+      matchReason: chainReport.matchReason || null
+    }))
+  }
+}
+
+async function buildTenderlyStatusReport(
+  flags: Record<string, string>,
+  env: Record<string, string | undefined>
+): Promise<TTenderlyStatusReport> {
+  const identity = resolveTenderlyStatusIdentity(flags, env)
+  const recentTransactionCount = parseRecentTransactionCount(flags)
+  if (!identity.projectSlug) {
+    throw new Error(`Missing required value: ${identity.profile} project slug`)
+  }
+
+  const requestedChainId = parseOptionalInteger(getArg(flags, 'chain'), 'chain')
+  const configuredChains = parseTenderlyServerChains(env).filter(
+    (chain) => requestedChainId === undefined || chain.canonicalChainId === requestedChainId
+  )
+
+  if (configuredChains.length === 0) {
+    throw new Error(
+      requestedChainId === undefined
+        ? 'No Tenderly chains are configured in the current environment'
+        : `Tenderly chain ${requestedChainId} is not configured`
+    )
+  }
+
+  const vnetResult = await fetchTenderlyVnets(identity)
+    .then((vnets) => ({
+      vnets,
+      restMetadataAvailable: vnets.length > 0,
+      restMetadataNote: vnets.length > 0 ? undefined : 'available but empty'
+    }))
+    .catch((error) => ({
+      vnets: [] as TTenderlyVnetRecord[],
+      restMetadataAvailable: false,
+      restMetadataNote: sanitizeConsoleText(error instanceof Error ? error.message : String(error))
+    }))
+
+  const chainReports = await Promise.all(
+    configuredChains.map(async (chain) => {
+      const matchedVnet = selectMatchingTenderlyVnet({
+        vnets: vnetResult.vnets,
+        adminRpcUri: chain.adminRpcUri,
+        publicRpcUri: chain.rpcUri,
+        executionChainId: chain.executionChainId
+      })
+      const [liveState, recentTransactionsResult] = await Promise.all([
+        fetchTenderlyChainLiveState(chain),
+        fetchTenderlyRecentTransactions({
+          identity,
+          vnetId: matchedVnet?.record.id,
+          recentCount: recentTransactionCount
+        })
+          .then(({ recentTransactions, totalTransactionsCount, totalTransactionsNote }) => ({
+            recentTransactionsAvailable: true as const,
+            totalTransactionsCount,
+            totalTransactionsNote,
+            recentTransactions,
+            recentTransactionsNote: recentTransactions.length > 0 ? undefined : 'none'
+          }))
+          .catch((error) => ({
+            recentTransactionsAvailable: false as const,
+            totalTransactionsCount: undefined,
+            totalTransactionsNote: sanitizeConsoleText(error instanceof Error ? error.message : String(error)),
+            recentTransactions: [] as TTenderlyRecentTransaction[],
+            recentTransactionsNote: sanitizeConsoleText(error instanceof Error ? error.message : String(error))
+          }))
+      ])
+
+      return buildChainReport({
+        identity,
+        chain,
+        liveState,
+        matchedVnet,
+        recentTransactionsResult,
+        env
+      })
+    })
+  )
+
+  return {
+    profile: identity.profile,
+    accountSlug: identity.accountSlug,
+    projectSlug: identity.projectSlug,
+    restMetadataAvailable: vnetResult.restMetadataAvailable,
+    restMetadataNote: vnetResult.restMetadataNote,
+    recentTransactionCount,
+    chainReports
+  }
+}
+
+async function main(): Promise<void> {
+  const parsedArgs = parseCliArgs(process.argv.slice(2))
+  const { flags } = parsedArgs
+
+  if ('help' in flags || 'h' in flags) {
+    console.log(HELP_TEXT)
+    return
+  }
+
+  const scriptDir = resolvePath(fileURLToPath(import.meta.url), '..')
+  const envFromFile = readEnvFile(resolvePath(scriptDir, '../.env'))
+  const env = { ...envFromFile, ...process.env }
+  const report = await buildTenderlyStatusReport(flags, env)
+
+  if ('json' in flags) {
+    console.log(JSON.stringify(buildTenderlyStatusJson(report), null, 2))
+    return
+  }
+
+  console.log(buildTenderlyStatusMarkdown(report))
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? sanitizeConsoleText(error.message) : sanitizeConsoleText(String(error)))
+  process.exitCode = 1
+})

--- a/scripts/tenderly-vnet.test.ts
+++ b/scripts/tenderly-vnet.test.ts
@@ -7,8 +7,14 @@ import {
   buildTenderlyApiErrorMessage,
   buildTenderlyEnvFragment,
   buildVnetConsoleSummary,
+  normalizeTenderlyRpcNameComponent,
   resolveExplorerUriFromResponse,
+  resolveRequiredRpcName,
+  resolveRpcOwner,
+  resolveTenderlyCredentials,
   sanitizeConsoleText,
+  suggestTenderlyRpcName,
+  suggestTenderlyRpcOwner,
   validateWritableOutputPath,
   writeOutputFile
 } from './tenderly-vnet'
@@ -31,6 +37,130 @@ const response = {
 }
 
 describe('tenderly-vnet console safety', () => {
+  it('prefers webops account and project slugs over legacy and personal env vars', () => {
+    expect(
+      resolveTenderlyCredentials(
+        { profile: 'webops' },
+        {
+          WEBOPS_TENDERLY_API_KEY: 'webops-key',
+          WEBOPS_ACCOUNT_SLUG: 'webops-account',
+          WEBOPS_PROJECT_SLUG: 'webops-project',
+          TENDERLY_ACCOUNT_SLUG: 'legacy-account',
+          TENDERLY_PROJECT_SLUG: 'legacy-project',
+          PERSONAL_ACCOUNT_SLUG: 'personal-account',
+          PERSONAL_PROJECT_SLUG: 'personal-project'
+        }
+      )
+    ).toMatchObject({
+      apiKey: 'webops-key',
+      accountSlug: 'webops-account',
+      projectSlug: 'webops-project',
+      profile: 'webops'
+    })
+  })
+
+  it('falls back to legacy webops slug env vars when WEBOPS slugs are unset', () => {
+    expect(
+      resolveTenderlyCredentials(
+        { profile: 'webops' },
+        {
+          WEBOPS_TENDERLY_API_KEY: 'webops-key',
+          TENDERLY_ACCOUNT_SLUG: 'legacy-account',
+          TENDERLY_PROJECT_SLUG: 'legacy-project'
+        }
+      )
+    ).toMatchObject({
+      accountSlug: 'legacy-account',
+      projectSlug: 'legacy-project'
+    })
+  })
+
+  it('suggests stable rpc names by profile', () => {
+    expect(suggestTenderlyRpcName('webops', { networkId: 10, owner: 'ross' })).toBe('yearn-fi-webops-vnet-10-ross')
+    expect(suggestTenderlyRpcName('personal', { networkId: 8453 })).toBe('yearn-fi-personal-vnet-8453')
+  })
+
+  it('normalizes owner suffixes and resolves profile-specific owner env vars', () => {
+    expect(normalizeTenderlyRpcNameComponent('Ross Yearn')).toBe('ross-yearn')
+    expect(
+      resolveRpcOwner(
+        { profile: 'webops' },
+        {
+          WEBOPS_TENDERLY_RPC_OWNER: 'Ross'
+        },
+        'webops'
+      )
+    ).toBe('ross')
+    expect(suggestTenderlyRpcOwner({ USER: 'Ross' })).toBe('ross')
+  })
+
+  it('requires a stable rpc owner in non-interactive webops mode when no explicit rpc name is configured', async () => {
+    await expect(
+      resolveRequiredRpcName({
+        flags: {},
+        env: {},
+        profile: 'webops',
+        networkId: 10,
+        canPrompt: false
+      })
+    ).rejects.toThrow('Missing Tenderly RPC owner')
+  })
+
+  it('derives stable rpc names from owner-aware defaults and prompts for webops owner when needed', async () => {
+    await expect(
+      resolveRequiredRpcName({
+        flags: {},
+        env: {
+          WEBOPS_TENDERLY_RPC_OWNER: 'Ross'
+        },
+        profile: 'webops',
+        networkId: 10
+      })
+    ).resolves.toBe('yearn-fi-webops-vnet-10-ross')
+
+    await expect(
+      resolveRequiredRpcName({
+        flags: {},
+        env: {
+          USER: 'Ross'
+        },
+        profile: 'webops',
+        networkId: 10
+      })
+    ).resolves.toBe('yearn-fi-webops-vnet-10-ross')
+
+    await expect(
+      resolveRequiredRpcName({
+        flags: {},
+        env: {},
+        profile: 'webops',
+        networkId: 10,
+        canPrompt: true,
+        promptOwner: async () => ''
+      })
+    ).resolves.toBe('yearn-fi-webops-vnet-10-yourname')
+
+    await expect(
+      resolveRequiredRpcName({
+        flags: {},
+        env: {},
+        profile: 'webops',
+        networkId: 10,
+        canPrompt: true,
+        promptOwner: async () => 'Ross'
+      })
+    ).resolves.toBe('yearn-fi-webops-vnet-10-ross')
+
+    await expect(
+      resolveRequiredRpcName({
+        flags: {},
+        env: {},
+        profile: 'personal',
+        networkId: 8453
+      })
+    ).resolves.toBe('yearn-fi-personal-vnet-8453')
+  })
+
   it('redacts URLs in console text', () => {
     expect(sanitizeConsoleText('failed at https://admin.rpc/secret-path')).toBe('failed at [redacted-url]')
   })
@@ -68,7 +198,8 @@ describe('tenderly-vnet console safety', () => {
       chainId: 694201,
       networkId: 1,
       response,
-      details: connectionDetails
+      details: connectionDetails,
+      rpcName: 'yearn-fi-personal-vnet-1'
     }).join('\n')
 
     expect(summary).toContain('Created Tenderly Virtual TestNet')
@@ -87,6 +218,7 @@ describe('tenderly-vnet console safety', () => {
       networkId: 1,
       response,
       details: connectionDetails,
+      rpcName: 'yearn-fi-webops-vnet-1-ross',
       envFilePath: '/tmp/tenderly-vnet.env',
       responseFilePath: '/tmp/tenderly-vnet.json'
     }).join('\n')
@@ -105,13 +237,15 @@ describe('tenderly-vnet console safety', () => {
       chainId: 694201,
       networkId: 1,
       response,
-      details: connectionDetails
+      details: connectionDetails,
+      rpcName: 'yearn-fi-personal-vnet-1'
     })
 
     const serialized = JSON.stringify(sanitized)
 
     expect(serialized).toContain('"has_admin_rpc":true')
     expect(serialized).toContain('"has_public_rpc":true')
+    expect(serialized).toContain('"rpc_name"')
     expect(serialized).not.toContain('"rpcs"')
     expect(serialized).not.toContain(connectionDetails.adminRpc)
     expect(serialized).not.toContain(connectionDetails.publicRpc)

--- a/scripts/tenderly-vnet.ts
+++ b/scripts/tenderly-vnet.ts
@@ -2,6 +2,7 @@
 
 import { accessSync, chmodSync, constants, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
+import { createInterface } from 'node:readline/promises'
 import { fileURLToPath } from 'node:url'
 
 type TParsedCliArgs = {
@@ -18,12 +19,32 @@ type TResolvedTenderlyCredentials = {
   profile: TTenderlyProfile
 }
 
+type TTenderlyProfileDefaults = {
+  apiKeyEnv: string
+  accountEnvKeys: string[]
+  projectEnvKeys: string[]
+  rpcNameEnv: string
+  rpcOwnerEnv: string
+}
+
 type TTenderlyVnetResponse = {
   slug?: string
   display_name?: string
   chain_id?: number
   network_id?: number
   id?: string
+  fork_config?: {
+    network_id?: number | string
+    block_number?: number | string
+  }
+  virtual_network_config?: {
+    chain_config?: {
+      chain_id?: number | string
+    }
+  }
+  explorer_page_config?: {
+    enabled?: boolean
+  }
   rpcs?: Array<{
     name: string
     url: string
@@ -36,6 +57,13 @@ type TTenderlyVnetConnectionDetails = {
   publicRpc?: string
   predictablePublicRpc?: string
   explorerUri?: string
+}
+
+type TTenderlyCurrentChainMapping = {
+  canonicalChainId: number
+  executionChainId?: number
+  adminRpcUri?: string
+  publicRpcUri?: string
 }
 
 type TCreateVnetPayload = {
@@ -66,8 +94,28 @@ type TCreateVnetPayload = {
 const DEFAULT_ACCOUNT_SLUG = 'me'
 const DEFAULT_NETWORK_ID = 1
 const DEFAULT_CHAIN_ID_PREFIX = '69420'
+const DEFAULT_RPC_NAMES: Record<TTenderlyProfile, string> = {
+  webops: 'yearn-fi-webops-vnet',
+  personal: 'yearn-fi-personal-vnet'
+}
 const TENDERLY_API_URL = 'https://api.tenderly.co/api/v1/account'
 const REDACTED_URL = '[redacted-url]'
+const TENDERLY_PROFILE_DEFAULTS: Record<TTenderlyProfile, TTenderlyProfileDefaults> = {
+  personal: {
+    apiKeyEnv: 'PERSONAL_TENDERLY_API_KEY',
+    accountEnvKeys: ['PERSONAL_ACCOUNT_SLUG', 'ACCOUNT_SLUG'],
+    projectEnvKeys: ['PERSONAL_PROJECT_SLUG', 'PROJECT_SLUG'],
+    rpcNameEnv: 'PERSONAL_TENDERLY_RPC_NAME',
+    rpcOwnerEnv: 'PERSONAL_TENDERLY_RPC_OWNER'
+  },
+  webops: {
+    apiKeyEnv: 'WEBOPS_TENDERLY_API_KEY',
+    accountEnvKeys: ['WEBOPS_ACCOUNT_SLUG', 'TENDERLY_ACCOUNT_SLUG'],
+    projectEnvKeys: ['WEBOPS_PROJECT_SLUG', 'TENDERLY_PROJECT_SLUG'],
+    rpcNameEnv: 'WEBOPS_TENDERLY_RPC_NAME',
+    rpcOwnerEnv: 'WEBOPS_TENDERLY_RPC_OWNER'
+  }
+}
 
 const HELP_TEXT = `Tenderly Virtual TestNet bootstrap
 
@@ -87,20 +135,26 @@ Options:
   --network-id <id>       Parent network id (default: 1)
   --block-number <num>    Fork block number or latest (default: latest)
   --chain-id <id>         Execution chain id (default: 69420<network-id>)
-  --rpc-name <name>       Stable public RPC name for predictable endpoint reuse
+  --rpc-name <name>       Stable public RPC name override for predictable endpoint reuse
+  --rpc-owner <name>      Owner suffix used to derive the default stable public RPC name
   --enable-sync           Enable state sync (default: false)
   --enable-explorer       Enable public explorer (default: false)
+  --keep-previous         Keep the currently configured VNet instead of deleting it after a successful replacement
   --json                  Print a sanitized JSON summary
   --write-env <path>      Write the generated Tenderly env fragment to a local file
   --write-response <path> Write the raw Tenderly API response JSON to a local file
   --help                  Show this help text
 
 Profiles:
-  webops   -> WEBOPS_TENDERLY_API_KEY, TENDERLY_ACCOUNT_SLUG, TENDERLY_PROJECT_SLUG, WEBOPS_TENDERLY_RPC_NAME
-  personal -> PERSONAL_TENDERLY_API_KEY, PERSONAL_ACCOUNT_SLUG, PERSONAL_PROJECT_SLUG, PERSONAL_TENDERLY_RPC_NAME
+  webops   -> WEBOPS_TENDERLY_API_KEY, WEBOPS_ACCOUNT_SLUG, WEBOPS_PROJECT_SLUG, WEBOPS_TENDERLY_RPC_NAME, WEBOPS_TENDERLY_RPC_OWNER
+              legacy slug fallback: TENDERLY_ACCOUNT_SLUG, TENDERLY_PROJECT_SLUG
+  personal -> PERSONAL_TENDERLY_API_KEY, PERSONAL_ACCOUNT_SLUG, PERSONAL_PROJECT_SLUG, PERSONAL_TENDERLY_RPC_NAME, PERSONAL_TENDERLY_RPC_OWNER
 
 Sensitive RPC values are never printed to stdout. Use --write-env or --write-response when you need them locally.
 Explicit flags always win over profile defaults.
+If no explicit stable RPC name is configured, the script derives one from profile + chain + owner.
+For webops, owner resolution prefers WEBOPS_TENDERLY_RPC_OWNER, then TENDERLY_RPC_OWNER, then the local shell user.
+If no owner can be inferred, the script prompts in interactive shells and otherwise fails with a suggested owner.
 `
 
 function parseProfile(value: string | undefined): TTenderlyProfile {
@@ -142,7 +196,7 @@ function parseCliArgs(argv: readonly string[]): TParsedCliArgs {
   return recurse(0, { flags: {}, positionals: [] })
 }
 
-function readEnvFile(path = '.env'): Record<string, string> {
+export function readEnvFile(path = '.env'): Record<string, string> {
   if (!existsSync(path)) return {}
 
   const envLines = readFileSync(path, 'utf8').split('\n')
@@ -212,11 +266,15 @@ function getEnvValue(env: Record<string, string | undefined>, key?: string): str
   return env[key]?.trim()
 }
 
+function getFirstEnvValue(env: Record<string, string | undefined>, keys: string[]): string | undefined {
+  return keys.map((key) => env[key]?.trim()).find(Boolean)
+}
+
 export function sanitizeConsoleText(value: string): string {
   return value.replace(/https?:\/\/\S+/gi, REDACTED_URL)
 }
 
-function resolveTenderlyCredentials(
+export function resolveTenderlyCredentials(
   flags: Record<string, string>,
   env: Record<string, string | undefined>
 ): TResolvedTenderlyCredentials {
@@ -268,16 +326,117 @@ function resolveTenderlyCredentials(
   }
 }
 
-function resolveRpcName(
+export function resolveRpcName(
   flags: Record<string, string>,
   env: Record<string, string | undefined>,
   profile: TTenderlyProfile
 ): string | undefined {
-  const profileDefaultEnvKey = profile === 'personal' ? 'PERSONAL_TENDERLY_RPC_NAME' : 'WEBOPS_TENDERLY_RPC_NAME'
-  return getArg(flags, 'rpc-name') || getEnvValue(env, profileDefaultEnvKey) || env.TENDERLY_RPC_NAME?.trim()
+  const profileDefaults = TENDERLY_PROFILE_DEFAULTS[profile]
+  return getArg(flags, 'rpc-name') || getEnvValue(env, profileDefaults.rpcNameEnv) || env.TENDERLY_RPC_NAME?.trim()
 }
 
-function buildPredictablePublicRpcUrl(accountSlug: string, projectSlug: string, rpcName: string): string {
+export function normalizeTenderlyRpcNameComponent(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function resolveRpcOwner(
+  flags: Record<string, string>,
+  env: Record<string, string | undefined>,
+  profile: TTenderlyProfile
+): string | undefined {
+  const profileDefaults = TENDERLY_PROFILE_DEFAULTS[profile]
+  const rawValue =
+    getArg(flags, 'rpc-owner') || getEnvValue(env, profileDefaults.rpcOwnerEnv) || env.TENDERLY_RPC_OWNER?.trim()
+
+  if (!rawValue) {
+    return undefined
+  }
+
+  const normalizedValue = normalizeTenderlyRpcNameComponent(rawValue)
+  return normalizedValue || undefined
+}
+
+export function suggestTenderlyRpcOwner(env: Record<string, string | undefined>): string | undefined {
+  const rawValue = getFirstEnvValue(env, ['TENDERLY_RPC_OWNER', 'USER', 'LOGNAME', 'USERNAME'])
+  if (!rawValue) {
+    return undefined
+  }
+
+  const normalizedValue = normalizeTenderlyRpcNameComponent(rawValue)
+  return normalizedValue || undefined
+}
+
+export function suggestTenderlyRpcName(
+  profile: TTenderlyProfile,
+  params?: {
+    networkId?: number
+    owner?: string
+  }
+): string {
+  const suffixParts = [params?.networkId?.toString(), params?.owner].filter(Boolean)
+  return [DEFAULT_RPC_NAMES[profile], ...suffixParts].join('-')
+}
+
+export async function resolveRequiredRpcName(params: {
+  flags: Record<string, string>
+  env: Record<string, string | undefined>
+  profile: TTenderlyProfile
+  networkId: number
+  canPrompt?: boolean
+  promptOwner?: (suggestedOwner: string, suggestedRpcName: string) => Promise<string>
+}): Promise<string> {
+  const configuredRpcName = resolveRpcName(params.flags, params.env, params.profile)
+  if (configuredRpcName) {
+    return configuredRpcName
+  }
+
+  const configuredOwner = resolveRpcOwner(params.flags, params.env, params.profile)
+  if (configuredOwner) {
+    return suggestTenderlyRpcName(params.profile, {
+      networkId: params.networkId,
+      owner: configuredOwner
+    })
+  }
+
+  if (params.profile !== 'webops') {
+    return suggestTenderlyRpcName(params.profile, { networkId: params.networkId })
+  }
+
+  const suggestedOwner = suggestTenderlyRpcOwner(params.env)
+  if (suggestedOwner) {
+    return suggestTenderlyRpcName(params.profile, {
+      networkId: params.networkId,
+      owner: suggestedOwner
+    })
+  }
+
+  const fallbackSuggestedOwner = 'yourname'
+  const suggestedRpcName = suggestTenderlyRpcName(params.profile, {
+    networkId: params.networkId,
+    owner: fallbackSuggestedOwner
+  })
+
+  if (params.canPrompt && params.promptOwner) {
+    const promptedValue = normalizeTenderlyRpcNameComponent(
+      await params.promptOwner(fallbackSuggestedOwner, suggestedRpcName)
+    )
+    return suggestTenderlyRpcName(params.profile, {
+      networkId: params.networkId,
+      owner: promptedValue || fallbackSuggestedOwner
+    })
+  }
+
+  throw new Error(
+    `Missing Tenderly RPC owner. Set WEBOPS_TENDERLY_RPC_OWNER, pass --rpc-owner, or use the suggested value: ${fallbackSuggestedOwner}. The derived stable RPC name would be: ${suggestedRpcName}`
+  )
+}
+
+export function buildPredictablePublicRpcUrl(accountSlug: string, projectSlug: string, rpcName: string): string {
   return `https://virtual.rpc.tenderly.co/${encodeURIComponent(accountSlug)}/${encodeURIComponent(projectSlug)}/public/${encodeURIComponent(rpcName)}`
 }
 
@@ -335,6 +494,81 @@ function getConnectionDetails(
     predictablePublicRpc: rpcName ? buildPredictablePublicRpcUrl(accountSlug, projectSlug, rpcName) : undefined,
     explorerUri: resolveExplorerUriFromResponse(response)
   }
+}
+
+function resolveVnetRpcUrl(vnet: TTenderlyVnetResponse, rpcName: string): string | undefined {
+  return vnet.rpcs?.find((rpc) => rpc.name === rpcName)?.url
+}
+
+function normalizeVnetListResponse(responseBody: string): TTenderlyVnetResponse[] {
+  const parsed = parseResponseBody(responseBody) as unknown
+
+  if (Array.isArray(parsed)) {
+    return parsed.filter((entry): entry is TTenderlyVnetResponse => isRecord(entry))
+  }
+
+  if (isRecord(parsed)) {
+    const nestedList = [parsed.vnets, parsed.virtual_networks, parsed.data].find(Array.isArray)
+    if (nestedList) {
+      return nestedList.filter((entry): entry is TTenderlyVnetResponse => isRecord(entry))
+    }
+  }
+
+  return []
+}
+
+function resolveCurrentChainMapping(
+  env: Record<string, string | undefined>,
+  canonicalChainId: number
+): TTenderlyCurrentChainMapping | undefined {
+  const executionChainId = parseOptionalInteger(
+    getEnvValue(env, `VITE_TENDERLY_CHAIN_ID_FOR_${canonicalChainId}`),
+    `VITE_TENDERLY_CHAIN_ID_FOR_${canonicalChainId}`
+  )
+  const adminRpcUri = getEnvValue(env, `TENDERLY_ADMIN_RPC_URI_FOR_${canonicalChainId}`)
+  const publicRpcUri = getEnvValue(env, `VITE_TENDERLY_RPC_URI_FOR_${canonicalChainId}`)
+
+  if (!executionChainId && !adminRpcUri && !publicRpcUri) {
+    return undefined
+  }
+
+  return {
+    canonicalChainId,
+    executionChainId,
+    adminRpcUri,
+    publicRpcUri
+  }
+}
+
+function selectMatchingConfiguredVnet(params: {
+  vnets: TTenderlyVnetResponse[]
+  currentMapping: TTenderlyCurrentChainMapping
+}): TTenderlyVnetResponse | undefined {
+  const adminRpcMatch = params.currentMapping.adminRpcUri
+    ? params.vnets.find((vnet) => resolveVnetRpcUrl(vnet, 'Admin RPC') === params.currentMapping.adminRpcUri)
+    : undefined
+
+  if (adminRpcMatch) {
+    return adminRpcMatch
+  }
+
+  const publicRpcMatch = params.currentMapping.publicRpcUri
+    ? params.vnets.find((vnet) => resolveVnetRpcUrl(vnet, 'Public RPC') === params.currentMapping.publicRpcUri)
+    : undefined
+
+  if (publicRpcMatch) {
+    return publicRpcMatch
+  }
+
+  const executionChainMatches =
+    params.currentMapping.executionChainId === undefined
+      ? []
+      : params.vnets.filter(
+          (vnet) =>
+            Number(vnet.virtual_network_config?.chain_config?.chain_id) === params.currentMapping.executionChainId
+        )
+
+  return executionChainMatches.length === 1 ? executionChainMatches[0] : undefined
 }
 
 function selectPublicRpc(details: TTenderlyVnetConnectionDetails): string | undefined {
@@ -422,8 +656,12 @@ export function buildSanitizedVnetJson(params: {
   networkId: number
   response: TTenderlyVnetResponse
   details: TTenderlyVnetConnectionDetails
+  rpcName: string
   envFilePath?: string
   responseFilePath?: string
+  replacedVnetId?: string
+  deletedPreviousVnetId?: string
+  deletionNote?: string
 }): Record<string, unknown> {
   const sanitizedResponse = Object.fromEntries(
     Object.entries(params.response).filter(([key]) => key !== 'rpcs')
@@ -439,10 +677,14 @@ export function buildSanitizedVnetJson(params: {
     display_name: params.response.display_name || params.displayName,
     chain_id: params.chainId,
     network_id: params.networkId,
+    rpc_name: params.rpcName,
     has_admin_rpc: Boolean(params.details.adminRpc),
     has_public_rpc: Boolean(selectPublicRpc(params.details)),
     env_file_path: params.envFilePath || null,
     response_file_path: params.responseFilePath || null,
+    replaced_vnet_id: params.replacedVnetId || null,
+    deleted_previous_vnet_id: params.deletedPreviousVnetId || null,
+    deletion_note: params.deletionNote || null,
     note:
       hasSensitiveValues && !params.envFilePath && !params.responseFilePath
         ? 'Sensitive RPC values were returned but were not printed. Use --write-env or --write-response to persist them locally.'
@@ -458,8 +700,12 @@ export function buildVnetConsoleSummary(params: {
   networkId: number
   response: TTenderlyVnetResponse
   details: TTenderlyVnetConnectionDetails
+  rpcName: string
   envFilePath?: string
   responseFilePath?: string
+  replacedVnetId?: string
+  deletedPreviousVnetId?: string
+  deletionNote?: string
 }): string[] {
   const hasSensitiveValues = Boolean(
     params.details.adminRpc || params.details.publicRpc || params.details.predictablePublicRpc
@@ -470,11 +716,15 @@ export function buildVnetConsoleSummary(params: {
     `profile: ${params.profile}`,
     `slug: ${params.response.slug || params.requestedSlug}`,
     `display name: ${params.response.display_name || params.displayName}`,
+    `rpc name: ${params.rpcName}`,
     params.envFilePath ? `wrote env fragment: ${params.envFilePath}` : undefined,
     params.responseFilePath ? `wrote raw response json: ${params.responseFilePath}` : undefined,
     hasSensitiveValues && !params.envFilePath && !params.responseFilePath
       ? 'Sensitive RPC values were returned but not printed. Use --write-env <path> or --write-response <path> to persist them locally.'
       : undefined,
+    params.replacedVnetId ? `replaced previous vnet: ${params.replacedVnetId}` : undefined,
+    params.deletedPreviousVnetId ? `deleted previous vnet: ${params.deletedPreviousVnetId}` : undefined,
+    params.deletionNote ? `previous vnet deletion note: ${params.deletionNote}` : undefined,
     `chain-id: ${params.chainId}`,
     `network-id: ${params.networkId}`
   ].filter((line): line is string => Boolean(line))
@@ -529,6 +779,59 @@ async function createVirtualTestNet(
   return parsed
 }
 
+async function listVirtualTestNets(
+  apiKey: string,
+  accountSlug: string,
+  projectSlug: string
+): Promise<TTenderlyVnetResponse[]> {
+  const response = await fetch(
+    `${TENDERLY_API_URL}/${encodeURIComponent(accountSlug)}/project/${encodeURIComponent(projectSlug)}/vnets`,
+    {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        'X-Access-Key': apiKey
+      }
+    }
+  )
+
+  const responseBody = (await response.text()) || '[]'
+  if (!response.ok) {
+    throw new Error(
+      buildTenderlyApiErrorMessage({ status: response.status, parsedBody: parseResponseBody(responseBody) })
+    )
+  }
+
+  return normalizeVnetListResponse(responseBody)
+}
+
+async function deleteVirtualTestNet(
+  apiKey: string,
+  accountSlug: string,
+  projectSlug: string,
+  vnetId: string
+): Promise<void> {
+  const response = await fetch(
+    `${TENDERLY_API_URL}/${encodeURIComponent(accountSlug)}/project/${encodeURIComponent(projectSlug)}/vnets/${encodeURIComponent(vnetId)}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/json',
+        'X-Access-Key': apiKey
+      }
+    }
+  )
+
+  if (response.ok || response.status === 404) {
+    return
+  }
+
+  const responseBody = (await response.text()) || '{}'
+  throw new Error(
+    buildTenderlyApiErrorMessage({ status: response.status, parsedBody: parseResponseBody(responseBody) })
+  )
+}
+
 async function main(): Promise<void> {
   const parsedArgs = parseCliArgs(process.argv.slice(2))
   const { flags } = parsedArgs
@@ -542,16 +845,42 @@ async function main(): Promise<void> {
   const envFromFile = readEnvFile(resolve(scriptDir, '../.env'))
   const env = { ...envFromFile, ...process.env }
   const { apiKey, accountSlug, projectSlug, profile } = resolveTenderlyCredentials(flags, env)
-  const rpcName = resolveRpcName(flags, env, profile)
+  const networkId = parseOptionalInteger(getArg(flags, 'network-id'), 'network-id') || DEFAULT_NETWORK_ID
+  const chainId = parseOptionalInteger(getArg(flags, 'chain-id'), 'chain-id') || resolveDefaultChainId(networkId)
+  const rpcName = await resolveRequiredRpcName({
+    flags,
+    env,
+    profile,
+    networkId,
+    canPrompt: Boolean(process.stdin.isTTY && process.stderr.isTTY),
+    promptOwner: async (suggestedOwner: string, suggestedRpcName: string): Promise<string> => {
+      const readline = createInterface({
+        input: process.stdin,
+        output: process.stderr
+      })
+
+      try {
+        return await readline.question(`Tenderly RPC owner suffix [${suggestedOwner}] -> ${suggestedRpcName}: `)
+      } finally {
+        readline.close()
+      }
+    }
+  })
+  const currentChainMapping = resolveCurrentChainMapping(env, networkId)
+  const currentVnetToReplace = currentChainMapping
+    ? selectMatchingConfiguredVnet({
+        vnets: await listVirtualTestNets(apiKey, accountSlug, projectSlug),
+        currentMapping: currentChainMapping
+      })
+    : undefined
   const timestamp = Date.now().toString()
   const requestedSlug = getArg(flags, 'slug') || `vnet-${timestamp}`
   const defaultDisplayNamePrefix = profile === 'personal' ? 'Personal VNet' : 'Webops VNet'
   const displayName = getArg(flags, 'display-name') || `${defaultDisplayNamePrefix} ${timestamp}`
-  const networkId = parseOptionalInteger(getArg(flags, 'network-id'), 'network-id') || DEFAULT_NETWORK_ID
-  const chainId = parseOptionalInteger(getArg(flags, 'chain-id'), 'chain-id') || resolveDefaultChainId(networkId)
   const blockNumber = getArg(flags, 'block-number') || 'latest'
   const enableSync = parseBooleanFlag(flags, 'enable-sync', false)
   const enableExplorer = parseBooleanFlag(flags, 'enable-explorer', false)
+  const keepPrevious = parseBooleanFlag(flags, 'keep-previous', false)
   const { envFilePath, responseFilePath } = resolveRequestedOutputPaths(flags)
 
   const payload: TCreateVnetPayload = {
@@ -579,6 +908,16 @@ async function main(): Promise<void> {
 
   const response = await createVirtualTestNet(apiKey, accountSlug, projectSlug, payload)
   const details = getConnectionDetails(response, accountSlug, projectSlug, rpcName)
+  let deletedPreviousVnetId: string | undefined
+  let deletionNote: string | undefined
+  if (!keepPrevious && currentVnetToReplace?.id && currentVnetToReplace.id !== response.id) {
+    try {
+      await deleteVirtualTestNet(apiKey, accountSlug, projectSlug, currentVnetToReplace.id)
+      deletedPreviousVnetId = currentVnetToReplace.id
+    } catch (error) {
+      deletionNote = error instanceof Error ? sanitizeConsoleText(error.message) : 'Failed to delete previous vnet'
+    }
+  }
   if (envFilePath) {
     writeOutputFile(
       envFilePath,
@@ -604,8 +943,12 @@ async function main(): Promise<void> {
           networkId,
           response,
           details,
+          rpcName,
           envFilePath,
-          responseFilePath
+          responseFilePath,
+          replacedVnetId: currentVnetToReplace?.id,
+          deletedPreviousVnetId,
+          deletionNote
         }),
         null,
         2
@@ -622,8 +965,12 @@ async function main(): Promise<void> {
     networkId,
     response,
     details,
+    rpcName,
     envFilePath,
-    responseFilePath
+    responseFilePath,
+    replacedVnetId: currentVnetToReplace?.id,
+    deletedPreviousVnetId,
+    deletionNote
   }).forEach((line) => {
     console.log(line)
   })


### PR DESCRIPTION
## Description

Updates the tenderly scripts to be more robust and allow better skill use by agents. They now more effectively support multiple virtual testnets by chain and by different team members.

To test:
Get WEBOPS_TENDERLY_API_KEY, WEBOPS_ACCOUNT_SLUG, and WEBOPS_PROJECT_SLUG from secrets vault and install skills (see internal discussion). Ask your agent to create virtual testnets for you or use `/tenderly-init` (claude) or `$tenderly-init` (codex) to have the agent spin up new testnets on the webops account. They can do it for all supported chains. Give a name so we can suffix everyone's testnets and not step on each other's feet/paws.

`tenderly-status` is a second skill that prints out info about all the testnets in your env.