### PR TITLE
chore: remove kat haircut schedule info

### DIFF
--- a/src/components/pages/vaults/components/table/KatanaApyTooltip.tsx
+++ b/src/components/pages/vaults/components/table/KatanaApyTooltip.tsx
@@ -88,17 +88,6 @@ export function KatanaApyTooltipContent({
             <p className={'-mt-1 mb-2 w-full text-left text-xs text-text-secondary wrap-break-word'}>
               {'Limited time KAT rewards'}
             </p>
-            <p className={'-mt-1 mb-2 w-full text-left text-xs text-text-secondary break-words'}>
-              {'* claimable after 28 days, subject to '}
-              <a
-                href={'https://x.com/katana/status/1961475531188126178'}
-                target={'_blank'}
-                rel={'noopener noreferrer'}
-                className={KATANA_LINK_CLASS}
-              >
-                {'haircut schedule.'}
-              </a>
-            </p>
           </>
         ) : null}
         {hasAppRewards ? (

--- a/src/components/pages/vaults/components/table/KatanaApyTooltip.tsx
+++ b/src/components/pages/vaults/components/table/KatanaApyTooltip.tsx
@@ -136,7 +136,7 @@ export function KatanaApyTooltipContent({
         {hasSteerPoints ? (
           <>
             <div className={'my-2 h-px w-full bg-surface-tertiary/60'} />
-            <p className={'-mt-1 mb-2 w-full text-left text-sm text-text-secondary wrap-break-word whitespace-normal'}>
+            <p className={'-mt-1 mb-2 w-full text-left text-xs text-text-secondary wrap-break-word whitespace-normal'}>
               {'The Steer Points program has concluded.'}
               <a
                 href={'https://app.steer.finance/points'}


### PR DESCRIPTION
## Description

Katana has removed their haircut/vesting schedule for KAT rewards. This PR removes that text from the APY modals

## Motivation and Context

content accuracy and partner request

## How Has This Been Tested?

- locally tested. 
- To test, run `bun run dev` and click on an APY value for a katana vault in the vault list view or on a katana vault page. The modal that pops up should no longer show the "claimable after 28 days, subject to haircut schedule" text.

## Screenshots (if appropriate):
old: 
<img width="584" height="473" alt="image" src="https://github.com/user-attachments/assets/10e759c5-f2af-4b82-aabf-2dca7fe894b1" />
new: 
<img width="732" height="534" alt="image" src="https://github.com/user-attachments/assets/d8985ded-8ed0-4eb1-a24d-628cdc2b0380" />
