### PR TITLE
chore: disable enso crosschain zaps to and from katana

### DIFF
--- a/api/enso/route.ts
+++ b/api/enso/route.ts
@@ -1,6 +1,18 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 
 const ENSO_API_BASE = 'https://api.enso.finance'
+const KATANA_CHAIN_ID = 747474
+
+function isKatanaCrossChainRoute(chainId: string, destinationChainId?: string): boolean {
+  const sourceChainId = Number(chainId)
+  const targetChainId = Number(destinationChainId || chainId)
+
+  if (!Number.isFinite(sourceChainId) || !Number.isFinite(targetChainId)) {
+    return false
+  }
+
+  return sourceChainId !== targetChainId && (sourceChainId === KATANA_CHAIN_ID || targetChainId === KATANA_CHAIN_ID)
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
@@ -23,6 +35,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
   if (!amountIn || typeof amountIn !== 'string') {
     return res.status(400).json({ error: 'Missing or invalid amountIn' })
+  }
+  if (
+    destinationChainId &&
+    typeof destinationChainId === 'string' &&
+    isKatanaCrossChainRoute(chainId, destinationChainId)
+  ) {
+    return res.status(400).json({
+      error: 'unsupported_route',
+      message: 'Cross-chain zaps involving Katana are disabled',
+      requestId: 'katana-crosschain-disabled',
+      statusCode: 400
+    })
   }
 
   const apiKey = process.env.ENSO_API_KEY

--- a/api/server.ts
+++ b/api/server.ts
@@ -226,6 +226,19 @@ function handleEnsoStatus(): Response {
   return Response.json({ configured: !!apiKey })
 }
 
+const KATANA_CHAIN_ID = 747474
+
+function isKatanaCrossChainRoute(chainId: string, destinationChainId?: string): boolean {
+  const sourceChainId = Number(chainId)
+  const targetChainId = Number(destinationChainId || chainId)
+
+  if (!Number.isFinite(sourceChainId) || !Number.isFinite(targetChainId)) {
+    return false
+  }
+
+  return sourceChainId !== targetChainId && (sourceChainId === KATANA_CHAIN_ID || targetChainId === KATANA_CHAIN_ID)
+}
+
 async function handleEnsoRoute(req: Request): Promise<Response> {
   const url = new URL(req.url)
   const fromAddress = url.searchParams.get('fromAddress')
@@ -239,6 +252,17 @@ async function handleEnsoRoute(req: Request): Promise<Response> {
 
   if (!fromAddress || !chainId || !tokenIn || !tokenOut || !amountIn) {
     return Response.json({ error: 'Missing required parameters' }, { status: 400 })
+  }
+  if (destinationChainId && isKatanaCrossChainRoute(chainId, destinationChainId)) {
+    return Response.json(
+      {
+        error: 'unsupported_route',
+        message: 'Cross-chain zaps involving Katana are disabled',
+        requestId: 'katana-crosschain-disabled',
+        statusCode: 400
+      },
+      { status: 400 }
+    )
   }
 
   const apiKey = process.env.ENSO_API_KEY

--- a/src/components/pages/vaults/components/widget/TokenSelector.test.tsx
+++ b/src/components/pages/vaults/components/widget/TokenSelector.test.tsx
@@ -83,6 +83,70 @@ describe('TokenSelector', () => {
     expect(html).not.toContain('Base Token')
   })
 
+  it('hides the chain selector when only one allowed chain is provided', () => {
+    mockUseWallet.mockReturnValue({
+      isLoading: false,
+      balances: {
+        747474: {
+          [BASE_TOKEN_ADDRESS]: buildToken({
+            chainID: 747474,
+            value: 100
+          })
+        }
+      },
+      getToken: () =>
+        buildToken({
+          chainID: 747474,
+          value: 100
+        })
+    })
+
+    const html = renderToStaticMarkup(
+      <TokenSelector
+        value={BASE_TOKEN_ADDRESS}
+        onChange={() => undefined}
+        chainId={747474}
+        allowedChainIds={[747474]}
+      />
+    )
+
+    expect(html).not.toContain('alt="Katana"')
+    expect(html).not.toContain('alt="Ethereum"')
+    expect(html).not.toContain('alt="Optimism"')
+  })
+
+  it('excludes Katana when allowedChainIds omit it', () => {
+    mockUseWallet.mockReturnValue({
+      isLoading: false,
+      balances: {
+        1: {
+          [BASE_TOKEN_ADDRESS]: buildToken({
+            chainID: 1,
+            value: 100
+          })
+        }
+      },
+      getToken: () =>
+        buildToken({
+          chainID: 1,
+          value: 100
+        })
+    })
+
+    const html = renderToStaticMarkup(
+      <TokenSelector
+        value={BASE_TOKEN_ADDRESS}
+        onChange={() => undefined}
+        chainId={1}
+        allowedChainIds={[1, 10, 137, 42161, 8453]}
+      />
+    )
+
+    expect(html).toContain('alt="Ethereum"')
+    expect(html).toContain('alt="Base"')
+    expect(html).not.toContain('alt="Katana"')
+  })
+
   it('preserves wallet balance and value when an extra token only overrides metadata', () => {
     mockUseYearn.mockReturnValue({
       allVaults: {},

--- a/src/components/pages/vaults/components/widget/TokenSelector.tsx
+++ b/src/components/pages/vaults/components/widget/TokenSelector.tsx
@@ -15,6 +15,7 @@ import { type FC, useCallback, useMemo, useState } from 'react'
 import { isAddress } from 'viem'
 import { CloseIcon } from './shared/Icons'
 import { getTokenLogoSources } from './tokenLogo.utils'
+import { TOKEN_SELECTOR_AVAILABLE_CHAINS } from './tokenSelectorChains'
 import {
   filterAndSortTokenSelectorTokens,
   getDepositMinValueExemptTokenAddresses,
@@ -26,15 +27,6 @@ import {
 
 type TTokenType = 'asset' | 'vault' | 'staking' | undefined
 
-const AVAILABLE_CHAINS = [
-  { id: 1, name: 'Ethereum' },
-  { id: 10, name: 'Optimism' },
-  { id: 137, name: 'Polygon' },
-  { id: 42161, name: 'Arbitrum' },
-  { id: 8453, name: 'Base' },
-  { id: 747474, name: 'Katana' }
-] as const
-
 const LEGACY_SELECTOR_TOKEN_ADDRESSES_BY_CHAIN: Record<number, `0x${string}`[]> = {
   1: ['0x85E30b8b263bC64d94b827ed450F2EdFEE8579dA'] // Legacy USDaf
 }
@@ -43,6 +35,7 @@ interface TokenSelectorProps {
   value: `0x${string}` | undefined
   onChange: (address: `0x${string}`, chainId?: number) => void
   chainId: number
+  allowedChainIds?: number[]
   limitTokens?: `0x${string}`[]
   excludeTokens?: `0x${string}`[]
   priorityTokens?: Record<number, `0x${string}`[]> // chainId -> addresses to always show
@@ -126,6 +119,7 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
   value,
   onChange,
   chainId,
+  allowedChainIds,
   limitTokens,
   excludeTokens,
   priorityTokens,
@@ -144,30 +138,45 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
   const { getToken, isLoading, balances } = useWallet()
   const { tokenLists } = useTokenList()
   const { allVaults, getPrice } = useYearn()
+  const availableChains = useMemo(
+    () =>
+      TOKEN_SELECTOR_AVAILABLE_CHAINS.filter((chain) =>
+        allowedChainIds && allowedChainIds.length > 0 ? allowedChainIds.includes(chain.id) : true
+      ),
+    [allowedChainIds]
+  )
+  const activeChainId = useMemo(() => {
+    if (availableChains.some((chain) => chain.id === selectedChainId)) {
+      return selectedChainId
+    }
+
+    return availableChains[0]?.id ?? chainId
+  }, [availableChains, chainId, selectedChainId])
+  const shouldShowChainSelector = availableChains.length > 1
   const customAddress = useMemo(
     () => (searchText && isAddress(searchText) ? (searchText as `0x${string}`) : undefined),
     [searchText]
   )
 
   const priorityTokenAddresses = useMemo(
-    () => (priorityTokens?.[selectedChainId] || []).map((address) => toAddress(address) as `0x${string}`),
-    [priorityTokens, selectedChainId]
+    () => (priorityTokens?.[activeChainId] || []).map((address) => toAddress(address) as `0x${string}`),
+    [activeChainId, priorityTokens]
   )
   const topTokenAddresses = useMemo(
-    () => (topTokens?.[selectedChainId] || []).map((address) => toAddress(address) as `0x${string}`),
-    [selectedChainId, topTokens]
+    () => (topTokens?.[activeChainId] || []).map((address) => toAddress(address) as `0x${string}`),
+    [activeChainId, topTokens]
   )
 
   const chainExtraTokens = useMemo(
-    () => (extraTokens || []).filter((token) => token.chainID === selectedChainId),
-    [extraTokens, selectedChainId]
+    () => (extraTokens || []).filter((token) => token.chainID === activeChainId),
+    [activeChainId, extraTokens]
   )
   const hiddenVaultTokenAddresses = useMemo(() => {
     const hiddenAddresses = new Set<`0x${string}`>()
 
     Object.values(allVaults).forEach((vault) => {
       const isHidden = getVaultInfo(vault).isHidden
-      if (!isHidden || getVaultChainID(vault) !== selectedChainId) {
+      if (!isHidden || getVaultChainID(vault) !== activeChainId) {
         return
       }
 
@@ -181,13 +190,13 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
     })
 
     return [...hiddenAddresses]
-  }, [allVaults, selectedChainId])
+  }, [activeChainId, allVaults])
   const hiddenVaultExemptAddresses = useMemo(
     () =>
-      mode === 'withdraw' && allowHiddenVaultTokenSelection && selectedChainId === chainId && vaultAddress
+      mode === 'withdraw' && allowHiddenVaultTokenSelection && activeChainId === chainId && vaultAddress
         ? [toAddress(vaultAddress) as `0x${string}`]
         : [],
-    [allowHiddenVaultTokenSelection, chainId, mode, selectedChainId, vaultAddress]
+    [activeChainId, allowHiddenVaultTokenSelection, chainId, mode, vaultAddress]
   )
   const combinedExcludeTokens = useMemo(
     () => [
@@ -197,23 +206,23 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
           ...hiddenVaultTokenAddresses.filter(
             (address) => !hiddenVaultExemptAddresses.includes(toAddress(address) as `0x${string}`)
           ),
-          ...(LEGACY_SELECTOR_TOKEN_ADDRESSES_BY_CHAIN[selectedChainId] || [])
+          ...(LEGACY_SELECTOR_TOKEN_ADDRESSES_BY_CHAIN[activeChainId] || [])
         ].map((address) => toAddress(address))
       )
     ],
-    [excludeTokens, hiddenVaultExemptAddresses, hiddenVaultTokenAddresses, selectedChainId]
+    [activeChainId, excludeTokens, hiddenVaultExemptAddresses, hiddenVaultTokenAddresses]
   )
   const assetLogoToken = useMemo(() => {
-    if (selectedChainId !== assetChainId || !assetAddress) {
+    if (activeChainId !== assetChainId || !assetAddress) {
       return undefined
     }
 
     return getToken({ address: toAddress(assetAddress), chainID: assetChainId })
-  }, [assetAddress, assetChainId, getToken, selectedChainId])
+  }, [activeChainId, assetAddress, assetChainId, getToken])
 
   // Get all tokens with balances from wallet context
   const tokens = useMemo(() => {
-    const chainBalances = balances[selectedChainId] || {}
+    const chainBalances = balances[activeChainId] || {}
     const tokenMap = new Map<string, TToken>()
 
     const setIfMissing = (token?: TToken): void => {
@@ -264,7 +273,7 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
 
     // Also include the currently selected token even if it has no balance
     if (value && !tokenMap.has(value.toLowerCase())) {
-      const selectedToken = getToken({ address: toAddress(value), chainID: selectedChainId })
+      const selectedToken = getToken({ address: toAddress(value), chainID: activeChainId })
       if (selectedToken.symbol) {
         setIfMissing(selectedToken)
       }
@@ -273,7 +282,7 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
     // Include priority tokens even if they have no balance
     for (const priorityAddress of priorityTokenAddresses) {
       if (!tokenMap.has(priorityAddress.toLowerCase())) {
-        const priorityToken = getToken({ address: toAddress(priorityAddress), chainID: selectedChainId })
+        const priorityToken = getToken({ address: toAddress(priorityAddress), chainID: activeChainId })
         if (priorityToken.symbol) {
           setIfMissing(priorityToken)
         }
@@ -282,7 +291,7 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
 
     // Include custom address if valid
     if (customAddress && isAddress(customAddress) && !tokenMap.has(customAddress.toLowerCase())) {
-      const customToken = getToken({ address: toAddress(customAddress), chainID: selectedChainId })
+      const customToken = getToken({ address: toAddress(customAddress), chainID: activeChainId })
       if (customToken.symbol) {
         setIfMissing(customToken)
       }
@@ -295,16 +304,16 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
     }
 
     return [...tokenMap.values()]
-  }, [balances, selectedChainId, value, customAddress, getToken, priorityTokenAddresses, chainExtraTokens])
+  }, [balances, activeChainId, value, customAddress, getToken, priorityTokenAddresses, chainExtraTokens])
 
   const yearnKnownTokenAddresses = useMemo(
     () =>
       getYearnKnownTokenAddresses({
-        chainId: selectedChainId,
-        chainTokenList: tokenLists[selectedChainId],
+        chainId: activeChainId,
+        chainTokenList: tokenLists[activeChainId],
         allVaults
       }),
-    [allVaults, selectedChainId, tokenLists]
+    [activeChainId, allVaults, tokenLists]
   )
 
   const explicitTokenAddresses = useMemo(
@@ -314,17 +323,17 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
         priorityTokenAddresses: mode === 'deposit' ? [] : priorityTokenAddresses,
         chainExtraTokens,
         currentTokenAddresses:
-          mode === 'deposit' || selectedChainId !== chainId ? [] : [assetAddress, vaultAddress, stakingAddress],
+          mode === 'deposit' || activeChainId !== chainId ? [] : [assetAddress, vaultAddress, stakingAddress],
         customAddress
       }),
     [
+      activeChainId,
       assetAddress,
       chainExtraTokens,
       chainId,
       customAddress,
       mode,
       priorityTokenAddresses,
-      selectedChainId,
       stakingAddress,
       value,
       vaultAddress
@@ -338,11 +347,11 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
             chainExtraTokens,
             assetAddress,
             assetChainId,
-            selectedChainId,
+            selectedChainId: activeChainId,
             customAddress
           })
         : explicitTokenAddresses,
-    [assetAddress, assetChainId, chainExtraTokens, customAddress, explicitTokenAddresses, mode, selectedChainId, value]
+    [activeChainId, assetAddress, assetChainId, chainExtraTokens, customAddress, explicitTokenAddresses, mode, value]
   )
 
   const getTokenUsdValue = useCallback(
@@ -383,12 +392,12 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
 
   const handleSelect = useCallback(
     (address: `0x${string}`) => {
-      onChange(address, selectedChainId)
+      onChange(address, activeChainId)
       if (onClose) {
         onClose()
       }
     },
-    [onChange, onClose, selectedChainId]
+    [activeChainId, onChange, onClose]
   )
 
   const getTokenType = useCallback(
@@ -409,27 +418,31 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
     >
       {/* Header with chain selector and close button */}
       <div className="flex items-center justify-between p-4 border-b border-border">
-        <div className="flex items-center gap-1 rounded-lg bg-surface-secondary p-1 shadow-inner">
-          {AVAILABLE_CHAINS.map((chain) => (
-            <button
-              key={chain.id}
-              onClick={() => setSelectedChainId(chain.id)}
-              className={cl(
-                'size-9 flex items-center justify-center rounded-md transition-all',
-                selectedChainId === chain.id ? 'bg-surface shadow-sm' : 'bg-transparent hover:bg-surface/50'
-              )}
-              type="button"
-            >
-              <ImageWithFallback
-                src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/chains/${chain.id}/logo.svg`}
-                alt={chain.name}
-                width={20}
-                height={20}
-                className="rounded-full"
-              />
-            </button>
-          ))}
-        </div>
+        {shouldShowChainSelector ? (
+          <div className="flex items-center gap-1 rounded-lg bg-surface-secondary p-1 shadow-inner">
+            {availableChains.map((chain) => (
+              <button
+                key={chain.id}
+                onClick={() => setSelectedChainId(chain.id)}
+                className={cl(
+                  'size-9 flex items-center justify-center rounded-md transition-all',
+                  activeChainId === chain.id ? 'bg-surface shadow-sm' : 'bg-transparent hover:bg-surface/50'
+                )}
+                type="button"
+              >
+                <ImageWithFallback
+                  src={`${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/chains/${chain.id}/logo.svg`}
+                  alt={chain.name}
+                  width={20}
+                  height={20}
+                  className="rounded-full"
+                />
+              </button>
+            ))}
+          </div>
+        ) : (
+          <div />
+        )}
         <button onClick={onClose} className="p-1 hover:bg-surface-secondary rounded-lg transition-colors" type="button">
           <CloseIcon className="w-5 h-5 text-text-secondary" />
         </button>

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -23,6 +23,7 @@ import { useWidgetContext } from '../shared/useWidgetContext'
 import { formatWidgetAllowance, formatWidgetValue } from '../shared/valueDisplay'
 import { WidgetHeader } from '../shared/WidgetHeader'
 import { WidgetLoadingSkeleton } from '../shared/WidgetLoadingSkeleton'
+import { getAllowedTokenSelectorChainIds } from '../tokenSelectorChains'
 import { DEPOSIT_COMMON_TOKENS_BY_CHAIN } from '../withdraw/constants'
 import { AnnualReturnOverlay } from './AnnualReturnOverlay'
 import { ApprovalOverlay } from './ApprovalOverlay'
@@ -160,6 +161,7 @@ export function WidgetDeposit({
     ensoEnabled
   } = useWidgetContext({ chainId, vaultAddress })
   const { allVaults } = useYearn()
+  const tokenSelectorAllowedChainIds = useMemo(() => getAllowedTokenSelectorChainIds(chainId), [chainId])
 
   const [showVaultSharesModal, setShowVaultSharesModal] = useState(false)
   const [showVaultShareValueModal, setShowVaultShareValueModal] = useState(false)
@@ -253,8 +255,11 @@ export function WidgetDeposit({
     if (appliedPrefillRef.current === key) return
     appliedPrefillRef.current = key
 
+    const isSameChainPrefill = prefill.chainId === chainId
+    const isAllowedPrefillChain = tokenSelectorAllowedChainIds.includes(prefill.chainId)
     const canApplyPrefilledToken =
-      ensoEnabled || (toAddress(prefill.address) === toAddress(assetAddress) && prefill.chainId === chainId)
+      (ensoEnabled && isAllowedPrefillChain) ||
+      (toAddress(prefill.address) === toAddress(assetAddress) && isSameChainPrefill)
 
     setSelectedToken(canApplyPrefilledToken ? prefill.address : assetAddress)
     setSelectedChainId(canApplyPrefilledToken ? prefill.chainId : undefined)
@@ -262,10 +267,11 @@ export function WidgetDeposit({
       setDepositInput(prefill.amount)
     }
     onPrefillApplied?.()
-  }, [prefill, ensoEnabled, assetAddress, chainId, setDepositInput, onPrefillApplied])
+  }, [prefill, ensoEnabled, tokenSelectorAllowedChainIds, assetAddress, chainId, setDepositInput, onPrefillApplied])
 
   useResetEnsoSelection({
     ensoEnabled,
+    allowedChainIds: tokenSelectorAllowedChainIds,
     selectedToken,
     selectedChainId,
     assetAddress,
@@ -864,6 +870,7 @@ export function WidgetDeposit({
         onChange={handleTokenChange}
         mode={'deposit'}
         chainId={sourceChainId}
+        allowedChainIds={tokenSelectorAllowedChainIds}
         value={selectedToken}
         priorityTokens={{ [chainId]: [assetAddress] }}
         topTokens={tokenSelectorTopTokens}

--- a/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
@@ -80,6 +80,7 @@ export const useDepositFlow = ({
   // Determine routing type
   const routeType = useDepositRoute({
     chainId,
+    sourceChainId,
     depositToken,
     assetAddress,
     directDepositTokenAddress,

--- a/src/components/pages/vaults/components/widget/deposit/useDepositRoute.test.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositRoute.test.ts
@@ -10,6 +10,7 @@ const OTHER = '0x0000000000000000000000000000000000000004' as Address
 describe('resolveDepositRouteType', () => {
   it('returns DIRECT_DEPOSIT for asset-to-vault deposits', () => {
     const route = resolveDepositRouteType({
+      chainId: 1,
       depositToken: ASSET,
       assetAddress: ASSET,
       destinationToken: VAULT,
@@ -23,6 +24,7 @@ describe('resolveDepositRouteType', () => {
 
   it('returns DIRECT_STAKE for vault-to-staking deposits', () => {
     const route = resolveDepositRouteType({
+      chainId: 1,
       depositToken: VAULT,
       assetAddress: ASSET,
       destinationToken: STAKING,
@@ -36,6 +38,7 @@ describe('resolveDepositRouteType', () => {
 
   it('returns ENSO for non-direct routes when Enso is enabled', () => {
     const route = resolveDepositRouteType({
+      chainId: 1,
       depositToken: OTHER,
       assetAddress: ASSET,
       destinationToken: VAULT,
@@ -49,12 +52,43 @@ describe('resolveDepositRouteType', () => {
 
   it('returns NO_ROUTE for non-direct routes when Enso is disabled', () => {
     const route = resolveDepositRouteType({
+      chainId: 1,
       depositToken: OTHER,
       assetAddress: ASSET,
       destinationToken: VAULT,
       vaultAddress: VAULT,
       stakingAddress: STAKING,
       ensoEnabled: false
+    })
+
+    expect(route).toBe('NO_ROUTE')
+  })
+
+  it('returns NO_ROUTE for Katana cross-chain deposits even when Enso is enabled', () => {
+    const route = resolveDepositRouteType({
+      chainId: 747474,
+      sourceChainId: 1,
+      depositToken: OTHER,
+      assetAddress: ASSET,
+      destinationToken: VAULT,
+      vaultAddress: VAULT,
+      stakingAddress: STAKING,
+      ensoEnabled: true
+    })
+
+    expect(route).toBe('NO_ROUTE')
+  })
+
+  it('returns NO_ROUTE for deposits from Katana into a non-Katana vault even when Enso is enabled', () => {
+    const route = resolveDepositRouteType({
+      chainId: 1,
+      sourceChainId: 747474,
+      depositToken: OTHER,
+      assetAddress: ASSET,
+      destinationToken: VAULT,
+      vaultAddress: VAULT,
+      stakingAddress: STAKING,
+      ensoEnabled: true
     })
 
     expect(route).toBe('NO_ROUTE')

--- a/src/components/pages/vaults/components/widget/deposit/useDepositRoute.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositRoute.ts
@@ -1,3 +1,4 @@
+import { KATANA_CHAIN_ID } from '@pages/vaults/constants/addresses'
 import { useEnsoEnabled } from '@pages/vaults/hooks/useEnsoEnabled'
 import { useMemo } from 'react'
 import { type Address, isAddressEqual } from 'viem'
@@ -5,6 +6,7 @@ import type { DepositRouteType } from './types'
 
 interface UseDepositRouteProps {
   chainId: number
+  sourceChainId?: number
   depositToken: Address
   assetAddress: Address
   directDepositTokenAddress?: Address
@@ -13,11 +15,13 @@ interface UseDepositRouteProps {
   stakingAddress?: Address
 }
 
-interface ResolveDepositRouteTypeProps extends Omit<UseDepositRouteProps, 'chainId'> {
+interface ResolveDepositRouteTypeProps extends UseDepositRouteProps {
   ensoEnabled: boolean
 }
 
 export function resolveDepositRouteType({
+  chainId,
+  sourceChainId,
   depositToken,
   assetAddress,
   directDepositTokenAddress,
@@ -26,6 +30,14 @@ export function resolveDepositRouteType({
   stakingAddress,
   ensoEnabled
 }: ResolveDepositRouteTypeProps): DepositRouteType {
+  if (
+    sourceChainId !== undefined &&
+    sourceChainId !== chainId &&
+    (chainId === KATANA_CHAIN_ID || sourceChainId === KATANA_CHAIN_ID)
+  ) {
+    return 'NO_ROUTE'
+  }
+
   // Case 1: Direct vault deposit (asset → vault)
   if (
     (isAddressEqual(depositToken, assetAddress) ||
@@ -59,6 +71,7 @@ export function resolveDepositRouteType({
  */
 export function useDepositRoute({
   chainId,
+  sourceChainId,
   depositToken,
   assetAddress,
   directDepositTokenAddress,
@@ -71,6 +84,8 @@ export function useDepositRoute({
   return useMemo(
     () =>
       resolveDepositRouteType({
+        chainId,
+        sourceChainId,
         depositToken,
         assetAddress,
         directDepositTokenAddress,
@@ -79,6 +94,16 @@ export function useDepositRoute({
         stakingAddress,
         ensoEnabled
       }),
-    [ensoEnabled, depositToken, assetAddress, directDepositTokenAddress, destinationToken, vaultAddress, stakingAddress]
+    [
+      ensoEnabled,
+      chainId,
+      sourceChainId,
+      depositToken,
+      assetAddress,
+      directDepositTokenAddress,
+      destinationToken,
+      vaultAddress,
+      stakingAddress
+    ]
   )
 }

--- a/src/components/pages/vaults/components/widget/shared/TokenSelectorOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TokenSelectorOverlay.tsx
@@ -10,6 +10,7 @@ interface TokenSelectorOverlayProps {
   onClose: () => void
   onChange: (address: Address, chainId?: number) => void
   chainId: number
+  allowedChainIds?: number[]
   value?: Address
   excludeTokens?: Address[]
   priorityTokens?: Record<number, Address[]>
@@ -28,6 +29,7 @@ export const TokenSelectorOverlay: FC<TokenSelectorOverlayProps> = ({
   onClose,
   onChange,
   chainId,
+  allowedChainIds,
   value,
   excludeTokens,
   priorityTokens,
@@ -70,6 +72,7 @@ export const TokenSelectorOverlay: FC<TokenSelectorOverlayProps> = ({
           value={value}
           onChange={onChange}
           chainId={chainId}
+          allowedChainIds={allowedChainIds}
           excludeTokens={excludeTokens}
           priorityTokens={priorityTokens}
           topTokens={topTokens}

--- a/src/components/pages/vaults/components/widget/shared/useResetEnsoSelection.ts
+++ b/src/components/pages/vaults/components/widget/shared/useResetEnsoSelection.ts
@@ -3,6 +3,7 @@ import { type Address, isAddressEqual } from 'viem'
 
 interface UseResetEnsoSelectionParams {
   ensoEnabled: boolean
+  allowedChainIds?: number[]
   selectedToken?: Address
   selectedChainId?: number
   assetAddress: Address
@@ -15,6 +16,7 @@ interface UseResetEnsoSelectionParams {
 
 export function useResetEnsoSelection({
   ensoEnabled,
+  allowedChainIds,
   selectedToken,
   selectedChainId,
   assetAddress,
@@ -25,28 +27,34 @@ export function useResetEnsoSelection({
   setShowTokenSelector
 }: UseResetEnsoSelectionParams): void {
   useEffect(() => {
-    if (ensoEnabled) {
-      return
-    }
-
     const hasNonAssetTokenSelected = selectedToken !== undefined && !isAddressEqual(selectedToken, assetAddress)
     const hasCrossChainSelection = selectedChainId !== undefined && selectedChainId !== chainId
+    const hasDisallowedChainSelection =
+      selectedChainId !== undefined &&
+      !!allowedChainIds &&
+      allowedChainIds.length > 0 &&
+      !allowedChainIds.includes(selectedChainId)
+    const shouldResetForChainRestriction = hasCrossChainSelection && hasDisallowedChainSelection
+    const shouldResetToken = hasNonAssetTokenSelected && (!ensoEnabled || shouldResetForChainRestriction)
+    const shouldResetChain = hasCrossChainSelection && (!ensoEnabled || shouldResetForChainRestriction)
+    const shouldCloseSelector = showTokenSelector && (!ensoEnabled || shouldResetForChainRestriction)
 
-    if (!hasNonAssetTokenSelected && !hasCrossChainSelection && !showTokenSelector) {
+    if (!shouldResetToken && !shouldResetChain && !shouldCloseSelector) {
       return
     }
 
-    if (hasNonAssetTokenSelected) {
+    if (shouldResetToken) {
       setSelectedToken(assetAddress)
     }
-    if (hasCrossChainSelection) {
+    if (shouldResetChain) {
       setSelectedChainId(undefined)
     }
-    if (showTokenSelector) {
+    if (shouldCloseSelector) {
       setShowTokenSelector(false)
     }
   }, [
     ensoEnabled,
+    allowedChainIds,
     selectedToken,
     selectedChainId,
     assetAddress,

--- a/src/components/pages/vaults/components/widget/tokenSelectorChains.ts
+++ b/src/components/pages/vaults/components/widget/tokenSelectorChains.ts
@@ -1,0 +1,22 @@
+import { KATANA_CHAIN_ID } from '@pages/vaults/constants/addresses'
+
+export const TOKEN_SELECTOR_AVAILABLE_CHAINS = [
+  { id: 1, name: 'Ethereum' },
+  { id: 10, name: 'Optimism' },
+  { id: 137, name: 'Polygon' },
+  { id: 42161, name: 'Arbitrum' },
+  { id: 8453, name: 'Base' },
+  { id: KATANA_CHAIN_ID, name: 'Katana' }
+] as const
+
+const NON_KATANA_SELECTOR_CHAIN_IDS = TOKEN_SELECTOR_AVAILABLE_CHAINS.map((chain) => chain.id).filter(
+  (chainId) => chainId !== KATANA_CHAIN_ID
+)
+
+export function getAllowedTokenSelectorChainIds(vaultChainId: number): number[] {
+  if (vaultChainId === KATANA_CHAIN_ID) {
+    return [KATANA_CHAIN_ID]
+  }
+
+  return [...NON_KATANA_SELECTOR_CHAIN_IDS]
+}

--- a/src/components/pages/vaults/components/widget/withdraw/index.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/index.tsx
@@ -20,6 +20,7 @@ import { useWidgetContext } from '../shared/useWidgetContext'
 import { formatWidgetAllowance, formatWidgetValue } from '../shared/valueDisplay'
 import { WidgetHeader } from '../shared/WidgetHeader'
 import { WidgetLoadingSkeleton } from '../shared/WidgetLoadingSkeleton'
+import { getAllowedTokenSelectorChainIds } from '../tokenSelectorChains'
 import { getPriorityTokens } from './constants'
 import { SourceSelector } from './SourceSelector'
 import type { WithdrawalSource, WithdrawWidgetProps } from './types'
@@ -124,6 +125,7 @@ export function WidgetWithdraw({
 }: WidgetWithdrawProps): ReactElement {
   const { account, openLoginModal, refreshWalletBalances, getToken, zapSlippage, getPrice, trackEvent, ensoEnabled } =
     useWidgetContext({ chainId, vaultAddress })
+  const tokenSelectorAllowedChainIds = useMemo(() => getAllowedTokenSelectorChainIds(chainId), [chainId])
 
   const resolvedDisplayAssetAddress = displayAssetAddress ?? assetAddress
 
@@ -163,6 +165,7 @@ export function WidgetWithdraw({
 
   useResetEnsoSelection({
     ensoEnabled,
+    allowedChainIds: tokenSelectorAllowedChainIds,
     selectedToken,
     selectedChainId,
     assetAddress: resolvedDisplayAssetAddress,
@@ -178,13 +181,23 @@ export function WidgetWithdraw({
     const key = `${prefillRequestKey ?? ''}-${prefill.address}-${prefill.chainId}-${prefill.amount}`
     if (appliedPrefillRef.current === key) return
     appliedPrefillRef.current = key
-    setSelectedToken(prefill.address)
-    setSelectedChainId(prefill.chainId)
+    const isCrossChainPrefillBlocked =
+      prefill.chainId !== chainId && !tokenSelectorAllowedChainIds.includes(prefill.chainId)
+    setSelectedToken(isCrossChainPrefillBlocked ? resolvedDisplayAssetAddress : prefill.address)
+    setSelectedChainId(isCrossChainPrefillBlocked ? undefined : prefill.chainId)
     if (prefill.amount !== undefined) {
       setWithdrawInput(prefill.amount)
     }
     onPrefillApplied?.()
-  }, [prefill, prefillRequestKey, setWithdrawInput, onPrefillApplied])
+  }, [
+    prefill,
+    prefillRequestKey,
+    tokenSelectorAllowedChainIds,
+    chainId,
+    resolvedDisplayAssetAddress,
+    setWithdrawInput,
+    onPrefillApplied
+  ])
 
   // Derived token values
   const withdrawToken = selectedToken || resolvedDisplayAssetAddress
@@ -224,6 +237,7 @@ export function WidgetWithdraw({
 
   useResetEnsoSelection({
     ensoEnabled,
+    allowedChainIds: tokenSelectorAllowedChainIds,
     selectedToken,
     selectedChainId,
     assetAddress: resolvedDisplayAssetAddress,
@@ -990,6 +1004,7 @@ export function WidgetWithdraw({
           activeFlow.periphery.resetQuote?.()
         }}
         chainId={chainId}
+        allowedChainIds={tokenSelectorAllowedChainIds}
         value={selectedToken}
         excludeTokens={stakingAddress ? [stakingAddress] : undefined}
         mode={'withdraw'}


### PR DESCRIPTION
## Description

Because the native katana bridge does not allow execution of calldata, Enso cannot use it to zap to and from the chain. This means that the only routes are using layerzero (and soon other bridges) that have unknown liquidity depth. In order to protect users from bad execution, this PR removes the ability to use enso to bridge to or from Katana.

## Summary

  Disable crosschain Enso zaps involving Katana across the vault widget flow.

  This change blocks:
  - crosschain deposits into Katana vaults
  - crosschain withdrawals out of Katana vaults
  - crosschain zaps from Katana into vaults on other chains
  - Katana as a selectable zap source/destination on non-Katana vaults

  It also removes the chain selector from the zap dropdown when there is only one valid chain option left, which keeps the Katana vault UX cleaner.

  ## Changes

  - add a shared token-selector chain policy so Katana vaults only allow Katana and non-Katana vaults exclude Katana
  - restrict deposit and withdraw token selector options to the allowed chain set
  - sanitize prefills and stale widget state when a disallowed Katana crosschain selection is present
  - hard-block Katana-involved crosschain deposit routes in the deposit route resolver
  - reject Katana-involved crosschain Enso route requests in both API proxies
  - hide the chain selector in the zap dropdown when only one allowed chain remains
  - add focused tests for Katana route blocking and token selector behavior

## To Test

- Open the vaults page and select any katana chain. In the deposit or withdraw widgets, select the asset dropdown. The only options should be assets on Katana.
- Open a non-Katana vault and again click on the asset dropdown in the deposit or withdraw widget. Katana should no longer be an option to zap to or from. 