### PR TITLE
add yvusd portfolio charts

### DIFF
--- a/api/holdings/history.ts
+++ b/api/holdings/history.ts
@@ -35,6 +35,62 @@ function isValidAddress(address: string): boolean {
   return /^0x[a-fA-F0-9]{40}$/.test(address)
 }
 
+function parseVaultFilters({
+  vault,
+  chainId,
+  vaults
+}: {
+  vault: string | string[] | undefined
+  chainId: string | string[] | undefined
+  vaults: string | string[] | undefined
+}): Array<{ chainId: number; vaultAddress: string }> | null | undefined {
+  if (vaults !== undefined) {
+    if (typeof vaults !== 'string') {
+      return null
+    }
+
+    const entries = vaults
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+    const parsedEntries = entries.map((entry) => {
+      const [entryChainId, entryVaultAddress] = entry.split(':')
+      const parsedChainId = Number(entryChainId)
+
+      if (
+        !entryChainId ||
+        !entryVaultAddress ||
+        !Number.isInteger(parsedChainId) ||
+        !isValidAddress(entryVaultAddress)
+      ) {
+        return null
+      }
+
+      return { chainId: parsedChainId, vaultAddress: entryVaultAddress }
+    })
+
+    if (parsedEntries.some((entry) => entry === null)) {
+      return null
+    }
+
+    return parsedEntries.filter((entry): entry is { chainId: number; vaultAddress: string } => entry !== null)
+  }
+
+  if (vault === undefined) {
+    return undefined
+  }
+
+  if (typeof vault !== 'string' || !isValidAddress(vault)) {
+    return null
+  }
+
+  if (!chainId || typeof chainId !== 'string' || !Number.isInteger(Number(chainId))) {
+    return null
+  }
+
+  return [{ chainId: Number(chainId), vaultAddress: vault }]
+}
+
 function parseHoldingsEventFetchType(value: string | string[] | undefined): HoldingsEventFetchType {
   return value === 'parallel' ? 'parallel' : 'seq'
 }
