### PR TITLE
fix: refresh portfolio balances without hard reload

### DIFF
--- a/api/enso/balances.ts
+++ b/api/enso/balances.ts
@@ -1,4 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { ENSO_BALANCES_CACHE_CONTROL } from './cache'
 
 const ENSO_API_BASE = 'https://api.enso.finance'
 
@@ -46,7 +47,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const data = await response.json()
 
-    res.setHeader('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300')
+    res.setHeader('Cache-Control', ENSO_BALANCES_CACHE_CONTROL)
     return res.status(200).json(data)
   } catch (error) {
     console.error('Error proxying Enso request:', error)

--- a/api/enso/cache.test.ts
+++ b/api/enso/cache.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { ENSO_BALANCES_CACHE_CONTROL } from './cache'
+
+describe('ENSO_BALANCES_CACHE_CONTROL', () => {
+  it('disables intermediary and browser caching for wallet balance responses', () => {
+    expect(ENSO_BALANCES_CACHE_CONTROL).toBe('private, no-store, max-age=0, must-revalidate')
+  })
+})

--- a/api/enso/cache.ts
+++ b/api/enso/cache.ts
@@ -1,0 +1,1 @@
+export const ENSO_BALANCES_CACHE_CONTROL = 'private, no-store, max-age=0, must-revalidate'

--- a/api/server.ts
+++ b/api/server.ts
@@ -5,6 +5,7 @@ import type {
   TTenderlyRevertRequest,
   TTenderlySnapshotRequest
 } from '../src/components/shared/types/tenderly'
+import { ENSO_BALANCES_CACHE_CONTROL } from './enso/cache'
 import {
   clearUserCache,
   deleteStaleCache,
@@ -487,7 +488,7 @@ async function handleEnsoBalances(req: Request): Promise<Response> {
     const data = await response.json()
     return Response.json(data, {
       headers: {
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300'
+        'Cache-Control': ENSO_BALANCES_CACHE_CONTROL
       }
     })
   } catch (error) {

--- a/api/server.ts
+++ b/api/server.ts
@@ -5,6 +5,7 @@ import type {
   TTenderlyRevertRequest,
   TTenderlySnapshotRequest
 } from '../src/components/shared/types/tenderly'
+import { ENSO_BALANCES_CACHE_CONTROL } from './enso/cache'
 import {
   buildTenderlyPanelStatus,
   buildTenderlyRevertResponse,
@@ -342,7 +343,7 @@ async function handleEnsoBalances(req: Request): Promise<Response> {
     const data = await response.json()
     return Response.json(data, {
       headers: {
-        'Cache-Control': 'public, s-maxage=60, stale-while-revalidate=300'
+        'Cache-Control': ENSO_BALANCES_CACHE_CONTROL
       }
     })
   } catch (error) {

--- a/src/components/pages/portfolio/hooks/usePortfolioEntryRefresh.helpers.test.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioEntryRefresh.helpers.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { shouldRequestPortfolioEntryRefresh } from './usePortfolioEntryRefresh.helpers'
+
+describe('shouldRequestPortfolioEntryRefresh', () => {
+  it('refreshes once when the portfolio page is active and has not refreshed yet', () => {
+    expect(shouldRequestPortfolioEntryRefresh({ hasRequestedRefresh: false, isActive: true })).toBe(true)
+  })
+
+  it('does not refresh when the portfolio page is not active', () => {
+    expect(shouldRequestPortfolioEntryRefresh({ hasRequestedRefresh: false, isActive: false })).toBe(false)
+  })
+
+  it('does not refresh again after the page-entry refresh already ran', () => {
+    expect(shouldRequestPortfolioEntryRefresh({ hasRequestedRefresh: true, isActive: true })).toBe(false)
+  })
+})

--- a/src/components/pages/portfolio/hooks/usePortfolioEntryRefresh.helpers.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioEntryRefresh.helpers.ts
@@ -1,0 +1,9 @@
+export function shouldRequestPortfolioEntryRefresh({
+  isActive,
+  hasRequestedRefresh
+}: {
+  isActive: boolean
+  hasRequestedRefresh: boolean
+}) {
+  return isActive && !hasRequestedRefresh
+}

--- a/src/components/pages/portfolio/hooks/usePortfolioEntryRefresh.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioEntryRefresh.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react'
+import { shouldRequestPortfolioEntryRefresh } from './usePortfolioEntryRefresh.helpers'
+
+export function usePortfolioEntryRefresh({
+  isActive,
+  onRefresh
+}: {
+  isActive: boolean
+  onRefresh: () => Promise<unknown>
+}) {
+  const hasRequestedRefreshRef = useRef(false)
+
+  useEffect(() => {
+    if (!shouldRequestPortfolioEntryRefresh({ isActive, hasRequestedRefresh: hasRequestedRefreshRef.current })) {
+      return
+    }
+
+    hasRequestedRefreshRef.current = true
+    // Portfolio freshness depends on an imperative wallet refresh when the route becomes active.
+    void onRefresh().catch(() => undefined)
+  }, [isActive, onRefresh])
+}

--- a/src/components/pages/portfolio/index.tsx
+++ b/src/components/pages/portfolio/index.tsx
@@ -1,5 +1,6 @@
 import { usePlausible } from '@hooks/usePlausible'
 import { EmptySectionCard } from '@pages/portfolio/components/EmptySectionCard'
+import { usePortfolioEntryRefresh } from '@pages/portfolio/hooks/usePortfolioEntryRefresh'
 import { type TPortfolioModel, usePortfolioModel } from '@pages/portfolio/hooks/usePortfolioModel'
 import { useVaultWithStakingRewards } from '@pages/portfolio/hooks/useVaultWithStakingRewards'
 import { VaultsListHead } from '@pages/vaults/components/list/VaultsListHead'
@@ -27,6 +28,7 @@ import { SwitchChainPrompt } from '@shared/components/SwitchChainPrompt'
 import { TokenLogo } from '@shared/components/TokenLogo'
 import { Tooltip } from '@shared/components/Tooltip'
 import { useNotifications } from '@shared/contexts/useNotifications'
+import { useWallet } from '@shared/contexts/useWallet'
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { useYearn } from '@shared/contexts/useYearn'
 import { useChainId, useSwitchChain } from '@shared/hooks/useAppWagmi'
@@ -1273,6 +1275,10 @@ function PortfolioPage(): ReactElement {
   const varsRef = useRef<HTMLDivElement>(null)
   const breadcrumbsRef = useRef<HTMLDivElement>(null)
   const historyFetchTimeframe: TPortfolioHistoryTimeframe = historyTimeframe === 'all' ? 'all' : '1y'
+  const { onRefresh } = useWallet()
+
+  usePortfolioEntryRefresh({ isActive: model.isActive, onRefresh })
+
   const activeTab = useMemo((): TPortfolioTabKey => {
     const tabParam = searchParams.get('tab')
     if (tabParam === 'activity' || tabParam === 'claim-rewards' || tabParam === 'positions') {

--- a/src/components/pages/portfolio/index.tsx
+++ b/src/components/pages/portfolio/index.tsx
@@ -1,5 +1,6 @@
 import { usePlausible } from '@hooks/usePlausible'
 import { EmptySectionCard } from '@pages/portfolio/components/EmptySectionCard'
+import { usePortfolioEntryRefresh } from '@pages/portfolio/hooks/usePortfolioEntryRefresh'
 import { type TPortfolioModel, usePortfolioModel } from '@pages/portfolio/hooks/usePortfolioModel'
 import { useVaultWithStakingRewards } from '@pages/portfolio/hooks/useVaultWithStakingRewards'
 import { VaultsListHead } from '@pages/vaults/components/list/VaultsListHead'
@@ -24,6 +25,7 @@ import { METRIC_VALUE_CLASS, MetricHeader, MetricsCard, type TMetricBlock } from
 import { SwitchChainPrompt } from '@shared/components/SwitchChainPrompt'
 import { Tooltip } from '@shared/components/Tooltip'
 import { useNotifications } from '@shared/contexts/useNotifications'
+import { useWallet } from '@shared/contexts/useWallet'
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { useYearn } from '@shared/contexts/useYearn'
 import { useChainId, useSwitchChain } from '@shared/hooks/useAppWagmi'
@@ -954,9 +956,12 @@ function PortfolioSuggestedSection({ suggestedRows }: TPortfolioSuggestedProps):
 
 function PortfolioPage(): ReactElement {
   const model = usePortfolioModel()
+  const { onRefresh } = useWallet()
   const [searchParams, setSearchParams] = useSearchParams()
   const varsRef = useRef<HTMLDivElement>(null)
   const breadcrumbsRef = useRef<HTMLDivElement>(null)
+
+  usePortfolioEntryRefresh({ isActive: model.isActive, onRefresh })
 
   const activeTab = useMemo((): TPortfolioTabKey => {
     const tabParam = searchParams.get('tab')

--- a/src/components/shared/hooks/balanceQueryConfig.test.ts
+++ b/src/components/shared/hooks/balanceQueryConfig.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { getBalanceQueryRefetchConfig } from './balanceQueryConfig'
+
+describe('getBalanceQueryRefetchConfig', () => {
+  it('always refetches wallet balances when the window regains focus', () => {
+    expect(getBalanceQueryRefetchConfig()).toMatchObject({
+      refetchOnWindowFocus: 'always',
+      refetchOnMount: false,
+      refetchOnReconnect: false
+    })
+  })
+})

--- a/src/components/shared/hooks/balanceQueryConfig.ts
+++ b/src/components/shared/hooks/balanceQueryConfig.ts
@@ -22,6 +22,14 @@ export const CHAIN_CACHE_CONFIG: Record<number, { staleTime: number; gcTime: num
 
 export const DEFAULT_CACHE_CONFIG = { staleTime: 5 * 60 * 1000, gcTime: 10 * 60 * 1000 }
 
+export function getBalanceQueryRefetchConfig() {
+  return {
+    refetchOnWindowFocus: 'always' as const,
+    refetchOnMount: false,
+    refetchOnReconnect: false
+  }
+}
+
 export function getChainCacheConfig(chainId: number) {
   return CHAIN_CACHE_CONFIG[chainId] || DEFAULT_CACHE_CONFIG
 }

--- a/src/components/shared/hooks/useBalancesQueries.ts
+++ b/src/components/shared/hooks/useBalancesQueries.ts
@@ -5,7 +5,7 @@ import { resolveExecutionChainId } from '@/config/tenderly'
 import type { TAddress } from '../types/address'
 import type { TChainTokens, TDict, TNDict, TToken } from '../types/mixed'
 import { isZeroAddress } from '../utils/tools.is'
-import { getChainConfig } from './balanceQueryConfig'
+import { getBalanceQueryRefetchConfig, getChainConfig } from './balanceQueryConfig'
 import { getBalances, type TUseBalancesTokens } from './useBalances.multichains'
 import { mergeStagedQueryData, partitionTokensByQueryStage } from './useBalancesQueries.helpers'
 import { balanceQueryKeys } from './useBalancesQuery'
@@ -26,6 +26,7 @@ function buildBalanceQueryOptions(
     const chainId = Number(chainIdStr)
     const executionChainId = resolveExecutionChainId(chainId)
     const config = getChainConfig(chainId)
+    const refetchConfig = getBalanceQueryRefetchConfig()
     const tokenAddresses = chainTokens.map((t) => t.address)
     const queryKey = balanceQueryKeys.byTokens(chainId, executionChainId, userAddress, tokenAddresses)
 
@@ -36,9 +37,7 @@ function buildBalanceQueryOptions(
       staleTime: config.cache.staleTime,
       gcTime: config.cache.gcTime,
       refetchInterval: false,
-      refetchOnWindowFocus: false,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
+      ...refetchConfig,
       retry: 3,
       retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000)
     }

--- a/src/components/shared/hooks/useEnsoBalances.ts
+++ b/src/components/shared/hooks/useEnsoBalances.ts
@@ -36,7 +36,7 @@ export const ENSO_SUPPORTED_CHAINS = SUPPORTED_NETWORKS.map((n) => n.id).filter(
 async function fetchEnsoBalances(address: TAddress): Promise<TEnsoBalanceResponse[]> {
   const params = new URLSearchParams({ eoaAddress: address })
   const url = `/api/enso/balances?${params}`
-  const response = await fetch(url)
+  const response = await fetch(url, { cache: 'no-store' })
 
   if (!response.ok) {
     let details = ''

--- a/src/components/shared/hooks/useEnsoBalances.ts
+++ b/src/components/shared/hooks/useEnsoBalances.ts
@@ -6,6 +6,7 @@ import { SUPPORTED_NETWORKS } from '../utils/constants'
 import { toNormalizedBN } from '../utils/format'
 import { toAddress } from '../utils/tools.address'
 import { isZeroAddress } from '../utils/tools.is'
+import { getBalanceQueryRefetchConfig } from './balanceQueryConfig'
 
 /*******************************************************************************
  ** Enso API response types
@@ -111,6 +112,7 @@ export function useEnsoBalances(
   chainErrorStatus: TNDict<boolean>
 } {
   const enabled = Boolean(options?.enabled !== false && userAddress && !isZeroAddress(userAddress))
+  const refetchConfig = getBalanceQueryRefetchConfig()
 
   const query = useQuery({
     queryKey: ['enso-balances', userAddress],
@@ -124,8 +126,7 @@ export function useEnsoBalances(
     enabled,
     staleTime: options?.staleTime ?? 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
-    refetchOnWindowFocus: false,
-    refetchOnMount: false,
+    ...refetchConfig,
     retry: 3,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000)
   })


### PR DESCRIPTION
## Summary
- disable caching for the Enso balances endpoint in both API entrypoints
- opt the client-side Enso balances fetch out of browser cache reuse
- refetch wallet balance queries whenever the app window regains focus
- refetch wallet balances once when the portfolio route becomes active
- add regression coverage for the Enso cache header, the wallet-balance focus refetch policy, and the portfolio-entry refresh policy

## Context
This splits the portfolio freshness work out from the Safe/Katana overlay branch.

The reported symptom was that portfolio holdings could stay stale across normal reloads or tab switches, while a hard refresh fixed the issue. That pointed to cached balance responses and insufficient foreground refetch behavior.

## Test Plan
- bun run tslint
- bun run lint:fix
- bunx vitest run src/components/pages/portfolio/hooks/usePortfolioEntryRefresh.helpers.test.ts src/components/shared/hooks/balanceQueryConfig.test.ts src/components/shared/hooks/useBalancesQuery.test.ts src/components/shared/hooks/useBalancesQueries.test.ts api/enso/cache.test.ts
