### PR TITLE
Feat/chart tweaks

### DIFF
--- a/api/lib/holdings/services/pnlSimple.ts
+++ b/api/lib/holdings/services/pnlSimple.ts
@@ -173,6 +173,7 @@ export interface HoldingsPnLSimpleHistoryFamilyPoint {
   date: string
   timestamp: number
   protocolReturnPct: number | null
+  growthWeightUsd: number | null
   growthIndex: number | null
 }
 
@@ -1847,6 +1848,7 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
         date: timestampToDateString(timestamp),
         timestamp,
         protocolReturnPct: hasOpenPosition ? (familyVault?.protocolReturnPct ?? null) : null,
+        growthWeightUsd: hasOpenPosition ? (familyVault?.growthWeightUsd ?? null) : null,
         growthIndex: hasOpenPosition ? state.growthIndex : null
       })
     })

--- a/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -292,7 +292,15 @@ function PortfolioGrowthIndexTooltip({
         }
       ]
     })
-    .sort((left, right) => (left.key === 'aggregate' ? -1 : right.key === 'aggregate' ? 1 : 0))
+    .sort((left, right) => {
+      if (left.key === 'aggregate') {
+        return -1
+      }
+      if (right.key === 'aggregate') {
+        return 1
+      }
+      return right.value - left.value
+    })
 
   return (
     <div

--- a/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -759,16 +759,22 @@ export function PortfolioHistoryChart({
   const renderHeader = (showControls = false): ReactElement => (
     <div className={'flex flex-col gap-2.5 md:gap-3'}>
       <div className={'flex items-start justify-between gap-3'}>
-        <div className={'flex flex-col gap-0.5'}>
+        <div className={'flex min-w-0 flex-1 flex-col gap-0.5'}>
           <h2 className={'text-xl font-semibold text-text-primary'}>
             {getChartTitle(activeTab, resolvedGrowthDisplayMode)}
           </h2>
-          <p className={'text-xs text-text-secondary'}>{getChartDescription(activeTab, resolvedGrowthDisplayMode)}</p>
-          {activeTab === 'growth' && autoGrowthDisplayExplanation ? (
-            <p className={'text-[11px] font-medium uppercase tracking-[0.08em] text-text-tertiary'}>
-              {autoGrowthDisplayExplanation}
-            </p>
-          ) : null}
+          <p className={'text-xs text-text-secondary min-h-[2lh]'}>
+            {getChartDescription(activeTab, resolvedGrowthDisplayMode)}
+          </p>
+          <p
+            aria-hidden={!autoGrowthDisplayExplanation}
+            className={cl(
+              'text-[11px] font-medium uppercase tracking-[0.08em] text-text-tertiary',
+              autoGrowthDisplayExplanation ? '' : 'invisible'
+            )}
+          >
+            {autoGrowthDisplayExplanation ?? 'Auto: stable-dominant portfolio, showing USD'}
+          </p>
         </div>
         {activeTab === 'balance' ? (
           <div className={cl('flex items-center gap-0.5 md:gap-1', SELECTOR_BAR_STYLES.container)}>

--- a/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -758,63 +758,65 @@ export function PortfolioHistoryChart({
 
   const renderHeader = (showControls = false): ReactElement => (
     <div className={'flex flex-col gap-2.5 md:gap-3'}>
-      <div className={'flex items-start justify-between gap-3'}>
-        <div className={'flex min-w-0 flex-1 flex-col gap-0.5'}>
-          <h2 className={'text-xl font-semibold text-text-primary'}>
+      <div className={'flex flex-col gap-px'}>
+        <div className={'flex items-center justify-between gap-3 h-[36px] max-md:h-[54px]'}>
+          <h2 className={'text-xl font-semibold leading-tight text-text-primary'}>
             {getChartTitle(activeTab, resolvedGrowthDisplayMode)}
           </h2>
-          <p className={'text-xs text-text-secondary min-h-[2lh]'}>
-            {getChartDescription(activeTab, resolvedGrowthDisplayMode)}
-          </p>
-          <p
-            aria-hidden={!autoGrowthDisplayExplanation}
-            className={cl(
-              'text-[11px] font-medium uppercase tracking-[0.08em] text-text-tertiary',
-              autoGrowthDisplayExplanation ? '' : 'invisible'
-            )}
-          >
-            {autoGrowthDisplayExplanation ?? 'Auto: stable-dominant portfolio, showing USD'}
-          </p>
+          {activeTab === 'balance' ? (
+            <div className={cl('flex shrink-0 items-center gap-0.5 md:gap-1', SELECTOR_BAR_STYLES.container)}>
+              {(['usd', 'eth'] as const).map((nextDenomination) => (
+                <button
+                  key={nextDenomination}
+                  type={'button'}
+                  onClick={() => onDenominationChange(nextDenomination)}
+                  className={cl(
+                    'flex-1 md:flex-initial rounded-sm px-2 md:px-3 py-2 md:py-1 text-xs font-semibold uppercase tracking-wide transition-all',
+                    'min-h-[36px] md:min-h-0 active:scale-[0.98]',
+                    SELECTOR_BAR_STYLES.buttonBase,
+                    denomination === nextDenomination
+                      ? SELECTOR_BAR_STYLES.buttonActive
+                      : SELECTOR_BAR_STYLES.buttonInactive
+                  )}
+                >
+                  {nextDenomination.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          ) : activeTab === 'growth' ? (
+            <div className={cl('flex shrink-0 items-center gap-0.5 md:gap-1', SELECTOR_BAR_STYLES.container)}>
+              {GROWTH_DISPLAY_MODES.map((mode) => (
+                <button
+                  key={mode.id}
+                  type={'button'}
+                  onClick={() => setGrowthDisplayMode(mode.id)}
+                  className={cl(
+                    'flex-1 md:flex-initial rounded-sm px-2 md:px-3 py-2 md:py-1 text-xs font-semibold uppercase tracking-wide transition-all',
+                    'min-h-[36px] md:min-h-0 active:scale-[0.98]',
+                    SELECTOR_BAR_STYLES.buttonBase,
+                    growthDisplayMode === mode.id
+                      ? SELECTOR_BAR_STYLES.buttonActive
+                      : SELECTOR_BAR_STYLES.buttonInactive
+                  )}
+                >
+                  {mode.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
         </div>
-        {activeTab === 'balance' ? (
-          <div className={cl('flex items-center gap-0.5 md:gap-1', SELECTOR_BAR_STYLES.container)}>
-            {(['usd', 'eth'] as const).map((nextDenomination) => (
-              <button
-                key={nextDenomination}
-                type={'button'}
-                onClick={() => onDenominationChange(nextDenomination)}
-                className={cl(
-                  'flex-1 md:flex-initial rounded-sm px-2 md:px-3 py-2 md:py-1 text-xs font-semibold uppercase tracking-wide transition-all',
-                  'min-h-[36px] md:min-h-0 active:scale-[0.98]',
-                  SELECTOR_BAR_STYLES.buttonBase,
-                  denomination === nextDenomination
-                    ? SELECTOR_BAR_STYLES.buttonActive
-                    : SELECTOR_BAR_STYLES.buttonInactive
-                )}
-              >
-                {nextDenomination.toUpperCase()}
-              </button>
-            ))}
-          </div>
-        ) : activeTab === 'growth' ? (
-          <div className={cl('flex items-center gap-0.5 md:gap-1', SELECTOR_BAR_STYLES.container)}>
-            {GROWTH_DISPLAY_MODES.map((mode) => (
-              <button
-                key={mode.id}
-                type={'button'}
-                onClick={() => setGrowthDisplayMode(mode.id)}
-                className={cl(
-                  'flex-1 md:flex-initial rounded-sm px-2 md:px-3 py-2 md:py-1 text-xs font-semibold uppercase tracking-wide transition-all',
-                  'min-h-[36px] md:min-h-0 active:scale-[0.98]',
-                  SELECTOR_BAR_STYLES.buttonBase,
-                  growthDisplayMode === mode.id ? SELECTOR_BAR_STYLES.buttonActive : SELECTOR_BAR_STYLES.buttonInactive
-                )}
-              >
-                {mode.label}
-              </button>
-            ))}
-          </div>
-        ) : null}
+        <p className={'min-h-[2lh] text-xs text-text-secondary'}>
+          {getChartDescription(activeTab, resolvedGrowthDisplayMode)}
+        </p>
+        <p
+          aria-hidden={!autoGrowthDisplayExplanation}
+          className={cl(
+            'text-[11px] font-medium uppercase tracking-[0.08em] text-text-tertiary',
+            autoGrowthDisplayExplanation ? '' : 'invisible'
+          )}
+        >
+          {autoGrowthDisplayExplanation ?? 'Auto: stable-dominant portfolio, showing USD'}
+        </p>
       </div>
       {showControls ? (
         <div className={'flex flex-col gap-2 md:flex-row md:items-center md:justify-between'}>

--- a/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -962,7 +962,7 @@ export function PortfolioHistoryChart({
           maxVaults={INDEX_SERIES_COLORS.length - 1}
           colors={[...INDEX_SERIES_COLORS.slice(1)]}
           title={''}
-          height={260}
+          height={236}
           showModeToggle={false}
           className={'pt-1'}
           emptyMessage={getEmptyMessage(activeTab, resolvedGrowthDisplayMode)}

--- a/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -98,11 +98,11 @@ const GROWTH_DISPLAY_TOOLTIP_COPY: Record<TGrowthDisplayMode, { title: string; b
   },
   usd: {
     title: 'USD',
-    body: 'Cumulative protocol growth in receipt-time USD equivalent. Best when the wallet is mostly dollar-denominated.'
+    body: 'Protocol growth during the selected timeframe in receipt-time USD equivalent.'
   },
   eth: {
     title: 'ETH',
-    body: 'Cumulative protocol growth in receipt-time ETH equivalent. Best when the wallet is mostly ETH-denominated.'
+    body: 'Protocol growth during the selected timeframe in receipt-time ETH equivalent.'
   }
 }
 const VAULT_GROWTH_MODES: Array<{ id: TPortfolioVaultGrowthChartMode; label: string }> = [
@@ -112,7 +112,7 @@ const VAULT_GROWTH_MODES: Array<{ id: TPortfolioVaultGrowthChartMode; label: str
 const VAULT_GROWTH_MODE_TOOLTIP_COPY: Record<TPortfolioVaultGrowthChartMode, { title: string; body: string }> = {
   position: {
     title: 'Position',
-    body: 'Shows actual protocol gain from your deposited positions.'
+    body: 'Shows actual protocol gain from your deposited positions during the selected timeframe.'
   },
   index: {
     title: 'Index',
@@ -208,6 +208,21 @@ function rebaseIndexPoints(points: TChartPoint[]): TChartPoint[] {
     date: point.date,
     value:
       typeof point.value === 'number' && Number.isFinite(point.value) ? (point.value / baseValue) * 100 : point.value
+  }))
+}
+
+function rebaseDeltaPoints(points: TChartPoint[]): TChartPoint[] {
+  const baseValue = points.find(
+    (point): point is { date: string; value: number } => typeof point.value === 'number' && Number.isFinite(point.value)
+  )?.value
+
+  if (baseValue === undefined) {
+    return points
+  }
+
+  return points.map((point) => ({
+    date: point.date,
+    value: typeof point.value === 'number' && Number.isFinite(point.value) ? point.value - baseValue : point.value
   }))
 }
 
@@ -327,8 +342,8 @@ function getChartDescription(activeTab: TPortfolioHistoryChartTab, growthDisplay
     return growthDisplayMode === 'index'
       ? 'Normalized protocol-return index for the whole wallet. Starts at 100 at the beginning of the selected timeframe.'
       : growthDisplayMode === 'eth'
-        ? 'Cumulative protocol growth earned while funds were held in your wallet, shown in receipt-time ETH equivalent.'
-        : 'Cumulative protocol growth earned while funds were held in your wallet, shown in receipt-time USD equivalent.'
+        ? 'Protocol growth earned during the selected timeframe, shown in receipt-time ETH equivalent.'
+        : 'Protocol growth earned during the selected timeframe, shown in receipt-time USD equivalent.'
   }
 
   if (activeTab === 'index') {
@@ -443,10 +458,12 @@ export function PortfolioHistoryChart({
         ? protocolReturnData
         : protocolReturnData.slice(-limit)
 
-    return points.map((point) => ({
-      date: point.date,
-      value: point.growthWeightUsd
-    }))
+    return rebaseDeltaPoints(
+      points.map((point) => ({
+        date: point.date,
+        value: point.growthWeightUsd
+      }))
+    )
   }, [protocolReturnData, timeframe])
 
   const filteredGrowthEthData = useMemo<TChartPoint[]>(() => {
@@ -460,10 +477,12 @@ export function PortfolioHistoryChart({
         ? protocolReturnData
         : protocolReturnData.slice(-limit)
 
-    return points.map((point) => ({
-      date: point.date,
-      value: point.growthWeightEth
-    }))
+    return rebaseDeltaPoints(
+      points.map((point) => ({
+        date: point.date,
+        value: point.growthWeightEth
+      }))
+    )
   }, [protocolReturnData, timeframe])
 
   const filteredGrowthIndexData = useMemo<TChartPoint[]>(() => {

--- a/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -31,10 +31,12 @@ import type {
   TPortfolioProtocolReturnHistorySummary
 } from '../types/api'
 import { PortfolioHistoryBreakdownModal } from './PortfolioHistoryBreakdownModal'
+import type { TPortfolioVaultGrowthChartMode, TPortfolioVaultGrowthChartSeries } from './PortfolioVaultGrowthChart'
+import { PortfolioVaultGrowthChart } from './PortfolioVaultGrowthChart'
 
 export type TPortfolioHistoryChartTimeframe = '30d' | '90d' | '1y' | 'all'
 type TPortfolioHistoryChartTab = 'balance' | 'growth' | 'return' | 'annualized' | 'index'
-type TGrowthDisplayMode = 'auto' | 'index' | 'usd' | 'eth'
+type TGrowthDisplayMode = 'auto' | 'usd' | 'eth'
 type TResolvedGrowthDisplayMode = Exclude<TGrowthDisplayMode, 'auto'>
 
 type TPortfolioHistoryChartProps = {
@@ -61,19 +63,6 @@ type TChartPoint = {
   value: number | null
 }
 
-type TIndexChartPoint = {
-  date: string
-  aggregate: number | null
-  [seriesKey: string]: string | number | null
-}
-
-type TIndexedFamilySeries = {
-  key: string
-  label: string
-  color: string
-  points: TChartPoint[]
-}
-
 type TPortfolioHistoryTooltipProps = {
   active?: boolean
   payload?: Array<{
@@ -81,6 +70,7 @@ type TPortfolioHistoryTooltipProps = {
     payload?: {
       date?: string
       value?: unknown
+      [key: string]: unknown
     }
   }>
 }
@@ -98,9 +88,12 @@ const CHART_TABS: Array<{ id: TPortfolioHistoryChartTab; label: string }> = [
 ]
 const GROWTH_DISPLAY_MODES: Array<{ id: TGrowthDisplayMode; label: string }> = [
   { id: 'auto', label: 'Auto' },
-  { id: 'index', label: 'Index' },
   { id: 'usd', label: 'USD' },
   { id: 'eth', label: 'ETH' }
+]
+const VAULT_GROWTH_MODES: Array<{ id: TPortfolioVaultGrowthChartMode; label: string }> = [
+  { id: 'position', label: 'Position' },
+  { id: 'index', label: 'Index' }
 ]
 
 const INDEX_SERIES_COLORS = ['#2578ff', '#46a2ff', '#94adf2', '#7bb3a8', '#e1a23b', '#b67ae5'] as const
@@ -173,36 +166,19 @@ function formatReturnValue(value: number): string {
   return absolute
 }
 
-function formatIndexValue(value: number): string {
-  return value >= 1000 ? value.toFixed(0) : value >= 100 ? value.toFixed(1) : value.toFixed(2)
-}
-
-function rebaseIndexPoints(points: TChartPoint[]): TChartPoint[] {
-  const baseValue = points.find(
-    (point): point is { date: string; value: number } =>
-      typeof point.value === 'number' && Number.isFinite(point.value) && point.value !== 0
-  )?.value
-
-  if (!baseValue) {
-    return points
-  }
-
-  return points.map((point) => ({
-    date: point.date,
-    value:
-      typeof point.value === 'number' && Number.isFinite(point.value) ? (point.value / baseValue) * 100 : point.value
-  }))
-}
-
 function resolveGrowthDisplayMode(
   selectedMode: TGrowthDisplayMode,
   summary: TPortfolioProtocolReturnHistorySummary | null,
   protocolReturnData: TPortfolioProtocolReturnHistoryChartData | null
 ): TResolvedGrowthDisplayMode {
-  const recommendedMode = selectedMode === 'auto' ? (summary?.recommendedGrowthDisplay ?? 'index') : selectedMode
+  const recommendedMode = selectedMode === 'auto' ? (summary?.recommendedGrowthDisplay ?? 'usd') : selectedMode
   const hasEthSeries = Boolean(protocolReturnData?.some((point) => point.growthWeightEth !== null))
 
-  return recommendedMode === 'eth' && !hasEthSeries ? 'index' : recommendedMode
+  if (recommendedMode === 'eth') {
+    return hasEthSeries ? 'eth' : 'usd'
+  }
+
+  return 'usd'
 }
 
 function getAutoGrowthDisplayExplanation(args: {
@@ -219,111 +195,27 @@ function getAutoGrowthDisplayExplanation(args: {
     : summary.recommendedGrowthDisplayReason === 'eth_dominant'
       ? args.resolvedMode === 'eth'
         ? 'Auto: ETH-dominant portfolio, showing ETH'
-        : 'Auto: ETH-dominant portfolio, ETH history unavailable, showing Index'
-      : 'Auto: mixed portfolio, showing Index'
+        : 'Auto: ETH-dominant portfolio, ETH history unavailable, showing USD'
+      : 'Auto: mixed portfolio, showing USD'
 }
 
-function buildIndexedFamilySeries(
+function buildPortfolioVaultGrowthSeries(
   familySeries: TPortfolioProtocolReturnHistoryFamilySeries,
-  timeframe: TPortfolioHistoryChartTimeframe,
   labelByVaultKey: Record<string, string>
-): TIndexedFamilySeries[] {
-  const limit = getTimeframeLimit(timeframe)
-
-  return familySeries
-    .map((series) => {
-      const points =
-        !Number.isFinite(limit) || limit >= series.dataPoints.length
-          ? series.dataPoints
-          : series.dataPoints.slice(-limit)
-
-      return {
-        series,
-        points: rebaseIndexPoints(points.map((point) => ({ date: point.date, value: point.growthIndex })))
-      }
-    })
-    .filter(({ points }) => points.some((point) => point.value !== null))
-    .slice(0, INDEX_SERIES_COLORS.length - 1)
-    .map(({ series, points }, index) => ({
-      key: `family_${index}`,
-      label:
-        labelByVaultKey[`${series.chainId}:${series.vaultAddress.toLowerCase()}`] ??
-        series.symbol ??
-        `${series.vaultAddress.slice(0, 6)}…${series.vaultAddress.slice(-4)}`,
-      color: INDEX_SERIES_COLORS[index + 1],
-      points
+): TPortfolioVaultGrowthChartSeries[] {
+  return familySeries.map((series) => ({
+    vaultAddress: series.vaultAddress,
+    vaultName:
+      labelByVaultKey[`${series.chainId}:${series.vaultAddress.toLowerCase()}`] ??
+      series.symbol ??
+      `${series.vaultAddress.slice(0, 6)}…${series.vaultAddress.slice(-4)}`,
+    symbol: series.symbol,
+    points: series.dataPoints.map((point) => ({
+      timestamp: point.timestamp,
+      positionValueUsd: point.growthWeightUsd,
+      indexValue: point.growthIndex
     }))
-}
-
-function PortfolioGrowthIndexTooltip({
-  active,
-  payload,
-  indexSeriesLabels
-}: TPortfolioHistoryTooltipProps & {
-  indexSeriesLabels: Record<string, string>
-}): ReactElement | null {
-  if (!active || !payload?.length) {
-    return null
-  }
-
-  const date = payload[0]?.payload?.date
-  if (!date) {
-    return null
-  }
-
-  const rows = payload
-    .flatMap((entry) => {
-      const dataKey =
-        typeof (entry as { dataKey?: unknown }).dataKey === 'string' ? (entry as { dataKey: string }).dataKey : ''
-      const value = typeof entry.value === 'number' ? entry.value : Number(entry.value ?? NaN)
-      if (!Number.isFinite(value)) {
-        return []
-      }
-
-      return [
-        {
-          key: dataKey,
-          label: indexSeriesLabels[dataKey] ?? dataKey,
-          value,
-          color:
-            typeof (entry as { color?: unknown }).color === 'string'
-              ? ((entry as { color: string }).color as string)
-              : 'var(--color-text-primary)'
-        }
-      ]
-    })
-    .sort((left, right) => {
-      if (left.key === 'aggregate') {
-        return -1
-      }
-      if (right.key === 'aggregate') {
-        return 1
-      }
-      return right.value - left.value
-    })
-
-  return (
-    <div
-      className={
-        'pointer-events-none flex min-w-[13rem] flex-col gap-2 rounded-xl border border-border bg-surface px-3 py-3 shadow-xl'
-      }
-    >
-      <span className={'text-xs font-medium uppercase tracking-[0.12em] text-text-tertiary'}>
-        {formatChartTooltipDate(date)}
-      </span>
-      <div className={'flex flex-col gap-1.5'}>
-        {rows.map((row) => (
-          <div key={row.key} className={'flex items-center justify-between gap-3'}>
-            <span className={'inline-flex items-center gap-2 text-xs text-text-secondary'}>
-              <span className={'size-2 rounded-full'} style={{ backgroundColor: row.color }} />
-              <span>{row.label}</span>
-            </span>
-            <span className={'text-sm font-semibold text-text-primary'}>{formatIndexValue(row.value)}</span>
-          </div>
-        ))}
-      </div>
-    </div>
-  )
+  }))
 }
 
 function PortfolioHistoryTooltip({
@@ -353,12 +245,8 @@ function PortfolioHistoryTooltip({
     activeTab === 'balance'
       ? formatBalanceValue(value, denomination)
       : activeTab === 'growth'
-        ? growthDisplayMode === 'index'
-          ? formatIndexValue(value)
-          : formatGrowthValue(value, growthDisplayMode)
-        : activeTab === 'index'
-          ? formatIndexValue(value)
-          : formatReturnValue(value)
+        ? formatGrowthValue(value, growthDisplayMode)
+        : formatReturnValue(value)
 
   return (
     <div
@@ -386,15 +274,13 @@ function getChartDescription(
   growthDisplayMode: TResolvedGrowthDisplayMode
 ): string {
   if (activeTab === 'growth') {
-    return growthDisplayMode === 'index'
-      ? 'Normalized protocol-return index for the whole wallet. Starts at 100 at the beginning of the selected timeframe.'
-      : growthDisplayMode === 'eth'
-        ? 'Cumulative protocol growth earned while funds were held in your wallet, shown in receipt-time ETH equivalent.'
-        : 'Cumulative protocol growth earned while funds were held in your wallet, shown in receipt-time USD equivalent.'
+    return growthDisplayMode === 'eth'
+      ? 'Cumulative protocol growth earned while funds were held in your wallet, shown in receipt-time ETH equivalent.'
+      : 'Cumulative protocol growth earned while funds were held in your wallet, shown in receipt-time USD equivalent.'
   }
 
   if (activeTab === 'index') {
-    return 'Wallet growth index plus vault comparison lines. Each line starts at 100 at the beginning of the selected timeframe.'
+    return 'Compare actual vault contribution with normalized vault performance.'
   }
 
   if (activeTab === 'return') {
@@ -410,7 +296,7 @@ function getChartDescription(
 
 function getChartTitle(activeTab: TPortfolioHistoryChartTab, growthDisplayMode: TResolvedGrowthDisplayMode): string {
   if (activeTab === 'growth') {
-    return growthDisplayMode === 'index' ? 'Growth Index' : 'Protocol Growth'
+    return growthDisplayMode === 'eth' ? 'ETH Growth' : 'USD Growth'
   }
 
   if (activeTab === 'return') {
@@ -430,11 +316,9 @@ function getChartTitle(activeTab: TPortfolioHistoryChartTab, growthDisplayMode: 
 
 function getEmptyMessage(activeTab: TPortfolioHistoryChartTab, growthDisplayMode: TResolvedGrowthDisplayMode): string {
   if (activeTab === 'growth') {
-    return growthDisplayMode === 'index'
-      ? 'No growth index history available'
-      : growthDisplayMode === 'eth'
-        ? 'No ETH-equivalent protocol growth history available'
-        : 'No protocol growth history available'
+    return growthDisplayMode === 'eth'
+      ? 'No ETH-equivalent protocol growth history available'
+      : 'No protocol growth history available'
   }
 
   if (activeTab === 'return') {
@@ -473,6 +357,7 @@ export function PortfolioHistoryChart({
   const { allVaults } = useYearn()
   const [activeTab, setActiveTab] = useState<TPortfolioHistoryChartTab>('balance')
   const [growthDisplayMode, setGrowthDisplayMode] = useState<TGrowthDisplayMode>('auto')
+  const [vaultGrowthMode, setVaultGrowthMode] = useState<TPortfolioVaultGrowthChartMode>('position')
   const [hoveredBreakdownDate, setHoveredBreakdownDate] = useState<string | null>(null)
   const [selectedBreakdownDate, setSelectedBreakdownDate] = useState<string | null>(null)
   const [isBreakdownModalOpen, setIsBreakdownModalOpen] = useState(false)
@@ -535,25 +420,6 @@ export function PortfolioHistoryChart({
     }))
   }, [protocolReturnData, timeframe])
 
-  const filteredGrowthIndexData = useMemo<TChartPoint[]>(() => {
-    if (!protocolReturnData) {
-      return []
-    }
-
-    const limit = getTimeframeLimit(timeframe)
-    const points =
-      !Number.isFinite(limit) || limit >= protocolReturnData.length
-        ? protocolReturnData
-        : protocolReturnData.slice(-limit)
-
-    return rebaseIndexPoints(
-      points.map((point) => ({
-        date: point.date,
-        value: point.growthIndex
-      }))
-    )
-  }, [protocolReturnData, timeframe])
-
   const filteredReturnData = useMemo<TChartPoint[]>(() => {
     if (!protocolReturnData) {
       return []
@@ -601,11 +467,9 @@ export function PortfolioHistoryChart({
       : activeTab === 'growth'
         ? resolvedGrowthDisplayMode === 'eth'
           ? filteredGrowthEthData
-          : resolvedGrowthDisplayMode === 'usd'
-            ? filteredGrowthUsdData
-            : filteredGrowthIndexData
+          : filteredGrowthUsdData
         : activeTab === 'index'
-          ? filteredGrowthIndexData
+          ? filteredReturnData
           : activeTab === 'return'
             ? filteredReturnData
             : filteredAnnualizedReturnData
@@ -647,10 +511,6 @@ export function PortfolioHistoryChart({
     }
 
     if (activeTab === 'growth') {
-      if (resolvedGrowthDisplayMode === 'index') {
-        return formatIndexValue(numericValue)
-      }
-
       if (resolvedGrowthDisplayMode === 'eth') {
         if (absoluteValue >= 1_000) {
           return `${numericValue < 0 ? '-' : ''}${(absoluteValue / 1_000).toFixed(1)}k`
@@ -672,10 +532,6 @@ export function PortfolioHistoryChart({
       return `${numericValue < 0 ? '-' : ''}$${absoluteValue.toFixed(0)}`
     }
 
-    if (activeTab === 'index') {
-      return formatIndexValue(numericValue)
-    }
-
     if (absoluteValue >= 1000) {
       return `${numericValue.toFixed(0)}%`
     }
@@ -694,11 +550,9 @@ export function PortfolioHistoryChart({
               ? 'Total Value (ETH)'
               : 'Total Value (USD)'
             : activeTab === 'growth'
-              ? resolvedGrowthDisplayMode === 'index'
-                ? 'Growth Index'
-                : resolvedGrowthDisplayMode === 'eth'
-                  ? 'Protocol Growth (ETH)'
-                  : 'Protocol Growth (USD)'
+              ? resolvedGrowthDisplayMode === 'eth'
+                ? 'Protocol Growth (ETH)'
+                : 'Protocol Growth (USD)'
               : activeTab === 'index'
                 ? 'Growth Index'
                 : 'Protocol Return (%)',
@@ -805,6 +659,24 @@ export function PortfolioHistoryChart({
                     growthDisplayMode === mode.id
                       ? SELECTOR_BAR_STYLES.buttonActive
                       : SELECTOR_BAR_STYLES.buttonInactive
+                  )}
+                >
+                  {mode.label}
+                </button>
+              ))}
+            </div>
+          ) : activeTab === 'index' ? (
+            <div className={cl('flex shrink-0 items-center gap-0.5 md:gap-1', SELECTOR_BAR_STYLES.container)}>
+              {VAULT_GROWTH_MODES.map((mode) => (
+                <button
+                  key={mode.id}
+                  type={'button'}
+                  onClick={() => setVaultGrowthMode(mode.id)}
+                  className={cl(
+                    'flex-1 md:flex-initial rounded-sm px-2 md:px-3 py-2 md:py-1 text-xs font-semibold uppercase tracking-wide transition-all',
+                    'min-h-[36px] md:min-h-0 active:scale-[0.98]',
+                    SELECTOR_BAR_STYLES.buttonBase,
+                    vaultGrowthMode === mode.id ? SELECTOR_BAR_STYLES.buttonActive : SELECTOR_BAR_STYLES.buttonInactive
                   )}
                 >
                   {mode.label}
@@ -993,106 +865,24 @@ export function PortfolioHistoryChart({
   }
 
   if (activeTab === 'index') {
-    const indexedFamilySeries = buildIndexedFamilySeries(protocolReturnFamilySeries, timeframe, familyLabelByVaultKey)
-    const limit = getTimeframeLimit(timeframe)
-    const aggregatePoints =
-      !protocolReturnData || !Number.isFinite(limit) || limit >= protocolReturnData.length
-        ? (protocolReturnData ?? [])
-        : protocolReturnData.slice(-limit)
-    const aggregateIndexPoints = rebaseIndexPoints(
-      aggregatePoints.map((point) => ({ date: point.date, value: point.growthIndex }))
-    )
-    const indexData: TIndexChartPoint[] = aggregateIndexPoints.map((point, index) => {
-      const row: TIndexChartPoint = { date: point.date, aggregate: point.value }
-      indexedFamilySeries.forEach((family) => {
-        row[family.key] = family.points[index]?.value ?? null
-      })
-      return row
-    })
-    const indexTicks = isShortTimeframe
-      ? getChartWeeklyTicks(aggregateIndexPoints)
-      : getChartMonthlyTicks(aggregateIndexPoints)
-    const indexSeriesLabels: Record<string, string> = {
-      aggregate: 'Wallet',
-      ...Object.fromEntries(indexedFamilySeries.map((series) => [series.key, series.label]))
-    }
-
-    if (indexData.length === 0) {
-      return (
-        <section className={cl(sectionClassName, className)}>
-          {renderHeader(true)}
-          <div className={'flex min-h-[240px] items-center justify-center'}>
-            <p className={'text-base text-text-secondary'}>{getEmptyMessage(activeTab, resolvedGrowthDisplayMode)}</p>
-          </div>
-        </section>
-      )
-    }
+    const vaultGrowthSeries = buildPortfolioVaultGrowthSeries(protocolReturnFamilySeries, familyLabelByVaultKey)
 
     return (
       <section className={cl(sectionClassName, className)}>
         {renderHeader(true)}
-        <div className={'min-h-[240px] flex-1 pt-1'}>
-          <ChartContainer
-            config={{ aggregate: { label: 'Wallet', color: INDEX_SERIES_COLORS[0] } }}
-            style={{ height: '100%', aspectRatio: 'unset' }}
-          >
-            <ComposedChart data={indexData} margin={CHART_WITH_AXES_MARGIN}>
-              <CartesianGrid vertical={false} />
-              <XAxis
-                dataKey={'date'}
-                ticks={indexTicks}
-                tickFormatter={tickFormatter}
-                tick={{ fill: 'var(--chart-axis)' }}
-                axisLine={{ stroke: 'var(--chart-axis)' }}
-                tickLine={{ stroke: 'var(--chart-axis)' }}
-              />
-              <YAxis
-                domain={['auto', 'auto']}
-                tickFormatter={(value: number | string) => {
-                  const numericValue = Number(value)
-                  const absoluteValue = Math.abs(numericValue)
-                  return absoluteValue >= 1000 ? numericValue.toFixed(0) : numericValue.toFixed(1)
-                }}
-                mirror
-                width={CHART_Y_AXIS_WIDTH}
-                tickMargin={CHART_Y_AXIS_TICK_MARGIN}
-                tick={CHART_Y_AXIS_TICK_STYLE}
-                axisLine={{ stroke: 'var(--chart-axis)' }}
-                tickLine={{ stroke: 'var(--chart-axis)' }}
-              />
-              <ChartTooltip
-                cursor={{ stroke: 'var(--chart-cursor-line)', strokeWidth: 1 }}
-                content={(props) => <PortfolioGrowthIndexTooltip {...props} indexSeriesLabels={indexSeriesLabels} />}
-              />
-              <Line
-                type={'monotone'}
-                dataKey={'aggregate'}
-                name={'Wallet'}
-                stroke={INDEX_SERIES_COLORS[0]}
-                strokeWidth={2.5}
-                dot={false}
-                activeDot={{ r: 4, strokeWidth: 0, fill: INDEX_SERIES_COLORS[0] }}
-                connectNulls
-                isAnimationActive={false}
-              />
-              {indexedFamilySeries.map((series) => (
-                <Line
-                  key={series.key}
-                  type={'monotone'}
-                  dataKey={series.key}
-                  name={series.label}
-                  stroke={series.color}
-                  strokeWidth={1.75}
-                  strokeOpacity={0.9}
-                  dot={false}
-                  activeDot={{ r: 3.5, strokeWidth: 0, fill: series.color }}
-                  connectNulls
-                  isAnimationActive={false}
-                />
-              ))}
-            </ComposedChart>
-          </ChartContainer>
-        </div>
+        <PortfolioVaultGrowthChart
+          series={vaultGrowthSeries}
+          mode={vaultGrowthMode}
+          onModeChange={setVaultGrowthMode}
+          timeframe={timeframe}
+          maxVaults={INDEX_SERIES_COLORS.length - 1}
+          colors={[...INDEX_SERIES_COLORS.slice(1)]}
+          title={''}
+          height={260}
+          showModeToggle={false}
+          className={'pt-1'}
+          emptyMessage={getEmptyMessage(activeTab, resolvedGrowthDisplayMode)}
+        />
         <PortfolioHistoryBreakdownModal
           date={selectedBreakdownDate}
           isOpen={isBreakdownModalOpen}

--- a/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -177,6 +177,23 @@ function formatIndexValue(value: number): string {
   return value >= 1000 ? value.toFixed(0) : value >= 100 ? value.toFixed(1) : value.toFixed(2)
 }
 
+function rebaseIndexPoints(points: TChartPoint[]): TChartPoint[] {
+  const baseValue = points.find(
+    (point): point is { date: string; value: number } =>
+      typeof point.value === 'number' && Number.isFinite(point.value) && point.value !== 0
+  )?.value
+
+  if (!baseValue) {
+    return points
+  }
+
+  return points.map((point) => ({
+    date: point.date,
+    value:
+      typeof point.value === 'number' && Number.isFinite(point.value) ? (point.value / baseValue) * 100 : point.value
+  }))
+}
+
 function resolveGrowthDisplayMode(
   selectedMode: TGrowthDisplayMode,
   summary: TPortfolioProtocolReturnHistorySummary | null,
@@ -222,7 +239,7 @@ function buildIndexedFamilySeries(
 
       return {
         series,
-        points: points.map((point) => ({ date: point.date, value: point.growthIndex }))
+        points: rebaseIndexPoints(points.map((point) => ({ date: point.date, value: point.growthIndex })))
       }
     })
     .filter(({ points }) => points.some((point) => point.value !== null))
@@ -521,10 +538,12 @@ export function PortfolioHistoryChart({
         ? protocolReturnData
         : protocolReturnData.slice(-limit)
 
-    return points.map((point) => ({
-      date: point.date,
-      value: point.growthIndex
-    }))
+    return rebaseIndexPoints(
+      points.map((point) => ({
+        date: point.date,
+        value: point.growthIndex
+      }))
+    )
   }, [protocolReturnData, timeframe])
 
   const filteredReturnData = useMemo<TChartPoint[]>(() => {
@@ -964,7 +983,9 @@ export function PortfolioHistoryChart({
       !protocolReturnData || !Number.isFinite(limit) || limit >= protocolReturnData.length
         ? (protocolReturnData ?? [])
         : protocolReturnData.slice(-limit)
-    const aggregateIndexPoints = aggregatePoints.map((point) => ({ date: point.date, value: point.growthIndex }))
+    const aggregateIndexPoints = rebaseIndexPoints(
+      aggregatePoints.map((point) => ({ date: point.date, value: point.growthIndex }))
+    )
     const indexData: TIndexChartPoint[] = aggregateIndexPoints.map((point, index) => {
       const row: TIndexChartPoint = { date: point.date, aggregate: point.value }
       indexedFamilySeries.forEach((family) => {

--- a/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
@@ -1,0 +1,559 @@
+import type { ChartConfig } from '@pages/vaults/components/detail/charts/ChartPrimitives'
+import { ChartContainer, ChartTooltip } from '@pages/vaults/components/detail/charts/ChartPrimitives'
+import {
+  CHART_WITH_AXES_MARGIN,
+  CHART_Y_AXIS_TICK_MARGIN,
+  CHART_Y_AXIS_TICK_STYLE,
+  CHART_Y_AXIS_WIDTH
+} from '@pages/vaults/components/detail/charts/chartLayout'
+import {
+  formatChartMonthYearLabel,
+  formatChartTooltipDate,
+  formatChartWeekLabel,
+  formatUnixTimestamp,
+  getChartMonthlyTicks,
+  getChartWeeklyTicks,
+  getTimeframeLimit
+} from '@pages/vaults/utils/charts'
+import { cl, formatUSD, SELECTOR_BAR_STYLES } from '@shared/utils'
+import type { ReactElement } from 'react'
+import { useMemo, useState } from 'react'
+import { CartesianGrid, ComposedChart, Line, XAxis, YAxis } from 'recharts'
+
+export type TPortfolioVaultGrowthChartMode = 'position' | 'index'
+export type TPortfolioVaultGrowthChartTimeframe = '30d' | '90d' | '1y' | 'all'
+
+export type TPortfolioVaultGrowthChartPoint = {
+  timestamp: number
+  vaultAddress: string
+  vaultName: string
+  symbol: string
+  pricePerShare: number
+  underlyingUsdPrice: number
+  userShareBalance: number
+}
+
+export type TPortfolioVaultGrowthChartSeriesPoint = {
+  timestamp: number
+  positionValueUsd: number | null
+  indexValue: number | null
+}
+
+export type TPortfolioVaultGrowthChartSeries = {
+  vaultAddress: string
+  vaultName: string
+  symbol?: string | null
+  points: TPortfolioVaultGrowthChartSeriesPoint[]
+}
+
+export type TPortfolioVaultGrowthChartProps = {
+  points?: TPortfolioVaultGrowthChartPoint[]
+  series?: TPortfolioVaultGrowthChartSeries[]
+  mode?: TPortfolioVaultGrowthChartMode
+  initialMode?: TPortfolioVaultGrowthChartMode
+  onModeChange?: (mode: TPortfolioVaultGrowthChartMode) => void
+  timeframe?: TPortfolioVaultGrowthChartTimeframe
+  vaultOrder?: string[]
+  maxVaults?: number
+  indexBase?: number
+  colors?: string[]
+  title?: string
+  height?: number
+  showModeToggle?: boolean
+  className?: string
+  emptyMessage?: string
+}
+
+type TTransformedPoint = {
+  timestamp: number
+  date: string
+  value: number | null
+}
+
+type TTransformedSeries = {
+  key: string
+  vaultAddress: string
+  label: string
+  color: string
+  positionPoints: TTransformedPoint[]
+  indexPoints: TTransformedPoint[]
+}
+
+type TChartPoint = {
+  date: string
+  timestamp: number
+  [seriesKey: string]: string | number | null
+}
+
+type TTooltipProps = {
+  active?: boolean
+  payload?: Array<{
+    dataKey?: unknown
+    color?: unknown
+    value?: unknown
+    payload?: {
+      date?: string
+      [seriesKey: string]: unknown
+    }
+  }>
+}
+
+const DEFAULT_COLORS = ['#2578ff', '#46a2ff', '#94adf2', '#7bb3a8', '#e1a23b', '#b67ae5', '#f472b6', '#f97316']
+
+const MODE_COPY: Record<TPortfolioVaultGrowthChartMode, string> = {
+  position: 'Shows actual protocol gain from your deposited positions.',
+  index: 'Shows vault performance normalized to 100, ignoring position size.'
+}
+
+function getVaultKey(address: string): string {
+  return address.toLowerCase()
+}
+
+function normalizeTimestamp(timestamp: number): number {
+  return timestamp > 1_000_000_000_000 ? Math.floor(timestamp / 1000) : Math.floor(timestamp)
+}
+
+function isFinitePositive(value: number): boolean {
+  return Number.isFinite(value) && value > 0
+}
+
+function getValidShareBalance(point: TPortfolioVaultGrowthChartPoint): number {
+  return Number.isFinite(point.userShareBalance) && point.userShareBalance > 0 ? point.userShareBalance : 0
+}
+
+function buildPositionPoints(points: TPortfolioVaultGrowthChartPoint[]): TTransformedPoint[] {
+  let cumulativeGrowthUsd = 0
+  let previousPricePerShare: number | null = null
+  let previousShareBalance = 0
+
+  return points.map((point) => {
+    const timestamp = normalizeTimestamp(point.timestamp)
+    const shareBalance = getValidShareBalance(point)
+    const hasValidPrices = isFinitePositive(point.pricePerShare) && isFinitePositive(point.underlyingUsdPrice)
+
+    if (!hasValidPrices) {
+      return { timestamp, date: formatUnixTimestamp(timestamp), value: null }
+    }
+
+    if (previousPricePerShare !== null) {
+      // Position mode measures protocol PPS gain on shares held during the interval, not deposit size changes.
+      cumulativeGrowthUsd +=
+        previousShareBalance * (point.pricePerShare - previousPricePerShare) * point.underlyingUsdPrice
+    }
+
+    previousPricePerShare = point.pricePerShare
+    previousShareBalance = shareBalance
+
+    return { timestamp, date: formatUnixTimestamp(timestamp), value: cumulativeGrowthUsd }
+  })
+}
+
+function buildIndexPoints(points: TPortfolioVaultGrowthChartPoint[], indexBase: number): TTransformedPoint[] {
+  const basePricePerShare = points.find((point) => isFinitePositive(point.pricePerShare))?.pricePerShare
+
+  return points.map((point) => {
+    const timestamp = normalizeTimestamp(point.timestamp)
+    const value =
+      basePricePerShare && isFinitePositive(point.pricePerShare)
+        ? (point.pricePerShare / basePricePerShare) * indexBase
+        : null
+
+    return { timestamp, date: formatUnixTimestamp(timestamp), value }
+  })
+}
+
+function groupVaultPoints(points: TPortfolioVaultGrowthChartPoint[]): Map<string, TPortfolioVaultGrowthChartPoint[]> {
+  return points.reduce<Map<string, TPortfolioVaultGrowthChartPoint[]>>((groups, point) => {
+    const key = getVaultKey(point.vaultAddress)
+    const existing = groups.get(key) ?? []
+    existing.push({ ...point, timestamp: normalizeTimestamp(point.timestamp) })
+    groups.set(key, existing)
+    return groups
+  }, new Map())
+}
+
+function buildSeries(args: {
+  points: TPortfolioVaultGrowthChartPoint[]
+  timeframe: TPortfolioVaultGrowthChartTimeframe
+  vaultOrder?: string[]
+  maxVaults?: number
+  indexBase: number
+  colors: string[]
+}): TTransformedSeries[] {
+  const grouped = groupVaultPoints(args.points)
+  const groupedKeys = Array.from(grouped.keys())
+  const orderedKeys = args.vaultOrder?.length
+    ? args.vaultOrder.map(getVaultKey).filter((key) => grouped.has(key))
+    : groupedKeys
+  const selectedKeys = typeof args.maxVaults === 'number' ? orderedKeys.slice(0, args.maxVaults) : orderedKeys
+  const limit = getTimeframeLimit(args.timeframe)
+
+  return selectedKeys.flatMap((vaultKey, index) => {
+    const rawPoints = grouped.get(vaultKey)
+    if (!rawPoints?.length) {
+      return []
+    }
+
+    const sortedPoints = rawPoints.toSorted((left, right) => left.timestamp - right.timestamp)
+    const points = !Number.isFinite(limit) || limit >= sortedPoints.length ? sortedPoints : sortedPoints.slice(-limit)
+    const firstPoint = points[0]
+
+    return [
+      {
+        key: `vault_${index}`,
+        vaultAddress: firstPoint.vaultAddress,
+        label: firstPoint.vaultName || firstPoint.symbol || firstPoint.vaultAddress,
+        color: args.colors[index % args.colors.length] ?? DEFAULT_COLORS[index % DEFAULT_COLORS.length],
+        positionPoints: buildPositionPoints(points),
+        indexPoints: buildIndexPoints(points, args.indexBase)
+      }
+    ]
+  })
+}
+
+function buildPrecomputedIndexPoints(
+  points: TPortfolioVaultGrowthChartSeriesPoint[],
+  indexBase: number
+): TTransformedPoint[] {
+  const baseValue = points.find(
+    (point) => typeof point.indexValue === 'number' && Number.isFinite(point.indexValue)
+  )?.indexValue
+
+  return points.map((point) => {
+    const timestamp = normalizeTimestamp(point.timestamp)
+    const value =
+      baseValue && typeof point.indexValue === 'number' && Number.isFinite(point.indexValue)
+        ? (point.indexValue / baseValue) * indexBase
+        : null
+
+    return { timestamp, date: formatUnixTimestamp(timestamp), value }
+  })
+}
+
+function buildPrecomputedPositionPoints(points: TPortfolioVaultGrowthChartSeriesPoint[]): TTransformedPoint[] {
+  const baseValue =
+    points.find((point) => typeof point.positionValueUsd === 'number' && Number.isFinite(point.positionValueUsd))
+      ?.positionValueUsd ?? 0
+
+  return points.map((point) => {
+    const timestamp = normalizeTimestamp(point.timestamp)
+    const value =
+      typeof point.positionValueUsd === 'number' && Number.isFinite(point.positionValueUsd)
+        ? point.positionValueUsd - baseValue
+        : null
+
+    return { timestamp, date: formatUnixTimestamp(timestamp), value }
+  })
+}
+
+function buildSeriesFromPrecomputed(args: {
+  series: TPortfolioVaultGrowthChartSeries[]
+  timeframe: TPortfolioVaultGrowthChartTimeframe
+  vaultOrder?: string[]
+  maxVaults?: number
+  indexBase: number
+  colors: string[]
+}): TTransformedSeries[] {
+  const seriesByVaultKey = new Map(
+    args.series.map((vaultSeries) => [getVaultKey(vaultSeries.vaultAddress), vaultSeries])
+  )
+  const orderedKeys = args.vaultOrder?.length
+    ? args.vaultOrder.map(getVaultKey).filter((key) => seriesByVaultKey.has(key))
+    : Array.from(seriesByVaultKey.keys())
+  const selectedKeys = typeof args.maxVaults === 'number' ? orderedKeys.slice(0, args.maxVaults) : orderedKeys
+  const limit = getTimeframeLimit(args.timeframe)
+
+  return selectedKeys.flatMap((vaultKey, index) => {
+    const vaultSeries = seriesByVaultKey.get(vaultKey)
+    if (!vaultSeries?.points.length) {
+      return []
+    }
+
+    const sortedPoints = vaultSeries.points
+      .map((point) => ({ ...point, timestamp: normalizeTimestamp(point.timestamp) }))
+      .toSorted((left, right) => left.timestamp - right.timestamp)
+    const points = !Number.isFinite(limit) || limit >= sortedPoints.length ? sortedPoints : sortedPoints.slice(-limit)
+
+    return [
+      {
+        key: `vault_${index}`,
+        vaultAddress: vaultSeries.vaultAddress,
+        label: vaultSeries.vaultName || vaultSeries.symbol || vaultSeries.vaultAddress,
+        color: args.colors[index % args.colors.length] ?? DEFAULT_COLORS[index % DEFAULT_COLORS.length],
+        positionPoints: buildPrecomputedPositionPoints(points),
+        indexPoints: buildPrecomputedIndexPoints(points, args.indexBase)
+      }
+    ]
+  })
+}
+
+function buildChartData(series: TTransformedSeries[], mode: TPortfolioVaultGrowthChartMode): TChartPoint[] {
+  const timestamps = Array.from(
+    new Set(
+      series.flatMap((vaultSeries) =>
+        (mode === 'position' ? vaultSeries.positionPoints : vaultSeries.indexPoints).map((point) => point.timestamp)
+      )
+    )
+  ).toSorted((left, right) => left - right)
+
+  return timestamps.map((timestamp) => {
+    const row: TChartPoint = { timestamp, date: formatUnixTimestamp(timestamp) }
+
+    series.forEach((vaultSeries) => {
+      const points = mode === 'position' ? vaultSeries.positionPoints : vaultSeries.indexPoints
+      row[vaultSeries.key] = points.find((point) => point.timestamp === timestamp)?.value ?? null
+    })
+
+    return row
+  })
+}
+
+function formatPositionValue(value: number): string {
+  const absolute = formatUSD(Math.abs(value), 2, 2)
+  if (value > 0) {
+    return `+${absolute}`
+  }
+  if (value < 0) {
+    return `-${absolute}`
+  }
+  return absolute
+}
+
+function formatIndexValue(value: number): string {
+  return value >= 1000 ? value.toFixed(0) : value >= 100 ? value.toFixed(1) : value.toFixed(2)
+}
+
+function formatPositionTick(value: number | string): string {
+  const numericValue = Number(value)
+  const absoluteValue = Math.abs(numericValue)
+  if (absoluteValue >= 1_000_000) {
+    return `${numericValue < 0 ? '-' : ''}$${(absoluteValue / 1_000_000).toFixed(1)}M`
+  }
+  if (absoluteValue >= 1_000) {
+    return `${numericValue < 0 ? '-' : ''}$${(absoluteValue / 1_000).toFixed(1)}k`
+  }
+  return `${numericValue < 0 ? '-' : ''}$${absoluteValue.toFixed(0)}`
+}
+
+function formatIndexTick(value: number | string): string {
+  const numericValue = Number(value)
+  return Math.abs(numericValue) >= 1000 ? numericValue.toFixed(0) : numericValue.toFixed(1)
+}
+
+function PortfolioVaultGrowthTooltip({
+  active,
+  payload,
+  mode,
+  seriesLabels
+}: TTooltipProps & {
+  mode: TPortfolioVaultGrowthChartMode
+  seriesLabels: Record<string, string>
+}): ReactElement | null {
+  if (!active || !payload?.length) {
+    return null
+  }
+
+  const date = payload[0]?.payload?.date
+  if (!date) {
+    return null
+  }
+
+  const rows = payload.flatMap((entry) => {
+    const dataKey = typeof entry.dataKey === 'string' ? entry.dataKey : ''
+    const value = typeof entry.value === 'number' ? entry.value : Number(entry.value ?? NaN)
+
+    if (!Number.isFinite(value)) {
+      return []
+    }
+
+    return [
+      {
+        key: dataKey,
+        label: seriesLabels[dataKey] ?? dataKey,
+        value,
+        color: typeof entry.color === 'string' ? entry.color : 'var(--color-text-primary)'
+      }
+    ]
+  })
+
+  return (
+    <div
+      className={
+        'pointer-events-none flex min-w-[13rem] flex-col gap-2 rounded-xl border border-border bg-surface px-3 py-3 shadow-xl'
+      }
+    >
+      <span className={'text-xs font-medium uppercase tracking-[0.12em] text-text-tertiary'}>
+        {formatChartTooltipDate(date)}
+      </span>
+      <div className={'flex flex-col gap-1.5'}>
+        {rows.map((row) => (
+          <div key={row.key} className={'flex items-center justify-between gap-3'}>
+            <span className={'inline-flex items-center gap-2 text-xs text-text-secondary'}>
+              <span className={'size-2 rounded-full'} style={{ backgroundColor: row.color }} />
+              <span>{row.label}</span>
+            </span>
+            <span className={'text-sm font-semibold text-text-primary'}>
+              {mode === 'position' ? formatPositionValue(row.value) : formatIndexValue(row.value)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function PortfolioVaultGrowthChart({
+  points = [],
+  series: precomputedSeries,
+  mode,
+  initialMode = 'position',
+  onModeChange,
+  timeframe = 'all',
+  vaultOrder,
+  maxVaults,
+  indexBase = 100,
+  colors = DEFAULT_COLORS,
+  title = 'Vault Growth',
+  height = 300,
+  showModeToggle = true,
+  className,
+  emptyMessage = 'No vault growth history available'
+}: TPortfolioVaultGrowthChartProps): ReactElement {
+  const [uncontrolledMode, setUncontrolledMode] = useState<TPortfolioVaultGrowthChartMode>(initialMode)
+  const activeMode = mode ?? uncontrolledMode
+  const series = useMemo(() => {
+    if (precomputedSeries) {
+      return buildSeriesFromPrecomputed({
+        series: precomputedSeries,
+        timeframe,
+        vaultOrder,
+        maxVaults,
+        indexBase,
+        colors
+      })
+    }
+
+    return buildSeries({ points, timeframe, vaultOrder, maxVaults, indexBase, colors })
+  }, [colors, indexBase, maxVaults, points, precomputedSeries, timeframe, vaultOrder])
+  const chartData = useMemo(() => buildChartData(series, activeMode), [activeMode, series])
+  const chartConfig = useMemo<ChartConfig>(() => {
+    return Object.fromEntries(
+      series.map((vaultSeries) => [vaultSeries.key, { label: vaultSeries.label, color: vaultSeries.color }])
+    )
+  }, [series])
+  const seriesLabels = useMemo<Record<string, string>>(() => {
+    return Object.fromEntries(series.map((vaultSeries) => [vaultSeries.key, vaultSeries.label]))
+  }, [series])
+  const hasRenderableValue = chartData.some((point) =>
+    series.some((vaultSeries) => typeof point[vaultSeries.key] === 'number' && Number.isFinite(point[vaultSeries.key]))
+  )
+  const isShortRange = timeframe === '30d' || chartData.length <= 45
+  const ticks = isShortRange ? getChartWeeklyTicks(chartData) : getChartMonthlyTicks(chartData)
+  const tickFormatter = isShortRange ? formatChartWeekLabel : formatChartMonthYearLabel
+
+  const handleModeChange = (nextMode: TPortfolioVaultGrowthChartMode): void => {
+    if (!mode) {
+      setUncontrolledMode(nextMode)
+    }
+    onModeChange?.(nextMode)
+  }
+
+  return (
+    <section className={cl('flex flex-col gap-3', className)}>
+      <div className={'flex flex-col gap-2'}>
+        {title || showModeToggle ? (
+          <div className={'flex flex-col gap-2 md:flex-row md:items-center md:justify-between'}>
+            {title ? <h3 className={'text-base font-semibold text-text-primary'}>{title}</h3> : null}
+            {showModeToggle ? (
+              <div className={cl('flex w-full items-center gap-0.5 md:w-auto md:gap-1', SELECTOR_BAR_STYLES.container)}>
+                {(['position', 'index'] as const).map((nextMode) => (
+                  <button
+                    key={nextMode}
+                    type={'button'}
+                    onClick={() => handleModeChange(nextMode)}
+                    className={cl(
+                      'min-h-[36px] flex-1 rounded-sm px-3 py-2 text-xs font-semibold transition-all md:min-h-0 md:flex-initial md:py-1',
+                      'active:scale-[0.98]',
+                      SELECTOR_BAR_STYLES.buttonBase,
+                      activeMode === nextMode ? SELECTOR_BAR_STYLES.buttonActive : SELECTOR_BAR_STYLES.buttonInactive
+                    )}
+                  >
+                    {nextMode === 'position' ? 'Position' : 'Index'}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        <p className={'text-xs text-text-secondary'}>{MODE_COPY[activeMode]}</p>
+      </div>
+
+      {!hasRenderableValue ? (
+        <div
+          className={
+            'flex min-h-[240px] items-center justify-center rounded-xl border border-border/70 bg-surface-secondary/40'
+          }
+        >
+          <p className={'text-sm text-text-secondary'}>{emptyMessage}</p>
+        </div>
+      ) : (
+        <>
+          <div style={{ height }}>
+            <ChartContainer config={chartConfig} style={{ height: '100%', aspectRatio: 'unset' }}>
+              <ComposedChart data={chartData} margin={CHART_WITH_AXES_MARGIN}>
+                <CartesianGrid vertical={false} />
+                <XAxis
+                  dataKey={'date'}
+                  ticks={ticks}
+                  tickFormatter={tickFormatter}
+                  tick={{ fill: 'var(--chart-axis)' }}
+                  axisLine={{ stroke: 'var(--chart-axis)' }}
+                  tickLine={{ stroke: 'var(--chart-axis)' }}
+                />
+                <YAxis
+                  domain={['auto', 'auto']}
+                  tickFormatter={activeMode === 'position' ? formatPositionTick : formatIndexTick}
+                  mirror
+                  width={CHART_Y_AXIS_WIDTH}
+                  tickMargin={CHART_Y_AXIS_TICK_MARGIN}
+                  tick={CHART_Y_AXIS_TICK_STYLE}
+                  axisLine={{ stroke: 'var(--chart-axis)' }}
+                  tickLine={{ stroke: 'var(--chart-axis)' }}
+                />
+                <ChartTooltip
+                  cursor={{ stroke: 'var(--chart-cursor-line)', strokeWidth: 1 }}
+                  content={(props) => (
+                    <PortfolioVaultGrowthTooltip {...props} mode={activeMode} seriesLabels={seriesLabels} />
+                  )}
+                />
+                {series.map((vaultSeries) => (
+                  <Line
+                    key={vaultSeries.key}
+                    type={'monotone'}
+                    dataKey={vaultSeries.key}
+                    name={vaultSeries.label}
+                    stroke={vaultSeries.color}
+                    strokeWidth={2}
+                    strokeOpacity={0.9}
+                    dot={false}
+                    activeDot={{ r: 4, strokeWidth: 0, fill: vaultSeries.color }}
+                    connectNulls
+                    isAnimationActive={false}
+                  />
+                ))}
+              </ComposedChart>
+            </ChartContainer>
+          </div>
+          <div className={'flex flex-wrap items-center gap-x-4 gap-y-2'}>
+            {series.map((vaultSeries) => (
+              <span key={vaultSeries.key} className={'inline-flex items-center gap-2 text-xs text-text-secondary'}>
+                <span className={'size-2 rounded-full'} style={{ backgroundColor: vaultSeries.color }} />
+                <span>{vaultSeries.label}</span>
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+    </section>
+  )
+}

--- a/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
@@ -99,9 +99,10 @@ type TTooltipProps = {
 }
 
 const DEFAULT_COLORS = ['#2578ff', '#46a2ff', '#94adf2', '#7bb3a8', '#e1a23b', '#b67ae5', '#f472b6', '#f97316']
+const MIN_RELEVANCE_SCORE = 0.000001
 
 const MODE_COPY: Record<TPortfolioVaultGrowthChartMode, string> = {
-  position: 'Shows actual protocol gain from your deposited positions.',
+  position: 'Shows actual protocol gain from your deposited positions during the selected timeframe.',
   index: 'Shows vault performance normalized to 100, ignoring position size.'
 }
 
@@ -117,49 +118,168 @@ function isFinitePositive(value: number): boolean {
   return Number.isFinite(value) && value > 0
 }
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
 function getValidShareBalance(point: TPortfolioVaultGrowthChartPoint): number {
   return Number.isFinite(point.userShareBalance) && point.userShareBalance > 0 ? point.userShareBalance : 0
 }
 
+function hasRawExposure(points: TPortfolioVaultGrowthChartPoint[]): boolean {
+  return points.some((point) => getValidShareBalance(point) > 0)
+}
+
+function hasPrecomputedExposure(points: TPortfolioVaultGrowthChartSeriesPoint[]): boolean {
+  return points.some((point) => isFiniteNumber(point.positionValueUsd) || isFiniteNumber(point.indexValue))
+}
+
 function buildPositionPoints(points: TPortfolioVaultGrowthChartPoint[]): TTransformedPoint[] {
-  let cumulativeGrowthUsd = 0
-  let previousPricePerShare: number | null = null
-  let previousShareBalance = 0
+  return points.reduce<{
+    points: TTransformedPoint[]
+    cumulativeGrowthUsd: number
+    previousPricePerShare: number | null
+    previousShareBalance: number
+    hasSeenExposure: boolean
+  }>(
+    (state, point) => {
+      const timestamp = normalizeTimestamp(point.timestamp)
+      const shareBalance = getValidShareBalance(point)
+      const hasValidPrices = isFinitePositive(point.pricePerShare) && isFinitePositive(point.underlyingUsdPrice)
 
-  return points.map((point) => {
-    const timestamp = normalizeTimestamp(point.timestamp)
-    const shareBalance = getValidShareBalance(point)
-    const hasValidPrices = isFinitePositive(point.pricePerShare) && isFinitePositive(point.underlyingUsdPrice)
+      if (!hasValidPrices) {
+        state.points.push({ timestamp, date: formatUnixTimestamp(timestamp), value: null })
+        return state
+      }
 
-    if (!hasValidPrices) {
-      return { timestamp, date: formatUnixTimestamp(timestamp), value: null }
+      const cumulativeGrowthUsd =
+        state.previousPricePerShare !== null
+          ? state.cumulativeGrowthUsd +
+            state.previousShareBalance * (point.pricePerShare - state.previousPricePerShare) * point.underlyingUsdPrice
+          : state.cumulativeGrowthUsd
+      const hasSeenExposure = state.hasSeenExposure || state.previousShareBalance > 0 || shareBalance > 0
+
+      state.points.push({
+        timestamp,
+        date: formatUnixTimestamp(timestamp),
+        value: hasSeenExposure ? cumulativeGrowthUsd : null
+      })
+
+      return {
+        points: state.points,
+        cumulativeGrowthUsd,
+        previousPricePerShare: point.pricePerShare,
+        previousShareBalance: shareBalance,
+        hasSeenExposure
+      }
+    },
+    {
+      points: [],
+      cumulativeGrowthUsd: 0,
+      previousPricePerShare: null,
+      previousShareBalance: 0,
+      hasSeenExposure: false
     }
-
-    if (previousPricePerShare !== null) {
-      // Position mode measures protocol PPS gain on shares held during the interval, not deposit size changes.
-      cumulativeGrowthUsd +=
-        previousShareBalance * (point.pricePerShare - previousPricePerShare) * point.underlyingUsdPrice
-    }
-
-    previousPricePerShare = point.pricePerShare
-    previousShareBalance = shareBalance
-
-    return { timestamp, date: formatUnixTimestamp(timestamp), value: cumulativeGrowthUsd }
-  })
+  ).points
 }
 
 function buildIndexPoints(points: TPortfolioVaultGrowthChartPoint[], indexBase: number): TTransformedPoint[] {
-  const basePricePerShare = points.find((point) => isFinitePositive(point.pricePerShare))?.pricePerShare
+  const basePricePerShare = points.find(
+    (point) => getValidShareBalance(point) > 0 && isFinitePositive(point.pricePerShare)
+  )?.pricePerShare
 
   return points.map((point) => {
     const timestamp = normalizeTimestamp(point.timestamp)
+    const hasOpenPosition = getValidShareBalance(point) > 0
     const value =
-      basePricePerShare && isFinitePositive(point.pricePerShare)
+      hasOpenPosition && basePricePerShare && isFinitePositive(point.pricePerShare)
         ? (point.pricePerShare / basePricePerShare) * indexBase
         : null
 
     return { timestamp, date: formatUnixTimestamp(timestamp), value }
   })
+}
+
+function getFiniteValues(points: TTransformedPoint[]): number[] {
+  return points.flatMap((point) => (isFiniteNumber(point.value) ? [point.value] : []))
+}
+
+function getPositionRelevance(points: TTransformedPoint[]): number {
+  return Math.max(0, ...getFiniteValues(points).map((value) => Math.abs(value)))
+}
+
+function getIndexRelevance(points: TTransformedPoint[], indexBase: number): number {
+  return Math.max(0, ...getFiniteValues(points).map((value) => Math.abs(value - indexBase)))
+}
+
+function selectRelevantSeries(args: {
+  series: TTransformedSeries[]
+  maxVaults?: number
+  indexBase: number
+}): TTransformedSeries[] {
+  const scoredSeries = args.series.map((vaultSeries) => {
+    const positionScore = getPositionRelevance(vaultSeries.positionPoints)
+    const indexScore = getIndexRelevance(vaultSeries.indexPoints, args.indexBase)
+    return {
+      vaultSeries,
+      positionScore,
+      indexScore,
+      combinedScore: positionScore + indexScore
+    }
+  })
+  const hasRelevantSeries = scoredSeries.some(
+    (series) => series.positionScore > MIN_RELEVANCE_SCORE || series.indexScore > MIN_RELEVANCE_SCORE
+  )
+  const candidates = hasRelevantSeries
+    ? scoredSeries.filter(
+        (series) => series.positionScore > MIN_RELEVANCE_SCORE || series.indexScore > MIN_RELEVANCE_SCORE
+      )
+    : scoredSeries
+
+  if (typeof args.maxVaults !== 'number' || candidates.length <= args.maxVaults) {
+    return candidates.map((series) => series.vaultSeries)
+  }
+
+  const maxVaults = args.maxVaults
+  const selectedKeys = new Set<string>()
+  const selectedSeries: TTransformedSeries[] = []
+  const addSeries = (vaultSeries: TTransformedSeries): void => {
+    if (selectedSeries.length >= maxVaults || selectedKeys.has(vaultSeries.vaultAddress.toLowerCase())) {
+      return
+    }
+    selectedKeys.add(vaultSeries.vaultAddress.toLowerCase())
+    selectedSeries.push(vaultSeries)
+  }
+  const positionTarget = Math.ceil(maxVaults / 2)
+
+  candidates
+    .toSorted((left, right) => right.positionScore - left.positionScore || right.combinedScore - left.combinedScore)
+    .slice(0, positionTarget)
+    .forEach((series) => {
+      addSeries(series.vaultSeries)
+    })
+
+  candidates
+    .toSorted((left, right) => right.indexScore - left.indexScore || right.combinedScore - left.combinedScore)
+    .forEach((series) => {
+      addSeries(series.vaultSeries)
+    })
+
+  candidates
+    .toSorted((left, right) => right.combinedScore - left.combinedScore)
+    .forEach((series) => {
+      addSeries(series.vaultSeries)
+    })
+
+  return selectedSeries
+}
+
+function applySeriesPresentation(series: TTransformedSeries[], colors: string[]): TTransformedSeries[] {
+  return series.map((vaultSeries, index) => ({
+    ...vaultSeries,
+    key: `vault_${index}`,
+    color: colors[index % colors.length] ?? DEFAULT_COLORS[index % DEFAULT_COLORS.length]
+  }))
 }
 
 function groupVaultPoints(points: TPortfolioVaultGrowthChartPoint[]): Map<string, TPortfolioVaultGrowthChartPoint[]> {
@@ -185,10 +305,9 @@ function buildSeries(args: {
   const orderedKeys = args.vaultOrder?.length
     ? args.vaultOrder.map(getVaultKey).filter((key) => grouped.has(key))
     : groupedKeys
-  const selectedKeys = typeof args.maxVaults === 'number' ? orderedKeys.slice(0, args.maxVaults) : orderedKeys
   const limit = getTimeframeLimit(args.timeframe)
 
-  return selectedKeys.flatMap((vaultKey, index) => {
+  const transformedSeries = orderedKeys.flatMap((vaultKey) => {
     const rawPoints = grouped.get(vaultKey)
     if (!rawPoints?.length) {
       return []
@@ -197,53 +316,71 @@ function buildSeries(args: {
     const sortedPoints = rawPoints.toSorted((left, right) => left.timestamp - right.timestamp)
     const points = !Number.isFinite(limit) || limit >= sortedPoints.length ? sortedPoints : sortedPoints.slice(-limit)
     const firstPoint = points[0]
+    if (!firstPoint || !hasRawExposure(points)) {
+      return []
+    }
 
     return [
       {
-        key: `vault_${index}`,
+        key: vaultKey,
         vaultAddress: firstPoint.vaultAddress,
         label: firstPoint.vaultName || firstPoint.symbol || firstPoint.vaultAddress,
-        color: args.colors[index % args.colors.length] ?? DEFAULT_COLORS[index % DEFAULT_COLORS.length],
+        color: args.colors[0] ?? DEFAULT_COLORS[0],
         positionPoints: buildPositionPoints(points),
         indexPoints: buildIndexPoints(points, args.indexBase)
       }
     ]
   })
+
+  return applySeriesPresentation(
+    selectRelevantSeries({ series: transformedSeries, maxVaults: args.maxVaults, indexBase: args.indexBase }),
+    args.colors
+  )
 }
 
 function buildPrecomputedIndexPoints(
   points: TPortfolioVaultGrowthChartSeriesPoint[],
   indexBase: number
 ): TTransformedPoint[] {
-  const baseValue = points.find(
-    (point) => typeof point.indexValue === 'number' && Number.isFinite(point.indexValue)
-  )?.indexValue
+  const baseValue = points.find((point) => isFiniteNumber(point.indexValue))?.indexValue
 
   return points.map((point) => {
     const timestamp = normalizeTimestamp(point.timestamp)
-    const value =
-      baseValue && typeof point.indexValue === 'number' && Number.isFinite(point.indexValue)
-        ? (point.indexValue / baseValue) * indexBase
-        : null
+    const value = baseValue && isFiniteNumber(point.indexValue) ? (point.indexValue / baseValue) * indexBase : null
 
     return { timestamp, date: formatUnixTimestamp(timestamp), value }
   })
 }
 
 function buildPrecomputedPositionPoints(points: TPortfolioVaultGrowthChartSeriesPoint[]): TTransformedPoint[] {
-  const baseValue =
-    points.find((point) => typeof point.positionValueUsd === 'number' && Number.isFinite(point.positionValueUsd))
-      ?.positionValueUsd ?? 0
+  return points.reduce<{
+    points: TTransformedPoint[]
+    baseValue: number | null
+    lastValue: number | null
+  }>(
+    (state, point) => {
+      const timestamp = normalizeTimestamp(point.timestamp)
+      const nextLastValue = isFiniteNumber(point.positionValueUsd) ? point.positionValueUsd : state.lastValue
+      const nextBaseValue = state.baseValue ?? nextLastValue
 
-  return points.map((point) => {
-    const timestamp = normalizeTimestamp(point.timestamp)
-    const value =
-      typeof point.positionValueUsd === 'number' && Number.isFinite(point.positionValueUsd)
-        ? point.positionValueUsd - baseValue
-        : null
+      state.points.push({
+        timestamp,
+        date: formatUnixTimestamp(timestamp),
+        value: nextBaseValue !== null && nextLastValue !== null ? nextLastValue - nextBaseValue : null
+      })
 
-    return { timestamp, date: formatUnixTimestamp(timestamp), value }
-  })
+      return {
+        points: state.points,
+        baseValue: nextBaseValue,
+        lastValue: nextLastValue
+      }
+    },
+    {
+      points: [],
+      baseValue: null,
+      lastValue: null
+    }
+  ).points
 }
 
 function buildSeriesFromPrecomputed(args: {
@@ -260,10 +397,9 @@ function buildSeriesFromPrecomputed(args: {
   const orderedKeys = args.vaultOrder?.length
     ? args.vaultOrder.map(getVaultKey).filter((key) => seriesByVaultKey.has(key))
     : Array.from(seriesByVaultKey.keys())
-  const selectedKeys = typeof args.maxVaults === 'number' ? orderedKeys.slice(0, args.maxVaults) : orderedKeys
   const limit = getTimeframeLimit(args.timeframe)
 
-  return selectedKeys.flatMap((vaultKey, index) => {
+  const transformedSeries = orderedKeys.flatMap((vaultKey) => {
     const vaultSeries = seriesByVaultKey.get(vaultKey)
     if (!vaultSeries?.points.length) {
       return []
@@ -273,18 +409,26 @@ function buildSeriesFromPrecomputed(args: {
       .map((point) => ({ ...point, timestamp: normalizeTimestamp(point.timestamp) }))
       .toSorted((left, right) => left.timestamp - right.timestamp)
     const points = !Number.isFinite(limit) || limit >= sortedPoints.length ? sortedPoints : sortedPoints.slice(-limit)
+    if (!hasPrecomputedExposure(points)) {
+      return []
+    }
 
     return [
       {
-        key: `vault_${index}`,
+        key: vaultKey,
         vaultAddress: vaultSeries.vaultAddress,
         label: vaultSeries.vaultName || vaultSeries.symbol || vaultSeries.vaultAddress,
-        color: args.colors[index % args.colors.length] ?? DEFAULT_COLORS[index % DEFAULT_COLORS.length],
+        color: args.colors[0] ?? DEFAULT_COLORS[0],
         positionPoints: buildPrecomputedPositionPoints(points),
         indexPoints: buildPrecomputedIndexPoints(points, args.indexBase)
       }
     ]
   })
+
+  return applySeriesPresentation(
+    selectRelevantSeries({ series: transformedSeries, maxVaults: args.maxVaults, indexBase: args.indexBase }),
+    args.colors
+  )
 }
 
 function buildChartData(series: TTransformedSeries[], mode: TPortfolioVaultGrowthChartMode): TChartPoint[] {
@@ -358,23 +502,25 @@ function PortfolioVaultGrowthTooltip({
     return null
   }
 
-  const rows = payload.flatMap((entry) => {
-    const dataKey = typeof entry.dataKey === 'string' ? entry.dataKey : ''
-    const value = typeof entry.value === 'number' ? entry.value : Number(entry.value ?? NaN)
+  const rows = payload
+    .flatMap((entry) => {
+      const dataKey = typeof entry.dataKey === 'string' ? entry.dataKey : ''
+      const value = typeof entry.value === 'number' ? entry.value : Number(entry.value ?? NaN)
 
-    if (!Number.isFinite(value)) {
-      return []
-    }
-
-    return [
-      {
-        key: dataKey,
-        label: seriesLabels[dataKey] ?? dataKey,
-        value,
-        color: typeof entry.color === 'string' ? entry.color : 'var(--color-text-primary)'
+      if (!Number.isFinite(value)) {
+        return []
       }
-    ]
-  })
+
+      return [
+        {
+          key: dataKey,
+          label: seriesLabels[dataKey] ?? dataKey,
+          value,
+          color: typeof entry.color === 'string' ? entry.color : 'var(--color-text-primary)'
+        }
+      ]
+    })
+    .toSorted((left, right) => right.value - left.value)
 
   return (
     <div
@@ -537,7 +683,7 @@ export function PortfolioVaultGrowthChart({
                     strokeOpacity={0.9}
                     dot={false}
                     activeDot={{ r: 4, strokeWidth: 0, fill: vaultSeries.color }}
-                    connectNulls
+                    connectNulls={activeMode === 'position'}
                     isAnimationActive={false}
                   />
                 ))}

--- a/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
@@ -606,8 +606,8 @@ export function PortfolioVaultGrowthChart({
 
   return (
     <section className={cl('flex flex-col gap-3', className)}>
-      <div className={'flex flex-col gap-2'}>
-        {title || showModeToggle ? (
+      {title || showModeToggle ? (
+        <div className={'flex flex-col gap-2'}>
           <div className={'flex flex-col gap-2 md:flex-row md:items-center md:justify-between'}>
             {title ? <h3 className={'text-base font-semibold text-text-primary'}>{title}</h3> : null}
             {showModeToggle ? (
@@ -630,9 +630,9 @@ export function PortfolioVaultGrowthChart({
               </div>
             ) : null}
           </div>
-        ) : null}
-        {showModeToggle ? <p className={'text-xs text-text-secondary'}>{MODE_COPY[activeMode]}</p> : null}
-      </div>
+          {showModeToggle ? <p className={'text-xs text-text-secondary'}>{MODE_COPY[activeMode]}</p> : null}
+        </div>
+      ) : null}
 
       {!hasRenderableValue ? (
         <div
@@ -643,62 +643,52 @@ export function PortfolioVaultGrowthChart({
           <p className={'text-sm text-text-secondary'}>{emptyMessage}</p>
         </div>
       ) : (
-        <>
-          <div style={{ height }}>
-            <ChartContainer config={chartConfig} style={{ height: '100%', aspectRatio: 'unset' }}>
-              <ComposedChart data={chartData} margin={CHART_WITH_AXES_MARGIN}>
-                <CartesianGrid vertical={false} />
-                <XAxis
-                  dataKey={'date'}
-                  ticks={ticks}
-                  tickFormatter={tickFormatter}
-                  tick={{ fill: 'var(--chart-axis)' }}
-                  axisLine={{ stroke: 'var(--chart-axis)' }}
-                  tickLine={{ stroke: 'var(--chart-axis)' }}
+        <div style={{ height }}>
+          <ChartContainer config={chartConfig} style={{ height: '100%', aspectRatio: 'unset' }}>
+            <ComposedChart data={chartData} margin={CHART_WITH_AXES_MARGIN}>
+              <CartesianGrid vertical={false} />
+              <XAxis
+                dataKey={'date'}
+                ticks={ticks}
+                tickFormatter={tickFormatter}
+                tick={{ fill: 'var(--chart-axis)' }}
+                axisLine={{ stroke: 'var(--chart-axis)' }}
+                tickLine={{ stroke: 'var(--chart-axis)' }}
+              />
+              <YAxis
+                domain={['auto', 'auto']}
+                tickFormatter={activeMode === 'position' ? formatPositionTick : formatIndexTick}
+                mirror
+                width={CHART_Y_AXIS_WIDTH}
+                tickMargin={CHART_Y_AXIS_TICK_MARGIN}
+                tick={CHART_Y_AXIS_TICK_STYLE}
+                axisLine={{ stroke: 'var(--chart-axis)' }}
+                tickLine={{ stroke: 'var(--chart-axis)' }}
+              />
+              <ChartTooltip
+                cursor={{ stroke: 'var(--chart-cursor-line)', strokeWidth: 1 }}
+                content={(props) => (
+                  <PortfolioVaultGrowthTooltip {...props} mode={activeMode} seriesLabels={seriesLabels} />
+                )}
+              />
+              {series.map((vaultSeries) => (
+                <Line
+                  key={vaultSeries.key}
+                  type={'monotone'}
+                  dataKey={vaultSeries.key}
+                  name={vaultSeries.label}
+                  stroke={vaultSeries.color}
+                  strokeWidth={2}
+                  strokeOpacity={0.9}
+                  dot={false}
+                  activeDot={{ r: 4, strokeWidth: 0, fill: vaultSeries.color }}
+                  connectNulls
+                  isAnimationActive={false}
                 />
-                <YAxis
-                  domain={['auto', 'auto']}
-                  tickFormatter={activeMode === 'position' ? formatPositionTick : formatIndexTick}
-                  mirror
-                  width={CHART_Y_AXIS_WIDTH}
-                  tickMargin={CHART_Y_AXIS_TICK_MARGIN}
-                  tick={CHART_Y_AXIS_TICK_STYLE}
-                  axisLine={{ stroke: 'var(--chart-axis)' }}
-                  tickLine={{ stroke: 'var(--chart-axis)' }}
-                />
-                <ChartTooltip
-                  cursor={{ stroke: 'var(--chart-cursor-line)', strokeWidth: 1 }}
-                  content={(props) => (
-                    <PortfolioVaultGrowthTooltip {...props} mode={activeMode} seriesLabels={seriesLabels} />
-                  )}
-                />
-                {series.map((vaultSeries) => (
-                  <Line
-                    key={vaultSeries.key}
-                    type={'monotone'}
-                    dataKey={vaultSeries.key}
-                    name={vaultSeries.label}
-                    stroke={vaultSeries.color}
-                    strokeWidth={2}
-                    strokeOpacity={0.9}
-                    dot={false}
-                    activeDot={{ r: 4, strokeWidth: 0, fill: vaultSeries.color }}
-                    connectNulls
-                    isAnimationActive={false}
-                  />
-                ))}
-              </ComposedChart>
-            </ChartContainer>
-          </div>
-          <div className={'flex flex-wrap items-center gap-x-4 gap-y-2'}>
-            {series.map((vaultSeries) => (
-              <span key={vaultSeries.key} className={'inline-flex items-center gap-2 text-xs text-text-secondary'}>
-                <span className={'size-2 rounded-full'} style={{ backgroundColor: vaultSeries.color }} />
-                <span>{vaultSeries.label}</span>
-              </span>
-            ))}
-          </div>
-        </>
+              ))}
+            </ComposedChart>
+          </ChartContainer>
+        </div>
       )}
     </section>
   )

--- a/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
@@ -683,7 +683,7 @@ export function PortfolioVaultGrowthChart({
                     strokeOpacity={0.9}
                     dot={false}
                     activeDot={{ r: 4, strokeWidth: 0, fill: vaultSeries.color }}
-                    connectNulls={activeMode === 'position'}
+                    connectNulls
                     isAnimationActive={false}
                   />
                 ))}

--- a/src/components/pages/portfolio/types/api.ts
+++ b/src/components/pages/portfolio/types/api.ts
@@ -32,6 +32,7 @@ const portfolioProtocolReturnHistoryFamilyPointSchema = z.object({
   date: z.string(),
   timestamp: z.number(),
   protocolReturnPct: z.number().nullable(),
+  growthWeightUsd: z.number().nullable(),
   growthIndex: z.number().nullable()
 })
 
@@ -187,6 +188,7 @@ export type TPortfolioProtocolReturnHistoryFamilySeries = Array<{
     date: string
     timestamp: number
     protocolReturnPct: number | null
+    growthWeightUsd: number | null
     growthIndex: number | null
   }>
 }>


### PR DESCRIPTION
## Summary

This stacks on #1190 and polishes the portfolio protocol-return charts, with a focus on making timeframe behavior and vault-level comparisons easier to reason about.

## Changes

- rebase Growth Index, USD growth, and ETH growth views to the selected timeframe so short ranges do not inherit stale all-time starting values
- Edit Growth Index chart so it was showing relation between user portfolio performance (position based) and vault performance. Idea - "What actually grew portfolio" vs "Which vaults performed best"   
- add a reusable `PortfolioVaultGrowthChart` for vault-level comparison
- add `Position` and `Index` modes:
  - `Position` shows actual protocol gain contributed by the user’s vault positions
  - `Index` shows normalized vault performance independent of position size
- add vault-level `growthWeightUsd` to the simple-history family series so Position mode can use backend history directly
- sort tooltip rows by current value for easier hover inspection
- filter out flat/empty vault series so dust or stale positions do not dominate the chart
- keep realized Position growth visible after exit, while breaking Index lines when the user no longer has an open position (might be better to connect the lines actaully)
- stabilize chart header/control layout and fix mobile selector alignment (same as added to source branch recently)
- update chart copy and tooltips for Growth, Position, and Index modes

## Verification

- `git diff --check e47bc119be5620bf906bccd1c5a00439b2142c66 2befbac20240cee84fc3ca6e4e7993db52c65caa`
- `bun run lint`
- `bun run lint:fix`
- `bun run tslint`
