### PR TITLE
Add OWASP ZAP baseline scan workflow

### DIFF
--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -1,0 +1,25 @@
+name: OWASP ZAP Baseline Scan
+
+on:
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch:
+
+env:
+  OWASP_ZAP_TARGET_URL: https://yearn.fi
+
+jobs:
+  zap-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: ZAP Baseline Scan
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: ${{ env.OWASP_ZAP_TARGET_URL }}
+
+      - name: Upload Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: zap-report
+          path: report_html.html

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,9 @@ yearn.fi-worktree-*
 
 # codex settings
 .codex
+
+# ZAP scan artifacts
+report_html.html
+report_md.md
+report_json.json
+zap.yaml

--- a/README.md
+++ b/README.md
@@ -96,6 +96,24 @@ Notes:
     git push origin <branch-name>
     ```
 
+### Running the OWASP ZAP Scan Locally
+
+You can run the ZAP baseline scan workflow locally using [act](https://github.com/nektos/act):
+
+``` bash
+act workflow_dispatch -W .github/workflows/zap-baseline.yml
+```
+
+The scan targets the URL set in `OWASP_ZAP_TARGET_URL` (defaults to `https://yearn.fi`). Reports are written to the repo root:
+- `report_html.html` — full HTML report
+- `report_md.md` — markdown summary
+
+To override the target URL:
+
+``` bash
+act workflow_dispatch -W .github/workflows/zap-baseline.yml --env OWASP_ZAP_TARGET_URL=https://staging.yearn.fi
+```
+
 ### Submitting Pull Request
 
 - Go to your GitHub and navigate to your forked repo


### PR DESCRIPTION
### Summary
Adds a GitHub Actions workflow that runs an [OWASP ZAP](https://www.zaproxy.org/) baseline scan against the site. ZAP is an open-source web security scanner maintained by OWASP — the baseline scan passively crawls the target and checks for common security issues like missing headers (CSP, clickjacking, HSTS), insecure cookies, information leaks, mixed content, and other OWASP Top 10 surface-level findings. Running it regularly helps catch security regressions before they hit production, without needing a full pentest.

Runs weekly on Monday mornings and can be triggered manually via `workflow_dispatch`. Includes `.gitignore` entries for local scan artifacts and a README section on running the scan locally with `act`.

### How to review
- `zap-baseline.yml` is the whole workflow — 26 lines
- `.gitignore` and `README.md` changes are supporting housekeeping

### Test plan
- [x] Ran locally via `act workflow_dispatch` — scan completed with 57 passes, 10 info-level warnings, 0 failures

### Risk / impact
None — passive scan only, no effect on existing CI or deployments.