### PR TITLE
fix: show pending transaction function names in overlay

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "yearnfi",

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -18,6 +18,7 @@ import { isConnectedToExecutionChain } from '@/config/tenderly'
 import { AnimatedCheckmark, ErrorIcon, Spinner } from './TransactionStateIndicators'
 import {
   type CompletionDeferral,
+  getPendingTransactionTitle,
   type OverlayState,
   resolveCompletionDeferral,
   shouldAutoContinuePermitSuccess,
@@ -204,6 +205,9 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   // Check if current step is ready to execute
   const isStepReady = Boolean(step?.prepare.isSuccess && step?.prepare.data?.request)
   const executedStepLabel = executedStepRef.current?.label
+  const executedStepFunctionName = (
+    executedStepRef.current?.prepare.data?.request as { functionName?: unknown } | undefined
+  )?.functionName
   const executedStepAutoContinues = Boolean(
     executedStepLabel &&
       autoContinueToNextStep &&
@@ -844,7 +848,11 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
             <>
               <Spinner />
               <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">
-                {isPreparingNextStep ? 'Transaction confirmed' : 'Transaction pending'}
+                {getPendingTransactionTitle({
+                  isPreparingNextStep,
+                  functionName: executedStepFunctionName,
+                  fallbackLabel: executedStepLabel
+                })}
               </h3>
               <p className="text-sm text-text-secondary">
                 {isPreparingNextStep ? 'Preparing next step...' : 'Waiting for confirmation...'}

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatPendingTransactionFunctionName,
+  getPendingTransactionTitle,
+  resolveCompletionDeferral,
+  shouldAutoContinuePermitSuccess,
+  shouldRunDeferredCompletion
+} from './transactionOverlay.helpers'
+
+describe('transactionOverlay.helpers', () => {
+  it('formats pending transaction function names from onchain requests', () => {
+    expect(formatPendingTransactionFunctionName({ functionName: 'approve' })).toBe('Approve()')
+    expect(formatPendingTransactionFunctionName({ functionName: 'deposit' })).toBe('Deposit()')
+  })
+
+  it('falls back to the step label when the request function name is unavailable', () => {
+    expect(formatPendingTransactionFunctionName({ fallbackLabel: 'Withdraw' })).toBe('Withdraw()')
+  })
+
+  it('builds pending titles with the active function name', () => {
+    expect(
+      getPendingTransactionTitle({
+        isPreparingNextStep: false,
+        functionName: 'approve',
+        fallbackLabel: 'Approve'
+      })
+    ).toBe('Approve() transaction pending')
+
+    expect(
+      getPendingTransactionTitle({
+        isPreparingNextStep: false,
+        functionName: undefined,
+        fallbackLabel: 'Withdraw'
+      })
+    ).toBe('Withdraw() transaction pending')
+  })
+
+  it('keeps the confirmed copy while preparing a follow-up step', () => {
+    expect(
+      getPendingTransactionTitle({
+        isPreparingNextStep: true,
+        functionName: 'approve',
+        fallbackLabel: 'Approve'
+      })
+    ).toBe('Transaction confirmed')
+  })
+
+  it('determines whether permit success should auto-continue', () => {
+    expect(
+      shouldAutoContinuePermitSuccess({
+        overlayState: 'success',
+        executedStepIsPermit: true,
+        executedStepAutoContinues: true,
+        executedStepCompletesFlow: false,
+        currentStepLabel: 'Deposit',
+        executedStepLabel: 'Permit',
+        isStepReady: true,
+        hasAdvancedFromStep: null,
+        hasAutoContinuedFromStep: null
+      })
+    ).toBe(true)
+
+    expect(
+      shouldAutoContinuePermitSuccess({
+        overlayState: 'pending',
+        executedStepIsPermit: true,
+        executedStepAutoContinues: true,
+        executedStepCompletesFlow: false,
+        currentStepLabel: 'Deposit',
+        executedStepLabel: 'Permit',
+        isStepReady: true,
+        hasAdvancedFromStep: null,
+        hasAutoContinuedFromStep: null
+      })
+    ).toBe(false)
+  })
+
+  it('resolves completion deferrals and run conditions', () => {
+    expect(
+      resolveCompletionDeferral({
+        completedAllSteps: true,
+        deferOnAllCompleteUntilClose: false,
+        deferOnAllCompleteUntilConfettiEnd: true,
+        stepShowsConfetti: true
+      })
+    ).toBe('after-confetti')
+
+    expect(
+      shouldRunDeferredCompletion({
+        completionDeferral: 'after-confetti',
+        trigger: 'close'
+      })
+    ).toBe(true)
+
+    expect(
+      shouldRunDeferredCompletion({
+        completionDeferral: 'after-close',
+        trigger: 'confetti'
+      })
+    ).toBe(false)
+  })
+})

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,6 +1,51 @@
 export type OverlayState = 'idle' | 'confirming' | 'pending' | 'refreshing' | 'success' | 'error'
 export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
 
+function capitalizeWord(value: string): string {
+  if (!value) return value
+  return `${value[0]?.toUpperCase() || ''}${value.slice(1)}`
+}
+
+export function formatPendingTransactionFunctionName(params: {
+  functionName?: unknown
+  fallbackLabel?: string
+}): string | undefined {
+  const { functionName, fallbackLabel } = params
+
+  if (typeof functionName === 'string' && functionName.length > 0) {
+    return `${capitalizeWord(functionName)}()`
+  }
+
+  if (fallbackLabel) {
+    return `${fallbackLabel}()`
+  }
+
+  return undefined
+}
+
+export function getPendingTransactionTitle(params: {
+  isPreparingNextStep: boolean
+  functionName?: unknown
+  fallbackLabel?: string
+}): string {
+  const { isPreparingNextStep, functionName, fallbackLabel } = params
+
+  if (isPreparingNextStep) {
+    return 'Transaction confirmed'
+  }
+
+  const pendingFunctionName = formatPendingTransactionFunctionName({
+    functionName,
+    fallbackLabel
+  })
+
+  if (!pendingFunctionName) {
+    return 'Transaction pending'
+  }
+
+  return `${pendingFunctionName} transaction pending`
+}
+
 export function shouldAutoContinuePermitSuccess(params: {
   overlayState: OverlayState
   executedStepIsPermit?: boolean


### PR DESCRIPTION
## Summary
- show the pending transaction function name in the transaction overlay when available
- fall back to the step label when the request function name is missing
- add helper coverage for pending transaction title formatting

## To Test
- make a transaction using the widget and confirm that the function being called is shown in the overlay that shows while the transaction is in flight.

## Screenshots
<img width="423" height="476" alt="image" src="https://github.com/user-attachments/assets/586ca7cf-8bf1-4deb-a693-b100176f9b65" />