@@ -91,6 +147,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const {
     address,
+    chainId: chainIdParam,
+    vault: vaultParam,
+    vaults: vaultsParam,
     version: versionParam,
     fetchType: fetchTypeParam,
     paginationMode: paginationModeParam,
@@ -104,6 +163,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   if (!isValidAddress(address)) {
     return res.status(400).json({ error: 'Invalid Ethereum address' })
+  }
+
+  const vaultFilters = parseVaultFilters({
+    vault: vaultParam,
+    chainId: chainIdParam,
+    vaults: vaultsParam
+  })
+
+  if (vaultFilters === null) {
+    return res.status(400).json({ error: 'Invalid vault filter' })
   }
 
   const version: VaultVersion = versionParam === 'v2' || versionParam === 'v3' ? versionParam : 'all'
@@ -120,7 +189,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       fetchType,
       paginationMode,
       denomination,
-      timeframe
+      timeframe,
+      vaultFilters
     )
 
     if (!holdings.hasActivity) {

--- a/api/holdings/pnl/simple-history.test.ts
+++ b/api/holdings/pnl/simple-history.test.ts
@@ -2,12 +2,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const ensureSchemaInitializedMock = vi.fn()
 const checkRateLimitMock = vi.fn()
-const getHistoricalHoldingsChartMock = vi.fn()
+const getHoldingsProtocolReturnHistoryMock = vi.fn()
 
-vi.mock('../lib/holdings', () => ({
+vi.mock('../../lib/holdings', () => ({
   ensureSchemaInitialized: ensureSchemaInitializedMock,
   checkRateLimit: checkRateLimitMock,
-  getHistoricalHoldingsChart: getHistoricalHoldingsChartMock
+  getHoldingsProtocolReturnHistory: getHoldingsProtocolReturnHistoryMock
 }))
 
 type TMockResponse = {
@@ -42,7 +42,7 @@ function createMockResponse(): TMockResponse {
   }
 }
 
-describe('holdings history route', () => {
+describe('holdings simple pnl history route', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
@@ -51,55 +51,30 @@ describe('holdings history route', () => {
     process.env.ENVIO_GRAPHQL_URL = 'https://envio.example/graphql'
   })
 
-  it('returns zero-filled settled history for wallets that only have same-day activity', async () => {
-    getHistoricalHoldingsChartMock.mockResolvedValue({
-      address: '0xA7b6f3d18db39F65C8056d0892Af76c07d15Fc5a',
-      periodDays: 365,
-      timeframe: '1y',
-      denomination: 'usd',
-      hasActivity: true,
-      dataPoints: [
-        { date: '2026-04-20', timestamp: 1776729599, value: 0 },
-        { date: '2026-04-21', timestamp: 1776815999, value: 0 }
-      ]
-    })
-
-    const { default: handler } = await import('./history')
-    const req = {
-      method: 'GET',
-      query: {
-        address: '0xA7b6f3d18db39F65C8056d0892Af76c07d15Fc5a'
-      },
-      headers: {}
-    } as any
-    const res = createMockResponse()
-
-    await handler(req, res as any)
-
-    expect(res.statusCode).toBe(200)
-    expect(res.body).toEqual({
-      address: '0xA7b6f3d18db39F65C8056d0892Af76c07d15Fc5a',
+  it('passes multi-vault filters through the simple history alias', async () => {
+    getHoldingsProtocolReturnHistoryMock.mockResolvedValue({
+      address: '0xa7b6f3d18db39f65c8056d0892af76c07d15fc5a',
       version: 'all',
-      denomination: 'usd',
       timeframe: '1y',
-      dataPoints: [
-        { date: '2026-04-20', value: 0 },
-        { date: '2026-04-21', value: 0 }
-      ]
+      generatedAt: '2026-04-28T00:00:00.000Z',
+      summary: {
+        totalVaults: 2,
+        completeVaults: 2,
+        partialVaults: 0,
+        recommendedGrowthDisplay: 'index',
+        recommendedGrowthDisplayReason: 'mixed',
+        openBaselineCompositionUsd: {
+          stable: 0,
+          ethFamily: 0,
+          other: 0
+        },
+        isComplete: true
+      },
+      dataPoints: [],
+      familySeries: []
     })
-  })
 
-  it('passes multi-vault filters to historical holdings chart', async () => {
-    getHistoricalHoldingsChartMock.mockResolvedValue({
-      address: '0xA7b6f3d18db39F65C8056d0892Af76c07d15Fc5a',
-      periodDays: 365,
-      timeframe: '1y',
-      denomination: 'usd',
-      hasActivity: true,
-      dataPoints: [{ date: '2026-04-21', timestamp: 1776815999, value: 42 }]
-    })
-
-    const { default: handler } = await import('./history')
+    const { default: handler } = await import('./simple-history')
     const req = {
       method: 'GET',
       query: {
@@ -113,12 +88,11 @@ describe('holdings history route', () => {
     await handler(req, res as any)
 
     expect(res.statusCode).toBe(200)
-    expect(getHistoricalHoldingsChartMock).toHaveBeenCalledWith(
+    expect(getHoldingsProtocolReturnHistoryMock).toHaveBeenCalledWith(
       '0xA7b6f3d18db39F65C8056d0892Af76c07d15Fc5a',
       'all',
       'seq',
       'paged',
-      'usd',
       '1y',
       [
         { chainId: 1, vaultAddress: '0x696d02Db93291651ED510704c9b286841d506987' },

--- a/api/holdings/protocol-return/history.ts
+++ b/api/holdings/protocol-return/history.ts
@@ -31,6 +31,62 @@ function isValidAddress(address: string): boolean {
   return /^0x[a-fA-F0-9]{40}$/.test(address)
 }
 
+function parseVaultFilters({
+  vault,
+  chainId,
+  vaults
+}: {
+  vault: string | string[] | undefined
+  chainId: string | string[] | undefined
+  vaults: string | string[] | undefined
+}): Array<{ chainId: number; vaultAddress: string }> | null | undefined {
+  if (vaults !== undefined) {
+    if (typeof vaults !== 'string') {
+      return null
+    }
+
+    const entries = vaults
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+    const parsedEntries = entries.map((entry) => {
+      const [entryChainId, entryVaultAddress] = entry.split(':')
+      const parsedChainId = Number(entryChainId)
+
+      if (
+        !entryChainId ||
+        !entryVaultAddress ||
+        !Number.isInteger(parsedChainId) ||
+        !isValidAddress(entryVaultAddress)
+      ) {
+        return null
+      }
+
+      return { chainId: parsedChainId, vaultAddress: entryVaultAddress }
+    })
+
+    if (parsedEntries.some((entry) => entry === null)) {
+      return null
+    }
+
+    return parsedEntries.filter((entry): entry is { chainId: number; vaultAddress: string } => entry !== null)
+  }
+
+  if (vault === undefined) {
+    return undefined
+  }
+
+  if (typeof vault !== 'string' || !isValidAddress(vault)) {
+    return null
+  }
+
+  if (!chainId || typeof chainId !== 'string' || !Number.isInteger(Number(chainId))) {
+    return null
+  }
+
+  return [{ chainId: Number(chainId), vaultAddress: vault }]
+}
+
 function parseHoldingsEventFetchType(value: string | string[] | undefined): HoldingsEventFetchType {
   return value === 'parallel' ? 'parallel' : 'seq'
 }
@@ -82,6 +138,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     address,
     chainId: chainIdParam,
     vault: vaultParam,
+    vaults: vaultsParam,
     version: versionParam,
     fetchType: fetchTypeParam,
     paginationMode: paginationModeParam,
@@ -96,16 +153,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return res.status(400).json({ error: 'Invalid Ethereum address' })
   }
 
-  if (vaultParam !== undefined && typeof vaultParam !== 'string') {
-    return res.status(400).json({ error: 'Invalid vault address' })
-  }
+  const vaultFilters = parseVaultFilters({
+    vault: vaultParam,
+    chainId: chainIdParam,
+    vaults: vaultsParam
+  })
 
-  if (vaultParam && !isValidAddress(vaultParam)) {
-    return res.status(400).json({ error: 'Invalid vault address' })
-  }
-
-  if (vaultParam && (!chainIdParam || typeof chainIdParam !== 'string' || !Number.isInteger(Number(chainIdParam)))) {
-    return res.status(400).json({ error: 'Missing or invalid chainId for vault filter' })
+  if (vaultFilters === null) {
+    return res.status(400).json({ error: 'Invalid vault filter' })
   }
 
   const version: VaultVersion = versionParam === 'v2' || versionParam === 'v3' ? versionParam : 'all'
@@ -114,15 +169,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const timeframe = parseHoldingsHistoryTimeframe(timeframeParam)
 
   try {
-    const { getHoldingsProtocolReturnHistory } = await import('../../../lib/holdings')
+    const { getHoldingsProtocolReturnHistory } = await import('../../lib/holdings')
     const history = await getHoldingsProtocolReturnHistory(
       address,
       version,
       fetchType,
       paginationMode,
       timeframe,
-      vaultParam,
-      vaultParam ? Number(chainIdParam) : undefined
+      vaultFilters
     )
 
     if (history.summary.totalVaults === 0) {

--- a/api/lib/holdings/index.ts
+++ b/api/lib/holdings/index.ts
@@ -15,7 +15,8 @@ export {
   type HoldingsHistoryChartResponse,
   type HoldingsHistoryDenomination,
   type HoldingsHistoryResponse,
-  type HoldingsHistoryTimeframe
+  type HoldingsHistoryTimeframe,
+  type HoldingsVaultFilter
 } from './services/aggregator'
 export { clearUserCache, deleteStaleCache } from './services/cache'
 export {

--- a/api/lib/holdings/services/aggregator.test.ts
+++ b/api/lib/holdings/services/aggregator.test.ts
@@ -172,6 +172,75 @@ describe('getHistoricalHoldings', () => {
     expect(fetchUserEventsMock).toHaveBeenCalledWith(userAddress, 'all', 101, 'seq', 'paged')
   })
 
+  it('filters historical chart calculations to requested vaults without using aggregate cache', async () => {
+    const userAddress = '0x93a62da5a14c80f265dabc077fcee437b1a0efde'
+    const firstVaultAddress = '0x00000000000000000000000000000000000000a1'
+    const secondVaultAddress = '0x00000000000000000000000000000000000000a2'
+    const excludedVaultAddress = '0x00000000000000000000000000000000000000a3'
+    const tokenAddress = '0x0000000000000000000000000000000000000aa1'
+    const timeline = [{ blockTimestamp: 100, blockNumber: 1 }]
+    const vaults = [
+      { chainId: 1, vaultAddress: firstVaultAddress },
+      { chainId: 1, vaultAddress: secondVaultAddress },
+      { chainId: 1, vaultAddress: excludedVaultAddress }
+    ]
+
+    generateDailyTimestampsMock.mockReturnValue([100])
+    timestampToDateStringMock.mockImplementation((timestamp: number) => `date-${timestamp}`)
+    fetchUserEventsMock.mockResolvedValue({
+      deposits: [],
+      withdrawals: [],
+      transfersIn: [],
+      transfersOut: []
+    })
+    buildPositionTimelineMock.mockReturnValue(timeline)
+    getUniqueVaultsMock.mockReturnValue(vaults)
+    fetchMultipleVaultsMetadataMock.mockResolvedValue(
+      new Map(
+        vaults.map((vault) => [
+          `1:${vault.vaultAddress}`,
+          {
+            address: vault.vaultAddress,
+            chainId: 1,
+            version: 'v3',
+            token: {
+              address: tokenAddress,
+              symbol: 'TKN',
+              decimals: 18
+            },
+            decimals: 18
+          }
+        ])
+      )
+    )
+    fetchMultipleVaultsPPSMock.mockImplementation(async (requestedVaults: typeof vaults) => {
+      return new Map(requestedVaults.map((vault) => [`1:${vault.vaultAddress}`, new Map([[101, 1]])]))
+    })
+    fetchHistoricalPricesMock.mockResolvedValue(new Map([[`ethereum:${tokenAddress}`, new Map([[101, 1]])]]))
+    getChainPrefixMock.mockReturnValue('ethereum')
+    getPPSMock.mockReturnValue(1)
+    getPriceAtTimestampMock.mockReturnValue(1)
+    getShareBalanceAtTimestampMock.mockImplementation((_timeline: unknown, vaultAddress: string) => {
+      if (vaultAddress === firstVaultAddress) return 2n * 10n ** 18n
+      if (vaultAddress === secondVaultAddress) return 3n * 10n ** 18n
+      return 100n * 10n ** 18n
+    })
+
+    const { getHistoricalHoldingsChart } = await import('./aggregator')
+    const response = await getHistoricalHoldingsChart(userAddress, 'all', 'parallel', 'all', 'usd', '1y', [
+      { chainId: 1, vaultAddress: firstVaultAddress },
+      { chainId: 1, vaultAddress: secondVaultAddress }
+    ])
+
+    expect(getCachedTotalsWithTimestampMock).not.toHaveBeenCalled()
+    expect(saveCachedTotalsMock).not.toHaveBeenCalled()
+    expect(fetchMultipleVaultsPPSMock).toHaveBeenCalledWith([
+      { chainId: 1, vaultAddress: firstVaultAddress },
+      { chainId: 1, vaultAddress: secondVaultAddress }
+    ])
+    expect(response.dataPoints).toEqual([{ date: 'date-100', timestamp: 101, value: 5 }])
+  })
+
   it('returns fully cached history after validating cache staleness', async () => {
     const userAddress = '0x93a62da5a14c80f265dabc077fcee437b1a0efde'
     const vaultAddress = '0x00000000000000000000000000000000000000dd'

--- a/api/lib/holdings/services/aggregator.ts
+++ b/api/lib/holdings/services/aggregator.ts
@@ -29,14 +29,11 @@ import {
   deriveNestedVaultAssetPriceData,
   expandNestedVaultAssetPriceRequests,
   getNestedVaultPpsIdentifiersFromPriceRequests,
-  mergeVaultIdentifiers
+  mergeVaultIdentifiers,
+  resolveNestedVaultAssetMetadata
 } from './nestedVaultPrices'
 import { toVaultKey } from './pnlShared'
-import {
-  getSettledAddressScopedContext,
-  getSettledVersionedPpsContext,
-  resolveNestedVaultAssetMetadata
-} from './settledHoldingsContext'
+import { getSettledAddressScopedContext, getSettledVersionedPpsContext } from './settledHoldingsContext'
 import { fetchMultipleVaultsMetadata } from './vaults'
 
 export interface HoldingsHistoryResponse {

--- a/api/lib/holdings/services/aggregator.ts
+++ b/api/lib/holdings/services/aggregator.ts
@@ -46,6 +46,7 @@ export interface HoldingsHistoryResponse {
 
 export type HoldingsHistoryDenomination = 'usd' | 'eth'
 export type HoldingsHistoryTimeframe = '1y' | 'all'
+export type HoldingsVaultFilter = { chainId: number; vaultAddress: string }
 
 export interface HoldingsHistoryChartResponse {
   address: string
@@ -117,6 +118,20 @@ function filterVaultsByAuthoritativeVersion<
   })
 }
 
+function filterVaultsByRequestedVault<TVault extends { chainId: number; vaultAddress: string }>(
+  vaults: TVault[],
+  requestedVaults?: HoldingsVaultFilter[]
+): TVault[] {
+  if (!requestedVaults?.length) {
+    return vaults
+  }
+
+  const requestedVaultKeys = new Set(
+    requestedVaults.map((vault) => toVaultKey(vault.chainId, vault.vaultAddress.toLowerCase()))
+  )
+  return vaults.filter((vault) => requestedVaultKeys.has(toVaultKey(vault.chainId, vault.vaultAddress)))
+}
+
 function buildEmptyBreakdownResponse(
   userAddress: string,
   version: VaultVersion,
@@ -151,7 +166,8 @@ export async function getHistoricalHoldings(
   version: VaultVersion = 'all',
   fetchType: HoldingsEventFetchType = 'seq',
   paginationMode: HoldingsEventPaginationMode = 'paged',
-  timeframe: HoldingsHistoryTimeframe = '1y'
+  timeframe: HoldingsHistoryTimeframe = '1y',
+  requestedVaults?: HoldingsVaultFilter[]
 ): Promise<HoldingsHistoryResponse> {
   const defaultDays = config.historyDays
   const baseContext = await getSettledAddressScopedContext({
@@ -176,7 +192,9 @@ export async function getHistoricalHoldings(
   // Fetch cached totals with timestamp info for staleness check
   let cachedTotals: CachedTotal[] = []
   let oldestUpdatedAt: Date | null = null
-  if (timeframe !== 'all') {
+  const shouldReadCache = timeframe !== 'all' && !requestedVaults?.length
+  const shouldWriteCache = !requestedVaults?.length
+  if (shouldReadCache) {
     const startDate = timestampToDateString(timestamps[0])
     const endDate = timestampToDateString(timestamps[timestamps.length - 1])
     const cachedResult = await getCachedTotalsWithTimestamp(userAddress, version, startDate, endDate)
@@ -215,7 +233,12 @@ export async function getHistoricalHoldings(
   }
 
   const vaultMetadata = baseContext.vaultMetadata
-  const vaults = filterVaultsByAuthoritativeVersion(baseContext.rawVaultIdentifiers, vaultMetadata, version)
+  const versionFilteredVaults = filterVaultsByAuthoritativeVersion(
+    baseContext.rawVaultIdentifiers,
+    vaultMetadata,
+    version
+  )
+  const vaults = filterVaultsByRequestedVault(versionFilteredVaults, requestedVaults)
   debugLog('history', 'resolved authoritative vault versions for history', {
     version,
     fetchType,
@@ -226,7 +249,7 @@ export async function getHistoricalHoldings(
   })
 
   // Check if any vaults have been invalidated since cache was written
-  if (cachedTotals.length > 0 && vaults.length > 0) {
+  if (shouldReadCache && cachedTotals.length > 0 && vaults.length > 0) {
     const vaultIdentifiers = vaults.map((v) => ({ address: v.vaultAddress, chainId: v.chainId }))
     const isStale = await checkCacheStaleness(vaultIdentifiers, oldestUpdatedAt)
     debugLog('history', 'completed cache staleness check', {
@@ -420,7 +443,7 @@ export async function getHistoricalHoldings(
       })
     }
 
-    if (newTotals.length > 0) {
+    if (shouldWriteCache && newTotals.length > 0) {
       await saveCachedTotals(userAddress, version, newTotals)
       debugLog('history', 'saved recalculated totals to cache', {
         version,
@@ -464,9 +487,17 @@ export async function getHistoricalHoldingsChart(
   fetchType: HoldingsEventFetchType = 'seq',
   paginationMode: HoldingsEventPaginationMode = 'paged',
   denomination: HoldingsHistoryDenomination = 'usd',
-  timeframe: HoldingsHistoryTimeframe = '1y'
+  timeframe: HoldingsHistoryTimeframe = '1y',
+  requestedVaults?: HoldingsVaultFilter[]
 ): Promise<HoldingsHistoryChartResponse> {
-  const holdings = await getHistoricalHoldings(userAddress, version, fetchType, paginationMode, timeframe)
+  const holdings = await getHistoricalHoldings(
+    userAddress,
+    version,
+    fetchType,
+    paginationMode,
+    timeframe,
+    requestedVaults
+  )
 
   if (denomination === 'usd') {
     return {

--- a/api/lib/holdings/services/nestedVaultPrices.test.ts
+++ b/api/lib/holdings/services/nestedVaultPrices.test.ts
@@ -10,6 +10,7 @@ import { toVaultKey } from './pnlShared'
 
 const INNER_VAULT = '0x696d02db93291651ed510704c9b286841d506987'
 const OUTER_VAULT = '0xaaafea48472f77563961cdb53291dedfb46f9040'
+const SUPER_VAULT = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
 const UNDERLYING = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
 
 const metadata = new Map<string, VaultMetadata>([
@@ -38,6 +39,21 @@ const metadata = new Map<string, VaultMetadata>([
       token: {
         address: INNER_VAULT,
         symbol: 'yvUSD',
+        decimals: 6
+      },
+      decimals: 6
+    }
+  ],
+  [
+    toVaultKey(1, SUPER_VAULT),
+    {
+      address: SUPER_VAULT,
+      chainId: 1,
+      version: 'v3',
+      category: 'stable',
+      token: {
+        address: OUTER_VAULT,
+        symbol: 'Locked yvUSD',
         decimals: 6
       },
       decimals: 6
@@ -90,6 +106,59 @@ describe('nested vault asset prices', () => {
     ).toEqual([{ chainId: 1, vaultAddress: INNER_VAULT }])
   })
 
+  it('recursively expands multi-level vault-share asset price requests', () => {
+    const requests = expandNestedVaultAssetPriceRequests(
+      [
+        {
+          chainId: 1,
+          address: SUPER_VAULT,
+          timestamps: [100]
+        }
+      ],
+      metadata
+    )
+
+    expect(requests).toEqual([
+      {
+        chainId: 1,
+        address: SUPER_VAULT,
+        timestamps: [100]
+      },
+      {
+        chainId: 1,
+        address: OUTER_VAULT,
+        timestamps: [100]
+      },
+      {
+        chainId: 1,
+        address: INNER_VAULT,
+        timestamps: [100]
+      },
+      {
+        chainId: 1,
+        address: UNDERLYING,
+        timestamps: [100]
+      }
+    ])
+
+    expect(
+      getNestedVaultPpsIdentifiersFromPriceRequests(
+        [
+          {
+            chainId: 1,
+            address: SUPER_VAULT,
+            timestamps: [100]
+          }
+        ],
+        metadata
+      )
+    ).toEqual([
+      { chainId: 1, vaultAddress: SUPER_VAULT },
+      { chainId: 1, vaultAddress: OUTER_VAULT },
+      { chainId: 1, vaultAddress: INNER_VAULT }
+    ])
+  })
+
   it('derives missing vault-share token prices from inner PPS and underlying token price', () => {
     const priceData = deriveNestedVaultAssetPriceData({
       priceData: new Map([
@@ -124,6 +193,70 @@ describe('nested vault asset prices', () => {
     const derivedInnerPrices = priceData.get(`ethereum:${INNER_VAULT}`)
     expect(derivedInnerPrices?.get(100)).toBe(1.005)
     expect(derivedInnerPrices?.get(200)).toBeCloseTo(1.02102)
+  })
+
+  it('recursively derives multi-level vault-share token prices', () => {
+    const priceData = deriveNestedVaultAssetPriceData({
+      priceData: new Map([
+        [
+          `ethereum:${UNDERLYING}`,
+          new Map([
+            [100, 1],
+            [200, 1]
+          ])
+        ]
+      ]),
+      priceRequests: [
+        {
+          chainId: 1,
+          address: SUPER_VAULT,
+          timestamps: [100, 200]
+        },
+        {
+          chainId: 1,
+          address: OUTER_VAULT,
+          timestamps: [100, 200]
+        },
+        {
+          chainId: 1,
+          address: INNER_VAULT,
+          timestamps: [100, 200]
+        },
+        {
+          chainId: 1,
+          address: UNDERLYING,
+          timestamps: [100, 200]
+        }
+      ],
+      vaultMetadata: metadata,
+      ppsData: new Map([
+        [
+          toVaultKey(1, INNER_VAULT),
+          new Map([
+            [100, 1.01],
+            [200, 1.02]
+          ])
+        ],
+        [
+          toVaultKey(1, OUTER_VAULT),
+          new Map([
+            [100, 1.03],
+            [200, 1.04]
+          ])
+        ],
+        [
+          toVaultKey(1, SUPER_VAULT),
+          new Map([
+            [100, 1.05],
+            [200, 1.06]
+          ])
+        ]
+      ])
+    })
+
+    expect(priceData.get(`ethereum:${INNER_VAULT}`)?.get(200)).toBeCloseTo(1.02)
+    expect(priceData.get(`ethereum:${OUTER_VAULT}`)?.get(200)).toBeCloseTo(1.0608)
+    expect(priceData.get(`ethereum:${SUPER_VAULT}`)?.get(200)).toBeCloseTo(1.124448)
   })
 
   it('dedupes PPS identifiers while preserving chain and vault address', () => {

--- a/api/lib/holdings/services/nestedVaultPrices.ts
+++ b/api/lib/holdings/services/nestedVaultPrices.ts
@@ -1,5 +1,5 @@
-import type { VaultMetadata } from '../types'
-import { getChainPrefix, getPriceAtTimestamp, type THistoricalPriceRequest } from './defillama'
+import { SUPPORTED_CHAINS, type VaultMetadata } from '../types'
+import type { THistoricalPriceRequest } from './defillama'
 import { getPPS, type PPSTimeline } from './kong'
 import { toVaultKey } from './pnlShared'
 
@@ -16,8 +16,27 @@ type TVaultIdentifier = {
   vaultAddress: string
 }
 
+const DEFAULT_MAX_NESTED_VAULT_DEPTH = 4
+
 function priceMapKey(chainId: number, tokenAddress: string): string {
   return `${getChainPrefix(chainId)}:${tokenAddress.toLowerCase()}`
+}
+
+function getChainPrefix(chainId: number): string {
+  return SUPPORTED_CHAINS.find((chain) => chain.id === chainId)?.defillamaPrefix || 'ethereum'
+}
+
+function getPriceAtTimestamp(priceMap: Map<number, number>, targetTimestamp: number): number {
+  if (priceMap.has(targetTimestamp)) {
+    return priceMap.get(targetTimestamp)!
+  }
+
+  const closestPriorTimestamp = Array.from(priceMap.keys())
+    .sort((left, right) => left - right)
+    .filter((timestamp) => timestamp <= targetTimestamp)
+    .at(-1)
+
+  return closestPriorTimestamp === undefined ? 0 : priceMap.get(closestPriorTimestamp) || 0
 }
 
 function priceRequestKey(chainId: number, tokenAddress: string): string {
@@ -85,50 +104,119 @@ export function getAssetVaultMetadataLookupIdentifiers(vaultMetadata: Map<string
   )
 }
 
-export function getNestedVaultPpsIdentifiersFromPriceRequests(
-  requests: THistoricalPriceRequest[],
-  vaultMetadata: Map<string, VaultMetadata>
-): TVaultIdentifier[] {
-  return mergeVaultIdentifiers(
-    requests.flatMap((request) => {
-      const nestedVault = vaultMetadata.get(toVaultKey(request.chainId, request.address))
+export async function resolveNestedVaultAssetMetadata(
+  vaultMetadata: Map<string, VaultMetadata>,
+  maxDepth = DEFAULT_MAX_NESTED_VAULT_DEPTH
+): Promise<Map<string, VaultMetadata>> {
+  if (maxDepth <= 0) {
+    return vaultMetadata
+  }
 
-      return nestedVault ? [{ chainId: nestedVault.chainId, vaultAddress: nestedVault.address }] : []
-    })
+  const missingAssetVaultIdentifiers = getAssetVaultMetadataLookupIdentifiers(vaultMetadata).filter(
+    (identifier) => !vaultMetadata.has(toVaultKey(identifier.chainId, identifier.vaultAddress))
   )
+
+  if (missingAssetVaultIdentifiers.length === 0) {
+    return vaultMetadata
+  }
+
+  const { fetchMultipleVaultsMetadata } = await import('./vaults')
+  const assetVaultMetadata = await fetchMultipleVaultsMetadata(missingAssetVaultIdentifiers, {
+    skipSnapshotFallback: true
+  })
+  const newEntries = Array.from(assetVaultMetadata.entries()).filter(([key]) => !vaultMetadata.has(key))
+
+  if (newEntries.length === 0) {
+    return vaultMetadata
+  }
+
+  return resolveNestedVaultAssetMetadata(new Map([...vaultMetadata, ...newEntries]), maxDepth - 1)
 }
 
-export function expandNestedVaultAssetPriceRequests(
-  requests: THistoricalPriceRequest[],
-  vaultMetadata: Map<string, VaultMetadata>
-): THistoricalPriceRequest[] {
-  const drafts = new Map<string, TPriceRequestDraft>()
+function getNestedVaultPpsIdentifiersForRequest(
+  request: THistoricalPriceRequest,
+  vaultMetadata: Map<string, VaultMetadata>,
+  maxDepth: number
+): TVaultIdentifier[] {
+  if (maxDepth <= 0) {
+    return []
+  }
 
-  requests.forEach((request) => {
-    const includeUncachedTimestamps = request.uncachedTimestamps !== undefined
-    addPriceRequest(drafts, request, includeUncachedTimestamps)
+  const nestedVault = vaultMetadata.get(toVaultKey(request.chainId, request.address))
 
-    const nestedVault = vaultMetadata.get(toVaultKey(request.chainId, request.address))
-    if (!nestedVault) {
-      return
-    }
+  if (!nestedVault) {
+    return []
+  }
 
-    addPriceRequest(
-      drafts,
+  return [
+    { chainId: nestedVault.chainId, vaultAddress: nestedVault.address },
+    ...getNestedVaultPpsIdentifiersForRequest(
       {
         chainId: nestedVault.chainId,
         address: nestedVault.token.address,
         timestamps: request.timestamps,
         uncachedTimestamps: request.uncachedTimestamps
       },
-      includeUncachedTimestamps
+      vaultMetadata,
+      maxDepth - 1
     )
+  ]
+}
+
+export function getNestedVaultPpsIdentifiersFromPriceRequests(
+  requests: THistoricalPriceRequest[],
+  vaultMetadata: Map<string, VaultMetadata>,
+  maxDepth = DEFAULT_MAX_NESTED_VAULT_DEPTH
+): TVaultIdentifier[] {
+  return mergeVaultIdentifiers(
+    requests.flatMap((request) => getNestedVaultPpsIdentifiersForRequest(request, vaultMetadata, maxDepth))
+  )
+}
+
+function addNestedVaultAssetPriceRequests(
+  drafts: Map<string, TPriceRequestDraft>,
+  request: THistoricalPriceRequest,
+  vaultMetadata: Map<string, VaultMetadata>,
+  includeUncachedTimestamps: boolean,
+  maxDepth: number
+): void {
+  if (maxDepth <= 0) {
+    return
+  }
+
+  const nestedVault = vaultMetadata.get(toVaultKey(request.chainId, request.address))
+  if (!nestedVault) {
+    return
+  }
+
+  const nestedAssetRequest = {
+    chainId: nestedVault.chainId,
+    address: nestedVault.token.address,
+    timestamps: request.timestamps,
+    uncachedTimestamps: request.uncachedTimestamps
+  }
+
+  addPriceRequest(drafts, nestedAssetRequest, includeUncachedTimestamps)
+  addNestedVaultAssetPriceRequests(drafts, nestedAssetRequest, vaultMetadata, includeUncachedTimestamps, maxDepth - 1)
+}
+
+export function expandNestedVaultAssetPriceRequests(
+  requests: THistoricalPriceRequest[],
+  vaultMetadata: Map<string, VaultMetadata>,
+  maxDepth = DEFAULT_MAX_NESTED_VAULT_DEPTH
+): THistoricalPriceRequest[] {
+  const drafts = new Map<string, TPriceRequestDraft>()
+
+  requests.forEach((request) => {
+    const includeUncachedTimestamps = request.uncachedTimestamps !== undefined
+    addPriceRequest(drafts, request, includeUncachedTimestamps)
+    addNestedVaultAssetPriceRequests(drafts, request, vaultMetadata, includeUncachedTimestamps, maxDepth)
   })
 
   return materializePriceRequests(drafts)
 }
 
-export function deriveNestedVaultAssetPriceData(args: {
+function deriveNestedVaultAssetPriceDataOnce(args: {
   priceData: Map<string, Map<number, number>>
   priceRequests: THistoricalPriceRequest[]
   vaultMetadata: Map<string, VaultMetadata>
@@ -169,4 +257,25 @@ export function deriveNestedVaultAssetPriceData(args: {
   })
 
   return result
+}
+
+export function deriveNestedVaultAssetPriceData(args: {
+  priceData: Map<string, Map<number, number>>
+  priceRequests: THistoricalPriceRequest[]
+  vaultMetadata: Map<string, VaultMetadata>
+  ppsData: Map<string, PPSTimeline>
+  maxDepth?: number
+}): Map<string, Map<number, number>> {
+  const maxDepth = args.maxDepth ?? DEFAULT_MAX_NESTED_VAULT_DEPTH
+
+  return Array.from({ length: Math.max(1, maxDepth) }).reduce(
+    (priceData) =>
+      deriveNestedVaultAssetPriceDataOnce({
+        priceData,
+        priceRequests: args.priceRequests,
+        vaultMetadata: args.vaultMetadata,
+        ppsData: args.ppsData
+      }),
+    args.priceData
+  )
 }

--- a/api/lib/holdings/services/pnlSimple.test.ts
+++ b/api/lib/holdings/services/pnlSimple.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import type { VaultMetadata } from '../types'
 import type { TransactionActivityEvents } from './graphql'
 import { mergeAddressScopedRawPnlEventsWithTransactionActivity } from './pnlEvents'
@@ -13,6 +13,11 @@ import {
 } from './pnlSimple'
 import type { TRawPnlEvent } from './pnlTypes'
 
+vi.mock('../db/connection', () => ({
+  getPool: vi.fn(() => null),
+  isDatabaseEnabled: vi.fn(() => false)
+}))
+
 const USER = '0x1111111111111111111111111111111111111111'
 const OTHER = '0x2222222222222222222222222222222222222222'
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
@@ -21,6 +26,12 @@ const ASSET = '0x4444444444444444444444444444444444444444'
 const VAULT_KEY = toVaultKey(1, VAULT)
 const ASSET_PRICE_KEY = `ethereum:${ASSET}`
 const ONE = 10n ** 18n
+const YVUSD_UNDERLYING = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+const YVUSD_UNLOCKED = '0x696d02db93291651ed510704c9b286841d506987'
+const YVUSD_LOCKED = '0xaaafea48472f77563961cdb53291dedfb46f9040'
+const YVUSD_UNLOCKED_KEY = toVaultKey(1, YVUSD_UNLOCKED)
+const YVUSD_LOCKED_KEY = toVaultKey(1, YVUSD_LOCKED)
+const YVUSD_ONE = 10n ** 6n
 
 const metadata = new Map<string, VaultMetadata>([
   [
@@ -1126,6 +1137,135 @@ describe('pnl simple protocol return', () => {
     expect(familyHistory[0]?.dataPoints[1]?.protocolReturnPct).toBeCloseTo(10)
     expect(familyHistory[0]?.dataPoints[0]?.growthIndex).toBeCloseTo(100)
     expect(familyHistory[0]?.dataPoints[1]?.growthIndex).toBeCloseTo(110)
+  })
+
+  it('keeps locked and unlocked yvUSD as separate protocol-return families', () => {
+    const yvUsdMetadata = new Map<string, VaultMetadata>([
+      [
+        YVUSD_UNLOCKED_KEY,
+        {
+          address: YVUSD_UNLOCKED,
+          chainId: 1,
+          version: 'v3',
+          category: 'stable',
+          token: {
+            address: YVUSD_UNDERLYING,
+            symbol: 'USDC',
+            decimals: 6
+          },
+          decimals: 6
+        }
+      ],
+      [
+        YVUSD_LOCKED_KEY,
+        {
+          address: YVUSD_LOCKED,
+          chainId: 1,
+          version: 'v3',
+          category: 'stable',
+          token: {
+            address: YVUSD_UNLOCKED,
+            symbol: 'yvUSD',
+            decimals: 6
+          },
+          decimals: 6
+        }
+      ]
+    ])
+    const yvUsdPpsData = new Map([
+      [
+        YVUSD_UNLOCKED_KEY,
+        new Map([
+          [100, 1],
+          [200, 1.02]
+        ])
+      ],
+      [
+        YVUSD_LOCKED_KEY,
+        new Map([
+          [100, 1],
+          [200, 1.05]
+        ])
+      ]
+    ])
+    const yvUsdPriceData = new Map([
+      [
+        `ethereum:${YVUSD_UNDERLYING}`,
+        new Map([
+          [100, 1],
+          [200, 1]
+        ])
+      ],
+      [
+        `ethereum:${YVUSD_UNLOCKED}`,
+        new Map([
+          [100, 1.01],
+          [200, 1.02]
+        ])
+      ]
+    ])
+    const events = [
+      baseEvent({
+        kind: 'deposit',
+        id: 'unlocked-deposit',
+        vaultAddress: YVUSD_UNLOCKED,
+        familyVaultAddress: YVUSD_UNLOCKED,
+        shares: 100n * YVUSD_ONE,
+        assets: 100n * YVUSD_ONE,
+        owner: USER,
+        sender: USER
+      }),
+      baseEvent({
+        kind: 'deposit',
+        id: 'locked-deposit',
+        vaultAddress: YVUSD_LOCKED,
+        familyVaultAddress: YVUSD_LOCKED,
+        blockTimestamp: 100,
+        blockNumber: 1,
+        logIndex: 1,
+        transactionHash: '0xlocked-deposit',
+        shares: 100n * YVUSD_ONE,
+        assets: 100n * YVUSD_ONE,
+        owner: USER,
+        sender: USER
+      })
+    ]
+    const ledgers = buildProtocolReturnLedgers({
+      events,
+      userAddress: USER,
+      metadata: yvUsdMetadata,
+      ppsData: yvUsdPpsData,
+      priceData: yvUsdPriceData,
+      currentTimestamp: 200
+    })
+    const selectedVaults = materializeProtocolReturnVaults({
+      ledgers,
+      metadata: yvUsdMetadata,
+      ppsData: yvUsdPpsData,
+      currentTimestamp: 200
+    })
+    const lockedVault = selectedVaults.find((vault) => vault.vaultAddress === YVUSD_LOCKED)
+    const familyHistory = buildProtocolReturnFamilyHistorySeries({
+      events,
+      userAddress: USER,
+      metadata: yvUsdMetadata,
+      ppsData: yvUsdPpsData,
+      priceData: yvUsdPriceData,
+      timestamps: [100, 200],
+      selectedVaults
+    })
+
+    expect(selectedVaults).toHaveLength(2)
+    expect(lockedVault?.currentUnderlying).toBeCloseTo(105)
+    expect(lockedVault?.growthUnderlying).toBeCloseTo(5)
+    expect(lockedVault?.growthWeightUsd).toBeCloseTo(5.05)
+    expect(familyHistory.map((series) => series.vaultAddress).sort()).toEqual([YVUSD_LOCKED, YVUSD_UNLOCKED].sort())
+    expect(
+      familyHistory.find((series) => series.vaultAddress === YVUSD_LOCKED)?.dataPoints[1]?.growthWeightUsd
+    ).toBeCloseTo(5.05)
+    expect(
+      familyHistory.find((series) => series.vaultAddress === YVUSD_UNLOCKED)?.dataPoints[1]?.growthWeightUsd
+    ).toBeCloseTo(2)
   })
 
   it('stops emitting family growth index points after a vault is fully exited', () => {

--- a/api/lib/holdings/services/pnlSimple.test.ts
+++ b/api/lib/holdings/services/pnlSimple.test.ts
@@ -389,6 +389,94 @@ describe('pnl simple protocol return', () => {
     expect(history[1]?.pricePerShare).toBeCloseTo(1.1)
   })
 
+  it('combines current underlying and growth fields for multi-vault history points', () => {
+    const combinedMetadata = new Map<string, VaultMetadata>([
+      ...metadata,
+      [
+        YVUSD_UNLOCKED_KEY,
+        {
+          address: YVUSD_UNLOCKED,
+          chainId: 1,
+          version: 'v3',
+          category: 'stable',
+          token: {
+            address: YVUSD_UNDERLYING,
+            symbol: 'USDC',
+            decimals: 6
+          },
+          decimals: 6
+        }
+      ],
+      [
+        YVUSD_LOCKED_KEY,
+        {
+          address: YVUSD_LOCKED,
+          chainId: 1,
+          version: 'v3',
+          category: 'stable',
+          token: {
+            address: YVUSD_UNLOCKED,
+            symbol: 'yvUSD',
+            decimals: 6
+          },
+          decimals: 18
+        }
+      ]
+    ])
+    const history = buildProtocolReturnHistorySeries({
+      events: [
+        baseEvent({
+          kind: 'deposit',
+          id: 'unlocked-deposit',
+          vaultAddress: YVUSD_UNLOCKED,
+          familyVaultAddress: YVUSD_UNLOCKED,
+          blockTimestamp: 100,
+          shares: 100n * YVUSD_ONE,
+          assets: 100n * YVUSD_ONE,
+          owner: USER,
+          sender: USER
+        }),
+        baseEvent({
+          kind: 'deposit',
+          id: 'locked-deposit',
+          vaultAddress: YVUSD_LOCKED,
+          familyVaultAddress: YVUSD_LOCKED,
+          blockTimestamp: 100,
+          shares: 2n * ONE,
+          assets: 200n * YVUSD_ONE,
+          owner: USER,
+          sender: USER
+        })
+      ],
+      userAddress: USER,
+      metadata: combinedMetadata,
+      ppsData: new Map([
+        [
+          YVUSD_UNLOCKED_KEY,
+          new Map([
+            [100, 1],
+            [200, 1.1]
+          ])
+        ],
+        [
+          YVUSD_LOCKED_KEY,
+          new Map([
+            [100, 100],
+            [200, 110]
+          ])
+        ]
+      ]),
+      priceData: new Map([[`ethereum:${YVUSD_UNDERLYING}`, new Map([[100, 1]])]]),
+      timestamps: [100, 200],
+      selectedVaultKeys: [YVUSD_UNLOCKED_KEY, YVUSD_LOCKED_KEY]
+    })
+
+    expect(history[0]?.currentUnderlying).toBeCloseTo(300)
+    expect(history[0]?.growthUnderlying).toBeCloseTo(0)
+    expect(history[1]?.currentUnderlying).toBeCloseTo(330)
+    expect(history[1]?.growthUnderlying).toBeCloseTo(30)
+  })
+
   it('keeps ETH growth history available when another vault is missing receipt prices', () => {
     const MISSING_VAULT = '0x5555555555555555555555555555555555555555'
     const MISSING_ASSET = '0x6666666666666666666666666666666666666666'

--- a/api/lib/holdings/services/pnlSimple.ts
+++ b/api/lib/holdings/services/pnlSimple.ts
@@ -219,6 +219,8 @@ export interface HoldingsPnLSimpleHistoryResponse {
 
 const SECONDS_PER_YEAR = 365 * 24 * 60 * 60
 
+type TProtocolReturnVaultFilter = { chainId: number; vaultAddress: string }
+
 function emptyLedger(chainId: number, vaultAddress: string): TProtocolReturnLedger {
   return {
     chainId,
@@ -348,6 +350,50 @@ function resolveRecommendedGrowthDisplay(composition: { stable: number; ethFamil
   }
 }
 
+function normalizeProtocolReturnVaultFilters(
+  requestedVaultFilters?: TProtocolReturnVaultFilter[] | string,
+  legacyVaultChainId?: number
+): TProtocolReturnVaultFilter[] | undefined {
+  if (typeof requestedVaultFilters === 'string') {
+    return Number.isInteger(legacyVaultChainId)
+      ? [{ chainId: Number(legacyVaultChainId), vaultAddress: lowerCaseAddress(requestedVaultFilters) }]
+      : undefined
+  }
+
+  return requestedVaultFilters?.map((vault) => ({
+    chainId: Number(vault.chainId),
+    vaultAddress: lowerCaseAddress(vault.vaultAddress)
+  }))
+}
+
+function filterEventsByRequestedVaults(
+  events: TRawPnlEvent[],
+  requestedVaults?: TProtocolReturnVaultFilter[]
+): TRawPnlEvent[] {
+  if (!requestedVaults?.length) {
+    return events
+  }
+
+  const requestedVaultKeys = new Set(
+    requestedVaults.map((vault) => toVaultKey(vault.chainId, lowerCaseAddress(vault.vaultAddress)))
+  )
+
+  return events.filter((event) => requestedVaultKeys.has(toVaultKey(event.chainId, event.familyVaultAddress)))
+}
+
+function filterVaultIdentifiersByRequestedVaults(
+  vaults: TProtocolReturnVaultFilter[],
+  requestedVaults?: TProtocolReturnVaultFilter[]
+): TProtocolReturnVaultFilter[] {
+  if (!requestedVaults?.length) {
+    return vaults
+  }
+
+  const requestedVaultKeys = new Set(
+    requestedVaults.map((vault) => toVaultKey(vault.chainId, lowerCaseAddress(vault.vaultAddress)))
+  )
+  return vaults.filter((vault) => requestedVaultKeys.has(toVaultKey(vault.chainId, vault.vaultAddress)))
+}
 function tokenPriceMapKey(metadata: VaultMetadata): string {
   return `${getChainPrefix(metadata.chainId)}:${metadata.token.address.toLowerCase()}`
 }
@@ -1720,6 +1766,7 @@ export function buildProtocolReturnHistorySeries(args: {
   ethPriceData?: Map<number, number>
   timestamps: number[]
   selectedVaultKey?: string
+  selectedVaultKeys?: string[]
 }): HoldingsPnLSimpleHistoryPoint[] {
   const userAddress = lowerCaseAddress(args.userAddress)
   const effectiveEvents = buildEffectiveSimpleEvents(args.events, userAddress)
@@ -1761,9 +1808,11 @@ export function buildProtocolReturnHistorySeries(args: {
       ppsData: args.ppsData,
       currentTimestamp: timestamp
     })
-    const selectedVault = args.selectedVaultKey
-      ? vaults.find((vault) => toVaultKey(vault.chainId, vault.vaultAddress) === args.selectedVaultKey)
-      : null
+    const selectedVaultKeys = args.selectedVaultKeys ?? (args.selectedVaultKey ? [args.selectedVaultKey] : [])
+    const selectedVaultKeySet = new Set(selectedVaultKeys)
+    const selectedVaults = selectedVaultKeys.length
+      ? vaults.filter((vault) => selectedVaultKeySet.has(toVaultKey(vault.chainId, vault.vaultAddress)))
+      : []
     const summary = buildSummary(vaults)
     const growthWeightEth = buildGrowthWeightEthSummary({
       ledgers,
@@ -1790,12 +1839,12 @@ export function buildProtocolReturnHistorySeries(args: {
       protocolReturnPct: summary.protocolReturnPct,
       annualizedProtocolReturnPct: summary.annualizedProtocolReturnPct,
       growthIndex,
-      ...(args.selectedVaultKey
+      ...(selectedVaultKeys.length > 0
         ? {
-            currentUnderlying: selectedVault?.currentUnderlying ?? 0,
-            growthUnderlying: selectedVault?.growthUnderlying ?? 0,
-            sharesFormatted: selectedVault?.sharesFormatted ?? 0,
-            pricePerShare: selectedVault?.pricePerShare ?? 0
+            currentUnderlying: selectedVaults.reduce((sum, vault) => sum + vault.currentUnderlying, 0),
+            growthUnderlying: selectedVaults.reduce((sum, vault) => sum + vault.growthUnderlying, 0),
+            sharesFormatted: selectedVaults.reduce((sum, vault) => sum + vault.sharesFormatted, 0),
+            pricePerShare: selectedVaults.length === 1 ? selectedVaults[0]!.pricePerShare : 0
           }
         : {})
     }
@@ -1944,8 +1993,8 @@ export async function getHoldingsProtocolReturnHistory(
   fetchType: HoldingsEventFetchType = 'seq',
   paginationMode: HoldingsEventPaginationMode = 'paged',
   timeframe: '1y' | 'all' = '1y',
-  vaultAddress?: string,
-  vaultChainId?: number
+  requestedVaultFilters?: Array<{ chainId: number; vaultAddress: string }> | string,
+  legacyVaultChainId?: number
 ): Promise<HoldingsPnLSimpleHistoryResponse> {
   debugLog('protocol-return-history', 'starting holdings protocol return history calculation', {
     version,
@@ -1954,27 +2003,27 @@ export async function getHoldingsProtocolReturnHistory(
     timeframe
   })
 
-  const requestedVault =
-    vaultAddress && Number.isInteger(vaultChainId)
-      ? {
-          chainId: Number(vaultChainId),
-          vaultAddress: lowerCaseAddress(vaultAddress)
-        }
-      : undefined
+  const requestedVaults = normalizeProtocolReturnVaultFilters(requestedVaultFilters, legacyVaultChainId)
+  const singleRequestedVault = requestedVaults?.length === 1 ? requestedVaults[0] : undefined
   const settledContext = await getSettledVersionedPpsContext({
     userAddress,
     version,
     fetchType,
     paginationMode,
-    requestedVault
+    requestedVault: singleRequestedVault,
+    vaultIdentifiers: requestedVaults
   })
+  const selectedEvents = filterEventsByRequestedVaults(settledContext.selectedEvents, requestedVaults)
   const rawEvents = await enrichSimpleHistoryRawEvents({
-    events: settledContext.selectedEvents,
+    events: selectedEvents,
     version,
     maxTimestamp: settledContext.maxTimestamp
   })
   const effectiveEvents = rawEvents
-  const filteredVaultIdentifiers = getVaultIdentifiers(effectiveEvents)
+  const filteredVaultIdentifiers = filterVaultIdentifiersByRequestedVaults(
+    getVaultIdentifiers(effectiveEvents),
+    requestedVaults
+  )
   const vaultMetadata = settledContext.vaultMetadata
 
   if (effectiveEvents.length === 0 || filteredVaultIdentifiers.length === 0) {
@@ -2049,10 +2098,9 @@ export async function getHoldingsProtocolReturnHistory(
     priceData,
     ethPriceData,
     timestamps,
-    selectedVaultKey:
-      requestedVault && filteredVaultIdentifiers.length > 0
-        ? toVaultKey(filteredVaultIdentifiers[0]!.chainId, filteredVaultIdentifiers[0]!.vaultAddress)
-        : undefined
+    selectedVaultKeys: requestedVaults
+      ? filteredVaultIdentifiers.map((vault) => toVaultKey(vault.chainId, vault.vaultAddress))
+      : undefined
   })
   const familySeries = buildProtocolReturnFamilyHistorySeries({
     events: effectiveEvents,
@@ -2062,7 +2110,7 @@ export async function getHoldingsProtocolReturnHistory(
     priceData,
     ethPriceData,
     timestamps,
-    selectedVaults: requestedVault ? [] : selectedHistoryFamilies
+    selectedVaults: requestedVaults ? [] : selectedHistoryFamilies
   })
   const openBaselineCompositionUsd = buildOpenBaselineCompositionUsd({
     ledgers: finalLedgers,

--- a/api/lib/holdings/services/settledHoldingsContext.ts
+++ b/api/lib/holdings/services/settledHoldingsContext.ts
@@ -10,7 +10,11 @@ import {
 } from './graphql'
 import { buildPositionTimeline, generateDailyTimestamps, getUniqueVaults, toSettledDayTimestamp } from './holdings'
 import { fetchMultipleVaultsPPS, type PPSTimeline } from './kong'
-import { getNestedVaultPpsIdentifiersFromPriceRequests, mergeVaultIdentifiers } from './nestedVaultPrices'
+import {
+  getNestedVaultPpsIdentifiersFromPriceRequests,
+  mergeVaultIdentifiers,
+  resolveNestedVaultAssetMetadata
+} from './nestedVaultPrices'
 import { buildAddressScopedRawPnlEvents } from './pnlEvents'
 import { lowerCaseAddress, toVaultKey } from './pnlShared'
 import type { TRawPnlEvent } from './pnlTypes'
@@ -123,24 +127,6 @@ export function filterEventsByAuthoritativeVersion(
 
     return eventMetadata?.version === version
   })
-}
-
-export async function resolveNestedVaultAssetMetadata(
-  vaultMetadata: Map<string, VaultMetadata>
-): Promise<Map<string, VaultMetadata>> {
-  const assetVaultIdentifiers = mergeVaultIdentifiers(
-    Array.from(vaultMetadata.values()).map((metadata) => ({
-      chainId: metadata.chainId,
-      vaultAddress: metadata.token.address
-    }))
-  )
-
-  if (assetVaultIdentifiers.length === 0) {
-    return vaultMetadata
-  }
-
-  const assetVaultMetadata = await fetchMultipleVaultsMetadata(assetVaultIdentifiers, { skipSnapshotFallback: true })
-  return new Map([...vaultMetadata, ...assetVaultMetadata])
 }
 
 function buildUnderlyingTokenRequests(

--- a/api/lib/holdings/services/settledHoldingsContext.ts
+++ b/api/lib/holdings/services/settledHoldingsContext.ts
@@ -65,17 +65,23 @@ function getContextKey(args: {
   fetchType: HoldingsEventFetchType
   paginationMode: HoldingsEventPaginationMode
   requestedVault?: TRequestedVault
+  vaultIdentifiers?: TVaultIdentifier[]
 }): string {
-  const normalizedRequestedVault = args.requestedVault
-    ? `${args.requestedVault.chainId}:${lowerCaseAddress(args.requestedVault.vaultAddress)}`
-    : 'all'
+  const normalizedVaultScope = args.vaultIdentifiers?.length
+    ? args.vaultIdentifiers
+        .map((vault) => `${vault.chainId}:${lowerCaseAddress(vault.vaultAddress)}`)
+        .sort()
+        .join(',')
+    : args.requestedVault
+      ? `${args.requestedVault.chainId}:${lowerCaseAddress(args.requestedVault.vaultAddress)}`
+      : 'all'
 
   return [
     lowerCaseAddress(args.userAddress),
     args.version ?? 'all',
     args.fetchType,
     args.paginationMode,
-    normalizedRequestedVault
+    normalizedVaultScope
   ].join(':')
 }
 

--- a/api/server.ts
+++ b/api/server.ts
@@ -141,6 +141,50 @@ function isValidAddress(address: string): boolean {
   return /^0x[a-fA-F0-9]{40}$/.test(address)
 }
 
+function parseVaultFilters(url: URL): Array<{ chainId: number; vaultAddress: string }> | null | undefined {
+  const vaults = url.searchParams.get('vaults')
+
+  if (vaults !== null) {
+    const entries = vaults
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+    const parsedEntries = entries.map((entry) => {
+      const [entryChainId, entryVaultAddress] = entry.split(':')
+      const parsedChainId = Number(entryChainId)
+
+      if (
+        !entryChainId ||
+        !entryVaultAddress ||
+        !Number.isInteger(parsedChainId) ||
+        !isValidAddress(entryVaultAddress)
+      ) {
+        return null
+      }
+
+      return { chainId: parsedChainId, vaultAddress: entryVaultAddress }
+    })
+
+    if (parsedEntries.some((entry) => entry === null)) {
+      return null
+    }
+
+    return parsedEntries.filter((entry): entry is { chainId: number; vaultAddress: string } => entry !== null)
+  }
+
+  const vault = url.searchParams.get('vault')
+  if (vault === null) {
+    return undefined
+  }
+
+  const chainId = url.searchParams.get('chainId')
+  if (!isValidAddress(vault) || !chainId || !Number.isInteger(Number(chainId))) {
+    return null
+  }
+
+  return [{ chainId: Number(chainId), vaultAddress: vault }]
+}
+
 interface InvalidateRequestBody {
   vaults: Array<{ address: string; chainId: number }>
 }
@@ -496,6 +540,7 @@ async function handleHoldingsHistory(req: Request): Promise<Response> {
   const paginationMode = parseHoldingsEventPaginationMode(url.searchParams.get('paginationMode'))
   const denomination = parseHoldingsHistoryDenomination(url.searchParams.get('denomination'))
   const timeframe = parseHoldingsHistoryTimeframe(url.searchParams.get('timeframe'))
+  const vaultFilters = parseVaultFilters(url)
   const debugEnabled =
     isHoldingsDebugRequested(url.searchParams.get('debug')) || isHoldingsDebugRequested(process.env.HOLDINGS_DEBUG)
   const debugLotsEnabled = isHoldingsDebugRequested(url.searchParams.get('debugLots'))
@@ -510,6 +555,10 @@ async function handleHoldingsHistory(req: Request): Promise<Response> {
 
   if (!isValidAddress(address)) {
     return Response.json({ error: 'Invalid Ethereum address', status: 400 }, { status: 400 })
+  }
+
+  if (vaultFilters === null) {
+    return Response.json({ error: 'Invalid vault filter', status: 400 }, { status: 400 })
   }
 
   const version: VaultVersion = versionParam === 'v2' || versionParam === 'v3' ? versionParam : 'all'
@@ -544,7 +593,8 @@ async function handleHoldingsHistory(req: Request): Promise<Response> {
             fetchType,
             paginationMode,
             denomination,
-            timeframe
+            timeframe,
+            vaultFilters
           )
           debugLog('route', 'completed holdings history request', {
             version,
@@ -720,9 +770,8 @@ async function handleHoldingsBreakdown(req: Request): Promise<Response> {
 async function handleHoldingsProtocolReturnHistory(req: Request): Promise<Response> {
   const url = new URL(req.url)
   const address = url.searchParams.get('address')
-  const chainIdParam = url.searchParams.get('chainId')
   const versionParam = url.searchParams.get('version')
-  const vault = url.searchParams.get('vault')
+  const vaultFilters = parseVaultFilters(url)
   const timeframe = parseHoldingsHistoryTimeframe(url.searchParams.get('timeframe'))
   const debugEnabled =
     isHoldingsDebugRequested(url.searchParams.get('debug')) || isHoldingsDebugRequested(process.env.HOLDINGS_DEBUG)
@@ -740,12 +789,8 @@ async function handleHoldingsProtocolReturnHistory(req: Request): Promise<Respon
     return Response.json({ error: 'Invalid Ethereum address', status: 400 }, { status: 400 })
   }
 
-  if (vault !== null && !isValidAddress(vault)) {
-    return Response.json({ error: 'Invalid vault address', status: 400 }, { status: 400 })
-  }
-
-  if (vault !== null && (!chainIdParam || !Number.isInteger(Number(chainIdParam)))) {
-    return Response.json({ error: 'Missing or invalid chainId for vault filter', status: 400 }, { status: 400 })
+  if (vaultFilters === null) {
+    return Response.json({ error: 'Invalid vault filter', status: 400 }, { status: 400 })
   }
 
   const version: VaultVersion = versionParam === 'v2' || versionParam === 'v3' ? versionParam : 'all'
@@ -761,8 +806,7 @@ async function handleHoldingsProtocolReturnHistory(req: Request): Promise<Respon
         debugLog('route', 'started holdings protocol return history request', {
           version,
           timeframe,
-          vault: vault?.toLowerCase() ?? null,
-          chainId: vault !== null ? Number(chainIdParam) : null,
+          vaults: vaultFilters?.map((vault) => `${vault.chainId}:${vault.vaultAddress.toLowerCase()}`) ?? null,
           fetchType,
           paginationMode,
           debugLotsEnabled,
@@ -777,14 +821,12 @@ async function handleHoldingsProtocolReturnHistory(req: Request): Promise<Respon
             fetchType,
             paginationMode,
             timeframe,
-            vault ?? undefined,
-            vault !== null ? Number(chainIdParam) : undefined
+            vaultFilters
           )
           debugLog('route', 'completed holdings protocol return history request', {
             version,
             timeframe,
-            vault: vault?.toLowerCase() ?? null,
-            chainId: vault !== null ? Number(chainIdParam) : null,
+            vaults: vaultFilters?.map((vault) => `${vault.chainId}:${vault.vaultAddress.toLowerCase()}`) ?? null,
             fetchType,
             paginationMode,
             totalVaults: response.summary.totalVaults,
@@ -795,8 +837,7 @@ async function handleHoldingsProtocolReturnHistory(req: Request): Promise<Respon
           debugError('route', 'holdings protocol return history request failed', error, {
             version,
             timeframe,
-            vault: vault?.toLowerCase() ?? null,
-            chainId: vault !== null ? Number(chainIdParam) : null,
+            vaults: vaultFilters?.map((vault) => `${vault.chainId}:${vault.vaultAddress.toLowerCase()}`) ?? null,
             fetchType,
             paginationMode
           })
@@ -1036,13 +1077,13 @@ async function main() {
     idleTimeout: 120
   })
 
-  console.log(`🚀 API server running on http://localhost:${API_SERVER_PORT}`)
-  console.log(`📊 Holdings API: http://localhost:${API_SERVER_PORT}/api/holdings/history?address=0x...`)
-  console.log(`🗂️ Holdings Activity API: http://localhost:${API_SERVER_PORT}/api/holdings/activity?address=0x...`)
-  console.log(`🧩 Holdings Breakdown API: http://localhost:${API_SERVER_PORT}/api/holdings/breakdown?address=0x...`)
-  console.log(
-    `📈 Protocol Return History API: http://localhost:${API_SERVER_PORT}/api/holdings/protocol-return/history?address=0x...`
-  )
+  const apiServerUrl = `http://localhost:${API_SERVER_PORT}`
+  console.log(`🚀 API server running on ${apiServerUrl}`)
+  console.log(`📊 Holdings API: ${apiServerUrl}/api/holdings/history?address=0x...`)
+  console.log(`🗂️ Holdings Activity API: ${apiServerUrl}/api/holdings/activity?address=0x...`)
+  console.log(`🧩 Holdings Breakdown API: ${apiServerUrl}/api/holdings/breakdown?address=0x...`)
+  console.log(`📈 Protocol Return History API: ${apiServerUrl}/api/holdings/protocol-return/history?address=0x...`)
+  console.log(`📊 Simple PnL History Alias: ${apiServerUrl}/api/holdings/pnl/simple-history?address=0x...`)
 }
 
 main().catch((error) => {

--- a/src/components/pages/portfolio/components/PortfolioHistoryBreakdownModal.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryBreakdownModal.tsx
@@ -7,7 +7,6 @@ import {
   type TKongVaultInput
 } from '@pages/vaults/domain/kongVaultSelectors'
 import { getVaultPrimaryLogoSrc } from '@pages/vaults/utils/vaultLogo'
-import { isYvUsdAddress, YVUSD_CHAIN_ID, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { TokenLogo } from '@shared/components/TokenLogo'
 import { useYearn } from '@shared/contexts/useYearn'
 import { IconClose } from '@shared/icons/IconClose'
@@ -81,64 +80,14 @@ function getChainName(chainId: number): string {
   return SUPPORTED_NETWORKS.find((network) => network.id === chainId)?.name ?? `Chain ${chainId}`
 }
 
-function getStatusPriority(status: TPortfolioBreakdownVault['status']): number {
-  switch (status) {
-    case 'missing_metadata':
-      return 3
-    case 'missing_pps':
-      return 2
-    case 'missing_price':
-      return 1
-    default:
-      return 0
-  }
-}
-
-function getMergedStatus(statuses: TPortfolioBreakdownVault['status'][]): TPortfolioBreakdownVault['status'] {
-  return statuses.reduce<TPortfolioBreakdownVault['status']>((selectedStatus, currentStatus) => {
-    return getStatusPriority(currentStatus) > getStatusPriority(selectedStatus) ? currentStatus : selectedStatus
-  }, 'ok')
-}
-
-function getBreakdownDisplayKey(vault: TPortfolioBreakdownVault): string {
-  if (vault.chainId === YVUSD_CHAIN_ID && isYvUsdAddress(vault.vaultAddress)) {
-    return `${YVUSD_CHAIN_ID}:${YVUSD_UNLOCKED_ADDRESS}`
-  }
-
-  return `${vault.chainId}:${toAddress(vault.vaultAddress)}`
-}
-
 function getBreakdownDisplayVaults(vaults: TPortfolioBreakdownVault[]): TBreakdownDisplayVault[] {
-  const groupedVaults = new Map<string, TBreakdownDisplayVault>()
-
-  vaults.forEach((vault) => {
-    const displayKey = getBreakdownDisplayKey(vault)
-    const normalizedVaultAddress =
-      vault.chainId === YVUSD_CHAIN_ID && isYvUsdAddress(vault.vaultAddress)
-        ? YVUSD_UNLOCKED_ADDRESS
-        : toAddress(vault.vaultAddress)
-
-    const existingVault = groupedVaults.get(displayKey)
-    if (!existingVault) {
-      groupedVaults.set(displayKey, {
-        chainId: vault.chainId,
-        vaultAddress: normalizedVaultAddress,
-        usdValue: vault.usdValue ?? 0,
-        status: vault.status,
-        metadata: vault.metadata
-      })
-      return
-    }
-
-    groupedVaults.set(displayKey, {
-      ...existingVault,
-      usdValue: existingVault.usdValue + (vault.usdValue ?? 0),
-      status: getMergedStatus([existingVault.status, vault.status]),
-      metadata: existingVault.metadata ?? vault.metadata
-    })
-  })
-
-  return [...groupedVaults.values()]
+  return vaults.map((vault) => ({
+    chainId: vault.chainId,
+    vaultAddress: toAddress(vault.vaultAddress),
+    usdValue: vault.usdValue ?? 0,
+    status: vault.status,
+    metadata: vault.metadata
+  }))
 }
 
 export function PortfolioHistoryBreakdownModal({
@@ -203,15 +152,11 @@ export function PortfolioHistoryBreakdownModal({
 
   const enrichedVaults = useMemo<TEnrichedBreakdownVault[]>(() => {
     const displayedVaults = getBreakdownDisplayVaults(resolvedData?.vaults ?? [])
-    const yvUsdDisplayVault = allVaults[YVUSD_UNLOCKED_ADDRESS] as TKongVaultInput | undefined
 
     return displayedVaults
       .map((vault): TEnrichedBreakdownVault => {
         const normalizedVaultAddress = toAddress(vault.vaultAddress)
-        const isMergedYvUsdVault = vault.chainId === YVUSD_CHAIN_ID && normalizedVaultAddress === YVUSD_UNLOCKED_ADDRESS
-        const currentVault = isMergedYvUsdVault
-          ? yvUsdDisplayVault
-          : (allVaults[normalizedVaultAddress] as TKongVaultInput | undefined)
+        const currentVault = allVaults[normalizedVaultAddress] as TKongVaultInput | undefined
         const fallbackTokenAddress = vault.metadata?.tokenAddress
         const fallbackLogoSrc = fallbackTokenAddress
           ? `${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${vault.chainId}/${toAddress(fallbackTokenAddress).toLowerCase()}/logo-128.png`
@@ -224,11 +169,7 @@ export function PortfolioHistoryBreakdownModal({
           vaultHref: `/vaults/${vault.chainId}/${normalizedVaultAddress}`,
           displayName: currentVault ? getVaultName(currentVault) : vault.metadata?.symbol || normalizedVaultAddress,
           displaySymbol: currentVault ? getVaultSymbol(currentVault) : vault.metadata?.symbol || 'Unknown',
-          logoSrc: currentVault
-            ? getVaultPrimaryLogoSrc(currentVault)
-            : isMergedYvUsdVault
-              ? `${import.meta.env.BASE_URL || '/'}yvUSD-seal.png`
-              : fallbackLogoSrc,
+          logoSrc: currentVault ? getVaultPrimaryLogoSrc(currentVault) : fallbackLogoSrc,
           altLogoSrc: currentVault
             ? `${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/${getVaultChainID(currentVault)}/${toAddress(getVaultToken(currentVault).address).toLowerCase()}/logo-128.png`
             : undefined,

--- a/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/src/components/pages/vaults/[chainID]/[address].tsx
@@ -521,6 +521,18 @@ function Index(): ReactElement | null {
     !!address && currentVault?.address && Number.isInteger(currentVault?.chainID)
       ? getBalance({ address: toAddress(currentVault.address), chainID: currentVault.chainID }).raw
       : 0n
+  const yvUsdUnlockedShareBalance =
+    !!address && isYvUsd
+      ? getBalance({
+          address: toAddress(yvUsdUnlockedVault?.address ?? YVUSD_UNLOCKED_ADDRESS),
+          chainID: YVUSD_CHAIN_ID
+        }).raw
+      : 0n
+  const yvUsdLockedShareBalance =
+    !!address && isYvUsd
+      ? getBalance({ address: toAddress(yvUsdLockedVault?.address ?? YVUSD_LOCKED_ADDRESS), chainID: YVUSD_CHAIN_ID })
+          .raw
+      : 0n
 
   const stakingShareBalance =
     !!address && !!stakingAddress && Number.isInteger(currentVault?.chainID) && !!currentVault
@@ -530,7 +542,8 @@ function Index(): ReactElement | null {
   const isMigratable = Boolean(currentVault?.migration?.available)
   const canShowMigrateAction = isMigratable && vaultShareBalance > 0n
   const isRetired = Boolean(currentVault?.info?.isRetired)
-  const hasUserFundsInVault = vaultShareBalance > 0n || stakingShareBalance > 0n
+  const hasYvUsdFunds = yvUsdUnlockedShareBalance > 0n || yvUsdLockedShareBalance > 0n
+  const hasUserFundsInVault = isYvUsd ? hasYvUsdFunds : vaultShareBalance > 0n || stakingShareBalance > 0n
   const canShowUserCharts = !isWalletLoading && hasUserFundsInVault
   const retiredVaultAlertMessage = useMemo(() => {
     if (!isRetired || !currentVault) return null
@@ -766,7 +779,7 @@ function Index(): ReactElement | null {
         shouldRender: Number.isInteger(chainId),
         ref: sectionRefs.charts,
         content: isYvUsd ? (
-          <YvUsdChartsSection chartHeightPx={180} chartHeightMdPx={230} />
+          <YvUsdChartsSection chartHeightPx={180} chartHeightMdPx={230} enableUserPositionChart={canShowUserCharts} />
         ) : (
           <VaultChartsSection
             key={`${currentVault.address}-${address ?? 'disconnected'}`}
@@ -804,7 +817,7 @@ function Index(): ReactElement | null {
         content: <VaultInfoSection currentVault={currentVault} inceptTime={snapshotVault?.inceptTime ?? null} />
       }
     ]
-  }, [chainId, currentVault, isYvUsd, sectionRefs, snapshotVault?.inceptTime])
+  }, [canShowUserCharts, chainId, currentVault, isYvUsd, sectionRefs, snapshotVault?.inceptTime])
 
   const renderableSections = useMemo(() => sections.filter((section) => section.shouldRender), [sections])
   const sectionTabs = renderableSections.map((section) => ({
@@ -1142,7 +1155,13 @@ function Index(): ReactElement | null {
 
   function renderDetailCharts(chartHeightPx: number, chartHeightMdPx: number): ReactElement {
     if (isYvUsd) {
-      return <YvUsdChartsSection chartHeightPx={chartHeightPx} chartHeightMdPx={chartHeightMdPx} />
+      return (
+        <YvUsdChartsSection
+          chartHeightPx={chartHeightPx}
+          chartHeightMdPx={chartHeightMdPx}
+          enableUserPositionChart={canShowUserCharts}
+        />
+      )
     }
 
     return (

--- a/src/components/pages/vaults/components/detail/VaultChartsSection.tsx
+++ b/src/components/pages/vaults/components/detail/VaultChartsSection.tsx
@@ -30,6 +30,7 @@ type VaultChartsSectionProps = {
   enableUserCharts?: boolean
   userUnitLabel?: string
   overlayUserPositionOnTvlTab?: boolean
+  userHistoryVaults?: Array<{ chainId: number; vaultAddress: string }>
 }
 
 export const VAULT_CHART_TIMEFRAME_OPTIONS = [
@@ -71,7 +72,8 @@ export function VaultChartsSection({
   chartHeightMdPx,
   enableUserCharts = false,
   userUnitLabel = 'assets',
-  overlayUserPositionOnTvlTab = false
+  overlayUserPositionOnTvlTab = false,
+  userHistoryVaults
 }: VaultChartsSectionProps): ReactElement {
   const { data, error, isLoading } = useVaultChartTimeseries({
     chainId,
@@ -106,6 +108,7 @@ export function VaultChartsSection({
   } = useVaultUserHistory({
     chainId,
     vaultAddress,
+    vaults: userHistoryVaults,
     timeframe: activeTimeframe,
     enabled: (enableUserCharts && activeTabIsUserChart) || shouldOverlayUserPositionOnTvlTab
   })

--- a/src/components/pages/vaults/components/detail/YvUsdChartsSection.tsx
+++ b/src/components/pages/vaults/components/detail/YvUsdChartsSection.tsx
@@ -1,7 +1,9 @@
+import { useVaultUserHistory } from '@pages/vaults/hooks/useVaultUserHistory'
 import { type TYvUsdSeriesPoint, useYvUsdCharts } from '@pages/vaults/hooks/useYvUsdCharts'
+import { YVUSD_CHAIN_ID, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { cl, SELECTOR_BAR_STYLES } from '@shared/utils'
 import type { ReactElement } from 'react'
-import { useState } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useState } from 'react'
 import { ChartErrorBoundary } from './charts/ChartErrorBoundary'
 import ChartSkeleton from './charts/ChartSkeleton'
 import ChartsLoader from './charts/ChartsLoader'
@@ -9,7 +11,12 @@ import { FixedHeightChartContainer } from './charts/FixedHeightChartContainer'
 import { YvUsdApyChart, YvUsdChartLegend, YvUsdPerformanceChart, YvUsdTvlChart } from './charts/YvUsdDualLineChart'
 import { VAULT_CHART_TABS, VAULT_CHART_TIMEFRAME_OPTIONS } from './VaultChartsSection'
 
-export type TYvUsdChartTab = (typeof VAULT_CHART_TABS)[number]['id']
+const VaultTvlGrowthChart = lazy(() =>
+  import('./charts/VaultTvlGrowthChart').then((m) => ({ default: m.VaultTvlGrowthChart }))
+)
+
+type TYvUsdUserChartTab = 'user-position'
+export type TYvUsdChartTab = (typeof VAULT_CHART_TABS)[number]['id'] | TYvUsdUserChartTab
 export type TYvUsdChartTimeframe = (typeof VAULT_CHART_TIMEFRAME_OPTIONS)[number]['value']
 
 type YvUsdChartsSectionProps = {
@@ -20,6 +27,7 @@ type YvUsdChartsSectionProps = {
   shouldRenderSelectors?: boolean
   chartHeightPx?: number
   chartHeightMdPx?: number
+  enableUserPositionChart?: boolean
 }
 
 function getActiveChartData({
@@ -73,12 +81,10 @@ export function YvUsdChartsSection({
   onTimeframeChange,
   shouldRenderSelectors = true,
   chartHeightPx,
-  chartHeightMdPx
+  chartHeightMdPx,
+  enableUserPositionChart = false
 }: YvUsdChartsSectionProps): ReactElement {
   const { apyData, performanceData, tvlData, isLoading, error } = useYvUsdCharts()
-
-  const chartsLoading = isLoading || !apyData || !performanceData || !tvlData
-  const hasError = Boolean(error)
 
   const [uncontrolledTab, setUncontrolledTab] = useState<TYvUsdChartTab>('historical-apy')
   const [uncontrolledTimeframe, setUncontrolledTimeframe] = useState<TYvUsdChartTimeframe>('1y')
@@ -87,7 +93,44 @@ export function YvUsdChartsSection({
   const activeTimeframe = timeframe ?? uncontrolledTimeframe
   const setActiveTab = onChartTabChange ?? setUncontrolledTab
   const setActiveTimeframe = onTimeframeChange ?? setUncontrolledTimeframe
-  const activeChartData = getActiveChartData({ activeTab, apyData, performanceData, tvlData })
+  const availableTabs = useMemo(
+    () =>
+      enableUserPositionChart
+        ? [...VAULT_CHART_TABS, { id: 'user-position' as const, label: 'Your Position' }]
+        : VAULT_CHART_TABS,
+    [enableUserPositionChart]
+  )
+  const fallbackTab = availableTabs[0]?.id ?? 'historical-apy'
+  const resolvedActiveTab = availableTabs.some((tab) => tab.id === activeTab) ? activeTab : fallbackTab
+  const activeChartData = getActiveChartData({ activeTab: resolvedActiveTab, apyData, performanceData, tvlData })
+  const activeTabIsUserChart = resolvedActiveTab === 'user-position'
+  const {
+    balanceData: userBalanceData,
+    growthData: userGrowthData,
+    isLoading: isUserHistoryLoading,
+    isEmpty: isUserHistoryEmpty,
+    error: userHistoryError
+  } = useVaultUserHistory({
+    vaults: [
+      { chainId: YVUSD_CHAIN_ID, vaultAddress: YVUSD_UNLOCKED_ADDRESS },
+      { chainId: YVUSD_CHAIN_ID, vaultAddress: YVUSD_LOCKED_ADDRESS }
+    ],
+    timeframe: activeTimeframe,
+    enabled: enableUserPositionChart && activeTabIsUserChart,
+    valueMode: 'usd'
+  })
+  const yvUsdChartsLoading = isLoading || !apyData || !performanceData || !tvlData
+  const chartsLoading = activeTabIsUserChart ? isUserHistoryLoading : yvUsdChartsLoading
+  const hasError = Boolean(activeTabIsUserChart ? userHistoryError : error)
+  const showUserEmptyState = activeTabIsUserChart && !chartsLoading && !hasError && isUserHistoryEmpty
+
+  useEffect(() => {
+    if (resolvedActiveTab === activeTab) {
+      return
+    }
+
+    setActiveTab(resolvedActiveTab)
+  }, [activeTab, resolvedActiveTab, setActiveTab])
 
   return (
     <div className={'space-y-3 md:space-y-4 pt-4 rounded-lg'}>
@@ -95,7 +138,7 @@ export function YvUsdChartsSection({
         <div className={'flex flex-col gap-2 md:gap-3 px-3 md:px-4 md:flex-row md:items-start md:justify-between'}>
           <div className={'flex flex-col'}>
             <div className={cl('flex items-center gap-0.5 md:gap-1 w-full md:w-auto', SELECTOR_BAR_STYLES.container)}>
-              {VAULT_CHART_TABS.map((tab) => (
+              {availableTabs.map((tab) => (
                 <button
                   key={tab.id}
                   type={'button'}
@@ -104,7 +147,7 @@ export function YvUsdChartsSection({
                     'flex-1 md:flex-initial rounded-sm px-2 md:px-3 py-2 md:py-1 text-xs font-semibold transition-all',
                     'min-h-[36px] md:min-h-0 active:scale-[0.98]',
                     SELECTOR_BAR_STYLES.buttonBase,
-                    activeTab === tab.id ? SELECTOR_BAR_STYLES.buttonActive : SELECTOR_BAR_STYLES.buttonInactive
+                    resolvedActiveTab === tab.id ? SELECTOR_BAR_STYLES.buttonActive : SELECTOR_BAR_STYLES.buttonInactive
                   )}
                 >
                   {tab.label}
@@ -143,16 +186,39 @@ export function YvUsdChartsSection({
       ) : chartsLoading ? (
         <div className={'relative'}>
           <ChartSkeleton />
-          <ChartsLoader loadingState={isLoading ? 'Loading charts' : 'Preparing charts'} />
+          <ChartsLoader
+            loadingState={
+              activeTabIsUserChart ? 'Loading your history' : isLoading ? 'Loading charts' : 'Preparing charts'
+            }
+          />
+        </div>
+      ) : showUserEmptyState ? (
+        <div className={'bg-neutral-300 p-6 text-center text-sm text-text-secondary'}>
+          {'No wallet history is available for this vault yet.'}
         </div>
       ) : (
         <div className="space-y-0">
           <FixedHeightChartContainer heightPx={chartHeightPx} heightMdPx={chartHeightMdPx} className={'mx-4'}>
             <ChartErrorBoundary>
-              {renderActiveChart({ activeTab, activeTimeframe, apyData, performanceData, tvlData })}
+              {activeTabIsUserChart ? (
+                userBalanceData || userGrowthData ? (
+                  <Suspense fallback={<ChartSkeleton />}>
+                    <VaultTvlGrowthChart
+                      balanceData={userBalanceData}
+                      growthData={userGrowthData}
+                      timeframe={activeTimeframe}
+                      unitLabel={'USDC'}
+                    />
+                  </Suspense>
+                ) : null
+              ) : (
+                renderActiveChart({ activeTab: resolvedActiveTab, activeTimeframe, apyData, performanceData, tvlData })
+              )}
             </ChartErrorBoundary>
           </FixedHeightChartContainer>
-          {activeChartData ? <YvUsdChartLegend chartData={activeChartData} timeframe={activeTimeframe} /> : null}
+          {!activeTabIsUserChart && activeChartData ? (
+            <YvUsdChartLegend chartData={activeChartData} timeframe={activeTimeframe} />
+          ) : null}
         </div>
       )}
     </div>

--- a/src/components/pages/vaults/components/list/VaultsListRow.tsx
+++ b/src/components/pages/vaults/components/list/VaultsListRow.tsx
@@ -418,7 +418,7 @@ function VaultsListRowComponent({
     </svg>
   )
   const hasHoldings = Boolean(flags?.hasHoldings)
-  const showUserViews = hasHoldings && !isYvUsd
+  const showUserViews = hasHoldings
   const showHoldingsChip = showHoldingsChipOverride ?? hasHoldings
   const showHoldingsValue = hasHoldings
   const holdingsFormatOptions = isYvUsd ? YVUSD_HOLDINGS_FORMAT_OPTIONS : undefined

--- a/src/components/pages/vaults/components/list/VaultsListRowExpandedContent.tsx
+++ b/src/components/pages/vaults/components/list/VaultsListRowExpandedContent.tsx
@@ -19,7 +19,7 @@ import {
   type TKongVaultStrategy
 } from '@pages/vaults/domain/kongVaultSelectors'
 import { useVaultSnapshot } from '@pages/vaults/hooks/useVaultSnapshot'
-import { isYvUsdAddress } from '@pages/vaults/utils/yvUsd'
+import { isYvUsdAddress, YVUSD_CHAIN_ID, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import {
   AllocationChart,
   DARK_MODE_COLORS,
@@ -86,11 +86,22 @@ export default function VaultsListRowExpandedContent({
   })
   const snapshotMergedVault = useMemo(() => getVaultView(currentVault, snapshotVault), [currentVault, snapshotVault])
   const chartTab = isExpandedChartView(expandedView) ? EXPANDED_VIEW_TO_CHART_TAB[expandedView] : undefined
+  const shouldUsePortfolioUserTvlOverlay = chartVariant === 'portfolio-user-tvl-overlay' && showUserViews
   const yvUsdChartTab =
-    chartTab === 'historical-apy' || chartTab === 'historical-pps' || chartTab === 'historical-tvl'
-      ? chartTab
-      : undefined
-  const shouldUsePortfolioUserTvlOverlay = chartVariant === 'portfolio-user-tvl-overlay' && showUserViews && !isYvUsd
+    shouldUsePortfolioUserTvlOverlay && chartTab === 'historical-tvl'
+      ? 'user-position'
+      : chartTab === 'historical-apy' || chartTab === 'historical-pps' || chartTab === 'historical-tvl'
+        ? chartTab
+        : undefined
+  const yvUsdUserHistoryVaults = useMemo(
+    () => [
+      { chainId: YVUSD_CHAIN_ID, vaultAddress: YVUSD_UNLOCKED_ADDRESS },
+      { chainId: YVUSD_CHAIN_ID, vaultAddress: YVUSD_LOCKED_ADDRESS }
+    ],
+    []
+  )
+  const nonYvUsdUserHistoryVaults = useMemo(() => [{ chainId: chainID, vaultAddress }], [chainID, vaultAddress])
+  const vaultUserHistoryVaults = isYvUsd ? yvUsdUserHistoryVaults : nonYvUsdUserHistoryVaults
   const viewOptions = useMemo<Array<{ id: TVaultsExpandedView; label: string }>>(
     () => [
       { id: 'strategies', label: 'Strategies' },
@@ -152,6 +163,7 @@ export default function VaultsListRowExpandedContent({
                   timeframe={chartTimeframe}
                   chartHeightPx={200}
                   chartHeightMdPx={200}
+                  enableUserPositionChart={shouldUsePortfolioUserTvlOverlay}
                 />
               ) : (
                 <VaultChartsSection
@@ -165,6 +177,7 @@ export default function VaultsListRowExpandedContent({
                   enableUserCharts={false}
                   userUnitLabel={snapshotMergedVault.token?.symbol || snapshotMergedVault.symbol || 'assets'}
                   overlayUserPositionOnTvlTab={shouldUsePortfolioUserTvlOverlay}
+                  userHistoryVaults={vaultUserHistoryVaults}
                 />
               )
             ) : (

--- a/src/components/pages/vaults/hooks/useVaultUserHistory.ts
+++ b/src/components/pages/vaults/hooks/useVaultUserHistory.ts
@@ -7,14 +7,17 @@ import { z } from 'zod'
 type TVaultUserHistoryTimeframe = '30d' | '90d' | '1y' | 'all'
 
 type TUseVaultUserHistoryParams = {
-  chainId: number
-  vaultAddress: string
+  chainId?: number
+  vaultAddress?: string
+  vaults?: Array<{ chainId: number; vaultAddress: string }>
   timeframe: TVaultUserHistoryTimeframe
   enabled?: boolean
+  valueMode?: 'underlying' | 'usd'
 }
 
 const vaultUserHistoryPointSchema = z.object({
   date: z.string(),
+  growthWeightUsd: z.number().optional().default(0),
   currentUnderlying: z.number().optional().default(0),
   growthUnderlying: z.number().optional().default(0),
   sharesFormatted: z.number().optional().default(0),
@@ -27,20 +30,66 @@ const vaultUserHistoryResponseSchema = z.object({
   dataPoints: z.array(vaultUserHistoryPointSchema)
 })
 
-export function useVaultUserHistory({ chainId, vaultAddress, timeframe, enabled = true }: TUseVaultUserHistoryParams) {
+const vaultUserBalanceHistoryPointSchema = z.object({
+  date: z.string(),
+  value: z.number().optional().default(0)
+})
+
+const vaultUserBalanceHistoryResponseSchema = z.object({
+  address: z.string(),
+  denomination: z.enum(['usd', 'eth']).optional().default('usd'),
+  timeframe: z.enum(['1y', 'all']).optional().default('1y'),
+  dataPoints: z.array(vaultUserBalanceHistoryPointSchema)
+})
+
+export function useVaultUserHistory({
+  chainId,
+  vaultAddress,
+  vaults,
+  timeframe,
+  enabled = true,
+  valueMode = 'underlying'
+}: TUseVaultUserHistoryParams) {
   const { address } = useWeb3()
   const apiTimeframe = timeframe === 'all' ? 'all' : '1y'
+  const vaultFilter = useMemo(() => {
+    if (vaults?.length) {
+      return `vaults=${vaults
+        .map((vault) => `${vault.chainId}:${vault.vaultAddress}`)
+        .map(encodeURIComponent)
+        .join(',')}`
+    }
 
-  const endpoint = useMemo(() => {
-    if (!enabled || !address || !vaultAddress || !Number.isInteger(chainId)) {
+    if (!vaultAddress || !Number.isInteger(chainId)) {
       return null
     }
 
-    return `/api/holdings/protocol-return/history?address=${address}&chainId=${chainId}&vault=${vaultAddress}&timeframe=${apiTimeframe}&debug=1&fetchType=parallel`
-  }, [address, apiTimeframe, chainId, enabled, vaultAddress])
+    return `chainId=${chainId}&vault=${vaultAddress}`
+  }, [chainId, vaultAddress, vaults])
 
-  const { data, isLoading, isFetching, error } = useFetch({
-    endpoint,
+  const pnlEndpoint = useMemo(() => {
+    if (!enabled || !address || !vaultFilter) {
+      return null
+    }
+
+    return `/api/holdings/protocol-return/history?address=${address}&${vaultFilter}&timeframe=${apiTimeframe}&debug=1&fetchType=parallel`
+  }, [address, apiTimeframe, enabled, vaultFilter])
+
+  const balanceEndpoint = useMemo(() => {
+    if (valueMode !== 'usd' || !enabled || !address || !vaultFilter) {
+      return null
+    }
+
+    return `/api/holdings/history?address=${address}&${vaultFilter}&denomination=usd&timeframe=${apiTimeframe}&debug=1&fetchType=parallel`
+  }, [address, apiTimeframe, enabled, valueMode, vaultFilter])
+
+  const {
+    data: pnlData,
+    isLoading: isPnlLoading,
+    isFetching: isPnlFetching,
+    error: pnlError
+  } = useFetch({
+    endpoint: pnlEndpoint,
     schema: vaultUserHistoryResponseSchema,
     config: {
       enabled,
@@ -49,30 +98,58 @@ export function useVaultUserHistory({ chainId, vaultAddress, timeframe, enabled 
       timeout: 2 * 60 * 1000
     }
   })
+  const {
+    data: usdBalanceData,
+    isLoading: isBalanceLoading,
+    isFetching: isBalanceFetching,
+    error: balanceError
+  } = useFetch({
+    endpoint: balanceEndpoint,
+    schema: vaultUserBalanceHistoryResponseSchema,
+    config: {
+      enabled: enabled && valueMode === 'usd',
+      cacheDuration: 5 * 60 * 1000,
+      keepPreviousData: false,
+      timeout: 2 * 60 * 1000
+    }
+  })
 
   const balanceData = useMemo<TVaultUserHistoryChartData | null>(() => {
-    if (!data?.dataPoints) {
+    if (valueMode === 'usd') {
+      if (!usdBalanceData?.dataPoints) {
+        return null
+      }
+
+      return usdBalanceData.dataPoints.map((point) => ({
+        date: point.date,
+        value: point.value
+      }))
+    }
+
+    if (!pnlData?.dataPoints) {
       return null
     }
 
-    return data.dataPoints.map((point) => ({
+    return pnlData.dataPoints.map((point) => ({
       date: point.date,
       value: point.currentUnderlying
     }))
-  }, [data])
+  }, [pnlData, usdBalanceData, valueMode])
 
   const growthData = useMemo<TVaultUserHistoryChartData | null>(() => {
-    if (!data?.dataPoints) {
+    if (!pnlData?.dataPoints) {
       return null
     }
 
-    return data.dataPoints.map((point) => ({
+    return pnlData.dataPoints.map((point) => ({
       date: point.date,
-      value: point.growthUnderlying
+      value: valueMode === 'usd' ? point.growthWeightUsd : point.growthUnderlying
     }))
-  }, [data])
+  }, [pnlData, valueMode])
 
-  const isLoadingState = isLoading || isFetching
+  const isLoadingState =
+    isPnlLoading || isPnlFetching || (valueMode === 'usd' && (isBalanceLoading || isBalanceFetching))
+  const error = pnlError ?? (valueMode === 'usd' ? balanceError : null)
   const errorStatus =
     (error as { response?: { status?: number }; status?: number } | null)?.response?.status ??
     (error as { status?: number } | null)?.status

--- a/src/components/pages/vaults/utils/yvUsd.test.ts
+++ b/src/components/pages/vaults/utils/yvUsd.test.ts
@@ -12,8 +12,15 @@ import {
   getYvUsdLockedWithdrawDisplayMode,
   getYvUsdUnderlyingPricePerShare,
   YVUSD_CUSTOM_RISK_SCORE,
+  YVUSD_DECIMALS,
   YVUSD_RISK_SCORE_ITEMS
 } from './yvUsd'
+
+describe('yvUSD token metadata', () => {
+  it('uses Kong vault-share decimals for balance discovery', () => {
+    expect(YVUSD_DECIMALS).toBe(6)
+  })
+})
 
 describe('getWeightedYvUsdApy', () => {
   it('returns the unlocked APY when only unlocked value is present', () => {

--- a/src/components/pages/vaults/utils/yvUsd.ts
+++ b/src/components/pages/vaults/utils/yvUsd.ts
@@ -3,6 +3,7 @@ import { toAddress } from '@shared/utils'
 import { type Address, formatUnits, parseUnits } from 'viem'
 
 export const YVUSD_CHAIN_ID = 1
+export const YVUSD_DECIMALS = 6
 export const YVUSD_UNLOCKED_ADDRESS = toAddress('0x696d02Db93291651ED510704c9b286841d506987') as Address
 export const YVUSD_LOCKED_ADDRESS = toAddress('0xAaaFEa48472f77563961Cdb53291DEDfB46F9040') as Address
 export const YVUSD_LOCKED_ZAP_ADDRESS = toAddress('0x7ba61c8e19414dcB8fe769a7Be63B508C8062bbA') as Address

--- a/src/components/shared/contexts/useWallet.tsx
+++ b/src/components/shared/contexts/useWallet.tsx
@@ -267,7 +267,7 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
       }
     }
     return [cumulatedValueInV2Vaults, cumulatedValueInV3Vaults]
-  }, [allVaults, balances, getPrice, yvUsdLockedSharePrice, yvUsdUnlockedSharePrice])
+  }, [allVaults, balances, getPrice, getVaultHoldingsUsd, yvUsdLockedSharePrice, yvUsdUnlockedSharePrice])
 
   /***************************************************************************
    **	Setup and render the Context provider to use in the app.

--- a/src/components/shared/contexts/useYearn.helper.tsx
+++ b/src/components/shared/contexts/useYearn.helper.tsx
@@ -9,7 +9,7 @@ import {
   type TKongVault
 } from '@pages/vaults/domain/kongVaultSelectors'
 import { getHoldingsAliasVaultAddress } from '@pages/vaults/domain/normalizeVault'
-import { YVUSD_CHAIN_ID, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
+import { YVUSD_CHAIN_ID, YVUSD_DECIMALS, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { useDeepCompareMemo } from '@react-hookz/web'
 import { useTokenList } from '@shared/contexts/WithTokenList'
 import type { TUseBalancesTokens } from '@shared/hooks/useBalances.multichains'
@@ -112,11 +112,17 @@ export function useYearnTokens({
         { chainID: 8453, address: ETH_TOKEN_ADDRESS, decimals: 18, name: 'Ether', symbol: 'ETH' },
         { chainID: 42161, address: ETH_TOKEN_ADDRESS, decimals: 18, name: 'Ether', symbol: 'ETH' },
         { chainID: 747474, address: ETH_TOKEN_ADDRESS, decimals: 18, name: 'Ether', symbol: 'ETH' },
-        { chainID: YVUSD_CHAIN_ID, address: YVUSD_UNLOCKED_ADDRESS, decimals: 18, name: 'yvUSD', symbol: 'yvUSD' },
+        {
+          chainID: YVUSD_CHAIN_ID,
+          address: YVUSD_UNLOCKED_ADDRESS,
+          decimals: YVUSD_DECIMALS,
+          name: 'yvUSD',
+          symbol: 'yvUSD'
+        },
         {
           chainID: YVUSD_CHAIN_ID,
           address: YVUSD_LOCKED_ADDRESS,
-          decimals: 18,
+          decimals: YVUSD_DECIMALS,
           name: 'yvUSD (Locked)',
           symbol: 'yvUSD'
         }


### PR DESCRIPTION
## Description

Adds code to aggregate yvUSD charts to the portfolio page in the expanded rows and to the vault page in the charts section. The chart combines both locked and unlocked user positions and growth.

## Related Issue

adds the same functionality for yvUSD that was implemented for other vaults in #1190 

## Motivation and Context

May yvUSD charts equivalent to other vaults

## How Has This Been Tested?

To test:
- Run tests, build, and preview
- In a wallet with yvUSD balances, confirm that the yvUSD list row element on the portfolio page, when expanded, shows a combined balance and growth chart like the other rows.
- In a wallet with yvUSD balances, make sure the combined balance and growth chart shows up in the charts panel on the yvUSD vault page.
