### PR TITLE
fix clipped search results

### DIFF
--- a/src/components/pages/vaults/components/list/VaultsListEmpty.test.tsx
+++ b/src/components/pages/vaults/components/list/VaultsListEmpty.test.tsx
@@ -24,6 +24,7 @@ describe('VaultsListEmpty', () => {
     expect(html).toContain('Show legacy vaults (+2)')
     expect(html).toContain('Show single asset strategies (+1)')
     expect(html).toContain('Search')
+    expect(html).toContain('min-h-96')
     expect(html).not.toContain('Show all results')
   })
 

--- a/src/components/pages/vaults/components/list/VaultsListEmpty.tsx
+++ b/src/components/pages/vaults/components/list/VaultsListEmpty.tsx
@@ -95,7 +95,7 @@ export function VaultsListEmpty({
   if (hasSearch && (hasBlockingFilterActions || hasHiddenByFiltersResults)) {
     const hiddenByFiltersLabel = `${hiddenByFiltersCount} vault${hiddenByFiltersCount > 1 ? 's' : ''}`
     return (
-      <div className={'mx-auto flex h-96 w-full flex-col items-center justify-center gap-2 px-10 py-2 md:w-3/4'}>
+      <div className={'mx-auto flex min-h-96 w-full flex-col items-center justify-center gap-2 px-10 py-10 md:w-3/4'}>
         <b className={'text-center text-lg font-normal'}>{'No vaults found'}</b>
         <p className={'text-center text-neutral-600'}>{`No results for "${currentSearch}" with current filters.`}</p>
         {hiddenByFiltersCount > 0 ? (


### PR DESCRIPTION
## Description

Bug report that empty search result filters were getting clipped if there were lots of them.
<img width="1280" height="823" alt="image" src="https://github.com/user-attachments/assets/6e83ff30-324d-45c6-b68c-f9e71ecb9744" />

## Motivation and Context

fix it

## How Has This Been Tested?

locally. To search. Select single asset vaults, ethereum, and search for compound. nothing in the resulting prompt to widen your search should be cut off.

## Screenshots (if appropriate):
<img width="1239" height="691" alt="image" src="https://github.com/user-attachments/assets/b2dba0cc-1c8d-4023-a61f-ae6ecbce5b9e" />
