### PR TITLE
fix: handle Safe app Katana approval and improve safe transaction overlays and flows

### DIFF
--- a/api/enso/route.ts
+++ b/api/enso/route.ts
@@ -7,7 +7,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const { fromAddress, chainId, tokenIn, tokenOut, amountIn, slippage, destinationChainId, receiver } = req.query
+  const { fromAddress, chainId, tokenIn, tokenOut, amountIn, slippage, routingStrategy, destinationChainId, receiver } =
+    req.query
 
   if (!fromAddress || typeof fromAddress !== 'string') {
     return res.status(400).json({ error: 'Missing or invalid fromAddress' })
@@ -46,6 +47,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
     if (receiver && typeof receiver === 'string') {
       params.set('receiver', receiver)
+    }
+    if (routingStrategy && typeof routingStrategy === 'string') {
+      params.set('routingStrategy', routingStrategy)
     }
 
     const url = `${ENSO_API_BASE}/api/v1/shortcuts/route?${params}`

--- a/api/server.ts
+++ b/api/server.ts
@@ -490,6 +490,7 @@ async function handleEnsoRoute(req: Request): Promise<Response> {
   const tokenOut = url.searchParams.get('tokenOut')
   const amountIn = url.searchParams.get('amountIn')
   const slippage = url.searchParams.get('slippage') || '100'
+  const routingStrategy = url.searchParams.get('routingStrategy')
   const destinationChainId = url.searchParams.get('destinationChainId')
   const receiver = url.searchParams.get('receiver')
 
@@ -517,6 +518,9 @@ async function handleEnsoRoute(req: Request): Promise<Response> {
   }
   if (receiver) {
     params.set('receiver', receiver)
+  }
+  if (routingStrategy) {
+    params.set('routingStrategy', routingStrategy)
   }
 
   const ensoUrl = `${ENSO_API_BASE}/api/v1/shortcuts/route?${params}`

--- a/src/components/pages/vaults/components/widget/WalletPanel.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/WalletPanel.helpers.test.ts
@@ -1,0 +1,27 @@
+import type { TNotification } from '@shared/types/notifications'
+import { describe, expect, it } from 'vitest'
+import { getAwaitingExecutionEntries } from './WalletPanel.helpers'
+
+const baseNotification: TNotification = {
+  id: 1,
+  type: 'deposit',
+  address: '0x0000000000000000000000000000000000000001',
+  chainId: 747474,
+  amount: '1 ETH',
+  fromAddress: '0x0000000000000000000000000000000000000002',
+  fromTokenName: 'ETH',
+  status: 'submitted'
+}
+
+describe('getAwaitingExecutionEntries', () => {
+  it('returns only notifications still awaiting Safe execution', () => {
+    expect(
+      getAwaitingExecutionEntries([
+        { ...baseNotification, id: 1, awaitingExecution: true },
+        { ...baseNotification, id: 2, awaitingExecution: false },
+        { ...baseNotification, id: 3, status: 'pending', awaitingExecution: true },
+        { ...baseNotification, id: 4, status: 'success', awaitingExecution: true }
+      ])
+    ).toEqual([{ ...baseNotification, id: 1, awaitingExecution: true }])
+  })
+})

--- a/src/components/pages/vaults/components/widget/WalletPanel.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/WalletPanel.helpers.test.ts
@@ -1,6 +1,6 @@
 import type { TNotification } from '@shared/types/notifications'
 import { describe, expect, it } from 'vitest'
-import { getAwaitingExecutionEntries } from './WalletPanel.helpers'
+import { getAwaitingExecutionEntries, getNewlyCompletedAwaitingExecutionEntries } from './WalletPanel.helpers'
 
 const baseNotification: TNotification = {
   id: 1,
@@ -23,5 +23,25 @@ describe('getAwaitingExecutionEntries', () => {
         { ...baseNotification, id: 4, status: 'success', awaitingExecution: true }
       ])
     ).toEqual([{ ...baseNotification, id: 1, awaitingExecution: true }])
+  })
+})
+
+describe('getNewlyCompletedAwaitingExecutionEntries', () => {
+  it('returns entries that moved from awaiting Safe execution to success', () => {
+    const previousEntries: TNotification[] = [
+      { ...baseNotification, id: 1, awaitingExecution: true },
+      { ...baseNotification, id: 2, awaitingExecution: true },
+      { ...baseNotification, id: 3, status: 'pending', awaitingExecution: false }
+    ]
+
+    const nextEntries: TNotification[] = [
+      { ...baseNotification, id: 1, status: 'success', awaitingExecution: false },
+      { ...baseNotification, id: 2, awaitingExecution: true },
+      { ...baseNotification, id: 3, status: 'success', awaitingExecution: false }
+    ]
+
+    expect(getNewlyCompletedAwaitingExecutionEntries(previousEntries, nextEntries)).toEqual([
+      { ...baseNotification, id: 1, status: 'success', awaitingExecution: false }
+    ])
   })
 })

--- a/src/components/pages/vaults/components/widget/WalletPanel.helpers.ts
+++ b/src/components/pages/vaults/components/widget/WalletPanel.helpers.ts
@@ -1,0 +1,5 @@
+import type { TNotification } from '@shared/types/notifications'
+
+export function getAwaitingExecutionEntries(entries: TNotification[]): TNotification[] {
+  return entries.filter((entry) => entry.status === 'submitted' && entry.awaitingExecution)
+}

--- a/src/components/pages/vaults/components/widget/WalletPanel.helpers.ts
+++ b/src/components/pages/vaults/components/widget/WalletPanel.helpers.ts
@@ -1,5 +1,42 @@
 import type { TNotification } from '@shared/types/notifications'
 
+function getNotificationTransitionKey(entry: TNotification): string | undefined {
+  if (entry.id !== undefined) {
+    return String(entry.id)
+  }
+
+  if (entry.txHash) {
+    return `${entry.type}-${entry.txHash}`
+  }
+
+  return undefined
+}
+
 export function getAwaitingExecutionEntries(entries: TNotification[]): TNotification[] {
   return entries.filter((entry) => entry.status === 'submitted' && entry.awaitingExecution)
+}
+
+export function getNewlyCompletedAwaitingExecutionEntries(
+  previousEntries: TNotification[],
+  nextEntries: TNotification[]
+): TNotification[] {
+  const previousEntriesByKey = new Map(
+    previousEntries
+      .map((entry) => [getNotificationTransitionKey(entry), entry] as const)
+      .filter((entry): entry is readonly [string, TNotification] => Boolean(entry[0]))
+  )
+
+  return nextEntries.filter((entry) => {
+    const key = getNotificationTransitionKey(entry)
+    if (!key) {
+      return false
+    }
+
+    const previousEntry = previousEntriesByKey.get(key)
+    if (!previousEntry) {
+      return false
+    }
+
+    return previousEntry.status === 'submitted' && previousEntry.awaitingExecution && entry.status === 'success'
+  })
 }

--- a/src/components/pages/vaults/components/widget/WalletPanel.tsx
+++ b/src/components/pages/vaults/components/widget/WalletPanel.tsx
@@ -1,7 +1,6 @@
 import {
   getVaultDecimals,
   getVaultSymbol,
-  getVaultToken,
   getVaultTVL,
   type TKongVaultInput
 } from '@pages/vaults/domain/kongVaultSelectors'
@@ -15,7 +14,6 @@ import {
   YVUSD_UNLOCKED_ADDRESS
 } from '@pages/vaults/utils/yvUsd'
 import { useNotifications } from '@shared/contexts/useNotifications'
-import { useWallet } from '@shared/contexts/useWallet'
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { useYearn } from '@shared/contexts/useYearn'
 import { yvUsdLockedVaultAbi } from '@shared/contracts/abi/yvUsdLockedVault.abi'
@@ -37,10 +35,9 @@ import {
   truncateHex
 } from '@shared/utils'
 import { getNetwork } from '@shared/utils/wagmi/utils'
