### PR TITLE
Remove legacy site links from vault tour prompts

### DIFF
--- a/src/components/pages/vaults/components/tour/VaultDetailsWelcomeTour.tsx
+++ b/src/components/pages/vaults/components/tour/VaultDetailsWelcomeTour.tsx
@@ -186,29 +186,18 @@ export function VaultDetailsWelcomeTour({ onTourStateChange }: VaultDetailsWelco
                 </div>
               </div>
             </div>
-            <div className="mt-3 flex flex-wrap gap-2">
+            <div className="mt-3 flex w-full flex-col gap-2">
               <Button
                 variant="filled"
                 onClick={handleStartTour}
-                classNameOverride="yearn--button--nextgen yearn--button-smaller"
+                classNameOverride="yearn--button--nextgen yearn--button-smaller w-full"
               >
                 {'Take a tour'}
               </Button>
               <Button
-                as="a"
-                href="https://legacy.yearn.fi/v3"
-                target="_blank"
-                rel="noreferrer noopener"
                 variant="outlined"
                 onClick={handleDismiss}
-                classNameOverride="yearn--button--nextgen yearn--button-smaller"
-              >
-                {'Legacy site'}
-              </Button>
-              <Button
-                variant="outlined"
-                onClick={handleDismiss}
-                classNameOverride="yearn--button--nextgen yearn--button-smaller"
+                classNameOverride="yearn--button--nextgen yearn--button-smaller w-full"
               >
                 {'Dismiss'}
               </Button>

--- a/src/components/pages/vaults/components/tour/VaultsWelcomeTour.tsx
+++ b/src/components/pages/vaults/components/tour/VaultsWelcomeTour.tsx
@@ -181,29 +181,18 @@ export function VaultsWelcomeTour({ onTourStateChange }: VaultsWelcomeTourProps)
                 </div>
               </div>
             </div>
-            <div className="mt-3 flex flex-wrap gap-2 ">
+            <div className="mt-3 flex w-full flex-col gap-2">
               <Button
                 variant="filled"
                 onClick={handleStartTour}
-                classNameOverride="yearn--button--nextgen yearn--button-smaller font-semibold!"
+                classNameOverride="yearn--button--nextgen yearn--button-smaller w-full font-semibold!"
               >
                 {'Take a tour'}
               </Button>
               <Button
-                as="a"
-                href="https://legacy.yearn.fi/v3"
-                target="_blank"
-                rel="noreferrer noopener"
                 variant="outlined"
                 onClick={handleDismiss}
-                classNameOverride="yearn--button--nextgen yearn--button-smaller font-semibold"
-              >
-                {'Legacy site'}
-              </Button>
-              <Button
-                variant="outlined"
-                onClick={handleDismiss}
-                classNameOverride="yearn--button--nextgen yearn--button-smaller font-semibold"
+                classNameOverride="yearn--button--nextgen yearn--button-smaller w-full font-semibold"
               >
                 {'Dismiss'}
               </Button>


### PR DESCRIPTION
## Summary
- Remove the retired legacy.yearn.fi CTA from the vaults tour prompt
- Remove the same legacy CTA from the vault details tour prompt

## Verification
- bun run tslint
- bun run lint:fix
- rg -n "legacy\.yearn\.fi|Legacy site" .