### PR TITLE
Add CodeQL query for reflected XSS in Vercel serverless functions

### DIFF
--- a/.codeql/queries/VercelReflectedXss.ql
+++ b/.codeql/queries/VercelReflectedXss.ql
@@ -1,0 +1,131 @@
+/**
+ * @name Reflected XSS in Vercel serverless function
+ * @description User input from VercelRequest query parameters is interpolated
+ *              into an HTML response without sanitization, enabling cross-site
+ *              scripting attacks.
+ * @kind path-problem
+ * @problem.severity error
+ * @security-severity 7.8
+ * @precision high
+ * @id js/vercel-reflected-xss
+ * @tags security
+ *       external/cwe/cwe-079
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.ReflectedXssQuery
+import ReflectedXssFlow::PathGraph
+
+/** A Vercel serverless function handler identified by a VercelRequest-typed first parameter. */
+class VercelRouteHandler extends Http::Servers::StandardRouteHandler, DataFlow::FunctionNode {
+  VercelRouteHandler() {
+    this.getParameter(0).hasUnderlyingType("@vercel/node", "VercelRequest")
+  }
+}
+
+/** The first parameter of a Vercel handler, typed as VercelRequest. */
+class VercelRequestSource extends Http::Servers::RequestSource {
+  VercelRouteHandler rh;
+
+  VercelRequestSource() { this = rh.getParameter(0) }
+
+  override Http::RouteHandler getRouteHandler() { result = rh }
+}
+
+/** The second parameter of a Vercel handler, typed as VercelResponse. */
+class VercelResponseSource extends Http::Servers::ResponseSource {
+  VercelRouteHandler rh;
+
+  VercelResponseSource() {
+    this = rh.getParameter(1) and
+    this.hasUnderlyingType("@vercel/node", "VercelResponse")
+  }
+
+  override Http::RouteHandler getRouteHandler() { result = rh }
+}
+
+/** A chained response object from calls like res.status(200), res.type(), res.set(). */
+class VercelChainedResponseSource extends Http::Servers::ResponseSource {
+  VercelRouteHandler rh;
+
+  VercelChainedResponseSource() {
+    exists(VercelResponseSource src |
+      this = src.ref().getAMethodCall(["status", "type", "set"]) and
+      rh = src.getRouteHandler()
+    )
+  }
+
+  override Http::RouteHandler getRouteHandler() { result = rh }
+}
+
+/** Access to user-controlled input on a VercelRequest: query, body, headers, cookies. */
+class VercelRequestInputAccess extends Http::RequestInputAccess {
+  VercelRouteHandler rh;
+  string kind;
+
+  VercelRequestInputAccess() {
+    exists(VercelRequestSource src |
+      rh = src.getRouteHandler() and
+      (
+        this = src.ref().getAPropertyRead("query") and kind = "parameter"
+        or
+        this = src.ref().getAPropertyRead("body") and kind = "body"
+        or
+        this = src.ref().getAPropertyRead("headers") and kind = "header"
+        or
+        this = src.ref().getAPropertyRead("cookies") and kind = "cookie"
+      )
+    )
+  }
+
+  override Http::RouteHandler getRouteHandler() { result = rh }
+
+  override string getKind() { result = kind }
+
+  override predicate isThirdPartyControllable() { any() }
+}
+
+/** Argument to .send() on a VercelResponse, including chained calls like res.status(200).send(). */
+class VercelResponseSendArgument extends Http::ResponseSendArgument {
+  VercelRouteHandler rh;
+
+  VercelResponseSendArgument() {
+    exists(VercelResponseSource src |
+      this = src.ref().getAMethodCall("send").getArgument(0) and
+      rh = src.getRouteHandler()
+    )
+    or
+    exists(VercelChainedResponseSource chained |
+      this = chained.ref().getAMethodCall("send").getArgument(0) and
+      rh = chained.getRouteHandler()
+    )
+  }
+
+  override Http::RouteHandler getRouteHandler() { result = rh }
+}
+
+/** A call to res.setHeader() on a VercelResponse. */
+class VercelHeaderDefinition extends Http::ExplicitHeaderDefinition, DataFlow::CallNode {
+  VercelRouteHandler rh;
+
+  VercelHeaderDefinition() {
+    exists(VercelResponseSource src |
+      this = src.ref().getAMethodCall("setHeader") and
+      rh = src.getRouteHandler()
+    )
+  }
+
+  override Http::RouteHandler getRouteHandler() { result = rh }
+
+  override predicate definesHeaderValue(string name, DataFlow::Node value) {
+    name = this.getArgument(0).getStringValue().toLowerCase() and
+    value = this.getArgument(1)
+  }
+
+  override DataFlow::Node getNameNode() { result = this.getArgument(0) }
+}
+
+from ReflectedXssFlow::PathNode source, ReflectedXssFlow::PathNode sink
+where ReflectedXssFlow::flowPath(source, sink)
+select sink.getNode(), source, sink,
+  "Cross-site scripting vulnerability due to a $@.", source.getNode(), "user-provided value"

--- a/.codeql/queries/codeql-pack.lock.yml
+++ b/.codeql/queries/codeql-pack.lock.yml
@@ -1,0 +1,4 @@
+---
+lockVersion: 1.0.0
+dependencies: {}
+compiled: false

--- a/.codeql/queries/qlpack.yml
+++ b/.codeql/queries/qlpack.yml
@@ -1,0 +1,5 @@
+name: yearn/security-queries
+version: 0.0.1
+dependencies:
+  codeql/javascript-all: "*"
+  codeql/javascript-queries: "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,37 +40,19 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+        queries: security-extended
+        packs: ./.codeql/queries
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
-
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
+      uses: github/codeql-action/autobuild@v4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary
- CodeQL has no built-in framework model for `@vercel/node`, so the standard `js/reflected-xss` query misses vulnerabilities in `api/` serverless handlers. This adds a custom CodeQL query with inline Vercel framework models that detects reflected XSS specifically.
- Upgrades CI workflow: `actions/checkout` and `codeql-action` to v4, enables `security-extended` query suite, and runs the custom query pack alongside standard queries.
- Other vulnerability types (SSRF, SQLi, command injection, etc.) in Vercel handlers are **not** covered by this change — that requires either duplicating the model into additional query files or contributing the model upstream to [github/codeql](https://github.com/github/codeql).

## What the custom model teaches CodeQL
| Concept | What it recognizes |
|---|---|
| Route handler | Functions with a `VercelRequest`-typed first parameter |
| Request sources | `req.query`, `req.body`, `req.headers`, `req.cookies` |
| Response sinks | `res.send()`, `res.status().send()` |
| Headers | `res.setHeader()` (used to determine content-type for XSS relevance) |

## Test plan
- [ ] Verify CodeQL workflow runs successfully on this PR
- [ ] Confirm the custom query detects the reflected XSS in `api/vault/meta.ts`
- [ ] Confirm `security-extended` suite runs without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)