-import { useQueryClient } from '@tanstack/react-query'
-import { type FC, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type FC, type ReactElement, useCallback, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
-import { getAwaitingExecutionEntries, getNewlyCompletedAwaitingExecutionEntries } from './WalletPanel.helpers'
+import { getAwaitingExecutionEntries } from './WalletPanel.helpers'
 import { formatDuration, parseCooldownStatus, resolveCooldownWindowState } from './yvUSD/cooldownUtils'
 
 type WalletPanelProps = {
@@ -238,9 +235,7 @@ export const WalletPanel: FC<WalletPanelProps> = ({
   vaultUserData
 }) => {
   const { address, isActive: isWalletActive, openLoginModal } = useWeb3()
-  const { onRefresh: refreshWalletBalances } = useWallet()
   const { cachedEntries } = useNotifications()
-  const queryClient = useQueryClient()
   const navigate = useNavigate()
   const { getPrice } = useYearn()
   const [activeTab, setActiveTab] = useState<WalletTabKey>('balances')
@@ -252,8 +247,7 @@ export const WalletPanel: FC<WalletPanelProps> = ({
     depositedShares,
     pricePerShare,
     stakingWithdrawableAssets,
-    isLoading,
-    refetch: refetchVaultUserData
+    isLoading
   } = vaultUserData
   const isYvUsd = isYvUsdVault(currentVault)
   const vaultDecimals = getVaultDecimals(currentVault)
@@ -361,39 +355,6 @@ export const WalletPanel: FC<WalletPanelProps> = ({
     () => relatedEntries.filter((entry) => entry.status === 'pending' || entry.awaitingExecution),
     [relatedEntries]
   )
-  const previousRelatedEntriesRef = useRef<TNotification[]>(relatedEntries)
-  const walletRefreshTokens = useMemo(() => {
-    const tokens = [
-      { address: toAddress(assetToken?.address ?? getVaultToken(currentVault).address), chainID: chainId },
-      { address: vaultAddress, chainID: chainId }
-    ]
-
-    if (stakingAddress) {
-      tokens.push({ address: stakingAddress, chainID: chainId })
-    }
-
-    return tokens
-  }, [assetToken?.address, chainId, currentVault, stakingAddress, vaultAddress])
-
-  useEffect(() => {
-    const newlyCompletedEntries = getNewlyCompletedAwaitingExecutionEntries(
-      previousRelatedEntriesRef.current,
-      relatedEntries
-    )
-    previousRelatedEntriesRef.current = relatedEntries
-
-    if (!address || newlyCompletedEntries.length === 0) {
-      return
-    }
-
-    void (async () => {
-      await queryClient.invalidateQueries()
-      refetchVaultUserData()
-      await refreshWalletBalances(walletRefreshTokens).catch((error) => {
-        console.error('Failed to refresh wallet balances after Safe execution:', error)
-      })
-    })()
-  }, [address, queryClient, refetchVaultUserData, refreshWalletBalances, relatedEntries, walletRefreshTokens])
 
   return (
     <div

--- a/src/components/pages/vaults/components/widget/WalletPanel.tsx
+++ b/src/components/pages/vaults/components/widget/WalletPanel.tsx
@@ -19,6 +19,7 @@ import { useYearn } from '@shared/contexts/useYearn'
 import { yvUsdLockedVaultAbi } from '@shared/contracts/abi/yvUsdLockedVault.abi'
 import { useReadContract } from '@shared/hooks/useAppWagmi'
 import { useChainTimestamp } from '@shared/hooks/useChainTimestamp'
+import { useTransactionStatusPoller } from '@shared/hooks/useTransactionStatusPoller'
 import { IconCheck } from '@shared/icons/IconCheck'
 import { IconCross } from '@shared/icons/IconCross'
 import { IconLoader } from '@shared/icons/IconLoader'
@@ -36,6 +37,7 @@ import {
 import { getNetwork } from '@shared/utils/wagmi/utils'
 import { type FC, type ReactElement, useCallback, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
+import { getAwaitingExecutionEntries } from './WalletPanel.helpers'
 import { formatDuration, parseCooldownStatus, resolveCooldownWindowState } from './yvUSD/cooldownUtils'
 
 type WalletPanelProps = {
@@ -63,6 +65,21 @@ const STATUS_STYLES: Record<TNotificationStatus, { label: string; className: str
     icon: <IconLoader className="size-3 animate-spin" />
   },
   error: { label: 'Error', className: 'bg-[#C73203] text-white', icon: <IconCross className="size-3" /> }
+}
+
+function WalletNotificationPoller({ entry }: { entry: TNotification }): null {
+  useTransactionStatusPoller(entry)
+  return null
+}
+
+function WalletNotificationPollers({ entries }: { entries: TNotification[] }): ReactElement {
+  return (
+    <>
+      {entries.map((entry) => (
+        <WalletNotificationPoller key={entry.id ?? `${entry.type}-${entry.txHash}`} entry={entry} />
+      ))}
+    </>
+  )
 }
 
 function YvUsdVaultBalances({ account }: { account?: `0x${string}` }): ReactElement {
@@ -318,7 +335,7 @@ export const WalletPanel: FC<WalletPanelProps> = ({
     return addresses.map((addr) => toAddress(addr).toLowerCase())
   }, [isYvUsd, vaultAddress, stakingAddress])
 
-  const recentEntries = useMemo(() => {
+  const relatedEntries = useMemo(() => {
     const filtered = (
       address ? cachedEntries.filter((entry) => entry.address.toLowerCase() === address.toLowerCase()) : cachedEntries
     ).filter((entry) => {
@@ -329,8 +346,15 @@ export const WalletPanel: FC<WalletPanelProps> = ({
       return hasRelatedAddress && chainMatches
     })
 
-    return filtered.toReversed().slice(0, 3)
+    return filtered.toReversed()
   }, [address, cachedEntries, relatedAddresses, chainId])
+
+  const recentEntries = useMemo(() => relatedEntries.slice(0, 3), [relatedEntries])
+  const awaitingExecutionEntries = useMemo(() => getAwaitingExecutionEntries(relatedEntries), [relatedEntries])
+  const polledEntries = useMemo(
+    () => relatedEntries.filter((entry) => entry.status === 'pending' || entry.awaitingExecution),
+    [relatedEntries]
+  )
 
   return (
     <div
@@ -341,6 +365,7 @@ export const WalletPanel: FC<WalletPanelProps> = ({
       aria-hidden={!isPanelActive}
       data-tour="vault-detail-wallet-panel"
     >
+      <WalletNotificationPollers entries={polledEntries} />
       <div className="bg-surface border border-border rounded-lg flex flex-col flex-1 min-h-0">
         <div className="flex items-center justify-between gap-3 px-6 py-3">
           <h3 className="text-base font-semibold text-text-primary">Wallet</h3>
@@ -364,6 +389,22 @@ export const WalletPanel: FC<WalletPanelProps> = ({
             </div>
           </div>
         </div>
+        {awaitingExecutionEntries.length > 0 ? (
+          <div className="px-6 pb-1">
+            <button
+              type="button"
+              onClick={() => setActiveTab('transactions')}
+              className="flex items-center gap-2 rounded-md border border-[#2563EB]/20 bg-[#2563EB]/8 px-3 py-2 text-left text-xs text-text-primary transition-colors hover:bg-[#2563EB]/12"
+            >
+              <IconLoader className="size-3 animate-spin text-[#2563EB]" />
+              <span>
+                {awaitingExecutionEntries.length === 1
+                  ? '1 transaction is awaiting Safe execution.'
+                  : `${awaitingExecutionEntries.length} transactions are awaiting Safe execution.`}
+              </span>
+            </button>
+          </div>
+        ) : null}
         <div className="flex-1 overflow-y-auto overscroll-contain min-h-0 max-h-full p-6 pt-3" data-scroll-priority>
           <div className="space-y-6">
             {!isWalletActive || !address ? (

--- a/src/components/pages/vaults/components/widget/WalletPanel.tsx
+++ b/src/components/pages/vaults/components/widget/WalletPanel.tsx
@@ -1,6 +1,7 @@
 import {
   getVaultDecimals,
   getVaultSymbol,
+  getVaultToken,
   getVaultTVL,
   type TKongVaultInput
 } from '@pages/vaults/domain/kongVaultSelectors'
@@ -14,6 +15,7 @@ import {
   YVUSD_UNLOCKED_ADDRESS
 } from '@pages/vaults/utils/yvUsd'
 import { useNotifications } from '@shared/contexts/useNotifications'
+import { useWallet } from '@shared/contexts/useWallet'
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { useYearn } from '@shared/contexts/useYearn'
 import { yvUsdLockedVaultAbi } from '@shared/contracts/abi/yvUsdLockedVault.abi'
@@ -35,9 +37,10 @@ import {
   truncateHex
 } from '@shared/utils'
 import { getNetwork } from '@shared/utils/wagmi/utils'
-import { type FC, type ReactElement, useCallback, useMemo, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { type FC, type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
-import { getAwaitingExecutionEntries } from './WalletPanel.helpers'
+import { getAwaitingExecutionEntries, getNewlyCompletedAwaitingExecutionEntries } from './WalletPanel.helpers'
 import { formatDuration, parseCooldownStatus, resolveCooldownWindowState } from './yvUSD/cooldownUtils'
 
 type WalletPanelProps = {
@@ -235,7 +238,9 @@ export const WalletPanel: FC<WalletPanelProps> = ({
   vaultUserData
 }) => {
   const { address, isActive: isWalletActive, openLoginModal } = useWeb3()
+  const { onRefresh: refreshWalletBalances } = useWallet()
   const { cachedEntries } = useNotifications()
+  const queryClient = useQueryClient()
   const navigate = useNavigate()
   const { getPrice } = useYearn()
   const [activeTab, setActiveTab] = useState<WalletTabKey>('balances')
@@ -247,7 +252,8 @@ export const WalletPanel: FC<WalletPanelProps> = ({
     depositedShares,
     pricePerShare,
     stakingWithdrawableAssets,
-    isLoading
+    isLoading,
+    refetch: refetchVaultUserData
   } = vaultUserData
   const isYvUsd = isYvUsdVault(currentVault)
   const vaultDecimals = getVaultDecimals(currentVault)
@@ -355,6 +361,39 @@ export const WalletPanel: FC<WalletPanelProps> = ({
     () => relatedEntries.filter((entry) => entry.status === 'pending' || entry.awaitingExecution),
     [relatedEntries]
   )
+  const previousRelatedEntriesRef = useRef<TNotification[]>(relatedEntries)
+  const walletRefreshTokens = useMemo(() => {
+    const tokens = [
+      { address: toAddress(assetToken?.address ?? getVaultToken(currentVault).address), chainID: chainId },
+      { address: vaultAddress, chainID: chainId }
+    ]
+
+    if (stakingAddress) {
+      tokens.push({ address: stakingAddress, chainID: chainId })
+    }
+
+    return tokens
+  }, [assetToken?.address, chainId, currentVault, stakingAddress, vaultAddress])
+
+  useEffect(() => {
+    const newlyCompletedEntries = getNewlyCompletedAwaitingExecutionEntries(
+      previousRelatedEntriesRef.current,
+      relatedEntries
+    )
+    previousRelatedEntriesRef.current = relatedEntries
+
+    if (!address || newlyCompletedEntries.length === 0) {
+      return
+    }
+
+    void (async () => {
+      await queryClient.invalidateQueries()
+      refetchVaultUserData()
+      await refreshWalletBalances(walletRefreshTokens).catch((error) => {
+        console.error('Failed to refresh wallet balances after Safe execution:', error)
+      })
+    })()
+  }, [address, queryClient, refetchVaultUserData, refreshWalletBalances, relatedEntries, walletRefreshTokens])
 
   return (
     <div

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.helpers.ts
@@ -4,3 +4,19 @@ export function resolveApprovalOverlayConnectedChainId(params: {
 }): number {
   return params.accountChainId ?? params.currentChainId
 }
+
+export function resolveApprovalOverlayPendingSafeState(params: {
+  txState: 'idle' | 'confirming' | 'pending' | 'submitted' | 'success' | 'error'
+  isWalletSafe: boolean
+  hasReceiptTransactionHash: boolean
+  callsStatus?: 'pending' | 'success' | 'failure'
+}): 'idle' | 'confirming' | 'pending' | 'submitted' | 'success' | 'error' {
+  const { txState, isWalletSafe, hasReceiptTransactionHash, callsStatus } = params
+
+  if (txState !== 'pending') return txState
+  if (!isWalletSafe) return txState
+  if (hasReceiptTransactionHash) return txState
+  if (callsStatus === 'pending') return 'submitted'
+
+  return txState
+}

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.helpers.ts
@@ -1,8 +1,18 @@
 export function resolveApprovalOverlayConnectedChainId(params: {
   accountChainId: number | undefined
   currentChainId: number
+  targetChainId: number
+  isWalletSafe: boolean
 }): number {
-  return params.accountChainId ?? params.currentChainId
+  if (params.accountChainId) {
+    return params.accountChainId
+  }
+
+  if (params.isWalletSafe) {
+    return params.targetChainId
+  }
+
+  return params.currentChainId
 }
 
 export function resolveApprovalOverlayPendingSafeState(params: {

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.helpers.ts
@@ -1,0 +1,6 @@
+export function resolveApprovalOverlayConnectedChainId(params: {
+  accountChainId: number | undefined
+  currentChainId: number
+}): number {
+  return params.accountChainId ?? params.currentChainId
+}

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.helpers.ts
@@ -23,9 +23,10 @@ export function resolveApprovalOverlayPendingSafeState(params: {
 }): 'idle' | 'confirming' | 'pending' | 'submitted' | 'success' | 'error' {
   const { txState, isWalletSafe, hasReceiptTransactionHash, callsStatus } = params
 
-  if (txState !== 'pending') return txState
+  if (txState !== 'pending' && txState !== 'submitted') return txState
   if (!isWalletSafe) return txState
   if (hasReceiptTransactionHash) return txState
+  if (callsStatus === 'failure') return 'error'
   if (callsStatus === 'pending') return 'submitted'
 
   return txState

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.helpers.ts
@@ -1,3 +1,5 @@
+import type { SafeTransactionStatus } from '../shared/transactionOverlay.helpers'
+
 export function resolveApprovalOverlayConnectedChainId(params: {
   accountChainId: number | undefined
   currentChainId: number
@@ -18,14 +20,19 @@ export function resolveApprovalOverlayConnectedChainId(params: {
 export function resolveApprovalOverlayPendingSafeState(params: {
   txState: 'idle' | 'confirming' | 'pending' | 'submitted' | 'success' | 'error'
   isWalletSafe: boolean
-  hasReceiptTransactionHash: boolean
+  hasExecutionReceipt: boolean
+  safeTxStatus?: SafeTransactionStatus
   callsStatus?: 'pending' | 'success' | 'failure'
 }): 'idle' | 'confirming' | 'pending' | 'submitted' | 'success' | 'error' {
-  const { txState, isWalletSafe, hasReceiptTransactionHash, callsStatus } = params
+  const { txState, isWalletSafe, hasExecutionReceipt, safeTxStatus, callsStatus } = params
 
   if (txState !== 'pending' && txState !== 'submitted') return txState
   if (!isWalletSafe) return txState
-  if (hasReceiptTransactionHash) return txState
+  if (hasExecutionReceipt) return txState
+
+  if (safeTxStatus === 'FAILED' || safeTxStatus === 'CANCELLED') return 'error'
+  if (safeTxStatus === 'AWAITING_CONFIRMATIONS' || safeTxStatus === 'AWAITING_EXECUTION') return 'submitted'
+
   if (callsStatus === 'failure') return 'error'
   if (callsStatus === 'pending') return 'submitted'
 

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx
@@ -61,4 +61,15 @@ describe('resolveApprovalOverlayPendingSafeState', () => {
       })
     ).toBe('pending')
   })
+
+  it('lets submitted Safe approval overlays surface failures too', () => {
+    expect(
+      resolveApprovalOverlayPendingSafeState({
+        txState: 'submitted',
+        isWalletSafe: true,
+        hasReceiptTransactionHash: false,
+        callsStatus: 'failure'
+      })
+    ).toBe('error')
+  })
 })

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx
@@ -40,12 +40,37 @@ describe('resolveApprovalOverlayConnectedChainId', () => {
 })
 
 describe('resolveApprovalOverlayPendingSafeState', () => {
+  it('turns a Safe approval overlay into a dismissible submitted state when the Safe tx is awaiting confirmations', () => {
+    expect(
+      resolveApprovalOverlayPendingSafeState({
+        txState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'AWAITING_CONFIRMATIONS',
+        callsStatus: undefined
+      })
+    ).toBe('submitted')
+  })
+
   it('turns a Safe approval overlay into a dismissible submitted state when the Safe tx is queued', () => {
     expect(
       resolveApprovalOverlayPendingSafeState({
         txState: 'pending',
         isWalletSafe: true,
-        hasReceiptTransactionHash: false,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'AWAITING_EXECUTION',
+        callsStatus: undefined
+      })
+    ).toBe('submitted')
+  })
+
+  it('falls back to wallet_getCallsStatus when Safe details are not available yet', () => {
+    expect(
+      resolveApprovalOverlayPendingSafeState({
+        txState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: undefined,
         callsStatus: 'pending'
       })
     ).toBe('submitted')
@@ -56,10 +81,23 @@ describe('resolveApprovalOverlayPendingSafeState', () => {
       resolveApprovalOverlayPendingSafeState({
         txState: 'pending',
         isWalletSafe: false,
-        hasReceiptTransactionHash: false,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'AWAITING_EXECUTION',
         callsStatus: 'pending'
       })
     ).toBe('pending')
+  })
+
+  it('surfaces failed Safe approval transactions as errors', () => {
+    expect(
+      resolveApprovalOverlayPendingSafeState({
+        txState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'FAILED',
+        callsStatus: undefined
+      })
+    ).toBe('error')
   })
 
   it('lets submitted Safe approval overlays surface failures too', () => {
@@ -67,7 +105,8 @@ describe('resolveApprovalOverlayPendingSafeState', () => {
       resolveApprovalOverlayPendingSafeState({
         txState: 'submitted',
         isWalletSafe: true,
-        hasReceiptTransactionHash: false,
+        hasExecutionReceipt: false,
+        safeTxStatus: undefined,
         callsStatus: 'failure'
       })
     ).toBe('error')

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx
@@ -5,11 +5,24 @@ import {
 } from './ApprovalOverlay.helpers'
 
 describe('resolveApprovalOverlayConnectedChainId', () => {
-  it('falls back to the live wagmi chain id when useAccount().chain is missing for Safe/custom-chain sessions', () => {
+  it('falls back to the live wagmi chain id when useAccount().chain is missing for normal wallets', () => {
     expect(
       resolveApprovalOverlayConnectedChainId({
         accountChainId: undefined,
-        currentChainId: 747474
+        currentChainId: 747474,
+        targetChainId: 1,
+        isWalletSafe: false
+      })
+    ).toBe(747474)
+  })
+
+  it('prefers the target chain for Safe sessions when useAccount().chain is missing', () => {
+    expect(
+      resolveApprovalOverlayConnectedChainId({
+        accountChainId: undefined,
+        currentChainId: 1,
+        targetChainId: 747474,
+        isWalletSafe: true
       })
     ).toBe(747474)
   })
@@ -18,7 +31,9 @@ describe('resolveApprovalOverlayConnectedChainId', () => {
     expect(
       resolveApprovalOverlayConnectedChainId({
         accountChainId: 1,
-        currentChainId: 747474
+        currentChainId: 747474,
+        targetChainId: 747474,
+        isWalletSafe: true
       })
     ).toBe(1)
   })

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolveApprovalOverlayConnectedChainId } from './ApprovalOverlay.helpers'
+import {
+  resolveApprovalOverlayConnectedChainId,
+  resolveApprovalOverlayPendingSafeState
+} from './ApprovalOverlay.helpers'
 
 describe('resolveApprovalOverlayConnectedChainId', () => {
   it('falls back to the live wagmi chain id when useAccount().chain is missing for Safe/custom-chain sessions', () => {
@@ -18,5 +21,29 @@ describe('resolveApprovalOverlayConnectedChainId', () => {
         currentChainId: 747474
       })
     ).toBe(1)
+  })
+})
+
+describe('resolveApprovalOverlayPendingSafeState', () => {
+  it('turns a Safe approval overlay into a dismissible submitted state when the Safe tx is queued', () => {
+    expect(
+      resolveApprovalOverlayPendingSafeState({
+        txState: 'pending',
+        isWalletSafe: true,
+        hasReceiptTransactionHash: false,
+        callsStatus: 'pending'
+      })
+    ).toBe('submitted')
+  })
+
+  it('keeps normal wallet approval overlays pending until a receipt arrives', () => {
+    expect(
+      resolveApprovalOverlayPendingSafeState({
+        txState: 'pending',
+        isWalletSafe: false,
+        hasReceiptTransactionHash: false,
+        callsStatus: 'pending'
+      })
+    ).toBe('pending')
   })
 })

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { resolveApprovalOverlayConnectedChainId } from './ApprovalOverlay.helpers'
+
+describe('resolveApprovalOverlayConnectedChainId', () => {
+  it('falls back to the live wagmi chain id when useAccount().chain is missing for Safe/custom-chain sessions', () => {
+    expect(
+      resolveApprovalOverlayConnectedChainId({
+        accountChainId: undefined,
+        currentChainId: 747474
+      })
+    ).toBe(747474)
+  })
+
+  it('prefers the account chain id when it is available', () => {
+    expect(
+      resolveApprovalOverlayConnectedChainId({
+        accountChainId: 1,
+        currentChainId: 747474
+      })
+    ).toBe(1)
+  })
+})

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@shared/components/Button'
 import { useChainId, useSwitchChain, useWaitForTransactionReceipt } from '@shared/hooks/useAppWagmi'
+import { useSafeTransactionDetails } from '@shared/hooks/useSafeTransactionDetails'
 import { getApproveAbi } from '@shared/utils/approve'
 import { type FC, useCallback, useEffect, useState } from 'react'
 import { maxUint256 } from 'viem'
@@ -7,6 +8,7 @@ import { useAccount, useCallsStatus, useWriteContract } from 'wagmi'
 import { isConnectedToExecutionChain, resolveExecutionChainId } from '@/config/tenderly'
 import { InfoOverlay } from '../shared/InfoOverlay'
 import { AnimatedCheckmark, ErrorIcon, Spinner } from '../shared/TransactionStateIndicators'
+import { resolveExecutionTrackingHash } from '../shared/transactionOverlay.helpers'
 import {
   resolveApprovalOverlayConnectedChainId,
   resolveApprovalOverlayPendingSafeState
@@ -50,16 +52,29 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   })
   const { switchChainAsync } = useSwitchChain()
   const { writeContractAsync, data: txHash, reset } = useWriteContract()
-  const receipt = useWaitForTransactionReceipt({ hash: txHash, chainId })
+  const safeTransactionDetails = useSafeTransactionDetails({
+    safeTxHash: isWalletSafe ? txHash : undefined,
+    enabled: Boolean(isWalletSafe && txHash && (txState === 'pending' || txState === 'submitted'))
+  })
   const safeCallsStatus = useCallsStatus({
     id: txHash || '0x',
     query: {
       enabled: Boolean(
-        isWalletSafe && txHash && (txState === 'pending' || txState === 'submitted') && !receipt.data?.transactionHash
+        isWalletSafe &&
+          txHash &&
+          (txState === 'pending' || txState === 'submitted') &&
+          !safeTransactionDetails.data?.executionTxHash
       ),
       refetchInterval: 1500
     }
   })
+  const executionTrackingHash = resolveExecutionTrackingHash({
+    isWalletSafe,
+    submittedTxHash: txHash,
+    safeExecutionTxHash: safeTransactionDetails.data?.executionTxHash,
+    callsReceiptTxHash: safeCallsStatus.data?.receipts?.[0]?.transactionHash
+  })
+  const receipt = useWaitForTransactionReceipt({ hash: executionTrackingHash, chainId })
 
   // Reset state when overlay closes
   useEffect(() => {
@@ -82,14 +97,29 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
     const nextTxState = resolveApprovalOverlayPendingSafeState({
       txState,
       isWalletSafe,
-      hasReceiptTransactionHash: Boolean(receipt.data?.transactionHash),
+      hasExecutionReceipt: Boolean(receipt.data?.transactionHash),
+      safeTxStatus: safeTransactionDetails.data?.txStatus,
       callsStatus: safeCallsStatus.data?.status
     })
 
     if (nextTxState === 'submitted') {
       setTxState('submitted')
+      return
     }
-  }, [txState, isWalletSafe, receipt.data?.transactionHash, safeCallsStatus.data?.status])
+
+    if (nextTxState === 'error') {
+      setTxState('error')
+      setErrorMessage('Transaction failed in Safe. Please review your Safe queue and try again.')
+      reset()
+    }
+  }, [
+    txState,
+    isWalletSafe,
+    receipt.data?.transactionHash,
+    safeTransactionDetails.data?.txStatus,
+    safeCallsStatus.data?.status,
+    reset
+  ])
 
   // Handle transaction error
   useEffect(() => {

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -3,13 +3,16 @@ import { useChainId, useSwitchChain, useWaitForTransactionReceipt } from '@share
 import { getApproveAbi } from '@shared/utils/approve'
 import { type FC, useCallback, useEffect, useState } from 'react'
 import { maxUint256 } from 'viem'
-import { useAccount, useWriteContract } from 'wagmi'
+import { useAccount, useCallsStatus, useWriteContract } from 'wagmi'
 import { isConnectedToExecutionChain, resolveExecutionChainId } from '@/config/tenderly'
 import { InfoOverlay } from '../shared/InfoOverlay'
 import { AnimatedCheckmark, ErrorIcon, Spinner } from '../shared/TransactionStateIndicators'
-import { resolveApprovalOverlayConnectedChainId } from './ApprovalOverlay.helpers'
+import {
+  resolveApprovalOverlayConnectedChainId,
+  resolveApprovalOverlayPendingSafeState
+} from './ApprovalOverlay.helpers'
 
-type TxState = 'idle' | 'confirming' | 'pending' | 'success' | 'error'
+type TxState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'success' | 'error'
 
 interface ApprovalOverlayProps {
   isOpen: boolean
@@ -36,12 +39,20 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   const [txState, setTxState] = useState<TxState>('idle')
   const [errorMessage, setErrorMessage] = useState('')
 
-  const { address: account, chain } = useAccount()
+  const { address: account, chain, connector } = useAccount()
   const currentChainId = useChainId()
   const connectedChainId = resolveApprovalOverlayConnectedChainId({ accountChainId: chain?.id, currentChainId })
+  const isWalletSafe = connector?.id.toLowerCase().includes('safe') ?? false
   const { switchChainAsync } = useSwitchChain()
   const { writeContractAsync, data: txHash, reset } = useWriteContract()
   const receipt = useWaitForTransactionReceipt({ hash: txHash, chainId })
+  const safeCallsStatus = useCallsStatus({
+    id: txHash || '0x',
+    query: {
+      enabled: Boolean(isWalletSafe && txHash && txState === 'pending' && !receipt.data?.transactionHash),
+      refetchInterval: 1500
+    }
+  })
 
   // Reset state when overlay closes
   useEffect(() => {
@@ -59,6 +70,19 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
       reset()
     }
   }, [receipt.isSuccess, txState, reset])
+
+  useEffect(() => {
+    const nextTxState = resolveApprovalOverlayPendingSafeState({
+      txState,
+      isWalletSafe,
+      hasReceiptTransactionHash: Boolean(receipt.data?.transactionHash),
+      callsStatus: safeCallsStatus.data?.status
+    })
+
+    if (nextTxState === 'submitted') {
+      setTxState('submitted')
+    }
+  }, [txState, isWalletSafe, receipt.data?.transactionHash, safeCallsStatus.data?.status])
 
   // Handle transaction error
   useEffect(() => {
@@ -201,6 +225,25 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
                 <AnimatedCheckmark isVisible />
                 <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Approval updated</h3>
                 <p className="text-sm text-text-secondary mb-6">Your token allowance has been changed</p>
+                <Button
+                  onClick={onClose}
+                  variant="filled"
+                  className="w-full max-w-xs"
+                  classNameOverride="yearn--button--nextgen w-full"
+                >
+                  Done
+                </Button>
+              </>
+            )}
+
+            {txState === 'submitted' && (
+              <>
+                <AnimatedCheckmark isVisible />
+                <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Transaction submitted</h3>
+                <p className="text-sm text-text-secondary mb-6 whitespace-pre-line">
+                  Your approval transaction has been submitted to your Safe.\nExecution may happen separately after the
+                  required confirmations are collected.
+                </p>
                 <Button
                   onClick={onClose}
                   variant="filled"

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -41,8 +41,13 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
 
   const { address: account, chain, connector } = useAccount()
   const currentChainId = useChainId()
-  const connectedChainId = resolveApprovalOverlayConnectedChainId({ accountChainId: chain?.id, currentChainId })
   const isWalletSafe = connector?.id.toLowerCase().includes('safe') ?? false
+  const connectedChainId = resolveApprovalOverlayConnectedChainId({
+    accountChainId: chain?.id,
+    currentChainId,
+    targetChainId: chainId,
+    isWalletSafe
+  })
   const { switchChainAsync } = useSwitchChain()
   const { writeContractAsync, data: txHash, reset } = useWriteContract()
   const receipt = useWaitForTransactionReceipt({ hash: txHash, chainId })
@@ -109,9 +114,20 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
       if (!isConnectedToExecutionChain(connectedChainId, chainId)) {
         try {
           await switchChainAsync({ chainId })
-        } catch {
-          // User rejected chain switch - return to idle
-          setTxState('idle')
+        } catch (error: any) {
+          const isUserRejection =
+            error?.message?.toLowerCase().includes('rejected') ||
+            error?.message?.toLowerCase().includes('denied') ||
+            error?.code === 4001
+
+          if (isUserRejection) {
+            setTxState('idle')
+          } else {
+            setTxState('error')
+            setErrorMessage(
+              'Unable to switch networks for this approval. Please confirm your Safe is opened on the correct chain.'
+            )
+          }
           return
         }
       }

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -54,7 +54,9 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   const safeCallsStatus = useCallsStatus({
     id: txHash || '0x',
     query: {
-      enabled: Boolean(isWalletSafe && txHash && txState === 'pending' && !receipt.data?.transactionHash),
+      enabled: Boolean(
+        isWalletSafe && txHash && (txState === 'pending' || txState === 'submitted') && !receipt.data?.transactionHash
+      ),
       refetchInterval: 1500
     }
   })
@@ -70,7 +72,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
 
   // Handle transaction success
   useEffect(() => {
-    if (receipt.isSuccess && txState === 'pending') {
+    if (receipt.isSuccess && (txState === 'pending' || txState === 'submitted')) {
       setTxState('success')
       reset()
     }
@@ -91,7 +93,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
 
   // Handle transaction error
   useEffect(() => {
-    if (receipt.isError && txState === 'pending') {
+    if (receipt.isError && (txState === 'pending' || txState === 'submitted')) {
       setTxState('error')
       setErrorMessage('Transaction failed')
       reset()
@@ -257,8 +259,8 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
                 <AnimatedCheckmark isVisible />
                 <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Transaction submitted</h3>
                 <p className="text-sm text-text-secondary mb-6 whitespace-pre-line">
-                  Your approval transaction has been submitted to your Safe.\nExecution may happen separately after the
-                  required confirmations are collected.
+                  {`Your approval transaction has been submitted to your Safe.
+Execution may happen separately after the required confirmations are collected.`}
                 </p>
                 <Button
                   onClick={onClose}

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@shared/components/Button'
-import { useSwitchChain, useWaitForTransactionReceipt } from '@shared/hooks/useAppWagmi'
+import { useChainId, useSwitchChain, useWaitForTransactionReceipt } from '@shared/hooks/useAppWagmi'
 import { getApproveAbi } from '@shared/utils/approve'
 import { type FC, useCallback, useEffect, useState } from 'react'
 import { maxUint256 } from 'viem'
@@ -7,6 +7,7 @@ import { useAccount, useWriteContract } from 'wagmi'
 import { isConnectedToExecutionChain, resolveExecutionChainId } from '@/config/tenderly'
 import { InfoOverlay } from '../shared/InfoOverlay'
 import { AnimatedCheckmark, ErrorIcon, Spinner } from '../shared/TransactionStateIndicators'
+import { resolveApprovalOverlayConnectedChainId } from './ApprovalOverlay.helpers'
 
 type TxState = 'idle' | 'confirming' | 'pending' | 'success' | 'error'
 
@@ -36,6 +37,8 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   const [errorMessage, setErrorMessage] = useState('')
 
   const { address: account, chain } = useAccount()
+  const currentChainId = useChainId()
+  const connectedChainId = resolveApprovalOverlayConnectedChainId({ accountChainId: chain?.id, currentChainId })
   const { switchChainAsync } = useSwitchChain()
   const { writeContractAsync, data: txHash, reset } = useWriteContract()
   const receipt = useWaitForTransactionReceipt({ hash: txHash, chainId })
@@ -79,7 +82,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
       setErrorMessage('')
 
       // Handle chain switch if needed
-      if (!isConnectedToExecutionChain(chain?.id, chainId)) {
+      if (!isConnectedToExecutionChain(connectedChainId, chainId)) {
         try {
           await switchChainAsync({ chainId })
         } catch {
@@ -112,7 +115,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
         }
       }
     },
-    [chain?.id, chainId, tokenAddress, spenderAddress, writeContractAsync, switchChainAsync]
+    [connectedChainId, chainId, tokenAddress, spenderAddress, writeContractAsync, switchChainAsync]
   )
 
   const handleRevoke = useCallback(() => handleApprove(0n), [handleApprove])

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -1,3 +1,4 @@
+import { buildSafeDepositBatch } from '@pages/vaults/components/widget/deposit/safeDepositBatch'
 import { InputTokenAmount } from '@pages/vaults/components/widget/InputTokenAmount'
 import { useDebouncedInput } from '@pages/vaults/hooks/useDebouncedInput'
 import type { VaultUserData } from '@pages/vaults/hooks/useVaultUserData'
@@ -170,7 +171,8 @@ export function WidgetDeposit({
     isAutoStakingEnabled,
     getPrice,
     trackEvent,
-    ensoEnabled
+    ensoEnabled,
+    isWalletSafe
   } = useWidgetContext({ chainId, vaultAddress })
   const { allVaults } = useYearn()
 
@@ -311,6 +313,7 @@ export function WidgetDeposit({
     inputDecimals: inputToken?.decimals ?? 18,
     vaultDecimals: vault?.decimals ?? 18,
     slippage: ensoQuoteSlippage,
+    ensoRoutingStrategy: isWalletSafe ? 'router' : undefined,
     stakingSource
   })
 
@@ -596,10 +599,78 @@ export function WidgetDeposit({
       : null
   const effectiveDepositError = depositError || unpricedEnsoDepositError
 
+  const { spenderAddress: approvalSpenderAddress, spenderName: approvalSpenderName } = getDepositApprovalSpender({
+    routeType,
+    destinationToken,
+    stakingAddress,
+    routerAddress: activeFlow.periphery.routerAddress,
+    vaultSymbol,
+    stakingTokenSymbol: stakingToken?.symbol
+  })
   const formattedDepositAmount = formatTAmount({ value: depositAmount.bn, decimals: inputToken?.decimals ?? 18 })
   const needsApproval = !isNativeToken && !activeFlow.periphery.isAllowanceSufficient
+  const safeDepositBatch = useMemo(() => {
+    if (!isWalletSafe || !needsApproval) {
+      return undefined
+    }
+
+    return buildSafeDepositBatch({
+      routeType,
+      account,
+      depositToken: toAddress(depositToken),
+      amount: depositAmount.debouncedBn,
+      currentAllowance: activeFlow.periphery.allowance,
+      chainId: routeType === 'ENSO' ? sourceChainId : chainId,
+      vaultAddress,
+      stakingAddress,
+      stakingSource,
+      approvalSpenderAddress,
+      routerAddress: activeFlow.periphery.routerAddress ? toAddress(activeFlow.periphery.routerAddress) : undefined,
+      ensoTx: activeFlow.periphery.tx
+        ? {
+            to: toAddress(activeFlow.periphery.tx.to),
+            data: activeFlow.periphery.tx.data,
+            value: activeFlow.periphery.tx.value
+          }
+        : undefined
+    })
+  }, [
+    account,
+    activeFlow.periphery.allowance,
+    activeFlow.periphery.routerAddress,
+    activeFlow.periphery.tx,
+    approvalSpenderAddress,
+    chainId,
+    depositAmount.debouncedBn,
+    depositToken,
+    isWalletSafe,
+    needsApproval,
+    routeType,
+    sourceChainId,
+    stakingAddress,
+    stakingSource,
+    vaultAddress
+  ])
 
   const currentStep: TransactionStep | undefined = useMemo(() => {
+    const { actionLabel, progressLabel, pastTenseLabel } = getDepositActionCopy(routeType)
+
+    if (safeDepositBatch) {
+      return {
+        prepare: activeFlow.actions.prepareApprove,
+        batch: safeDepositBatch,
+        label: `Approve & ${actionLabel}`,
+        confirmMessage: `Submitting approval and ${actionLabel.toLowerCase()} to your Safe`,
+        successTitle: isCrossChain ? 'Transaction Submitted' : `${actionLabel} successful!`,
+        successMessage: isCrossChain
+          ? `Your cross-chain ${actionLabel.toLowerCase()} has been submitted.\nIt may take a few minutes to complete on the destination chain.`
+          : `You have ${pastTenseLabel} ${formattedDepositAmount} ${inputToken?.symbol || ''} into ${vaultSymbol}.`,
+        completesFlow: true,
+        showConfetti: true,
+        notification: depositNotificationParams
+      }
+    }
+
     if (needsApproval) {
       return {
         prepare: activeFlow.actions.prepareApprove,
@@ -611,8 +682,6 @@ export function WidgetDeposit({
         notification: approveNotificationParams
       }
     }
-
-    const { actionLabel, progressLabel, pastTenseLabel } = getDepositActionCopy(routeType)
 
     if (isCrossChain) {
       return {
@@ -641,6 +710,7 @@ export function WidgetDeposit({
     needsApproval,
     activeFlow.actions.prepareApprove,
     activeFlow.actions.prepareDeposit,
+    safeDepositBatch,
     formattedDepositAmount,
     inputToken?.symbol,
     vaultSymbol,
@@ -775,14 +845,6 @@ export function WidgetDeposit({
   // Render
   // ============================================================================
   const isSettingsVisible = !!account && !!isSettingsOpen
-  const { spenderAddress: approvalSpenderAddress, spenderName: approvalSpenderName } = getDepositApprovalSpender({
-    routeType,
-    destinationToken,
-    stakingAddress,
-    routerAddress: activeFlow.periphery.routerAddress,
-    vaultSymbol,
-    stakingTokenSymbol: stakingToken?.symbol
-  })
   const onAllowanceClick =
     !isNativeToken && activeFlow.periphery.allowance > 0n
       ? (): void => {

--- a/src/components/pages/vaults/components/widget/deposit/safeDepositBatch.ts
+++ b/src/components/pages/vaults/components/widget/deposit/safeDepositBatch.ts
@@ -1,0 +1,178 @@
+import type { DepositRouteType } from '@pages/vaults/components/widget/deposit/types'
+import { getDirectStakeCall } from '@pages/vaults/hooks/actions/stakingAdapter'
+import { YVUSD_LOCKED_ZAP_ADDRESS } from '@pages/vaults/utils/yvUsd'
+import { vaultAbi } from '@shared/contracts/abi/vaultV2.abi'
+import { yvUsdLockedZapAbi } from '@shared/contracts/abi/yvUsdLockedZap.abi'
+import { getApproveAbi } from '@shared/utils/approve'
+import type { Address, Hex } from 'viem'
+import { encodeFunctionData, isAddressEqual } from 'viem'
+
+export type TSafeBatchCall = {
+  to: Address
+  data: Hex
+  value?: bigint
+}
+
+type TEnsoTransaction = {
+  to: Address
+  data: Hex
+  value: string
+}
+
+type TBuildSafeDepositBatchParams = {
+  routeType: DepositRouteType
+  account?: Address
+  depositToken: Address
+  amount: bigint
+  currentAllowance?: bigint
+  chainId: number
+  vaultAddress: Address
+  stakingAddress?: Address
+  stakingSource?: string
+  approvalSpenderAddress?: Address
+  routerAddress?: Address
+  ensoTx?: TEnsoTransaction
+}
+
+function buildApproveCall({
+  depositToken,
+  approvalSpenderAddress,
+  amount
+}: {
+  depositToken: Address
+  approvalSpenderAddress: Address
+  amount: bigint
+}): TSafeBatchCall {
+  return {
+    to: depositToken,
+    data: encodeFunctionData({
+      abi: getApproveAbi(depositToken),
+      functionName: 'approve',
+      args: [approvalSpenderAddress, amount]
+    }),
+    value: 0n
+  }
+}
+
+function buildApprovalCalls({
+  depositToken,
+  approvalSpenderAddress,
+  amount,
+  currentAllowance = 0n
+}: {
+  depositToken: Address
+  approvalSpenderAddress: Address
+  amount: bigint
+  currentAllowance?: bigint
+}): TSafeBatchCall[] {
+  const approveAmountCall = buildApproveCall({
+    depositToken,
+    approvalSpenderAddress,
+    amount
+  })
+
+  if (currentAllowance <= 0n) {
+    return [approveAmountCall]
+  }
+
+  return [
+    buildApproveCall({
+      depositToken,
+      approvalSpenderAddress,
+      amount: 0n
+    }),
+    approveAmountCall
+  ]
+}
+
+function buildDirectDepositCall(params: TBuildSafeDepositBatchParams & { account: Address }): TSafeBatchCall {
+  if (params.routerAddress && isAddressEqual(params.routerAddress, YVUSD_LOCKED_ZAP_ADDRESS)) {
+    return {
+      to: YVUSD_LOCKED_ZAP_ADDRESS,
+      data: encodeFunctionData({
+        abi: yvUsdLockedZapAbi,
+        functionName: 'zapIn',
+        args: [params.amount, params.account]
+      }),
+      value: 0n
+    }
+  }
+
+  return {
+    to: params.vaultAddress,
+    data: encodeFunctionData({
+      abi: vaultAbi,
+      functionName: 'deposit',
+      args: [params.amount, params.account]
+    }),
+    value: 0n
+  }
+}
+
+function buildDirectStakeCall(params: TBuildSafeDepositBatchParams & { account: Address }): TSafeBatchCall | undefined {
+  if (!params.stakingAddress) {
+    return undefined
+  }
+
+  const stakeCall = getDirectStakeCall({
+    stakingSource: params.stakingSource,
+    amount: params.amount,
+    account: params.account
+  })
+
+  if (!stakeCall.args) {
+    return undefined
+  }
+
+  return {
+    to: params.stakingAddress,
+    data: encodeFunctionData({
+      abi: stakeCall.abi,
+      functionName: stakeCall.functionName,
+      args: stakeCall.args
+    }),
+    value: 0n
+  }
+}
+
+function buildEnsoCall(ensoTx?: TEnsoTransaction): TSafeBatchCall | undefined {
+  if (!ensoTx) {
+    return undefined
+  }
+
+  return {
+    to: ensoTx.to,
+    data: ensoTx.data,
+    value: BigInt(ensoTx.value || 0)
+  }
+}
+
+export function buildSafeDepositBatch(
+  params: TBuildSafeDepositBatchParams
+): { calls: readonly TSafeBatchCall[]; chainId: number } | undefined {
+  if (!params.account || !params.approvalSpenderAddress || params.amount <= 0n) {
+    return undefined
+  }
+
+  const approvalCalls = buildApprovalCalls({
+    depositToken: params.depositToken,
+    approvalSpenderAddress: params.approvalSpenderAddress,
+    amount: params.amount,
+    currentAllowance: params.currentAllowance
+  })
+  const executionCall =
+    params.routeType === 'DIRECT_DEPOSIT'
+      ? buildDirectDepositCall({ ...params, account: params.account })
+      : params.routeType === 'DIRECT_STAKE'
+        ? buildDirectStakeCall({ ...params, account: params.account })
+        : buildEnsoCall(params.ensoTx)
+
+  if (!executionCall) {
+    return undefined
+  }
+
+  return {
+    calls: [...approvalCalls, executionCall],
+    chainId: params.chainId
+  }
+}

--- a/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
@@ -3,11 +3,12 @@ import { useDirectDeposit } from '@pages/vaults/hooks/actions/useDirectDeposit'
 import { useDirectStake } from '@pages/vaults/hooks/actions/useDirectStake'
 import { useEnsoDeposit } from '@pages/vaults/hooks/actions/useEnsoDeposit'
 import { useYvUsdLockedZapDeposit } from '@pages/vaults/hooks/actions/useYvUsdLockedZapDeposit'
+import type { EnsoRoutingStrategy } from '@pages/vaults/hooks/solvers/useSolverEnso'
 import { YVUSD_LOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { toAddress } from '@shared/utils'
 import { toBasisPoints } from '@shared/utils/slippage'
 import { useMemo } from 'react'
-import { type Address, isAddressEqual } from 'viem'
+import { type Address, type Hex, isAddressEqual } from 'viem'
 import { useReadContract } from 'wagmi'
 import type { DepositRouteType } from './types'
 import { useDepositRoute } from './useDepositRoute'
@@ -34,6 +35,7 @@ interface UseDepositFlowProps {
   vaultDecimals: number
   // Settings
   slippage: number
+  ensoRoutingStrategy?: EnsoRoutingStrategy
   stakingSource?: string
 }
 
@@ -58,6 +60,13 @@ export interface DepositFlowResult {
       isLoadingExpectedOutNormalization: boolean
       isCrossChain: boolean
       routerAddress?: string
+      tx?: {
+        to: Address
+        data: Hex
+        value: string
+        from: Address
+      }
+      gas?: string
       error?: unknown
     }
   }
@@ -79,6 +88,7 @@ export const useDepositFlow = ({
   inputDecimals,
   vaultDecimals,
   slippage,
+  ensoRoutingStrategy,
   stakingSource
 }: UseDepositFlowProps): DepositFlowResult => {
   // Determine routing type
@@ -143,7 +153,8 @@ export const useDepositFlow = ({
     destinationChainId,
     decimalsOut: vaultDecimals,
     enabled: routeType === 'ENSO' && !!depositToken && amount > 0n && currentAmount > 0n,
-    slippage: toBasisPoints(slippage)
+    slippage: toBasisPoints(slippage),
+    routingStrategy: ensoRoutingStrategy
   })
 
   // Select active flow based on routing type
@@ -154,7 +165,7 @@ export const useDepositFlow = ({
     if (routeType === 'DIRECT_STAKE') return directStake
     return ensoFlow
   }, [routeType, isYvUsdLockedZapDeposit, yvUsdLockedZapDeposit, directDeposit, directStake, ensoFlow])
-
+  console.log('activeFlow', activeFlow)
   const shouldNormalizeExpectedOut =
     !!stakingAddress && isAddressEqual(destinationToken, stakingAddress) && activeFlow.periphery.expectedOut > 0n
   const shouldNormalizeMinExpectedOut =

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -381,7 +381,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
         await updateNotification({
           id: notificationId,
           status: params.status,
-          receipt: params.receipt
+          receipt: params.receipt,
+          awaitingExecution: params.awaitingExecution
         })
       } catch (error) {
         console.error('Failed to update notification:', error)

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -20,6 +20,7 @@ import {
   type CompletionDeferral,
   type OverlayState,
   resolveCompletionDeferral,
+  resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
   shouldAutoContinuePermitSuccess,
   shouldRunDeferredCompletion
@@ -182,6 +183,12 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const [txHash, setTxHash] = useState<`0x${string}` | undefined>()
   const { address: account, chain, connector } = useAccount()
   const isWalletSafe = connector?.id.toLowerCase().includes('safe') ?? false
+  const connectedChainId = resolveOverlayConnectedChainId({
+    accountChainId: chain?.id,
+    currentChainId,
+    targetChainId: ((step?.prepare.data?.request as any)?.chainId as number | undefined) ?? undefined,
+    isWalletSafe
+  })
 
   // Notification system integration
   const { createNotification, updateNotification } = useNotificationsActions()
@@ -437,14 +444,25 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
       const request = currentStep.prepare.data.request as any
       const txChainId = request.chainId
-      const wrongNetwork = txChainId && !isConnectedToExecutionChain(chain?.id, txChainId)
+      const wrongNetwork = txChainId && !isConnectedToExecutionChain(connectedChainId, txChainId)
 
       if (wrongNetwork && txChainId) {
         try {
           await switchChainAsync({ chainId: txChainId })
-        } catch {
-          console.warn('[TransactionOverlay] Chain switch rejected', { to: txChainId, step: currentStep.label })
-          onClose()
+        } catch (error: any) {
+          if (isUserRejectionError(error)) {
+            onClose()
+            return
+          }
+          console.warn('[TransactionOverlay] Chain switch failed', {
+            to: txChainId,
+            step: currentStep.label,
+            error: error?.message || error
+          })
+          setOverlayState('error')
+          setErrorMessage(
+            'Unable to switch networks for this transaction. Please confirm your Safe is opened on the correct chain.'
+          )
           return
         }
       }
@@ -511,7 +529,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       }
     },
     [
-      chain?.id,
+      connectedChainId,
       finalizeSuccessState,
       handleCreateNotification,
       isLastStep,

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -6,6 +6,7 @@ import {
   useSwitchChain,
   useWaitForTransactionReceipt
 } from '@shared/hooks/useAppWagmi'
+import { useSafeTransactionDetails } from '@shared/hooks/useSafeTransactionDetails'
 import type { TCreateNotificationParams } from '@shared/types/notifications'
 import { cl } from '@shared/utils'
 import { getNetwork, retrieveConfig } from '@shared/utils/wagmi'
@@ -20,6 +21,7 @@ import {
   type CompletionDeferral,
   type OverlayState,
   resolveCompletionDeferral,
+  resolveExecutionTrackingHash,
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
   shouldAutoContinuePermitSuccess,
@@ -202,7 +204,10 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
   const explorerChainId =
     ((executedStepRef.current?.prepare.data?.request as any)?.chainId as number | undefined) ?? undefined
-  const receipt = useWaitForTransactionReceipt({ hash: txHash, chainId: explorerChainId, confirmations })
+  const safeTransactionDetails = useSafeTransactionDetails({
+    safeTxHash: isWalletSafe ? txHash : undefined,
+    enabled: Boolean(isWalletSafe && txHash && (overlayState === 'pending' || overlayState === 'submitted'))
+  })
   const safeCallsStatus = useCallsStatus({
     id: txHash || '0x',
     query: {
@@ -210,15 +215,20 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
         isWalletSafe &&
           txHash &&
           (overlayState === 'pending' || overlayState === 'submitted') &&
-          !receipt.data?.transactionHash
+          !safeTransactionDetails.data?.executionTxHash
       ),
       refetchInterval: 1500
     }
   })
+  const executionTrackingHash = resolveExecutionTrackingHash({
+    isWalletSafe,
+    submittedTxHash: txHash,
+    safeExecutionTxHash: safeTransactionDetails.data?.executionTxHash,
+    callsReceiptTxHash: safeCallsStatus.data?.receipts?.[0]?.transactionHash
+  })
+  const receipt = useWaitForTransactionReceipt({ hash: executionTrackingHash, chainId: explorerChainId, confirmations })
   const blockExplorer = getNetwork(explorerChainId ?? currentChainId).defaultBlockExplorer
-  const explorerTransactionHash =
-    safeCallsStatus.data?.receipts?.[0]?.transactionHash ?? (!isWalletSafe ? txHash : undefined)
-  const explorerTxUrl = explorerTransactionHash && blockExplorer ? `${blockExplorer}/tx/${explorerTransactionHash}` : ''
+  const explorerTxUrl = executionTrackingHash && blockExplorer ? `${blockExplorer}/tx/${executionTrackingHash}` : ''
 
   // Track if the executed step was the last step (captured at execution time)
   const wasLastStepRef = useRef(false)
@@ -666,7 +676,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     const nextOverlayState = resolvePendingSafeOverlayState({
       overlayState,
       isWalletSafe,
-      hasReceiptTransactionHash: Boolean(receipt.data?.transactionHash),
+      hasExecutionReceipt: Boolean(receipt.data?.transactionHash),
+      safeTxStatus: safeTransactionDetails.data?.txStatus,
       callsStatus: safeCallsStatus.data?.status
     })
 
@@ -687,6 +698,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     overlayState,
     isWalletSafe,
     receipt.data?.transactionHash,
+    safeTransactionDetails.data?.txStatus,
     safeCallsStatus.data?.status,
     handleUpdateNotification,
     resetTxState

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -370,7 +370,11 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
   // Update notification with new status/receipt
   const handleUpdateNotification = useCallback(
-    async (params: { status?: 'pending' | 'submitted' | 'success' | 'error'; receipt?: any }) => {
+    async (params: {
+      status?: 'pending' | 'submitted' | 'success' | 'error'
+      receipt?: any
+      awaitingExecution?: boolean
+    }) => {
       if (!notificationId) return
 
       try {
@@ -667,8 +671,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
     if (nextOverlayState === 'submitted') {
       setOverlayState('submitted')
-      void handleUpdateNotification({ status: 'submitted' })
-      setNotificationId(undefined)
+      void handleUpdateNotification({ status: 'submitted', awaitingExecution: true })
       return
     }
 

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -25,6 +25,7 @@ import {
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
   shouldAutoContinuePermitSuccess,
+  shouldRefetchNextStepAfterReceipt,
   shouldRunDeferredCompletion
 } from './transactionOverlay.helpers'
 
@@ -846,13 +847,21 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   // When step 1 succeeds in a multi-step flow, the next step simulation may need a refetch
   // to pick up post-transaction state (e.g. unstake -> withdraw).
   useEffect(() => {
-    if (!isOpen || overlayState !== 'pending') return
-    if (!receipt.isSuccess || !receipt.data?.transactionHash) return
-    if (wasLastStepRef.current) return
-    if (!step?.label || step.label === executedStepRef.current?.label) return
-    if (isStepReady) return
+    if (
+      !shouldRefetchNextStepAfterReceipt({
+        isOpen,
+        overlayState,
+        hasReceiptTransactionHash: Boolean(receipt.data?.transactionHash),
+        wasLastStep: wasLastStepRef.current,
+        currentStepLabel: step?.label,
+        executedStepLabel: executedStepRef.current?.label,
+        isStepReady
+      })
+    ) {
+      return
+    }
 
-    const refetch = step.prepare.refetch
+    const refetch = step?.prepare.refetch
     if (!refetch) return
 
     void refetch()
@@ -863,15 +872,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     return () => {
       window.clearInterval(intervalId)
     }
-  }, [
-    isOpen,
-    overlayState,
-    receipt.isSuccess,
-    receipt.data?.transactionHash,
-    step?.label,
-    step?.prepare.refetch,
-    isStepReady
-  ])
+  }, [isOpen, overlayState, receipt.data?.transactionHash, step?.label, step?.prepare.refetch, isStepReady])
 
   return (
     <div
@@ -974,20 +975,22 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
           {/* Submitted State */}
           {overlayState === 'submitted' && (
             <>
-              <AnimatedCheckmark isVisible />
+              <Spinner />
               <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Transaction submitted</h3>
-              <p className="text-sm text-text-secondary whitespace-pre-line mb-6">
+              <p className="text-sm text-text-secondary whitespace-pre-line">
                 {`Your transaction has been submitted to your Safe.
 Execution may happen separately after the required confirmations are collected.`}
               </p>
-              <Button
-                onClick={handleClose}
-                variant="filled"
-                className="w-full max-w-xs"
-                classNameOverride="yearn--button--nextgen w-full"
-              >
-                Done
-              </Button>
+              {explorerTxUrl ? (
+                <a
+                  href={explorerTxUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-3 text-sm font-semibold text-text-primary underline"
+                >
+                  View on block explorer
+                </a>
+              ) : null}
             </>
           )}
 

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -18,12 +18,14 @@ import { useAccount, useCallsStatus, useSignTypedData, useWriteContract } from '
 import { isConnectedToExecutionChain } from '@/config/tenderly'
 import { AnimatedCheckmark, ErrorIcon, Spinner } from './TransactionStateIndicators'
 import {
+  AUTO_CONTINUE_SUCCESS_DELAY_MS,
   type CompletionDeferral,
   type OverlayState,
   resolveCompletionDeferral,
   resolveExecutionTrackingHash,
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
+  shouldAutoContinueFromSuccessState,
   shouldAutoContinuePermitSuccess,
   shouldRefetchNextStepAfterReceipt,
   shouldRunDeferredCompletion
@@ -730,7 +732,14 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       (overlayState === 'pending' || overlayState === 'submitted') &&
       canShowSuccess
     ) {
-      if (executedStepLabel && executedStepAutoContinues && !wasLastStepRef.current) {
+      if (
+        shouldAutoContinueFromSuccessState({
+          canShowSuccess,
+          executedStepAutoContinues,
+          wasLastStep: wasLastStepRef.current
+        }) &&
+        executedStepLabel
+      ) {
         if (hasAdvancedFromStepRef.current === executedStepLabel) {
           return
         }
@@ -744,7 +753,15 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
         hasAutoContinuedFromStepRef.current = executedStepLabel
         const nonceAtSchedule = autoContinueNonceRef.current
         setIsAutoContinuing(true)
+        finalizeSuccessState(false, executedStepRef.current)
         const advance = async () => {
+          await new Promise((resolve) => {
+            window.setTimeout(resolve, AUTO_CONTINUE_SUCCESS_DELAY_MS)
+          })
+          if (autoContinueNonceRef.current !== nonceAtSchedule) {
+            setIsAutoContinuing(false)
+            return
+          }
           await waitForAutoContinueBlock(executedStepLabel)
           if (autoContinueNonceRef.current !== nonceAtSchedule) {
             setIsAutoContinuing(false)

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -206,7 +206,12 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const safeCallsStatus = useCallsStatus({
     id: txHash || '0x',
     query: {
-      enabled: Boolean(isWalletSafe && txHash && overlayState === 'pending' && !receipt.data?.transactionHash),
+      enabled: Boolean(
+        isWalletSafe &&
+          txHash &&
+          (overlayState === 'pending' || overlayState === 'submitted') &&
+          !receipt.data?.transactionHash
+      ),
       refetchInterval: 1500
     }
   })
@@ -687,7 +692,11 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   useEffect(() => {
     // For multi-step flows, wait until next step is ready before showing success
     // Check that step has changed (different label) and is ready
-    if (receipt.isSuccess && receipt.data?.transactionHash && overlayState === 'pending') {
+    if (
+      receipt.isSuccess &&
+      receipt.data?.transactionHash &&
+      (overlayState === 'pending' || overlayState === 'submitted')
+    ) {
       executedStepBlockRef.current = receipt.data.blockNumber
       const executedStepLabel = executedStepRef.current?.label
       if (!hasReportedStepSuccessRef.current && executedStepLabel) {
@@ -698,7 +707,12 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
     const isNextStepReady = step?.label !== executedStepRef.current?.label && isStepReady
     const canShowSuccess = wasLastStepRef.current || isNextStepReady
-    if (receipt.isSuccess && receipt.data?.transactionHash && overlayState === 'pending' && canShowSuccess) {
+    if (
+      receipt.isSuccess &&
+      receipt.data?.transactionHash &&
+      (overlayState === 'pending' || overlayState === 'submitted') &&
+      canShowSuccess
+    ) {
       if (executedStepLabel && executedStepAutoContinues && !wasLastStepRef.current) {
         if (hasAdvancedFromStepRef.current === executedStepLabel) {
           return
@@ -802,7 +816,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
   // Handle transaction error
   useEffect(() => {
-    if (receipt.isError && receipt.error && overlayState === 'pending') {
+    if (receipt.isError && receipt.error && (overlayState === 'pending' || overlayState === 'submitted')) {
       setOverlayState('error')
       setErrorMessage('Transaction failed. Please try again.')
       resetTxState()
@@ -947,8 +961,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
               <AnimatedCheckmark isVisible />
               <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Transaction submitted</h3>
               <p className="text-sm text-text-secondary whitespace-pre-line mb-6">
-                Your transaction has been submitted to your Safe.\nExecution may happen separately after the required
-                confirmations are collected.
+                {`Your transaction has been submitted to your Safe.
+Execution may happen separately after the required confirmations are collected.`}
               </p>
               <Button
                 onClick={handleClose}

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -20,6 +20,7 @@ import { AnimatedCheckmark, ErrorIcon, Spinner } from './TransactionStateIndicat
 import {
   AUTO_CONTINUE_SUCCESS_DELAY_MS,
   type CompletionDeferral,
+  getAutoContinueConfirmDelayMs,
   type OverlayState,
   resolveCompletionDeferral,
   resolveExecutionTrackingHash,
@@ -761,6 +762,17 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
           if (autoContinueNonceRef.current !== nonceAtSchedule) {
             setIsAutoContinuing(false)
             return
+          }
+          const confirmDelayMs = getAutoContinueConfirmDelayMs({ isWalletSafe })
+          if (confirmDelayMs > 0) {
+            setOverlayState('confirming')
+            await new Promise((resolve) => {
+              window.setTimeout(resolve, confirmDelayMs)
+            })
+            if (autoContinueNonceRef.current !== nonceAtSchedule) {
+              setIsAutoContinuing(false)
+              return
+            }
           }
           await waitForAutoContinueBlock(executedStepLabel)
           if (autoContinueNonceRef.current !== nonceAtSchedule) {

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -13,13 +13,14 @@ import { getPublicClient } from '@wagmi/core'
 import { type FC, useCallback, useEffect, useId, useRef, useState } from 'react'
 import { useReward } from 'react-rewards'
 import type { TypedData, TypedDataDomain } from 'viem'
-import { useAccount, useSignTypedData, useWriteContract } from 'wagmi'
+import { useAccount, useCallsStatus, useSignTypedData, useWriteContract } from 'wagmi'
 import { isConnectedToExecutionChain } from '@/config/tenderly'
 import { AnimatedCheckmark, ErrorIcon, Spinner } from './TransactionStateIndicators'
 import {
   type CompletionDeferral,
   type OverlayState,
   resolveCompletionDeferral,
+  resolvePendingSafeOverlayState,
   shouldAutoContinuePermitSuccess,
   shouldRunDeferredCompletion
 } from './transactionOverlay.helpers'
@@ -179,7 +180,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const currentChainId = useChainId()
   const { switchChainAsync } = useSwitchChain()
   const [txHash, setTxHash] = useState<`0x${string}` | undefined>()
-  const { address: account, chain } = useAccount()
+  const { address: account, chain, connector } = useAccount()
+  const isWalletSafe = connector?.id.toLowerCase().includes('safe') ?? false
 
   // Notification system integration
   const { createNotification, updateNotification } = useNotificationsActions()
@@ -194,8 +196,17 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const explorerChainId =
     ((executedStepRef.current?.prepare.data?.request as any)?.chainId as number | undefined) ?? undefined
   const receipt = useWaitForTransactionReceipt({ hash: txHash, chainId: explorerChainId, confirmations })
+  const safeCallsStatus = useCallsStatus({
+    id: txHash || '0x',
+    query: {
+      enabled: Boolean(isWalletSafe && txHash && overlayState === 'pending' && !receipt.data?.transactionHash),
+      refetchInterval: 1500
+    }
+  })
   const blockExplorer = getNetwork(explorerChainId ?? currentChainId).defaultBlockExplorer
-  const explorerTxUrl = txHash && blockExplorer ? `${blockExplorer}/tx/${txHash}` : ''
+  const explorerTransactionHash =
+    safeCallsStatus.data?.receipts?.[0]?.transactionHash ?? (!isWalletSafe ? txHash : undefined)
+  const explorerTxUrl = explorerTransactionHash && blockExplorer ? `${blockExplorer}/tx/${explorerTransactionHash}` : ''
 
   // Track if the executed step was the last step (captured at execution time)
   const wasLastStepRef = useRef(false)
@@ -347,7 +358,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
   // Update notification with new status/receipt
   const handleUpdateNotification = useCallback(
-    async (params: { status?: 'pending' | 'success' | 'error'; receipt?: any }) => {
+    async (params: { status?: 'pending' | 'submitted' | 'success' | 'error'; receipt?: any }) => {
       if (!notificationId) return
 
       try {
@@ -623,6 +634,37 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     }
   }, [isOpen, overlayState, step, executeStep])
 
+  useEffect(() => {
+    const nextOverlayState = resolvePendingSafeOverlayState({
+      overlayState,
+      isWalletSafe,
+      hasReceiptTransactionHash: Boolean(receipt.data?.transactionHash),
+      callsStatus: safeCallsStatus.data?.status
+    })
+
+    if (nextOverlayState === 'submitted') {
+      setOverlayState('submitted')
+      void handleUpdateNotification({ status: 'submitted' })
+      setNotificationId(undefined)
+      return
+    }
+
+    if (nextOverlayState === 'error') {
+      setOverlayState('error')
+      setErrorMessage('Transaction failed in Safe. Please review your Safe queue and try again.')
+      resetTxState()
+      void handleUpdateNotification({ status: 'error' })
+      setNotificationId(undefined)
+    }
+  }, [
+    overlayState,
+    isWalletSafe,
+    receipt.data?.transactionHash,
+    safeCallsStatus.data?.status,
+    handleUpdateNotification,
+    resetTxState
+  ])
+
   // Handle transaction success
   useEffect(() => {
     // For multi-step flows, wait until next step is ready before showing success
@@ -808,8 +850,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
           isOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
         )}
       >
-        {/* Close button - only shown in success/error states */}
-        {(overlayState === 'success' || overlayState === 'error') && (
+        {/* Close button - only shown in success/error/submitted states */}
+        {(overlayState === 'success' || overlayState === 'error' || overlayState === 'submitted') && (
           <button
             onClick={handleClose}
             className="absolute top-4 right-4 p-1 hover:bg-surface-secondary rounded-lg transition-colors z-10"
@@ -878,6 +920,26 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
                   View on block explorer
                 </a>
               ) : null}
+            </>
+          )}
+
+          {/* Submitted State */}
+          {overlayState === 'submitted' && (
+            <>
+              <AnimatedCheckmark isVisible />
+              <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Transaction submitted</h3>
+              <p className="text-sm text-text-secondary whitespace-pre-line mb-6">
+                Your transaction has been submitted to your Safe.\nExecution may happen separately after the required
+                confirmations are collected.
+              </p>
+              <Button
+                onClick={handleClose}
+                variant="filled"
+                className="w-full max-w-xs"
+                classNameOverride="yearn--button--nextgen w-full"
+              >
+                Done
+              </Button>
             </>
           )}
 

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -13,7 +13,7 @@ import { getPublicClient } from '@wagmi/core'
 import { type FC, useCallback, useEffect, useId, useRef, useState } from 'react'
 import { useReward } from 'react-rewards'
 import type { TypedData, TypedDataDomain } from 'viem'
-import { useAccount, useSignTypedData, useWriteContract } from 'wagmi'
+import { useAccount, useCallsStatus, useSignTypedData, useWriteContract } from 'wagmi'
 import { isConnectedToExecutionChain } from '@/config/tenderly'
 import { AnimatedCheckmark, ErrorIcon, Spinner } from './TransactionStateIndicators'
 import {
@@ -22,6 +22,7 @@ import {
   getPendingTransactionTitle,
   type OverlayState,
   resolveCompletionDeferral,
+  resolvePendingSafeOverlayState,
   shouldAutoContinuePermitSuccess,
   shouldRunDeferredCompletion
 } from './transactionOverlay.helpers'
@@ -181,7 +182,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const currentChainId = useChainId()
   const { switchChainAsync } = useSwitchChain()
   const [txHash, setTxHash] = useState<`0x${string}` | undefined>()
-  const { address: account, chain } = useAccount()
+  const { address: account, chain, connector } = useAccount()
+  const isWalletSafe = connector?.id.toLowerCase().includes('safe') ?? false
 
   // Notification system integration
   const { createNotification, updateNotification } = useNotificationsActions()
@@ -196,8 +198,17 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const explorerChainId =
     ((executedStepRef.current?.prepare.data?.request as any)?.chainId as number | undefined) ?? undefined
   const receipt = useWaitForTransactionReceipt({ hash: txHash, chainId: explorerChainId, confirmations })
+  const safeCallsStatus = useCallsStatus({
+    id: txHash || '0x',
+    query: {
+      enabled: Boolean(isWalletSafe && txHash && overlayState === 'pending' && !receipt.data?.transactionHash),
+      refetchInterval: 1500
+    }
+  })
   const blockExplorer = getNetwork(explorerChainId ?? currentChainId).defaultBlockExplorer
-  const explorerTxUrl = txHash && blockExplorer ? `${blockExplorer}/tx/${txHash}` : ''
+  const explorerTransactionHash =
+    safeCallsStatus.data?.receipts?.[0]?.transactionHash ?? (!isWalletSafe ? txHash : undefined)
+  const explorerTxUrl = explorerTransactionHash && blockExplorer ? `${blockExplorer}/tx/${explorerTransactionHash}` : ''
 
   // Track if the executed step was the last step (captured at execution time)
   const wasLastStepRef = useRef(false)
@@ -403,7 +414,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
   // Update notification with new status/receipt
   const handleUpdateNotification = useCallback(
-    async (params: { status?: 'pending' | 'success' | 'error'; receipt?: any }) => {
+    async (params: { status?: 'pending' | 'submitted' | 'success' | 'error'; receipt?: any }) => {
       if (!notificationId) return
 
       try {
@@ -687,6 +698,37 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     }
   }, [isOpen, overlayState, step, executeStep])
 
+  useEffect(() => {
+    const nextOverlayState = resolvePendingSafeOverlayState({
+      overlayState,
+      isWalletSafe,
+      hasReceiptTransactionHash: Boolean(receipt.data?.transactionHash),
+      callsStatus: safeCallsStatus.data?.status
+    })
+
+    if (nextOverlayState === 'submitted') {
+      setOverlayState('submitted')
+      void handleUpdateNotification({ status: 'submitted' })
+      setNotificationId(undefined)
+      return
+    }
+
+    if (nextOverlayState === 'error') {
+      setOverlayState('error')
+      setErrorMessage('Transaction failed in Safe. Please review your Safe queue and try again.')
+      resetTxState()
+      void handleUpdateNotification({ status: 'error' })
+      setNotificationId(undefined)
+    }
+  }, [
+    overlayState,
+    isWalletSafe,
+    receipt.data?.transactionHash,
+    safeCallsStatus.data?.status,
+    handleUpdateNotification,
+    resetTxState
+  ])
+
   // Handle transaction success
   useEffect(() => {
     // For multi-step flows, wait until next step is ready before showing success
@@ -872,8 +914,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
           isOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4'
         )}
       >
-        {/* Close button - only shown in success/error states */}
-        {(overlayState === 'success' || overlayState === 'error') && (
+        {/* Close button - only shown in success/error/submitted states */}
+        {(overlayState === 'success' || overlayState === 'error' || overlayState === 'submitted') && (
           <button
             onClick={handleClose}
             className="absolute top-4 right-4 p-1 hover:bg-surface-secondary rounded-lg transition-colors z-10"
@@ -946,6 +988,26 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
                   View on block explorer
                 </a>
               ) : null}
+            </>
+          )}
+
+          {/* Submitted State */}
+          {overlayState === 'submitted' && (
+            <>
+              <AnimatedCheckmark isVisible />
+              <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Transaction submitted</h3>
+              <p className="text-sm text-text-secondary whitespace-pre-line mb-6">
+                Your transaction has been submitted to your Safe.\nExecution may happen separately after the required
+                confirmations are collected.
+              </p>
+              <Button
+                onClick={handleClose}
+                variant="filled"
+                className="w-full max-w-xs"
+                classNameOverride="yearn--button--nextgen w-full"
+              >
+                Done
+              </Button>
             </>
           )}
 

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -437,7 +437,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
         await updateNotification({
           id: notificationId,
           status: params.status,
-          receipt: params.receipt
+          receipt: params.receipt,
+          awaitingExecution: params.awaitingExecution
         })
       } catch (error) {
         console.error('Failed to update notification:', error)

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -22,6 +22,7 @@ import {
   getPendingTransactionTitle,
   type OverlayState,
   resolveCompletionDeferral,
+  resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
   shouldAutoContinuePermitSuccess,
   shouldRunDeferredCompletion
@@ -184,6 +185,12 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const [txHash, setTxHash] = useState<`0x${string}` | undefined>()
   const { address: account, chain, connector } = useAccount()
   const isWalletSafe = connector?.id.toLowerCase().includes('safe') ?? false
+  const connectedChainId = resolveOverlayConnectedChainId({
+    accountChainId: chain?.id,
+    currentChainId,
+    targetChainId: ((step?.prepare.data?.request as any)?.chainId as number | undefined) ?? undefined,
+    isWalletSafe
+  })
 
   // Notification system integration
   const { createNotification, updateNotification } = useNotificationsActions()
@@ -501,14 +508,25 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
       const request = currentStep.prepare.data.request as any
       const txChainId = request.chainId
-      const wrongNetwork = txChainId && !isConnectedToExecutionChain(chain?.id, txChainId)
+      const wrongNetwork = txChainId && !isConnectedToExecutionChain(connectedChainId, txChainId)
 
       if (wrongNetwork && txChainId) {
         try {
           await switchChainAsync({ chainId: txChainId })
-        } catch {
-          console.warn('[TransactionOverlay] Chain switch rejected', { to: txChainId, step: currentStep.label })
-          onClose()
+        } catch (error: any) {
+          if (isUserRejectionError(error)) {
+            onClose()
+            return
+          }
+          console.warn('[TransactionOverlay] Chain switch failed', {
+            to: txChainId,
+            step: currentStep.label,
+            error: error?.message || error
+          })
+          setOverlayState('error')
+          setErrorMessage(
+            'Unable to switch networks for this transaction. Please confirm your Safe is opened on the correct chain.'
+          )
           return
         }
       }
@@ -575,7 +593,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       }
     },
     [
-      chain?.id,
+      connectedChainId,
       finalizeSuccessState,
       handleCreateNotification,
       isLastStep,

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -6,6 +6,7 @@ import {
   useSwitchChain,
   useWaitForTransactionReceipt
 } from '@shared/hooks/useAppWagmi'
+import { useSafeTransactionDetails } from '@shared/hooks/useSafeTransactionDetails'
 import type { TCreateNotificationParams } from '@shared/types/notifications'
 import { cl } from '@shared/utils'
 import { getNetwork, retrieveConfig } from '@shared/utils/wagmi'
@@ -22,6 +23,7 @@ import {
   getPendingTransactionTitle,
   type OverlayState,
   resolveCompletionDeferral,
+  resolveExecutionTrackingHash,
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
   shouldAutoContinuePermitSuccess,
@@ -204,7 +206,10 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
   const explorerChainId =
     ((executedStepRef.current?.prepare.data?.request as any)?.chainId as number | undefined) ?? undefined
-  const receipt = useWaitForTransactionReceipt({ hash: txHash, chainId: explorerChainId, confirmations })
+  const safeTransactionDetails = useSafeTransactionDetails({
+    safeTxHash: isWalletSafe ? txHash : undefined,
+    enabled: Boolean(isWalletSafe && txHash && (overlayState === 'pending' || overlayState === 'submitted'))
+  })
   const safeCallsStatus = useCallsStatus({
     id: txHash || '0x',
     query: {
@@ -212,15 +217,20 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
         isWalletSafe &&
           txHash &&
           (overlayState === 'pending' || overlayState === 'submitted') &&
-          !receipt.data?.transactionHash
+          !safeTransactionDetails.data?.executionTxHash
       ),
       refetchInterval: 1500
     }
   })
+  const executionTrackingHash = resolveExecutionTrackingHash({
+    isWalletSafe,
+    submittedTxHash: txHash,
+    safeExecutionTxHash: safeTransactionDetails.data?.executionTxHash,
+    callsReceiptTxHash: safeCallsStatus.data?.receipts?.[0]?.transactionHash
+  })
+  const receipt = useWaitForTransactionReceipt({ hash: executionTrackingHash, chainId: explorerChainId, confirmations })
   const blockExplorer = getNetwork(explorerChainId ?? currentChainId).defaultBlockExplorer
-  const explorerTransactionHash =
-    safeCallsStatus.data?.receipts?.[0]?.transactionHash ?? (!isWalletSafe ? txHash : undefined)
-  const explorerTxUrl = explorerTransactionHash && blockExplorer ? `${blockExplorer}/tx/${explorerTransactionHash}` : ''
+  const explorerTxUrl = executionTrackingHash && blockExplorer ? `${blockExplorer}/tx/${executionTrackingHash}` : ''
 
   // Track if the executed step was the last step (captured at execution time)
   const wasLastStepRef = useRef(false)
@@ -730,7 +740,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     const nextOverlayState = resolvePendingSafeOverlayState({
       overlayState,
       isWalletSafe,
-      hasReceiptTransactionHash: Boolean(receipt.data?.transactionHash),
+      hasExecutionReceipt: Boolean(receipt.data?.transactionHash),
+      safeTxStatus: safeTransactionDetails.data?.txStatus,
       callsStatus: safeCallsStatus.data?.status
     })
 
@@ -751,6 +762,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     overlayState,
     isWalletSafe,
     receipt.data?.transactionHash,
+    safeTransactionDetails.data?.txStatus,
     safeCallsStatus.data?.status,
     handleUpdateNotification,
     resetTxState

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -13,16 +13,16 @@ import { getNetwork, retrieveConfig } from '@shared/utils/wagmi'
 import { getPublicClient } from '@wagmi/core'
 import { type FC, useCallback, useEffect, useId, useRef, useState } from 'react'
 import { useReward } from 'react-rewards'
-import type { TypedData, TypedDataDomain } from 'viem'
-import { useAccount, useCallsStatus, useSignTypedData, useWriteContract } from 'wagmi'
+import type { Address, TypedData, TypedDataDomain } from 'viem'
+import { useAccount, useCallsStatus, useSendCalls, useSignTypedData, useWriteContract } from 'wagmi'
 import { isConnectedToExecutionChain } from '@/config/tenderly'
 import { AnimatedCheckmark, ErrorIcon, Spinner } from './TransactionStateIndicators'
 import {
   AUTO_CONTINUE_SUCCESS_DELAY_MS,
   type CompletionDeferral,
   getInitialOverlayState,
-  getPendingTransactionTitle,
   getAutoContinueConfirmDelayMs,
+  getPendingTransactionTitle,
   type OverlayState,
   resolveCompletionDeferral,
   resolveExecutionTrackingHash,
@@ -47,6 +47,12 @@ export type PermitDataAsync = {
 
 export type PermitData = PermitDataDirect | PermitDataAsync
 
+export type TransactionBatchCall = {
+  to: Address
+  data: `0x${string}`
+  value?: bigint
+}
+
 export type TransactionStep = {
   prepare: AppUseSimulateContractReturnType
   label: string
@@ -60,6 +66,10 @@ export type TransactionStep = {
   isPermit?: boolean
   permitData?: PermitData
   onPermitSigned?: (signature: `0x${string}`) => void
+  batch?: {
+    chainId: number
+    calls: readonly TransactionBatchCall[]
+  }
 }
 
 type TPrepareDebugInfo = {
@@ -185,6 +195,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const [completedStepSnapshot, setCompletedStepSnapshot] = useState<TransactionStep | null>(null)
 
   const writeContract = useWriteContract()
+  const sendCalls = useSendCalls()
   const { signTypedDataAsync } = useSignTypedData()
   const currentChainId = useChainId()
   const { switchChainAsync } = useSwitchChain()
@@ -194,7 +205,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const connectedChainId = resolveOverlayConnectedChainId({
     accountChainId: chain?.id,
     currentChainId,
-    targetChainId: ((step?.prepare.data?.request as any)?.chainId as number | undefined) ?? undefined,
+    targetChainId:
+      step?.batch?.chainId ?? (((step?.prepare.data?.request as any)?.chainId as number | undefined) || undefined),
     isWalletSafe
   })
 
@@ -209,7 +221,9 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const executedStepRef = useRef<TransactionStep | null>(null)
 
   const explorerChainId =
-    ((executedStepRef.current?.prepare.data?.request as any)?.chainId as number | undefined) ?? undefined
+    executedStepRef.current?.batch?.chainId ??
+    ((executedStepRef.current?.prepare.data?.request as any)?.chainId as number | undefined) ??
+    undefined
   const safeTransactionDetails = useSafeTransactionDetails({
     safeTxHash: isWalletSafe ? txHash : undefined,
     enabled: Boolean(isWalletSafe && txHash && (overlayState === 'pending' || overlayState === 'submitted'))
@@ -241,7 +255,9 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const executedStepBlockRef = useRef<bigint | undefined>(undefined)
 
   // Check if current step is ready to execute
-  const isStepReady = Boolean(step?.prepare.isSuccess && step?.prepare.data?.request)
+  const isStepReady = Boolean(
+    step?.batch ? step.batch.calls.length > 0 : step?.prepare.isSuccess && step?.prepare.data?.request
+  )
   const executedStepLabel = executedStepRef.current?.label
   const executedStepFunctionName = (
     executedStepRef.current?.prepare.data?.request as { functionName?: unknown } | undefined
@@ -259,6 +275,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const hasAdvancedFromStepRef = useRef<string | null>(null)
   const autoContinueNonceRef = useRef(0)
   const writeContractResetRef = useRef(writeContract.reset)
+  const sendCallsResetRef = useRef(sendCalls.reset)
   const pendingCompletionRef = useRef<CompletionDeferral>('none')
   const handledConfettiRequestRef = useRef(0)
   const [isAutoContinuing, setIsAutoContinuing] = useState(false)
@@ -267,6 +284,10 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   useEffect(() => {
     writeContractResetRef.current = writeContract.reset
   }, [writeContract.reset])
+
+  useEffect(() => {
+    sendCallsResetRef.current = sendCalls.reset
+  }, [sendCalls.reset])
 
   const runAllCompleteIfPending = useCallback(
     (trigger: 'close' | 'confetti') => {
@@ -382,6 +403,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
   const resetTxState = useCallback((clearNotification = false) => {
     writeContractResetRef.current()
+    sendCallsResetRef.current()
     setTxHash(undefined)
     if (clearNotification) {
       setNotificationId(undefined)
@@ -519,6 +541,67 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
   const executeContractStep = useCallback(
     async (currentStep: TransactionStep) => {
+      if (currentStep.batch) {
+        if (!isWalletSafe) {
+          setOverlayState('error')
+          setErrorMessage('Batch transactions are only available in Safe.')
+          return
+        }
+        if (!account || currentStep.batch.calls.length === 0) {
+          setOverlayState('error')
+          setErrorMessage('Transaction not ready. Please try again.')
+          return
+        }
+
+        setStepExecutionContext(currentStep, isLastStep)
+        setOverlayState('confirming')
+        setErrorMessage('')
+
+        const txChainId = currentStep.batch.chainId
+        if (!isConnectedToExecutionChain(connectedChainId, txChainId)) {
+          try {
+            await switchChainAsync({ chainId: txChainId })
+          } catch (error: any) {
+            if (isUserRejectionError(error)) {
+              onClose()
+              return
+            }
+            console.warn('[TransactionOverlay] Safe batch chain switch failed', {
+              to: txChainId,
+              step: currentStep.label,
+              error: error?.message || error
+            })
+            setOverlayState('error')
+            setErrorMessage(
+              'Unable to switch networks for this transaction. Please confirm your Safe is opened on the correct chain.'
+            )
+            return
+          }
+        }
+
+        try {
+          const result = await sendCalls.sendCallsAsync({
+            account,
+            chainId: txChainId,
+            forceAtomic: true,
+            calls: currentStep.batch.calls
+          })
+          const hash = result.id as `0x${string}`
+          setTxHash(hash)
+          setOverlayState('pending')
+          await handleCreateNotification(hash, currentStep.notification, txChainId)
+        } catch (error: any) {
+          if (isUserRejectionError(error)) {
+            onClose()
+            return
+          }
+          console.error('Safe batch transaction failed:', error)
+          setOverlayState('error')
+          setErrorMessage(getTransactionErrorMessage(error))
+        }
+        return
+      }
+
       if (!currentStep.prepare.isSuccess || !currentStep.prepare.data?.request) {
         console.warn('[TransactionOverlay] Transaction not ready', getStepDebugInfo(currentStep))
         setOverlayState('error')
@@ -620,9 +703,12 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       connectedChainId,
       finalizeSuccessState,
       handleCreateNotification,
+      account,
       isLastStep,
+      isWalletSafe,
       onClose,
       requestConfetti,
+      sendCalls,
       setStepExecutionContext,
       switchChainAsync,
       writeContract
@@ -852,10 +938,11 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       const completedAllSteps = executedStepRef.current?.completesFlow ?? wasLastStepRef.current
       const capturedStep = executedStepRef.current
       const capturedReceipt = receipt.data
+      const capturedStatus = capturedStep?.notification?.type === 'crosschain zap' ? 'submitted' : 'success'
       resetTxState()
 
-      // Update notification to success
-      handleUpdateNotification({ receipt: capturedReceipt, status: 'success' })
+      // Cross-chain source execution is confirmed before destination funds arrive.
+      handleUpdateNotification({ receipt: capturedReceipt, status: capturedStatus })
       setNotificationId(undefined)
 
       if (completedAllSteps && onBeforeSuccess) {
@@ -891,6 +978,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     executedStepLabel,
     advanceToNextStep,
     finalizeSuccessState,
+    isWalletSafe,
     waitForAutoContinueBlock
   ])
 

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -20,8 +20,8 @@ import { AnimatedCheckmark, ErrorIcon, Spinner } from './TransactionStateIndicat
 import {
   AUTO_CONTINUE_SUCCESS_DELAY_MS,
   type CompletionDeferral,
-  getInitialOverlayState,
   getAutoContinueConfirmDelayMs,
+  getInitialOverlayState,
   getPendingTransactionTitle,
   type OverlayState,
   resolveCompletionDeferral,

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -426,7 +426,11 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
   // Update notification with new status/receipt
   const handleUpdateNotification = useCallback(
-    async (params: { status?: 'pending' | 'submitted' | 'success' | 'error'; receipt?: any }) => {
+    async (params: {
+      status?: 'pending' | 'submitted' | 'success' | 'error'
+      receipt?: any
+      awaitingExecution?: boolean
+    }) => {
       if (!notificationId) return
 
       try {
@@ -731,8 +735,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
     if (nextOverlayState === 'submitted') {
       setOverlayState('submitted')
-      void handleUpdateNotification({ status: 'submitted' })
-      setNotificationId(undefined)
+      void handleUpdateNotification({ status: 'submitted', awaitingExecution: true })
       return
     }
 

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -22,6 +22,7 @@ import {
   type CompletionDeferral,
   getInitialOverlayState,
   getPendingTransactionTitle,
+  getAutoContinueConfirmDelayMs,
   type OverlayState,
   resolveCompletionDeferral,
   resolveExecutionTrackingHash,
@@ -825,6 +826,17 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
           if (autoContinueNonceRef.current !== nonceAtSchedule) {
             setIsAutoContinuing(false)
             return
+          }
+          const confirmDelayMs = getAutoContinueConfirmDelayMs({ isWalletSafe })
+          if (confirmDelayMs > 0) {
+            setOverlayState('confirming')
+            await new Promise((resolve) => {
+              window.setTimeout(resolve, confirmDelayMs)
+            })
+            if (autoContinueNonceRef.current !== nonceAtSchedule) {
+              setIsAutoContinuing(false)
+              return
+            }
           }
           await waitForAutoContinueBlock(executedStepLabel)
           if (autoContinueNonceRef.current !== nonceAtSchedule) {

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -18,6 +18,7 @@ import { useAccount, useCallsStatus, useSignTypedData, useWriteContract } from '
 import { isConnectedToExecutionChain } from '@/config/tenderly'
 import { AnimatedCheckmark, ErrorIcon, Spinner } from './TransactionStateIndicators'
 import {
+  AUTO_CONTINUE_SUCCESS_DELAY_MS,
   type CompletionDeferral,
   getInitialOverlayState,
   getPendingTransactionTitle,
@@ -26,6 +27,7 @@ import {
   resolveExecutionTrackingHash,
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
+  shouldAutoContinueFromSuccessState,
   shouldAutoContinuePermitSuccess,
   shouldRefetchNextStepAfterReceipt,
   shouldRunDeferredCompletion
@@ -794,7 +796,14 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       (overlayState === 'pending' || overlayState === 'submitted') &&
       canShowSuccess
     ) {
-      if (executedStepLabel && executedStepAutoContinues && !wasLastStepRef.current) {
+      if (
+        shouldAutoContinueFromSuccessState({
+          canShowSuccess,
+          executedStepAutoContinues,
+          wasLastStep: wasLastStepRef.current
+        }) &&
+        executedStepLabel
+      ) {
         if (hasAdvancedFromStepRef.current === executedStepLabel) {
           return
         }
@@ -808,7 +817,15 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
         hasAutoContinuedFromStepRef.current = executedStepLabel
         const nonceAtSchedule = autoContinueNonceRef.current
         setIsAutoContinuing(true)
+        finalizeSuccessState(false, executedStepRef.current)
         const advance = async () => {
+          await new Promise((resolve) => {
+            window.setTimeout(resolve, AUTO_CONTINUE_SUCCESS_DELAY_MS)
+          })
+          if (autoContinueNonceRef.current !== nonceAtSchedule) {
+            setIsAutoContinuing(false)
+            return
+          }
           await waitForAutoContinueBlock(executedStepLabel)
           if (autoContinueNonceRef.current !== nonceAtSchedule) {
             setIsAutoContinuing(false)

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -208,7 +208,12 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const safeCallsStatus = useCallsStatus({
     id: txHash || '0x',
     query: {
-      enabled: Boolean(isWalletSafe && txHash && overlayState === 'pending' && !receipt.data?.transactionHash),
+      enabled: Boolean(
+        isWalletSafe &&
+          txHash &&
+          (overlayState === 'pending' || overlayState === 'submitted') &&
+          !receipt.data?.transactionHash
+      ),
       refetchInterval: 1500
     }
   })
@@ -751,7 +756,11 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   useEffect(() => {
     // For multi-step flows, wait until next step is ready before showing success
     // Check that step has changed (different label) and is ready
-    if (receipt.isSuccess && receipt.data?.transactionHash && overlayState === 'pending') {
+    if (
+      receipt.isSuccess &&
+      receipt.data?.transactionHash &&
+      (overlayState === 'pending' || overlayState === 'submitted')
+    ) {
       executedStepBlockRef.current = receipt.data.blockNumber
       const executedStepLabel = executedStepRef.current?.label
       if (!hasReportedStepSuccessRef.current && executedStepLabel) {
@@ -762,7 +771,12 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
     const isNextStepReady = step?.label !== executedStepRef.current?.label && isStepReady
     const canShowSuccess = wasLastStepRef.current || isNextStepReady
-    if (receipt.isSuccess && receipt.data?.transactionHash && overlayState === 'pending' && canShowSuccess) {
+    if (
+      receipt.isSuccess &&
+      receipt.data?.transactionHash &&
+      (overlayState === 'pending' || overlayState === 'submitted') &&
+      canShowSuccess
+    ) {
       if (executedStepLabel && executedStepAutoContinues && !wasLastStepRef.current) {
         if (hasAdvancedFromStepRef.current === executedStepLabel) {
           return
@@ -866,7 +880,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
 
   // Handle transaction error
   useEffect(() => {
-    if (receipt.isError && receipt.error && overlayState === 'pending') {
+    if (receipt.isError && receipt.error && (overlayState === 'pending' || overlayState === 'submitted')) {
       setOverlayState('error')
       setErrorMessage('Transaction failed. Please try again.')
       resetTxState()
@@ -1015,8 +1029,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
               <AnimatedCheckmark isVisible />
               <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Transaction submitted</h3>
               <p className="text-sm text-text-secondary whitespace-pre-line mb-6">
-                Your transaction has been submitted to your Safe.\nExecution may happen separately after the required
-                confirmations are collected.
+                {`Your transaction has been submitted to your Safe.
+Execution may happen separately after the required confirmations are collected.`}
               </p>
               <Button
                 onClick={handleClose}

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -27,6 +27,7 @@ import {
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
   shouldAutoContinuePermitSuccess,
+  shouldRefetchNextStepAfterReceipt,
   shouldRunDeferredCompletion
 } from './transactionOverlay.helpers'
 
@@ -910,13 +911,21 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   // When step 1 succeeds in a multi-step flow, the next step simulation may need a refetch
   // to pick up post-transaction state (e.g. unstake -> withdraw).
   useEffect(() => {
-    if (!isOpen || overlayState !== 'pending') return
-    if (!receipt.isSuccess || !receipt.data?.transactionHash) return
-    if (wasLastStepRef.current) return
-    if (!step?.label || step.label === executedStepRef.current?.label) return
-    if (isStepReady) return
+    if (
+      !shouldRefetchNextStepAfterReceipt({
+        isOpen,
+        overlayState,
+        hasReceiptTransactionHash: Boolean(receipt.data?.transactionHash),
+        wasLastStep: wasLastStepRef.current,
+        currentStepLabel: step?.label,
+        executedStepLabel: executedStepRef.current?.label,
+        isStepReady
+      })
+    ) {
+      return
+    }
 
-    const refetch = step.prepare.refetch
+    const refetch = step?.prepare.refetch
     if (!refetch) return
 
     void refetch()
@@ -927,15 +936,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     return () => {
       window.clearInterval(intervalId)
     }
-  }, [
-    isOpen,
-    overlayState,
-    receipt.isSuccess,
-    receipt.data?.transactionHash,
-    step?.label,
-    step?.prepare.refetch,
-    isStepReady
-  ])
+  }, [isOpen, overlayState, receipt.data?.transactionHash, step?.label, step?.prepare.refetch, isStepReady])
 
   return (
     <div
@@ -1042,20 +1043,22 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
           {/* Submitted State */}
           {overlayState === 'submitted' && (
             <>
-              <AnimatedCheckmark isVisible />
+              <Spinner />
               <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Transaction submitted</h3>
-              <p className="text-sm text-text-secondary whitespace-pre-line mb-6">
+              <p className="text-sm text-text-secondary whitespace-pre-line">
                 {`Your transaction has been submitted to your Safe.
 Execution may happen separately after the required confirmations are collected.`}
               </p>
-              <Button
-                onClick={handleClose}
-                variant="filled"
-                className="w-full max-w-xs"
-                classNameOverride="yearn--button--nextgen w-full"
-              >
-                Done
-              </Button>
+              {explorerTxUrl ? (
+                <a
+                  href={explorerTxUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-3 text-sm font-semibold text-text-primary underline"
+                >
+                  View on block explorer
+                </a>
+              ) : null}
             </>
           )}
 

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePendingSafeOverlayState } from './transactionOverlay.helpers'
+
+describe('resolvePendingSafeOverlayState', () => {
+  it('moves a Safe transaction overlay into a submitted state when the Safe tx is queued but not executed', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: true,
+        hasReceiptTransactionHash: false,
+        callsStatus: 'pending'
+      })
+    ).toBe('submitted')
+  })
+
+  it('keeps non-Safe pending overlays waiting for a normal receipt', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: false,
+        hasReceiptTransactionHash: false,
+        callsStatus: 'pending'
+      })
+    ).toBe('pending')
+  })
+
+  it('surfaces Safe call-batch failures as overlay errors', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: true,
+        hasReceiptTransactionHash: false,
+        callsStatus: 'failure'
+      })
+    ).toBe('error')
+  })
+})

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   resolveExecutionTrackingHash,
   resolveOverlayConnectedChainId,
-  resolvePendingSafeOverlayState
+  resolvePendingSafeOverlayState,
+  shouldRefetchNextStepAfterReceipt
 } from './transactionOverlay.helpers'
 
 describe('resolveOverlayConnectedChainId', () => {
@@ -136,5 +137,35 @@ describe('resolveExecutionTrackingHash', () => {
         callsReceiptTxHash: '0xfallback'
       })
     ).toBe('0xnormal')
+  })
+})
+
+describe('shouldRefetchNextStepAfterReceipt', () => {
+  it('refetches the next step after a Safe-submitted approval execution receipt arrives', () => {
+    expect(
+      shouldRefetchNextStepAfterReceipt({
+        isOpen: true,
+        overlayState: 'submitted',
+        hasReceiptTransactionHash: true,
+        wasLastStep: false,
+        currentStepLabel: 'Deposit',
+        executedStepLabel: 'Approve',
+        isStepReady: false
+      })
+    ).toBe(true)
+  })
+
+  it('does not refetch when the next step is already ready', () => {
+    expect(
+      shouldRefetchNextStepAfterReceipt({
+        isOpen: true,
+        overlayState: 'submitted',
+        hasReceiptTransactionHash: true,
+        wasLastStep: false,
+        currentStepLabel: 'Deposit',
+        executedStepLabel: 'Approve',
+        isStepReady: true
+      })
+    ).toBe(false)
   })
 })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
   AUTO_CONTINUE_SUCCESS_DELAY_MS,
+  getAutoContinueConfirmDelayMs,
   resolveExecutionTrackingHash,
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
+  SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS,
   shouldAutoContinueFromSuccessState,
   shouldRefetchNextStepAfterReceipt
 } from './transactionOverlay.helpers'
@@ -181,7 +183,7 @@ describe('shouldAutoContinueFromSuccessState', () => {
         wasLastStep: false
       })
     ).toBe(true)
-    expect(AUTO_CONTINUE_SUCCESS_DELAY_MS).toBeGreaterThanOrEqual(1000)
+    expect(AUTO_CONTINUE_SUCCESS_DELAY_MS).toBeGreaterThanOrEqual(1500)
   })
 
   it('does not auto-continue from the interstitial for terminal steps', () => {
@@ -192,5 +194,16 @@ describe('shouldAutoContinueFromSuccessState', () => {
         wasLastStep: true
       })
     ).toBe(false)
+  })
+})
+
+describe('getAutoContinueConfirmDelayMs', () => {
+  it('adds a short confirm interstitial before auto-continued Safe prompts', () => {
+    expect(getAutoContinueConfirmDelayMs({ isWalletSafe: true })).toBe(SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS)
+    expect(SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS).toBeGreaterThan(0)
+  })
+
+  it('does not delay the confirm screen for non-Safe flows', () => {
+    expect(getAutoContinueConfirmDelayMs({ isWalletSafe: false })).toBe(0)
   })
 })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { resolveOverlayConnectedChainId, resolvePendingSafeOverlayState } from './transactionOverlay.helpers'
+import {
+  resolveExecutionTrackingHash,
+  resolveOverlayConnectedChainId,
+  resolvePendingSafeOverlayState
+} from './transactionOverlay.helpers'
 
 describe('resolveOverlayConnectedChainId', () => {
   it('prefers the target chain for Safe sessions when account.chain is missing', () => {
@@ -15,12 +19,37 @@ describe('resolveOverlayConnectedChainId', () => {
 })
 
 describe('resolvePendingSafeOverlayState', () => {
+  it('moves a Safe transaction overlay into a submitted state when the Safe tx is awaiting confirmations', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'AWAITING_CONFIRMATIONS',
+        callsStatus: undefined
+      })
+    ).toBe('submitted')
+  })
+
   it('moves a Safe transaction overlay into a submitted state when the Safe tx is queued but not executed', () => {
     expect(
       resolvePendingSafeOverlayState({
         overlayState: 'pending',
         isWalletSafe: true,
-        hasReceiptTransactionHash: false,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'AWAITING_EXECUTION',
+        callsStatus: undefined
+      })
+    ).toBe('submitted')
+  })
+
+  it('falls back to wallet_getCallsStatus when Safe tx details are not available yet', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: undefined,
         callsStatus: 'pending'
       })
     ).toBe('submitted')
@@ -31,19 +60,33 @@ describe('resolvePendingSafeOverlayState', () => {
       resolvePendingSafeOverlayState({
         overlayState: 'pending',
         isWalletSafe: false,
-        hasReceiptTransactionHash: false,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'AWAITING_EXECUTION',
         callsStatus: 'pending'
       })
     ).toBe('pending')
   })
 
-  it('surfaces Safe call-batch failures as overlay errors', () => {
+  it('surfaces Safe detail failures as overlay errors', () => {
     expect(
       resolvePendingSafeOverlayState({
         overlayState: 'pending',
         isWalletSafe: true,
-        hasReceiptTransactionHash: false,
-        callsStatus: 'failure'
+        hasExecutionReceipt: false,
+        safeTxStatus: 'FAILED',
+        callsStatus: undefined
+      })
+    ).toBe('error')
+  })
+
+  it('surfaces cancelled Safe transactions as overlay errors', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'CANCELLED',
+        callsStatus: undefined
       })
     ).toBe('error')
   })
@@ -53,9 +96,45 @@ describe('resolvePendingSafeOverlayState', () => {
       resolvePendingSafeOverlayState({
         overlayState: 'submitted',
         isWalletSafe: true,
-        hasReceiptTransactionHash: false,
+        hasExecutionReceipt: false,
+        safeTxStatus: undefined,
         callsStatus: 'failure'
       })
     ).toBe('error')
+  })
+})
+
+describe('resolveExecutionTrackingHash', () => {
+  it('prefers the actual executed tx hash for Safe sessions', () => {
+    expect(
+      resolveExecutionTrackingHash({
+        isWalletSafe: true,
+        submittedTxHash: '0xsafe',
+        safeExecutionTxHash: '0xexecuted',
+        callsReceiptTxHash: '0xfallback'
+      })
+    ).toBe('0xexecuted')
+  })
+
+  it('falls back to calls-status receipt hash for Safe sessions when details have not resolved yet', () => {
+    expect(
+      resolveExecutionTrackingHash({
+        isWalletSafe: true,
+        submittedTxHash: '0xsafe',
+        safeExecutionTxHash: undefined,
+        callsReceiptTxHash: '0xfallback'
+      })
+    ).toBe('0xfallback')
+  })
+
+  it('uses the submitted tx hash directly for non-Safe sessions', () => {
+    expect(
+      resolveExecutionTrackingHash({
+        isWalletSafe: false,
+        submittedTxHash: '0xnormal',
+        safeExecutionTxHash: '0xexecuted',
+        callsReceiptTxHash: '0xfallback'
+      })
+    ).toBe('0xnormal')
   })
 })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
+  AUTO_CONTINUE_SUCCESS_DELAY_MS,
   resolveExecutionTrackingHash,
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
+  shouldAutoContinueFromSuccessState,
   shouldRefetchNextStepAfterReceipt
 } from './transactionOverlay.helpers'
 
@@ -165,6 +167,29 @@ describe('shouldRefetchNextStepAfterReceipt', () => {
         currentStepLabel: 'Deposit',
         executedStepLabel: 'Approve',
         isStepReady: true
+      })
+    ).toBe(false)
+  })
+})
+
+describe('shouldAutoContinueFromSuccessState', () => {
+  it('shows a short success interstitial before auto-continuing to the next step', () => {
+    expect(
+      shouldAutoContinueFromSuccessState({
+        canShowSuccess: true,
+        executedStepAutoContinues: true,
+        wasLastStep: false
+      })
+    ).toBe(true)
+    expect(AUTO_CONTINUE_SUCCESS_DELAY_MS).toBeGreaterThanOrEqual(1000)
+  })
+
+  it('does not auto-continue from the interstitial for terminal steps', () => {
+    expect(
+      shouldAutoContinueFromSuccessState({
+        canShowSuccess: true,
+        executedStepAutoContinues: true,
+        wasLastStep: true
       })
     ).toBe(false)
   })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { resolvePendingSafeOverlayState } from './transactionOverlay.helpers'
+import { resolveOverlayConnectedChainId, resolvePendingSafeOverlayState } from './transactionOverlay.helpers'
+
+describe('resolveOverlayConnectedChainId', () => {
+  it('prefers the target chain for Safe sessions when account.chain is missing', () => {
+    expect(
+      resolveOverlayConnectedChainId({
+        accountChainId: undefined,
+        currentChainId: 1,
+        targetChainId: 747474,
+        isWalletSafe: true
+      })
+    ).toBe(747474)
+  })
+})
 
 describe('resolvePendingSafeOverlayState', () => {
   it('moves a Safe transaction overlay into a submitted state when the Safe tx is queued but not executed', () => {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -47,4 +47,15 @@ describe('resolvePendingSafeOverlayState', () => {
       })
     ).toBe('error')
   })
+
+  it('keeps polling submitted Safe overlays so failures can still surface', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'submitted',
+        isWalletSafe: true,
+        hasReceiptTransactionHash: false,
+        callsStatus: 'failure'
+      })
+    ).toBe('error')
+  })
 })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -10,8 +10,8 @@ import {
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
   SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS,
-  shouldAutoContinuePermitSuccess,
   shouldAutoContinueFromSuccessState,
+  shouldAutoContinuePermitSuccess,
   shouldRefetchNextStepAfterReceipt,
   shouldRunDeferredCompletion
 } from './transactionOverlay.helpers'

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -4,10 +4,11 @@ import {
   getInitialOverlayState,
   getPendingTransactionTitle,
   resolveCompletionDeferral,
-  shouldAutoContinuePermitSuccess,
-  shouldRunDeferredCompletion,
+  resolveExecutionTrackingHash,
   resolveOverlayConnectedChainId,
-  resolvePendingSafeOverlayState
+  resolvePendingSafeOverlayState,
+  shouldAutoContinuePermitSuccess,
+  shouldRunDeferredCompletion
 } from './transactionOverlay.helpers'
 
 describe('resolveOverlayConnectedChainId', () => {
@@ -27,9 +28,7 @@ describe('transactionOverlay.helpers', () => {
   it('starts idle so conditionally mounted overlays can execute their first step on open', () => {
     expect(getInitialOverlayState()).toBe('idle')
   })
-})
 
-describe('transactionOverlay.helpers', () => {
   it('formats pending transaction function names from onchain requests', () => {
     expect(formatPendingTransactionFunctionName({ functionName: 'approve' })).toBe('Approve()')
     expect(formatPendingTransactionFunctionName({ functionName: 'deposit' })).toBe('Deposit()')
@@ -120,41 +119,80 @@ describe('transactionOverlay.helpers', () => {
         trigger: 'confetti'
       })
     ).toBe(false)
+  })
+})
 
-    describe('resolvePendingSafeOverlayState', () => {
-      it('moves a Safe transaction overlay into a submitted state when the Safe tx is queued but not executed', () => {
-        expect(
-          resolvePendingSafeOverlayState({
-            overlayState: 'pending',
-            isWalletSafe: true,
-            hasReceiptTransactionHash: false,
-            callsStatus: 'pending'
-          })
-        ).toBe('submitted')
+describe('resolvePendingSafeOverlayState', () => {
+  it('moves a Safe transaction overlay into a submitted state when the Safe tx is awaiting confirmations', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'AWAITING_CONFIRMATIONS',
+        callsStatus: undefined
       })
+    ).toBe('submitted')
+  })
 
-      it('keeps non-Safe pending overlays waiting for a normal receipt', () => {
-        expect(
-          resolvePendingSafeOverlayState({
-            overlayState: 'pending',
-            isWalletSafe: false,
-            hasReceiptTransactionHash: false,
-            callsStatus: 'pending'
-          })
-        ).toBe('pending')
+  it('moves a Safe transaction overlay into a submitted state when the Safe tx is queued but not executed', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'AWAITING_EXECUTION',
+        callsStatus: undefined
       })
+    ).toBe('submitted')
+  })
 
-      it('surfaces Safe call-batch failures as overlay errors', () => {
-        expect(
-          resolvePendingSafeOverlayState({
-            overlayState: 'pending',
-            isWalletSafe: true,
-            hasReceiptTransactionHash: false,
-            callsStatus: 'failure'
-          })
-        ).toBe('error')
+  it('falls back to wallet_getCallsStatus when Safe tx details are not available yet', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: undefined,
+        callsStatus: 'pending'
       })
-    })
+    ).toBe('submitted')
+  })
+
+  it('keeps non-Safe pending overlays waiting for a normal receipt', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: false,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'AWAITING_EXECUTION',
+        callsStatus: 'pending'
+      })
+    ).toBe('pending')
+  })
+
+  it('surfaces Safe detail failures as overlay errors', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'FAILED',
+        callsStatus: undefined
+      })
+    ).toBe('error')
+  })
+
+  it('surfaces cancelled Safe transactions as overlay errors', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'pending',
+        isWalletSafe: true,
+        hasExecutionReceipt: false,
+        safeTxStatus: 'CANCELLED',
+        callsStatus: undefined
+      })
+    ).toBe('error')
   })
 
   it('keeps polling submitted Safe overlays so failures can still surface', () => {
@@ -162,9 +200,45 @@ describe('transactionOverlay.helpers', () => {
       resolvePendingSafeOverlayState({
         overlayState: 'submitted',
         isWalletSafe: true,
-        hasReceiptTransactionHash: false,
+        hasExecutionReceipt: false,
+        safeTxStatus: undefined,
         callsStatus: 'failure'
       })
     ).toBe('error')
+  })
+})
+
+describe('resolveExecutionTrackingHash', () => {
+  it('prefers the actual executed tx hash for Safe sessions', () => {
+    expect(
+      resolveExecutionTrackingHash({
+        isWalletSafe: true,
+        submittedTxHash: '0xsafe',
+        safeExecutionTxHash: '0xexecuted',
+        callsReceiptTxHash: '0xfallback'
+      })
+    ).toBe('0xexecuted')
+  })
+
+  it('falls back to calls-status receipt hash for Safe sessions when details have not resolved yet', () => {
+    expect(
+      resolveExecutionTrackingHash({
+        isWalletSafe: true,
+        submittedTxHash: '0xsafe',
+        safeExecutionTxHash: undefined,
+        callsReceiptTxHash: '0xfallback'
+      })
+    ).toBe('0xfallback')
+  })
+
+  it('uses the submitted tx hash directly for non-Safe sessions', () => {
+    expect(
+      resolveExecutionTrackingHash({
+        isWalletSafe: false,
+        submittedTxHash: '0xnormal',
+        safeExecutionTxHash: '0xexecuted',
+        callsReceiptTxHash: '0xfallback'
+      })
+    ).toBe('0xnormal')
   })
 })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -5,7 +5,8 @@ import {
   getPendingTransactionTitle,
   resolveCompletionDeferral,
   shouldAutoContinuePermitSuccess,
-  shouldRunDeferredCompletion
+  shouldRunDeferredCompletion,
+  resolvePendingSafeOverlayState
 } from './transactionOverlay.helpers'
 
 describe('transactionOverlay.helpers', () => {
@@ -105,5 +106,40 @@ describe('transactionOverlay.helpers', () => {
         trigger: 'confetti'
       })
     ).toBe(false)
+
+    describe('resolvePendingSafeOverlayState', () => {
+      it('moves a Safe transaction overlay into a submitted state when the Safe tx is queued but not executed', () => {
+        expect(
+          resolvePendingSafeOverlayState({
+            overlayState: 'pending',
+            isWalletSafe: true,
+            hasReceiptTransactionHash: false,
+            callsStatus: 'pending'
+          })
+        ).toBe('submitted')
+      })
+
+      it('keeps non-Safe pending overlays waiting for a normal receipt', () => {
+        expect(
+          resolvePendingSafeOverlayState({
+            overlayState: 'pending',
+            isWalletSafe: false,
+            hasReceiptTransactionHash: false,
+            callsStatus: 'pending'
+          })
+        ).toBe('pending')
+      })
+
+      it('surfaces Safe call-batch failures as overlay errors', () => {
+        expect(
+          resolvePendingSafeOverlayState({
+            overlayState: 'pending',
+            isWalletSafe: true,
+            hasReceiptTransactionHash: false,
+            callsStatus: 'failure'
+          })
+        ).toBe('error')
+      })
+    })
   })
 })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -12,8 +12,8 @@ import {
   SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS,
   shouldAutoContinuePermitSuccess,
   shouldAutoContinueFromSuccessState,
-  shouldRunDeferredCompletion,
-  shouldRefetchNextStepAfterReceipt
+  shouldRefetchNextStepAfterReceipt,
+  shouldRunDeferredCompletion
 } from './transactionOverlay.helpers'
 
 describe('resolveOverlayConnectedChainId', () => {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  AUTO_CONTINUE_SUCCESS_DELAY_MS,
   formatPendingTransactionFunctionName,
   getInitialOverlayState,
   getPendingTransactionTitle,
@@ -8,6 +9,7 @@ import {
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
   shouldAutoContinuePermitSuccess,
+  shouldAutoContinueFromSuccessState,
   shouldRunDeferredCompletion,
   shouldRefetchNextStepAfterReceipt
 } from './transactionOverlay.helpers'
@@ -269,6 +271,29 @@ describe('shouldRefetchNextStepAfterReceipt', () => {
         currentStepLabel: 'Deposit',
         executedStepLabel: 'Approve',
         isStepReady: true
+      })
+    ).toBe(false)
+  })
+})
+
+describe('shouldAutoContinueFromSuccessState', () => {
+  it('shows a short success interstitial before auto-continuing to the next step', () => {
+    expect(
+      shouldAutoContinueFromSuccessState({
+        canShowSuccess: true,
+        executedStepAutoContinues: true,
+        wasLastStep: false
+      })
+    ).toBe(true)
+    expect(AUTO_CONTINUE_SUCCESS_DELAY_MS).toBeGreaterThanOrEqual(1000)
+  })
+
+  it('does not auto-continue from the interstitial for terminal steps', () => {
+    expect(
+      shouldAutoContinueFromSuccessState({
+        canShowSuccess: true,
+        executedStepAutoContinues: true,
+        wasLastStep: true
       })
     ).toBe(false)
   })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -8,7 +8,8 @@ import {
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
   shouldAutoContinuePermitSuccess,
-  shouldRunDeferredCompletion
+  shouldRunDeferredCompletion,
+  shouldRefetchNextStepAfterReceipt
 } from './transactionOverlay.helpers'
 
 describe('resolveOverlayConnectedChainId', () => {
@@ -240,5 +241,35 @@ describe('resolveExecutionTrackingHash', () => {
         callsReceiptTxHash: '0xfallback'
       })
     ).toBe('0xnormal')
+  })
+})
+
+describe('shouldRefetchNextStepAfterReceipt', () => {
+  it('refetches the next step after a Safe-submitted approval execution receipt arrives', () => {
+    expect(
+      shouldRefetchNextStepAfterReceipt({
+        isOpen: true,
+        overlayState: 'submitted',
+        hasReceiptTransactionHash: true,
+        wasLastStep: false,
+        currentStepLabel: 'Deposit',
+        executedStepLabel: 'Approve',
+        isStepReady: false
+      })
+    ).toBe(true)
+  })
+
+  it('does not refetch when the next step is already ready', () => {
+    expect(
+      shouldRefetchNextStepAfterReceipt({
+        isOpen: true,
+        overlayState: 'submitted',
+        hasReceiptTransactionHash: true,
+        wasLastStep: false,
+        currentStepLabel: 'Deposit',
+        executedStepLabel: 'Approve',
+        isStepReady: true
+      })
+    ).toBe(false)
   })
 })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -156,4 +156,15 @@ describe('transactionOverlay.helpers', () => {
       })
     })
   })
+
+  it('keeps polling submitted Safe overlays so failures can still surface', () => {
+    expect(
+      resolvePendingSafeOverlayState({
+        overlayState: 'submitted',
+        isWalletSafe: true,
+        hasReceiptTransactionHash: false,
+        callsStatus: 'failure'
+      })
+    ).toBe('error')
+  })
 })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from 'vitest'
 import {
   AUTO_CONTINUE_SUCCESS_DELAY_MS,
   formatPendingTransactionFunctionName,
+  getAutoContinueConfirmDelayMs,
   getInitialOverlayState,
   getPendingTransactionTitle,
   resolveCompletionDeferral,
   resolveExecutionTrackingHash,
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
+  SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS,
   shouldAutoContinuePermitSuccess,
   shouldAutoContinueFromSuccessState,
   shouldRunDeferredCompletion,
@@ -285,7 +287,7 @@ describe('shouldAutoContinueFromSuccessState', () => {
         wasLastStep: false
       })
     ).toBe(true)
-    expect(AUTO_CONTINUE_SUCCESS_DELAY_MS).toBeGreaterThanOrEqual(1000)
+    expect(AUTO_CONTINUE_SUCCESS_DELAY_MS).toBeGreaterThanOrEqual(1500)
   })
 
   it('does not auto-continue from the interstitial for terminal steps', () => {
@@ -296,5 +298,16 @@ describe('shouldAutoContinueFromSuccessState', () => {
         wasLastStep: true
       })
     ).toBe(false)
+  })
+})
+
+describe('getAutoContinueConfirmDelayMs', () => {
+  it('adds a short confirm interstitial before auto-continued Safe prompts', () => {
+    expect(getAutoContinueConfirmDelayMs({ isWalletSafe: true })).toBe(SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS)
+    expect(SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS).toBeGreaterThan(0)
+  })
+
+  it('does not delay the confirm screen for non-Safe flows', () => {
+    expect(getAutoContinueConfirmDelayMs({ isWalletSafe: false })).toBe(0)
   })
 })

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts
@@ -6,8 +6,22 @@ import {
   resolveCompletionDeferral,
   shouldAutoContinuePermitSuccess,
   shouldRunDeferredCompletion,
+  resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState
 } from './transactionOverlay.helpers'
+
+describe('resolveOverlayConnectedChainId', () => {
+  it('prefers the target chain for Safe sessions when account.chain is missing', () => {
+    expect(
+      resolveOverlayConnectedChainId({
+        accountChainId: undefined,
+        currentChainId: 1,
+        targetChainId: 747474,
+        isWalletSafe: true
+      })
+    ).toBe(747474)
+  })
+})
 
 describe('transactionOverlay.helpers', () => {
   it('starts idle so conditionally mounted overlays can execute their first step on open', () => {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,7 +1,8 @@
 export type OverlayState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'refreshing' | 'success' | 'error'
 export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
 export type SafeTransactionStatus = 'AWAITING_CONFIRMATIONS' | 'AWAITING_EXECUTION' | 'CANCELLED' | 'FAILED' | 'SUCCESS'
-export const AUTO_CONTINUE_SUCCESS_DELAY_MS = 1200
+export const AUTO_CONTINUE_SUCCESS_DELAY_MS = 1600
+export const SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS = 700
 
 export function resolveOverlayConnectedChainId(params: {
   accountChainId: number | undefined
@@ -115,6 +116,10 @@ export function shouldAutoContinueFromSuccessState(params: {
   wasLastStep: boolean
 }): boolean {
   return params.canShowSuccess && params.executedStepAutoContinues && !params.wasLastStep
+}
+
+export function getAutoContinueConfirmDelayMs(params: { isWalletSafe: boolean }): number {
+  return params.isWalletSafe ? SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS : 0
 }
 
 export function resolveCompletionDeferral(params: {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,6 +1,23 @@
 export type OverlayState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'refreshing' | 'success' | 'error'
 export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
 
+export function resolveOverlayConnectedChainId(params: {
+  accountChainId: number | undefined
+  currentChainId: number
+  targetChainId: number | undefined
+  isWalletSafe: boolean
+}): number {
+  if (params.accountChainId) {
+    return params.accountChainId
+  }
+
+  if (params.isWalletSafe && params.targetChainId) {
+    return params.targetChainId
+  }
+
+  return params.currentChainId
+}
+
 export function resolvePendingSafeOverlayState(params: {
   overlayState: OverlayState
   isWalletSafe: boolean

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,5 +1,22 @@
-export type OverlayState = 'idle' | 'confirming' | 'pending' | 'refreshing' | 'success' | 'error'
+export type OverlayState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'refreshing' | 'success' | 'error'
 export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
+
+export function resolvePendingSafeOverlayState(params: {
+  overlayState: OverlayState
+  isWalletSafe: boolean
+  hasReceiptTransactionHash: boolean
+  callsStatus?: 'pending' | 'success' | 'failure'
+}): OverlayState {
+  const { overlayState, isWalletSafe, hasReceiptTransactionHash, callsStatus } = params
+
+  if (overlayState !== 'pending') return overlayState
+  if (!isWalletSafe) return overlayState
+  if (hasReceiptTransactionHash) return overlayState
+  if (callsStatus === 'failure') return 'error'
+  if (callsStatus === 'pending') return 'submitted'
+
+  return overlayState
+}
 
 export function shouldAutoContinuePermitSuccess(params: {
   overlayState: OverlayState

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -89,6 +89,25 @@ export function shouldAutoContinuePermitSuccess(params: {
   return true
 }
 
+export function shouldRefetchNextStepAfterReceipt(params: {
+  isOpen: boolean
+  overlayState: OverlayState
+  hasReceiptTransactionHash: boolean
+  wasLastStep: boolean
+  currentStepLabel?: string
+  executedStepLabel?: string
+  isStepReady: boolean
+}): boolean {
+  if (!params.isOpen) return false
+  if (params.overlayState !== 'pending' && params.overlayState !== 'submitted') return false
+  if (!params.hasReceiptTransactionHash) return false
+  if (params.wasLastStep) return false
+  if (!params.currentStepLabel || params.currentStepLabel === params.executedStepLabel) return false
+  if (params.isStepReady) return false
+
+  return true
+}
+
 export function resolveCompletionDeferral(params: {
   completedAllSteps: boolean
   deferOnAllCompleteUntilClose: boolean

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,5 +1,6 @@
 export type OverlayState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'refreshing' | 'success' | 'error'
 export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
+export type SafeTransactionStatus = 'AWAITING_CONFIRMATIONS' | 'AWAITING_EXECUTION' | 'CANCELLED' | 'FAILED' | 'SUCCESS'
 
 export function resolveOverlayConnectedChainId(params: {
   accountChainId: number | undefined
@@ -21,18 +22,36 @@ export function resolveOverlayConnectedChainId(params: {
 export function resolvePendingSafeOverlayState(params: {
   overlayState: OverlayState
   isWalletSafe: boolean
-  hasReceiptTransactionHash: boolean
+  hasExecutionReceipt: boolean
+  safeTxStatus?: SafeTransactionStatus
   callsStatus?: 'pending' | 'success' | 'failure'
 }): OverlayState {
-  const { overlayState, isWalletSafe, hasReceiptTransactionHash, callsStatus } = params
+  const { overlayState, isWalletSafe, hasExecutionReceipt, safeTxStatus, callsStatus } = params
 
   if (overlayState !== 'pending' && overlayState !== 'submitted') return overlayState
   if (!isWalletSafe) return overlayState
-  if (hasReceiptTransactionHash) return overlayState
+  if (hasExecutionReceipt) return overlayState
+
+  if (safeTxStatus === 'FAILED' || safeTxStatus === 'CANCELLED') return 'error'
+  if (safeTxStatus === 'AWAITING_CONFIRMATIONS' || safeTxStatus === 'AWAITING_EXECUTION') return 'submitted'
+
   if (callsStatus === 'failure') return 'error'
   if (callsStatus === 'pending') return 'submitted'
 
   return overlayState
+}
+
+export function resolveExecutionTrackingHash(params: {
+  isWalletSafe: boolean
+  submittedTxHash?: `0x${string}`
+  safeExecutionTxHash?: `0x${string}`
+  callsReceiptTxHash?: `0x${string}`
+}): `0x${string}` | undefined {
+  if (!params.isWalletSafe) {
+    return params.submittedTxHash
+  }
+
+  return params.safeExecutionTxHash ?? params.callsReceiptTxHash
 }
 
 export function shouldAutoContinuePermitSuccess(params: {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,6 +1,7 @@
 export type OverlayState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'refreshing' | 'success' | 'error'
 export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
 export type SafeTransactionStatus = 'AWAITING_CONFIRMATIONS' | 'AWAITING_EXECUTION' | 'CANCELLED' | 'FAILED' | 'SUCCESS'
+export const AUTO_CONTINUE_SUCCESS_DELAY_MS = 1200
 
 export function resolveOverlayConnectedChainId(params: {
   accountChainId: number | undefined
@@ -106,6 +107,14 @@ export function shouldRefetchNextStepAfterReceipt(params: {
   if (params.isStepReady) return false
 
   return true
+}
+
+export function shouldAutoContinueFromSuccessState(params: {
+  canShowSuccess: boolean
+  executedStepAutoContinues: boolean
+  wasLastStep: boolean
+}): boolean {
+  return params.canShowSuccess && params.executedStepAutoContinues && !params.wasLastStep
 }
 
 export function resolveCompletionDeferral(params: {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -26,7 +26,7 @@ export function resolvePendingSafeOverlayState(params: {
 }): OverlayState {
   const { overlayState, isWalletSafe, hasReceiptTransactionHash, callsStatus } = params
 
-  if (overlayState !== 'pending') return overlayState
+  if (overlayState !== 'pending' && overlayState !== 'submitted') return overlayState
   if (!isWalletSafe) return overlayState
   if (hasReceiptTransactionHash) return overlayState
   if (callsStatus === 'failure') return 'error'

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,5 +1,6 @@
 export type OverlayState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'refreshing' | 'success' | 'error'
 export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
+export type SafeTransactionStatus = 'AWAITING_CONFIRMATIONS' | 'AWAITING_EXECUTION' | 'CANCELLED' | 'FAILED' | 'SUCCESS'
 
 export function getInitialOverlayState(): OverlayState {
   return 'idle'
@@ -69,18 +70,36 @@ export function resolveOverlayConnectedChainId(params: {
 export function resolvePendingSafeOverlayState(params: {
   overlayState: OverlayState
   isWalletSafe: boolean
-  hasReceiptTransactionHash: boolean
+  hasExecutionReceipt: boolean
+  safeTxStatus?: SafeTransactionStatus
   callsStatus?: 'pending' | 'success' | 'failure'
 }): OverlayState {
-  const { overlayState, isWalletSafe, hasReceiptTransactionHash, callsStatus } = params
+  const { overlayState, isWalletSafe, hasExecutionReceipt, safeTxStatus, callsStatus } = params
 
   if (overlayState !== 'pending' && overlayState !== 'submitted') return overlayState
   if (!isWalletSafe) return overlayState
-  if (hasReceiptTransactionHash) return overlayState
+  if (hasExecutionReceipt) return overlayState
+
+  if (safeTxStatus === 'FAILED' || safeTxStatus === 'CANCELLED') return 'error'
+  if (safeTxStatus === 'AWAITING_CONFIRMATIONS' || safeTxStatus === 'AWAITING_EXECUTION') return 'submitted'
+
   if (callsStatus === 'failure') return 'error'
   if (callsStatus === 'pending') return 'submitted'
 
   return overlayState
+}
+
+export function resolveExecutionTrackingHash(params: {
+  isWalletSafe: boolean
+  submittedTxHash?: `0x${string}`
+  safeExecutionTxHash?: `0x${string}`
+  callsReceiptTxHash?: `0x${string}`
+}): `0x${string}` | undefined {
+  if (!params.isWalletSafe) {
+    return params.submittedTxHash
+  }
+
+  return params.safeExecutionTxHash ?? params.callsReceiptTxHash
 }
 
 export function shouldAutoContinuePermitSuccess(params: {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -137,6 +137,25 @@ export function shouldAutoContinuePermitSuccess(params: {
   return true
 }
 
+export function shouldRefetchNextStepAfterReceipt(params: {
+  isOpen: boolean
+  overlayState: OverlayState
+  hasReceiptTransactionHash: boolean
+  wasLastStep: boolean
+  currentStepLabel?: string
+  executedStepLabel?: string
+  isStepReady: boolean
+}): boolean {
+  if (!params.isOpen) return false
+  if (params.overlayState !== 'pending' && params.overlayState !== 'submitted') return false
+  if (!params.hasReceiptTransactionHash) return false
+  if (params.wasLastStep) return false
+  if (!params.currentStepLabel || params.currentStepLabel === params.executedStepLabel) return false
+  if (params.isStepReady) return false
+
+  return true
+}
+
 export function resolveCompletionDeferral(params: {
   completedAllSteps: boolean
   deferOnAllCompleteUntilClose: boolean

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,4 +1,4 @@
-export type OverlayState = 'idle' | 'confirming' | 'pending' | 'refreshing' | 'success' | 'error'
+export type OverlayState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'refreshing' | 'success' | 'error'
 export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
 
 export function getInitialOverlayState(): OverlayState {
@@ -48,6 +48,23 @@ export function getPendingTransactionTitle(params: {
   }
 
   return `${pendingFunctionName} transaction pending`
+}
+
+export function resolvePendingSafeOverlayState(params: {
+  overlayState: OverlayState
+  isWalletSafe: boolean
+  hasReceiptTransactionHash: boolean
+  callsStatus?: 'pending' | 'success' | 'failure'
+}): OverlayState {
+  const { overlayState, isWalletSafe, hasReceiptTransactionHash, callsStatus } = params
+
+  if (overlayState !== 'pending') return overlayState
+  if (!isWalletSafe) return overlayState
+  if (hasReceiptTransactionHash) return overlayState
+  if (callsStatus === 'failure') return 'error'
+  if (callsStatus === 'pending') return 'submitted'
+
+  return overlayState
 }
 
 export function shouldAutoContinuePermitSuccess(params: {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -46,8 +46,24 @@ export function getPendingTransactionTitle(params: {
   if (!pendingFunctionName) {
     return 'Transaction pending'
   }
-
   return `${pendingFunctionName} transaction pending`
+}
+
+export function resolveOverlayConnectedChainId(params: {
+  accountChainId: number | undefined
+  currentChainId: number
+  targetChainId: number | undefined
+  isWalletSafe: boolean
+}): number {
+  if (params.accountChainId) {
+    return params.accountChainId
+  }
+
+  if (params.isWalletSafe && params.targetChainId) {
+    return params.targetChainId
+  }
+
+  return params.currentChainId
 }
 
 export function resolvePendingSafeOverlayState(params: {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,7 +1,8 @@
 export type OverlayState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'refreshing' | 'success' | 'error'
 export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
 export type SafeTransactionStatus = 'AWAITING_CONFIRMATIONS' | 'AWAITING_EXECUTION' | 'CANCELLED' | 'FAILED' | 'SUCCESS'
-export const AUTO_CONTINUE_SUCCESS_DELAY_MS = 1200
+export const AUTO_CONTINUE_SUCCESS_DELAY_MS = 1600
+export const SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS = 700
 
 export function getInitialOverlayState(): OverlayState {
   return 'idle'
@@ -163,6 +164,10 @@ export function shouldAutoContinueFromSuccessState(params: {
   wasLastStep: boolean
 }): boolean {
   return params.canShowSuccess && params.executedStepAutoContinues && !params.wasLastStep
+}
+
+export function getAutoContinueConfirmDelayMs(params: { isWalletSafe: boolean }): number {
+  return params.isWalletSafe ? SAFE_AUTO_CONTINUE_CONFIRM_DELAY_MS : 0
 }
 
 export function resolveCompletionDeferral(params: {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -74,7 +74,7 @@ export function resolvePendingSafeOverlayState(params: {
 }): OverlayState {
   const { overlayState, isWalletSafe, hasReceiptTransactionHash, callsStatus } = params
 
-  if (overlayState !== 'pending') return overlayState
+  if (overlayState !== 'pending' && overlayState !== 'submitted') return overlayState
   if (!isWalletSafe) return overlayState
   if (hasReceiptTransactionHash) return overlayState
   if (callsStatus === 'failure') return 'error'

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -1,6 +1,7 @@
 export type OverlayState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'refreshing' | 'success' | 'error'
 export type CompletionDeferral = 'none' | 'immediate' | 'after-close' | 'after-confetti'
 export type SafeTransactionStatus = 'AWAITING_CONFIRMATIONS' | 'AWAITING_EXECUTION' | 'CANCELLED' | 'FAILED' | 'SUCCESS'
+export const AUTO_CONTINUE_SUCCESS_DELAY_MS = 1200
 
 export function getInitialOverlayState(): OverlayState {
   return 'idle'
@@ -154,6 +155,14 @@ export function shouldRefetchNextStepAfterReceipt(params: {
   if (params.isStepReady) return false
 
   return true
+}
+
+export function shouldAutoContinueFromSuccessState(params: {
+  canShowSuccess: boolean
+  executedStepAutoContinues: boolean
+  wasLastStep: boolean
+}): boolean {
+  return params.canShowSuccess && params.executedStepAutoContinues && !params.wasLastStep
 }
 
 export function resolveCompletionDeferral(params: {

--- a/src/components/pages/vaults/components/widget/shared/useWidgetContext.ts
+++ b/src/components/pages/vaults/components/widget/shared/useWidgetContext.ts
@@ -20,11 +20,12 @@ type TWidgetContext = {
   getPrice: ReturnType<typeof useYearn>['getPrice']
   trackEvent: ReturnType<typeof usePlausible>
   ensoEnabled: boolean
+  isWalletSafe: boolean
 }
 
 export function useWidgetContext({ chainId, vaultAddress }: TUseWidgetContextParams): TWidgetContext {
   const { address: account } = useAccount()
-  const { openLoginModal } = useWeb3()
+  const { openLoginModal, isWalletSafe } = useWeb3()
   const { onRefresh: refreshWalletBalances, getToken } = useWallet()
   const { zapSlippage, isAutoStakingEnabled, getPrice } = useYearn()
   const trackEvent = usePlausible()
@@ -39,6 +40,7 @@ export function useWidgetContext({ chainId, vaultAddress }: TUseWidgetContextPar
     isAutoStakingEnabled,
     getPrice,
     trackEvent,
-    ensoEnabled
+    ensoEnabled,
+    isWalletSafe
   }
 }

--- a/src/components/pages/vaults/components/widget/withdraw/index.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/index.tsx
@@ -22,6 +22,7 @@ import { WidgetHeader } from '../shared/WidgetHeader'
 import { WidgetLoadingSkeleton } from '../shared/WidgetLoadingSkeleton'
 import { getPriorityTokens } from './constants'
 import { SourceSelector } from './SourceSelector'
+import { buildSafeWithdrawBatch } from './safeWithdrawBatch'
 import type { WithdrawalSource, WithdrawWidgetProps } from './types'
 import { useWithdrawError } from './useWithdrawError'
 import { useWithdrawFlow } from './useWithdrawFlow'
@@ -126,8 +127,17 @@ export function WidgetWithdraw({
   const bootstrapEnsoQuoteDebugRef = useRef<Record<string, unknown> | null>(null)
   const lastBootstrapEnsoQuoteDebugKeyRef = useRef<string | null>(null)
   const lastProtectedEnsoQuoteDebugKeyRef = useRef<string | null>(null)
-  const { account, openLoginModal, refreshWalletBalances, getToken, zapSlippage, getPrice, trackEvent, ensoEnabled } =
-    useWidgetContext({ chainId, vaultAddress })
+  const {
+    account,
+    openLoginModal,
+    refreshWalletBalances,
+    getToken,
+    zapSlippage,
+    getPrice,
+    trackEvent,
+    ensoEnabled,
+    isWalletSafe
+  } = useWidgetContext({ chainId, vaultAddress })
 
   const resolvedDisplayAssetAddress = displayAssetAddress ?? assetAddress
 
@@ -366,7 +376,8 @@ export function WidgetWithdraw({
     withdrawalSource,
     isUnstake,
     isDebouncing: disableFlow ? false : withdrawAmount.isDebouncing,
-    useErc4626: usesErc4626
+    useErc4626: usesErc4626,
+    ensoRoutingStrategy: isWalletSafe ? 'router' : undefined
   })
   const effectiveDirectWithdrawPrepare = blockDirectWithdrawStep
     ? undefined
@@ -737,6 +748,41 @@ export function WidgetWithdraw({
   })
   const formattedRequiredShares = formatTAmount({ value: effectiveRequiredShares, decimals: sharesDecimals })
   const formattedApprovalAmount = formatTAmount({ value: effectiveRequiredShares, decimals: sharesDecimals })
+  const safeWithdrawBatch = useMemo(() => {
+    if (!isWalletSafe || !approvalState.needsApproval) {
+      return undefined
+    }
+
+    return buildSafeWithdrawBatch({
+      routeType,
+      account,
+      sourceToken: toAddress(sourceToken),
+      amount: effectiveRequiredShares,
+      currentAllowance: activeFlow.periphery.allowance,
+      chainId,
+      approvalSpenderAddress: approvalState.spenderAddress,
+      routerAddress: activeFlow.periphery.routerAddress ? toAddress(activeFlow.periphery.routerAddress) : undefined,
+      ensoTx: activeFlow.periphery.tx
+        ? {
+            to: toAddress(activeFlow.periphery.tx.to),
+            data: activeFlow.periphery.tx.data,
+            value: activeFlow.periphery.tx.value
+          }
+        : undefined
+    })
+  }, [
+    account,
+    activeFlow.periphery.allowance,
+    activeFlow.periphery.routerAddress,
+    activeFlow.periphery.tx,
+    approvalState.needsApproval,
+    approvalState.spenderAddress,
+    chainId,
+    effectiveRequiredShares,
+    isWalletSafe,
+    routeType,
+    sourceToken
+  ])
 
   const currentStep: TransactionStep | undefined = useMemo(
     () =>
@@ -758,7 +804,8 @@ export function WidgetWithdraw({
         stakingTokenSymbol: stakingToken?.symbol,
         approveNotificationParams,
         unstakeNotificationParams,
-        withdrawNotificationParams
+        withdrawNotificationParams,
+        safeWithdrawBatch
       }),
     [
       approvalState.needsApproval,
@@ -778,7 +825,8 @@ export function WidgetWithdraw({
       stakingToken?.symbol,
       approveNotificationParams,
       unstakeNotificationParams,
-      withdrawNotificationParams
+      withdrawNotificationParams,
+      safeWithdrawBatch
     ]
   )
 

--- a/src/components/pages/vaults/components/widget/withdraw/safeWithdrawBatch.ts
+++ b/src/components/pages/vaults/components/widget/withdraw/safeWithdrawBatch.ts
@@ -1,0 +1,137 @@
+import { YVUSD_LOCKED_ZAP_ADDRESS } from '@pages/vaults/utils/yvUsd'
+import { yvUsdLockedZapAbi } from '@shared/contracts/abi/yvUsdLockedZap.abi'
+import { getApproveAbi } from '@shared/utils/approve'
+import type { Address, Hex } from 'viem'
+import { encodeFunctionData, isAddressEqual } from 'viem'
+import type { WithdrawRouteType } from './types'
+
+type TSafeBatchCall = {
+  to: Address
+  data: Hex
+  value?: bigint
+}
+
+type TEnsoTransaction = {
+  to: Address
+  data: Hex
+  value: string
+}
+
+type TBuildSafeWithdrawBatchParams = {
+  routeType: WithdrawRouteType
+  account?: Address
+  sourceToken: Address
+  amount: bigint
+  currentAllowance?: bigint
+  chainId: number
+  approvalSpenderAddress?: Address
+  routerAddress?: Address
+  ensoTx?: TEnsoTransaction
+}
+
+function buildApproveCall({
+  sourceToken,
+  approvalSpenderAddress,
+  amount
+}: {
+  sourceToken: Address
+  approvalSpenderAddress: Address
+  amount: bigint
+}): TSafeBatchCall {
+  return {
+    to: sourceToken,
+    data: encodeFunctionData({
+      abi: getApproveAbi(sourceToken),
+      functionName: 'approve',
+      args: [approvalSpenderAddress, amount]
+    }),
+    value: 0n
+  }
+}
+
+function buildApprovalCalls({
+  sourceToken,
+  approvalSpenderAddress,
+  amount,
+  currentAllowance = 0n
+}: {
+  sourceToken: Address
+  approvalSpenderAddress: Address
+  amount: bigint
+  currentAllowance?: bigint
+}): TSafeBatchCall[] {
+  const approveAmountCall = buildApproveCall({
+    sourceToken,
+    approvalSpenderAddress,
+    amount
+  })
+
+  if (currentAllowance <= 0n) {
+    return [approveAmountCall]
+  }
+
+  return [
+    buildApproveCall({
+      sourceToken,
+      approvalSpenderAddress,
+      amount: 0n
+    }),
+    approveAmountCall
+  ]
+}
+
+function buildYvUsdLockedZapWithdrawCall(params: TBuildSafeWithdrawBatchParams & { account: Address }): TSafeBatchCall {
+  return {
+    to: YVUSD_LOCKED_ZAP_ADDRESS,
+    data: encodeFunctionData({
+      abi: yvUsdLockedZapAbi,
+      functionName: 'zapOut',
+      args: [params.amount, params.account]
+    }),
+    value: 0n
+  }
+}
+
+function buildEnsoCall(ensoTx?: TEnsoTransaction): TSafeBatchCall | undefined {
+  if (!ensoTx) {
+    return undefined
+  }
+
+  return {
+    to: ensoTx.to,
+    data: ensoTx.data,
+    value: BigInt(ensoTx.value || 0)
+  }
+}
+
+export function buildSafeWithdrawBatch(
+  params: TBuildSafeWithdrawBatchParams
+): { calls: readonly TSafeBatchCall[]; chainId: number } | undefined {
+  if (!params.account || !params.approvalSpenderAddress || params.amount <= 0n) {
+    return undefined
+  }
+
+  const approvalCalls = buildApprovalCalls({
+    sourceToken: params.sourceToken,
+    approvalSpenderAddress: params.approvalSpenderAddress,
+    amount: params.amount,
+    currentAllowance: params.currentAllowance
+  })
+  const executionCall =
+    params.routeType === 'ENSO'
+      ? buildEnsoCall(params.ensoTx)
+      : params.routeType === 'DIRECT_WITHDRAW' &&
+          params.routerAddress &&
+          isAddressEqual(params.routerAddress, YVUSD_LOCKED_ZAP_ADDRESS)
+        ? buildYvUsdLockedZapWithdrawCall({ ...params, account: params.account })
+        : undefined
+
+  if (!executionCall) {
+    return undefined
+  }
+
+  return {
+    calls: [...approvalCalls, executionCall],
+    chainId: params.chainId
+  }
+}

--- a/src/components/pages/vaults/components/widget/withdraw/useWithdrawFlow.ts
+++ b/src/components/pages/vaults/components/widget/withdraw/useWithdrawFlow.ts
@@ -2,6 +2,7 @@ import { useDirectUnstake } from '@pages/vaults/hooks/actions/useDirectUnstake'
 import { useDirectWithdraw } from '@pages/vaults/hooks/actions/useDirectWithdraw'
 import { useEnsoWithdraw } from '@pages/vaults/hooks/actions/useEnsoWithdraw'
 import { useYvUsdLockedZapWithdraw } from '@pages/vaults/hooks/actions/useYvUsdLockedZapWithdraw'
+import type { EnsoRoutingStrategy } from '@pages/vaults/hooks/solvers/useSolverEnso'
 import type { UseWidgetWithdrawFlowReturn } from '@pages/vaults/types'
 import { YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { toAddress } from '@shared/utils'
@@ -44,6 +45,7 @@ interface UseWithdrawFlowProps {
   isUnstake: boolean
   isDebouncing: boolean
   useErc4626: boolean
+  ensoRoutingStrategy?: EnsoRoutingStrategy
 }
 
 export interface WithdrawFlowResult {
@@ -80,7 +82,8 @@ export function useWithdrawFlow({
   withdrawalSource,
   isUnstake,
   isDebouncing,
-  useErc4626
+  useErc4626,
+  ensoRoutingStrategy
 }: UseWithdrawFlowProps): WithdrawFlowResult {
   const routeType = useWithdrawRoute({
     vaultAddress,
@@ -159,7 +162,8 @@ export function useWithdrawFlow({
     destinationChainId,
     decimalsOut: outputDecimals,
     enabled: ensoEnabled,
-    slippage: toBasisPoints(slippage)
+    slippage: toBasisPoints(slippage),
+    routingStrategy: ensoRoutingStrategy
   })
 
   const activeFlow = useMemo((): UseWidgetWithdrawFlowReturn => {

--- a/src/components/pages/vaults/components/widget/withdraw/withdrawStepHelpers.ts
+++ b/src/components/pages/vaults/components/widget/withdraw/withdrawStepHelpers.ts
@@ -21,6 +21,7 @@ type TBuildWithdrawTransactionStepArgs = {
   approveNotificationParams?: TCreateNotificationParams
   unstakeNotificationParams?: TCreateNotificationParams
   withdrawNotificationParams?: TCreateNotificationParams
+  safeWithdrawBatch?: TransactionStep['batch']
 }
 
 type TWithdrawCtaStateArgs = {
@@ -65,8 +66,24 @@ export function buildWithdrawTransactionStep({
   stakingTokenSymbol,
   approveNotificationParams,
   unstakeNotificationParams,
-  withdrawNotificationParams
+  withdrawNotificationParams,
+  safeWithdrawBatch
 }: TBuildWithdrawTransactionStepArgs): TransactionStep | undefined {
+  if (needsApproval && approvePrepare && safeWithdrawBatch) {
+    return {
+      prepare: approvePrepare,
+      batch: safeWithdrawBatch,
+      label: 'Approve & Withdraw',
+      confirmMessage: 'Submitting approval and withdraw to your Safe',
+      successTitle: isCrossChain ? 'Transaction Submitted' : 'Withdraw successful!',
+      successMessage: isCrossChain
+        ? 'Your cross-chain withdraw has been submitted.\nIt may take a few minutes to complete on the destination chain.'
+        : `You have withdrawn ${formattedWithdrawAmount} ${assetTokenSymbol || ''}.`,
+      completesFlow: true,
+      notification: withdrawNotificationParams
+    }
+  }
+
   if (needsApproval && approvePrepare) {
     return {
       prepare: approvePrepare,
@@ -150,7 +167,7 @@ export function isWithdrawLastStep({
   routeType: WithdrawRouteType
 }): boolean {
   if (!currentStep) return true
-  if (needsApproval) return false
+  if (needsApproval) return Boolean(currentStep.batch && currentStep.completesFlow)
   if (routeType === 'DIRECT_UNSTAKE_WITHDRAW') {
     return currentStep.label === 'Withdraw'
   }

--- a/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
+++ b/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
@@ -1,6 +1,7 @@
 import type { UseWidgetDepositFlowReturn } from '@pages/vaults/types'
 import { useEffect, useMemo } from 'react'
 import type { Address } from 'viem'
+import type { EnsoRoutingStrategy } from '../solvers/useSolverEnso'
 import { useSolverEnso } from '../solvers/useSolverEnso'
 import { useEnsoOrder } from '../useEnsoOrder'
 
@@ -15,6 +16,7 @@ interface UseEnsoDepositParams {
   decimalsOut: number
   enabled: boolean
   slippage?: number
+  routingStrategy?: EnsoRoutingStrategy
 }
 
 export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFlowReturn {
@@ -26,7 +28,8 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
         params.depositToken,
         params.vaultAddress,
         params.account ?? 'no-account',
-        params.slippage ?? 'default'
+        params.slippage ?? 'default',
+        params.routingStrategy ?? 'default-strategy'
       ].join(':'),
     [
       params.chainId,
@@ -34,7 +37,8 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
       params.depositToken,
       params.vaultAddress,
       params.account,
-      params.slippage
+      params.slippage,
+      params.routingStrategy
     ]
   )
 
@@ -49,6 +53,7 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
     receiver: params.account,
     decimalsOut: params.decimalsOut,
     slippage: params.slippage,
+    routingStrategy: params.routingStrategy,
     requestKey: routeQueryKey,
     enabled: params.enabled
   })

--- a/src/components/pages/vaults/hooks/actions/useEnsoWithdraw.ts
+++ b/src/components/pages/vaults/hooks/actions/useEnsoWithdraw.ts
@@ -1,6 +1,7 @@
 import type { UseWidgetWithdrawFlowReturn } from '@pages/vaults/types'
 import { useEffect, useMemo } from 'react'
 import type { Address } from 'viem'
+import type { EnsoRoutingStrategy } from '../solvers/useSolverEnso'
 import { useSolverEnso } from '../solvers/useSolverEnso'
 import { useEnsoOrder } from '../useEnsoOrder'
 
@@ -16,6 +17,7 @@ interface UseEnsoWithdrawParams {
   decimalsOut: number
   enabled: boolean
   slippage?: number
+  routingStrategy?: EnsoRoutingStrategy
 }
 
 export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdrawFlowReturn {
@@ -28,7 +30,8 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
         params.withdrawToken,
         params.account ?? 'no-account',
         params.receiver ?? 'no-receiver',
-        params.slippage ?? 'default'
+        params.slippage ?? 'default',
+        params.routingStrategy ?? 'default-strategy'
       ].join(':'),
     [
       params.chainId,
@@ -37,7 +40,8 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
       params.withdrawToken,
       params.account,
       params.receiver,
-      params.slippage
+      params.slippage,
+      params.routingStrategy
     ]
   )
 
@@ -52,6 +56,7 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
     destinationChainId: params.destinationChainId,
     decimalsOut: params.decimalsOut,
     slippage: params.slippage,
+    routingStrategy: params.routingStrategy,
     requestKey: routeQueryKey,
     enabled: params.enabled
   })
@@ -97,6 +102,8 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
         routeHasSwap: ensoFlow.periphery.routeHasSwap,
         routerAddress: ensoFlow.periphery.routerAddress,
         error: ensoFlow.periphery.error?.message,
+        tx: ensoFlow.periphery.route?.tx,
+        gas: ensoFlow.periphery.route?.gas,
         resetQuote: ensoFlow.methods.resetRoute
       }
     }),

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
@@ -8,6 +8,7 @@ import { useTokenAllowance } from '../useTokenAllowance'
 import { type EnsoError, type EnsoRouteResponse, normalizeEnsoRouteResponse, routeHasSwapStep } from './ensoRoute'
 
 const ENSO_ROUTE_PROXY = '/api/enso/route'
+export type EnsoRoutingStrategy = 'router' | 'delegate' | 'router-legacy' | 'delegate-legacy' | 'ensowallet'
 
 // Known Enso router addresses per chain for pre-fetching allowance
 const ENSO_ROUTER_ADDRESSES: Record<number, Address> = {
@@ -28,6 +29,7 @@ interface UseSolverEnsoProps {
   chainId: number
   destinationChainId?: number
   slippage?: number // in basis points (e.g., 100 = 1%)
+  routingStrategy?: EnsoRoutingStrategy
   requestKey?: string
   enabled?: boolean
   decimalsOut?: number
@@ -67,6 +69,7 @@ export const useSolverEnso = ({
   chainId,
   destinationChainId,
   slippage = 100, // 1% default
+  routingStrategy,
   requestKey = 'default',
   decimalsOut = 18,
   enabled = true
@@ -118,6 +121,7 @@ export const useSolverEnso = ({
         tokenOut,
         amountIn: amountIn.toString(),
         slippage: normalizedSlippage.toString(),
+        ...(routingStrategy && { routingStrategy }),
         ...(isCrossChain && { destinationChainId: destinationChainId!.toString() }),
         ...(receiver && { receiver })
       })
@@ -202,6 +206,7 @@ export const useSolverEnso = ({
     chainId,
     destinationChainId,
     slippage,
+    routingStrategy,
     requestKey,
     enabled,
     isCrossChain

--- a/src/components/shared/contexts/useNotificationsActions.tsx
+++ b/src/components/shared/contexts/useNotificationsActions.tsx
@@ -41,7 +41,8 @@ export const WithNotificationsActions = ({ children }: { children: React.ReactEl
         status: 'pending',
         txHash: undefined,
         timeFinished: undefined,
-        blockNumber: undefined
+        blockNumber: undefined,
+        awaitingExecution: false
       })
       return id
     },
@@ -50,15 +51,20 @@ export const WithNotificationsActions = ({ children }: { children: React.ReactEl
 
   const updateNotification = useCallback(
     async (params: TUpdateNotificationParams): Promise<void> => {
-      // Set timeFinished for receipt confirmations or 'submitted' status (cross-chain zaps)
-      const shouldSetTimeFinished = params.receipt || params.status === 'submitted'
+      const shouldSetTimeFinished = Boolean(
+        params.receipt || (params.status === 'submitted' && !params.awaitingExecution)
+      )
 
       await updateEntry(
         {
           txHash: params.txHash ?? params.receipt?.transactionHash,
           timeFinished: shouldSetTimeFinished ? Date.now() / 1000 : undefined,
           blockNumber: params.receipt?.blockNumber,
-          status: params.status
+          status: params.status,
+          awaitingExecution:
+            params.receipt || params.status === 'success' || params.status === 'error'
+              ? false
+              : params.awaitingExecution
         },
         params.id
       )

--- a/src/components/shared/hooks/transactionStatusPoller.helpers.test.ts
+++ b/src/components/shared/hooks/transactionStatusPoller.helpers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { shouldPollNotificationStatus } from './transactionStatusPoller.helpers'
+
+describe('shouldPollNotificationStatus', () => {
+  it('polls normal pending notifications with a tx hash', () => {
+    expect(
+      shouldPollNotificationStatus({
+        id: 1,
+        status: 'pending',
+        txHash: '0xabc',
+        awaitingExecution: false
+      })
+    ).toBe(true)
+  })
+
+  it('polls submitted notifications that are still awaiting Safe execution', () => {
+    expect(
+      shouldPollNotificationStatus({
+        id: 1,
+        status: 'submitted',
+        txHash: '0xabc',
+        awaitingExecution: true
+      })
+    ).toBe(true)
+  })
+
+  it('does not poll submitted notifications that are already terminal', () => {
+    expect(
+      shouldPollNotificationStatus({
+        id: 1,
+        status: 'submitted',
+        txHash: '0xabc',
+        awaitingExecution: false
+      })
+    ).toBe(false)
+  })
+})

--- a/src/components/shared/hooks/transactionStatusPoller.helpers.test.ts
+++ b/src/components/shared/hooks/transactionStatusPoller.helpers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { shouldPollNotificationStatus } from './transactionStatusPoller.helpers'
+import {
+  shouldPollNotificationStatus,
+  shouldRefreshBeforeNotificationSettlement
+} from './transactionStatusPoller.helpers'
 
 describe('shouldPollNotificationStatus', () => {
   it('polls normal pending notifications with a tx hash', () => {
@@ -31,6 +34,38 @@ describe('shouldPollNotificationStatus', () => {
         status: 'submitted',
         txHash: '0xabc',
         awaitingExecution: false
+      })
+    ).toBe(false)
+  })
+})
+
+describe('shouldRefreshBeforeNotificationSettlement', () => {
+  it('refreshes before settling a successful Safe execution notification', () => {
+    expect(
+      shouldRefreshBeforeNotificationSettlement({
+        currentStatus: 'submitted',
+        awaitingExecution: true,
+        nextStatus: 'success'
+      })
+    ).toBe(true)
+  })
+
+  it('does not pre-refresh failed Safe execution notifications', () => {
+    expect(
+      shouldRefreshBeforeNotificationSettlement({
+        currentStatus: 'submitted',
+        awaitingExecution: true,
+        nextStatus: 'error'
+      })
+    ).toBe(false)
+  })
+
+  it('does not pre-refresh ordinary pending notifications', () => {
+    expect(
+      shouldRefreshBeforeNotificationSettlement({
+        currentStatus: 'pending',
+        awaitingExecution: false,
+        nextStatus: 'success'
       })
     ).toBe(false)
   })

--- a/src/components/shared/hooks/transactionStatusPoller.helpers.ts
+++ b/src/components/shared/hooks/transactionStatusPoller.helpers.ts
@@ -20,3 +20,11 @@ export function shouldPollNotificationStatus(params: {
 
   return false
 }
+
+export function shouldRefreshBeforeNotificationSettlement(params: {
+  currentStatus: TNotificationStatus
+  awaitingExecution?: boolean
+  nextStatus: 'success' | 'error'
+}): boolean {
+  return params.currentStatus === 'submitted' && params.awaitingExecution === true && params.nextStatus === 'success'
+}

--- a/src/components/shared/hooks/transactionStatusPoller.helpers.ts
+++ b/src/components/shared/hooks/transactionStatusPoller.helpers.ts
@@ -1,0 +1,22 @@
+import type { TNotificationStatus } from '@shared/types/notifications'
+
+export function shouldPollNotificationStatus(params: {
+  id?: number
+  status: TNotificationStatus
+  txHash?: string
+  awaitingExecution?: boolean
+}): boolean {
+  if (!params.id || !params.txHash) {
+    return false
+  }
+
+  if (params.status === 'pending') {
+    return true
+  }
+
+  if (params.status === 'submitted' && params.awaitingExecution) {
+    return true
+  }
+
+  return false
+}

--- a/src/components/shared/hooks/useSafeTransactionDetails.ts
+++ b/src/components/shared/hooks/useSafeTransactionDetails.ts
@@ -1,0 +1,51 @@
+import { type UseQueryResult, useQuery } from '@tanstack/react-query'
+
+export type SafeTransactionStatus = 'AWAITING_CONFIRMATIONS' | 'AWAITING_EXECUTION' | 'CANCELLED' | 'FAILED' | 'SUCCESS'
+
+export type TSafeTransactionDetails = {
+  safeTxHash: `0x${string}`
+  txStatus: SafeTransactionStatus
+  executionTxHash?: `0x${string}`
+}
+
+export async function fetchSafeTransactionDetails(
+  safeTxHash: `0x${string}`
+): Promise<TSafeTransactionDetails | undefined> {
+  const { default: SafeAppsSDK } = await import('@safe-global/safe-apps-sdk')
+  const sdk = new SafeAppsSDK()
+  const transaction = await sdk.txs.getBySafeTxHash(safeTxHash)
+
+  return {
+    safeTxHash,
+    txStatus: transaction.txStatus as SafeTransactionStatus,
+    executionTxHash: transaction.txHash ? (transaction.txHash as `0x${string}`) : undefined
+  }
+}
+
+export function useSafeTransactionDetails({
+  safeTxHash,
+  enabled
+}: {
+  safeTxHash?: `0x${string}`
+  enabled: boolean
+}): UseQueryResult<TSafeTransactionDetails | undefined> {
+  return useQuery({
+    queryKey: ['safeTransactionDetails', safeTxHash],
+    enabled: enabled && Boolean(safeTxHash) && typeof window !== 'undefined',
+    queryFn: async () => {
+      if (!safeTxHash) {
+        return undefined
+      }
+
+      return await fetchSafeTransactionDetails(safeTxHash)
+    },
+    refetchInterval: (query) => {
+      const status = query.state.data?.txStatus
+      if (status === 'SUCCESS' || status === 'FAILED' || status === 'CANCELLED') {
+        return false
+      }
+      return 1500
+    },
+    retry: false
+  })
+}

--- a/src/components/shared/hooks/useTransactionStatusPoller.ts
+++ b/src/components/shared/hooks/useTransactionStatusPoller.ts
@@ -1,12 +1,18 @@
 import { useNotifications } from '@shared/contexts/useNotifications'
+import { useWallet } from '@shared/contexts/useWallet'
+import { useWeb3 } from '@shared/contexts/useWeb3'
 import { fetchSafeTransactionDetails } from '@shared/hooks/useSafeTransactionDetails'
 import type { TNotification } from '@shared/types/notifications'
 import { getNetwork, retrieveConfig } from '@shared/utils/wagmi'
+import { useQueryClient } from '@tanstack/react-query'
 import { getConnectorClient } from '@wagmi/core'
 import { useCallback, useEffect, useRef } from 'react'
 import { getCallsStatus } from 'viem/actions'
 import { getBlock, waitForTransactionReceipt } from 'wagmi/actions'
-import { shouldPollNotificationStatus } from './transactionStatusPoller.helpers'
+import {
+  shouldPollNotificationStatus,
+  shouldRefreshBeforeNotificationSettlement
+} from './transactionStatusPoller.helpers'
 
 /************************************************************************************************
  * Custom hook to poll transaction status for pending notifications every minute.
@@ -17,7 +23,19 @@ import { shouldPollNotificationStatus } from './transactionStatusPoller.helpers'
  ************************************************************************************************/
 export function useTransactionStatusPoller(notification: TNotification): void {
   const { updateEntry } = useNotifications()
+  const { onRefresh } = useWallet()
+  const { address } = useWeb3()
+  const queryClient = useQueryClient()
   const pollIntervalRef = useRef<NodeJS.Timeout | undefined>(undefined)
+
+  const refreshBeforeSettlement = useCallback(async (): Promise<void> => {
+    await queryClient.invalidateQueries()
+    if (address) {
+      await onRefresh().catch((error) => {
+        console.error('Failed to refresh wallet balances after Safe execution:', error)
+      })
+    }
+  }, [address, onRefresh, queryClient])
 
   /************************************************************************************************
    * Function to check the transaction status and update the notification accordingly.
@@ -87,6 +105,16 @@ export function useTransactionStatusPoller(notification: TNotification): void {
                 blockNumber: receipt.blockNumber
               })
 
+              if (
+                shouldRefreshBeforeNotificationSettlement({
+                  currentStatus: notification.status,
+                  awaitingExecution: notification.awaitingExecution,
+                  nextStatus: receipt.status === 'success' ? 'success' : 'error'
+                })
+              ) {
+                await refreshBeforeSettlement()
+              }
+
               await updateEntry(
                 {
                   status: receipt.status === 'success' ? 'success' : 'error',
@@ -143,6 +171,16 @@ export function useTransactionStatusPoller(notification: TNotification): void {
           blockNumber: receipt.blockNumber
         })
 
+        if (
+          shouldRefreshBeforeNotificationSettlement({
+            currentStatus: notification.status,
+            awaitingExecution: notification.awaitingExecution,
+            nextStatus: receipt.status === 'success' ? 'success' : 'error'
+          })
+        ) {
+          await refreshBeforeSettlement()
+        }
+
         await updateEntry(
           {
             status: receipt.status === 'success' ? 'success' : 'error',
@@ -193,7 +231,7 @@ export function useTransactionStatusPoller(notification: TNotification): void {
         console.warn('Transaction status check failed:', error.message)
       }
     }
-  }, [notification, updateEntry])
+  }, [notification, refreshBeforeSettlement, updateEntry])
 
   /************************************************************************************************
    * Effect to set up polling for pending transactions. Polls every minute (60000ms) to check

--- a/src/components/shared/hooks/useTransactionStatusPoller.ts
+++ b/src/components/shared/hooks/useTransactionStatusPoller.ts
@@ -1,8 +1,11 @@
 import { useNotifications } from '@shared/contexts/useNotifications'
 import type { TNotification } from '@shared/types/notifications'
 import { getNetwork, retrieveConfig } from '@shared/utils/wagmi'
+import { getConnectorClient } from '@wagmi/core'
 import { useCallback, useEffect, useRef } from 'react'
+import { getCallsStatus } from 'viem/actions'
 import { getBlock, waitForTransactionReceipt } from 'wagmi/actions'
+import { shouldPollNotificationStatus } from './transactionStatusPoller.helpers'
 
 /************************************************************************************************
  * Custom hook to poll transaction status for pending notifications every minute.
@@ -21,7 +24,13 @@ export function useTransactionStatusPoller(notification: TNotification): void {
    * transaction was successful or failed.
    ************************************************************************************************/
   const checkTransactionStatus = useCallback(async (): Promise<void> => {
-    if (!notification.txHash || !notification.id || notification.status !== 'pending') {
+    if (!shouldPollNotificationStatus(notification)) {
+      return
+    }
+
+    const notificationId = notification.id
+    const txHash = notification.txHash
+    if (!notificationId || !txHash) {
       return
     }
 
@@ -35,43 +44,88 @@ export function useTransactionStatusPoller(notification: TNotification): void {
         return
       }
 
-      // Wait for transaction receipt with a short timeout to avoid blocking
-      const receipt = await waitForTransactionReceipt(config, {
-        chainId: pollingChainId,
-        hash: notification.txHash,
-        timeout: 5000 // 5 second timeout to avoid long waits
-      })
+      if (notification.status === 'submitted' && notification.awaitingExecution) {
+        const connectorClient = await getConnectorClient(config, {
+          chainId: pollingChainId,
+          assertChainId: false
+        })
+        const callsStatus = await getCallsStatus(connectorClient, { id: txHash })
 
-      if (receipt) {
-        const newStatus = receipt.status === 'success' ? 'success' : 'error'
+        if (callsStatus.status === 'pending') {
+          return
+        }
 
-        // Get the block information to retrieve the timestamp
+        if (callsStatus.status === 'failure') {
+          await updateEntry(
+            {
+              status: 'error',
+              awaitingExecution: false
+            },
+            notificationId
+          )
+
+          if (pollIntervalRef.current) {
+            clearInterval(pollIntervalRef.current)
+          }
+          return
+        }
+
+        const receipt = callsStatus.receipts?.[0]
+        if (!receipt) {
+          return
+        }
+
         const block = await getBlock(config, {
           chainId: pollingChainId,
           blockNumber: receipt.blockNumber
         })
 
-        // Use the actual block timestamp instead of current time
+        await updateEntry(
+          {
+            status: receipt.status === 'success' ? 'success' : 'error',
+            txHash: receipt.transactionHash,
+            timeFinished: Number(block.timestamp),
+            blockNumber: receipt.blockNumber,
+            awaitingExecution: false
+          },
+          notificationId
+        )
+
+        if (pollIntervalRef.current) {
+          clearInterval(pollIntervalRef.current)
+        }
+        return
+      }
+
+      const receipt = await waitForTransactionReceipt(config, {
+        chainId: pollingChainId,
+        hash: txHash,
+        timeout: 5000
+      })
+
+      if (receipt) {
+        const newStatus = receipt.status === 'success' ? 'success' : 'error'
+        const block = await getBlock(config, {
+          chainId: pollingChainId,
+          blockNumber: receipt.blockNumber
+        })
         const timeFinished = Number(block.timestamp)
 
-        // Update the notification with the new status and transaction details
         await updateEntry(
           {
             status: newStatus,
             timeFinished,
-            blockNumber: receipt.blockNumber
+            blockNumber: receipt.blockNumber,
+            awaitingExecution: false
           },
-          notification.id
+          notificationId
         )
 
-        // Clear the polling interval since transaction is complete
         if (pollIntervalRef.current) {
           clearInterval(pollIntervalRef.current)
         }
       }
     } catch (error) {
-      // If the transaction is not found or still pending, continue polling
-      // Only log actual errors, not timeout or not-found errors
       if (error instanceof Error && !error.message.includes('timeout')) {
         console.warn('Transaction status check failed:', error.message)
       }
@@ -84,18 +138,16 @@ export function useTransactionStatusPoller(notification: TNotification): void {
    * status changes or the component unmounts.
    ************************************************************************************************/
   useEffect(() => {
-    if (notification.status === 'pending' && notification.txHash && notification.id) {
-      // Check immediately
+    if (shouldPollNotificationStatus(notification)) {
       checkTransactionStatus()
 
-      // Then poll every minute
+      const pollIntervalMs = notification.awaitingExecution ? 15000 : 60000
       pollIntervalRef.current = setInterval(() => {
         checkTransactionStatus()
-      }, 60000)
+      }, pollIntervalMs)
     }
 
-    // Clear interval if notification is no longer pending
-    if (pollIntervalRef.current && notification.status !== 'pending') {
+    if (pollIntervalRef.current && !shouldPollNotificationStatus(notification)) {
       clearInterval(pollIntervalRef.current)
     }
 
@@ -104,7 +156,7 @@ export function useTransactionStatusPoller(notification: TNotification): void {
         clearInterval(pollIntervalRef.current)
       }
     }
-  }, [notification.status, notification.txHash, notification.id, checkTransactionStatus])
+  }, [notification, checkTransactionStatus])
 
   /************************************************************************************************
    * Cleanup effect to clear the polling interval when the hook unmounts

--- a/src/components/shared/hooks/useTransactionStatusPoller.ts
+++ b/src/components/shared/hooks/useTransactionStatusPoller.ts
@@ -1,4 +1,5 @@
 import { useNotifications } from '@shared/contexts/useNotifications'
+import { fetchSafeTransactionDetails } from '@shared/hooks/useSafeTransactionDetails'
 import type { TNotification } from '@shared/types/notifications'
 import { getNetwork, retrieveConfig } from '@shared/utils/wagmi'
 import { getConnectorClient } from '@wagmi/core'
@@ -45,6 +46,68 @@ export function useTransactionStatusPoller(notification: TNotification): void {
       }
 
       if (notification.status === 'submitted' && notification.awaitingExecution) {
+        try {
+          const safeTransaction = await fetchSafeTransactionDetails(txHash)
+
+          if (
+            safeTransaction?.txStatus === 'AWAITING_CONFIRMATIONS' ||
+            safeTransaction?.txStatus === 'AWAITING_EXECUTION' ||
+            safeTransaction?.txStatus === undefined
+          ) {
+            if (!safeTransaction?.executionTxHash) {
+              return
+            }
+          }
+
+          if (safeTransaction?.txStatus === 'FAILED' || safeTransaction?.txStatus === 'CANCELLED') {
+            await updateEntry(
+              {
+                status: 'error',
+                awaitingExecution: false
+              },
+              notificationId
+            )
+
+            if (pollIntervalRef.current) {
+              clearInterval(pollIntervalRef.current)
+            }
+            return
+          }
+
+          if (safeTransaction?.executionTxHash) {
+            const receipt = await waitForTransactionReceipt(config, {
+              chainId: pollingChainId,
+              hash: safeTransaction.executionTxHash,
+              timeout: 5000
+            })
+
+            if (receipt) {
+              const block = await getBlock(config, {
+                chainId: pollingChainId,
+                blockNumber: receipt.blockNumber
+              })
+
+              await updateEntry(
+                {
+                  status: receipt.status === 'success' ? 'success' : 'error',
+                  txHash: receipt.transactionHash,
+                  timeFinished: Number(block.timestamp),
+                  blockNumber: receipt.blockNumber,
+                  awaitingExecution: false
+                },
+                notificationId
+              )
+
+              if (pollIntervalRef.current) {
+                clearInterval(pollIntervalRef.current)
+              }
+              return
+            }
+          }
+        } catch (safeDetailError) {
+          console.warn('Safe transaction detail lookup failed, falling back to wallet_getCallsStatus:', safeDetailError)
+        }
+
         const connectorClient = await getConnectorClient(config, {
           chainId: pollingChainId,
           assertChainId: false

--- a/src/components/shared/types/notifications.ts
+++ b/src/components/shared/types/notifications.ts
@@ -40,6 +40,7 @@ export type TNotification = {
   txHash?: Hash
   timeFinished?: number
   blockNumber?: bigint
+  awaitingExecution?: boolean
   status: TNotificationStatus
 }
 
@@ -73,6 +74,7 @@ export type TUpdateNotificationParams = {
   txHash?: Hash
   status?: TNotificationStatus
   receipt?: TransactionReceipt
+  awaitingExecution?: boolean
 }
 
 export type TNotificationsActionsContext = {


### PR DESCRIPTION
## Summary
- fix Safe app Katana approval/revoke overlays by falling back to the live wagmi chain id when `useAccount().chain` is missing
- handle Safe queued transactions in both ApprovalOverlay and TransactionOverlay so overlays can move to a dismissible submitted state instead of hanging in pending forever
- Improve the flows when using the safe app to seamlessly go between the site and the SAFE app to sign with better messaging.
- add focused regression tests for Safe-specific approval and transaction-overlay state handling

## Root cause
In Safe app flows, `eth_sendTransaction` can return a Safe transaction hash before there is an on-chain execution hash/receipt. The previous overlays assumed a normal wallet flow and waited only on `useWaitForTransactionReceipt`, which left Safe transactions stuck in pending. The approval overlay also relied on `useAccount().chain?.id`, which can be missing in Safe/custom-chain sessions and caused false network-switch attempts on Katana.

## Test Plan
- `bunx vitest run src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.test.tsx src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.test.ts`
- `bun run tslint`
- `bun run lint:fix`
- create a new Safe App in the safe you want to test with, with the preview link provided below. Confirm that approvals can be added and revoked in the approvals overlay by clicking on "Existing Approval (asset) in the widget info above the button. Then try deposit and withdraw transactions and confirm the flow feels natural and completed transactions are picked up and flow into next transactions or complete states.

## Notes
- Transaction overlays now use Safe call-batch status to detect queued Safe transactions and show a dismissible submitted state without firing final completion handlers early.
- Approval/revoke overlays now support the same Safe queued/submitted behavior.
