### PR TITLE
Port portfolio speedups

### DIFF
--- a/api/lib/holdings/db/connection.ts
+++ b/api/lib/holdings/db/connection.ts
@@ -8,7 +8,11 @@ interface QueryResult<T> {
 }
 
 interface DatabasePool {
-  query: <T = Record<string, unknown>>(text: string, params?: unknown[]) => Promise<QueryResult<T>>
+  query: <T = Record<string, unknown>>(
+    text: string,
+    params?: unknown[],
+    options?: { disableOnFailure?: boolean }
+  ) => Promise<QueryResult<T>>
   end: () => Promise<void>
 }
 
@@ -21,7 +25,11 @@ let pool: DatabasePool | null = null
 let schemaInitializationPromise: Promise<void> | null = null
 let databaseDisabled = false
 
-const DB_QUERY_TIMEOUT_MS = 20_000
+const DEFAULT_DB_QUERY_TIMEOUT_MS = 20_000
+const DB_QUERY_TIMEOUT_MS = (() => {
+  const configuredTimeout = Number(process.env.HOLDINGS_DB_QUERY_TIMEOUT_MS)
+  return Number.isFinite(configuredTimeout) && configuredTimeout > 0 ? configuredTimeout : DEFAULT_DB_QUERY_TIMEOUT_MS
+})()
 const LOCAL_DB_QUERY_TIMEOUT_CODE = 'HOLDINGS_DB_QUERY_TIMEOUT'
 const RETRYABLE_CONNECTION_ERROR_CODES = new Set([
   'ECONNRESET',
@@ -118,12 +126,12 @@ async function createPool(): Promise<DatabasePool | null> {
     const neonPool = new Pool({ connectionString: holdingsConfig.databaseUrl })
 
     return {
-      query: async <T>(text: string, params?: unknown[]) => {
+      query: async <T>(text: string, params?: unknown[], options?: { disableOnFailure?: boolean }) => {
         try {
           const result = await withTimeout(neonPool.query(text, params), DB_QUERY_TIMEOUT_MS, 'Holdings DB query')
           return { rows: result.rows as T[], rowCount: result.rowCount ?? 0 }
         } catch (error) {
-          if (shouldDisableDatabaseOnQueryError(error)) {
+          if (options?.disableOnFailure !== false && shouldDisableDatabaseOnQueryError(error)) {
             disableDatabase('query failure', error)
           }
           throw error
@@ -171,6 +179,22 @@ export async function initializeSchema(): Promise<void> {
     ALTER TABLE holdings_totals ALTER COLUMN version SET DEFAULT 'all';
     ALTER TABLE holdings_totals ALTER COLUMN version SET NOT NULL;
 
+    CREATE TABLE IF NOT EXISTS token_prices (
+      token_key VARCHAR(100) NOT NULL,
+      timestamp INTEGER NOT NULL,
+      price NUMERIC NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW(),
+      PRIMARY KEY (token_key, timestamp)
+    );
+
+    CREATE TABLE IF NOT EXISTS token_price_misses (
+      token_key VARCHAR(100) NOT NULL,
+      timestamp INTEGER NOT NULL,
+      expires_at TIMESTAMP NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW(),
+      PRIMARY KEY (token_key, timestamp)
+    );
+
     CREATE TABLE IF NOT EXISTS rate_limits (
       ip VARCHAR(45) PRIMARY KEY,
       request_count INTEGER DEFAULT 1,
@@ -182,6 +206,17 @@ export async function initializeSchema(): Promise<void> {
       chain_id INTEGER NOT NULL,
       invalidated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
       PRIMARY KEY (vault_address, chain_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS protocol_return_history (
+      user_address_hash VARCHAR(64) NOT NULL,
+      version VARCHAR(8) NOT NULL,
+      timeframe VARCHAR(16) NOT NULL,
+      vault_filter_hash VARCHAR(64) NOT NULL,
+      latest_settled_timestamp INTEGER NOT NULL,
+      response_json JSONB NOT NULL,
+      updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+      PRIMARY KEY (user_address_hash, version, timeframe, vault_filter_hash, latest_settled_timestamp)
     );
 
     CREATE TABLE IF NOT EXISTS holdings_progress (
@@ -197,8 +232,12 @@ export async function initializeSchema(): Promise<void> {
       logs JSONB NOT NULL DEFAULT '[]'::jsonb
     );
 
+    CREATE INDEX IF NOT EXISTS idx_token_prices_token_key ON token_prices(token_key);
+    CREATE INDEX IF NOT EXISTS idx_token_price_misses_token_key ON token_price_misses(token_key);
+    CREATE INDEX IF NOT EXISTS idx_token_price_misses_expires_at ON token_price_misses(expires_at);
     CREATE INDEX IF NOT EXISTS idx_rate_limits_window ON rate_limits(window_start);
     CREATE INDEX IF NOT EXISTS idx_vault_invalidations_time ON vault_invalidations(invalidated_at);
+    CREATE INDEX IF NOT EXISTS idx_protocol_return_history_updated_at ON protocol_return_history(updated_at);
     CREATE INDEX IF NOT EXISTS idx_holdings_progress_updated_at ON holdings_progress(updated_at);
   `
 

--- a/api/lib/holdings/services/cache.test.ts
+++ b/api/lib/holdings/services/cache.test.ts
@@ -10,6 +10,7 @@ vi.mock('../db/connection', () => ({
 
 describe('cache writes', () => {
   beforeEach(() => {
+    vi.resetModules()
     vi.clearAllMocks()
   })
 
@@ -33,5 +34,152 @@ describe('cache writes', () => {
     expect(queryMock).toHaveBeenCalledTimes(2)
     expect(queryMock.mock.calls[0]?.[1]).toHaveLength(1_000)
     expect(queryMock.mock.calls[1]?.[1]).toHaveLength(988)
+  })
+})
+
+describe('price cache lookups', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('loads cached prices with compact array parameters', async () => {
+    const queryMock = vi.fn().mockResolvedValue({
+      rows: [{ token_key: 'ethereum:0xabc', timestamp: 1700000000, price: '1.23' }]
+    })
+
+    isDatabaseEnabledMock.mockReturnValue(true)
+    getPoolMock.mockResolvedValue({
+      query: queryMock,
+      end: vi.fn()
+    })
+
+    const { getCachedPricesForTokenTimestamps } = await import('./cache')
+    const result = await getCachedPricesForTokenTimestamps([
+      { tokenKey: 'ethereum:0xabc', timestamps: [1700000000, 1700003600] }
+    ])
+
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining('unnest($1::text[], $2::integer[])'), [
+      ['ethereum:0xabc', 'ethereum:0xabc'],
+      [1700000000, 1700003600]
+    ])
+    expect(result.get('ethereum:0xabc')?.get(1700000000)).toBe(1.23)
+  })
+
+  it('loads cached price misses with compact array parameters', async () => {
+    const queryMock = vi.fn().mockResolvedValue({
+      rows: [{ token_key: 'ethereum:0xabc', timestamp: 1700000000 }]
+    })
+
+    isDatabaseEnabledMock.mockReturnValue(true)
+    getPoolMock.mockResolvedValue({
+      query: queryMock,
+      end: vi.fn()
+    })
+
+    const { getCachedPriceMissesForTokenTimestamps } = await import('./cache')
+    const result = await getCachedPriceMissesForTokenTimestamps([
+      { tokenKey: 'ethereum:0xabc', timestamps: [1700000000, 1700003600] }
+    ])
+
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining('unnest($1::text[], $2::integer[])'), [
+      ['ethereum:0xabc', 'ethereum:0xabc'],
+      [1700000000, 1700003600]
+    ])
+    expect(result.get('ethereum:0xabc')?.has(1700000000)).toBe(true)
+  })
+})
+
+describe('protocol return history cache', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('loads cached protocol return history by wallet, timeframe, vault filter, and settled timestamp', async () => {
+    const queryMock = vi.fn().mockResolvedValue({
+      rows: [
+        { response_json: { dataPoints: [{ timestamp: 1700000000 }] }, updated_at: new Date('2026-05-11T00:00:00Z') }
+      ]
+    })
+
+    isDatabaseEnabledMock.mockReturnValue(true)
+    getPoolMock.mockResolvedValue({
+      query: queryMock,
+      end: vi.fn()
+    })
+
+    const { getCachedProtocolReturnHistory } = await import('./cache')
+    const result = await getCachedProtocolReturnHistory<{ dataPoints: Array<{ timestamp: number }> }>({
+      userAddress: '0x1111111111111111111111111111111111111111',
+      version: 'all',
+      timeframe: '1y',
+      vaultFilterKey: 'all',
+      latestSettledTimestamp: 1778457599,
+      maxAgeSeconds: 3600
+    })
+
+    expect(queryMock).toHaveBeenCalledWith(expect.stringContaining('FROM protocol_return_history'), [
+      expect.any(String),
+      'all',
+      '1y',
+      expect.any(String),
+      1778457599,
+      3600
+    ])
+    expect(result?.response.dataPoints[0]?.timestamp).toBe(1700000000)
+  })
+
+  it('saves cached protocol return history without disabling the database on write failure', async () => {
+    const queryMock = vi.fn().mockResolvedValue({ rowCount: 1, rows: [] })
+
+    isDatabaseEnabledMock.mockReturnValue(true)
+    getPoolMock.mockResolvedValue({
+      query: queryMock,
+      end: vi.fn()
+    })
+
+    const { saveCachedProtocolReturnHistory } = await import('./cache')
+    await saveCachedProtocolReturnHistory({
+      userAddress: '0x1111111111111111111111111111111111111111',
+      version: 'all',
+      timeframe: '1y',
+      vaultFilterKey: 'all',
+      latestSettledTimestamp: 1778457599,
+      response: { dataPoints: [] }
+    })
+
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO protocol_return_history'),
+      [expect.any(String), 'all', '1y', expect.any(String), 1778457599, JSON.stringify({ dataPoints: [] })],
+      { disableOnFailure: false }
+    )
+  })
+
+  it('serves protocol return history from memory when the database is disabled', async () => {
+    isDatabaseEnabledMock.mockReturnValue(false)
+    getPoolMock.mockResolvedValue(null)
+
+    const { getCachedProtocolReturnHistory, saveCachedProtocolReturnHistory } = await import('./cache')
+    await saveCachedProtocolReturnHistory({
+      userAddress: '0x2222222222222222222222222222222222222222',
+      version: 'all',
+      timeframe: '1y',
+      vaultFilterKey: 'all',
+      latestSettledTimestamp: 1778457599,
+      response: { dataPoints: [{ timestamp: 1778457599 }] }
+    })
+
+    const result = await getCachedProtocolReturnHistory<{ dataPoints: Array<{ timestamp: number }> }>({
+      userAddress: '0x2222222222222222222222222222222222222222',
+      version: 'all',
+      timeframe: '1y',
+      vaultFilterKey: 'all',
+      latestSettledTimestamp: 1778457599,
+      maxAgeSeconds: 3600
+    })
+
+    expect(getPoolMock).not.toHaveBeenCalled()
+    expect(result?.response.dataPoints[0]?.timestamp).toBe(1778457599)
   })
 })

--- a/api/lib/holdings/services/cache.ts
+++ b/api/lib/holdings/services/cache.ts
@@ -1,11 +1,43 @@
 import { createHash } from 'node:crypto'
 import { getPool, isDatabaseEnabled } from '../db/connection'
 import { debugError, debugLog } from './debug'
+import type { VaultVersion } from './graphql'
 
 export interface CachedTotal {
   date: string
   usdValue: number
 }
+
+export interface CachedPrice {
+  tokenKey: string
+  timestamp: number
+  price: number
+}
+
+export interface CachedPriceMiss {
+  tokenKey: string
+  timestamp: number
+}
+
+export interface CachedPriceLookup {
+  tokenKey: string
+  timestamps: number[]
+}
+
+export interface CachedProtocolReturnHistory<TResponse> {
+  response: TResponse
+  updatedAt: Date
+}
+
+type ProtocolReturnHistoryMemoryEntry = {
+  response: unknown
+  updatedAt: Date
+  latestSettledTimestamp: number
+}
+
+const PRICE_MISS_TTL_MS = 7 * 24 * 60 * 60 * 1_000
+const protocolReturnHistoryMemoryCache = new Map<string, ProtocolReturnHistoryMemoryEntry>()
+let protocolReturnHistoryPersistentCacheUnavailable = false
 
 function normalizeUserAddress(userAddress: string): string {
   return userAddress.toLowerCase()
@@ -13,6 +45,67 @@ function normalizeUserAddress(userAddress: string): string {
 
 function getUserAddressCacheKey(userAddress: string): string {
   return createHash('sha256').update(normalizeUserAddress(userAddress)).digest('hex')
+}
+
+function getProtocolReturnVaultFilterCacheKey(vaultFilterKey: string): string {
+  return createHash('sha256').update(vaultFilterKey).digest('hex')
+}
+
+function getProtocolReturnHistoryMemoryCacheKey(args: {
+  userAddressHash: string
+  version: VaultVersion
+  timeframe: string
+  vaultFilterHash: string
+  latestSettledTimestamp: number
+}): string {
+  return [
+    args.userAddressHash,
+    args.version,
+    args.timeframe,
+    args.vaultFilterHash,
+    args.latestSettledTimestamp.toString()
+  ].join(':')
+}
+
+function isMissingProtocolReturnHistoryTableError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code
+  const message = error instanceof Error ? error.message : String(error)
+  return code === '42P01' || message.includes('protocol_return_history')
+}
+
+function chunkItems<T>(items: T[], chunkSize: number): T[][] {
+  return Array.from({ length: Math.ceil(items.length / chunkSize) }, (_value, index) =>
+    items.slice(index * chunkSize, index * chunkSize + chunkSize)
+  )
+}
+
+function normalizeCachedPriceLookups(lookups: CachedPriceLookup[]): CachedPriceLookup[] {
+  const timestampsByToken = lookups.reduce<Map<string, Set<number>>>((result, lookup) => {
+    if (lookup.timestamps.length === 0) {
+      return result
+    }
+
+    const tokenKey = lookup.tokenKey.toLowerCase()
+    const timestampSet = result.get(tokenKey) ?? new Set<number>()
+    lookup.timestamps.forEach((timestamp) => {
+      timestampSet.add(timestamp)
+    })
+    result.set(tokenKey, timestampSet)
+    return result
+  }, new Map())
+
+  return Array.from(timestampsByToken.entries()).map(([tokenKey, timestampSet]) => ({
+    tokenKey,
+    timestamps: Array.from(timestampSet).sort((a, b) => a - b)
+  }))
+}
+
+function countCachedPriceLookupPoints(lookups: CachedPriceLookup[]): number {
+  return lookups.reduce((total, lookup) => total + lookup.timestamps.length, 0)
+}
+
+function parseCacheTimestamp(value: Date | string): Date {
+  return value instanceof Date ? value : new Date(value)
 }
 
 export async function getCachedTotals(
@@ -77,29 +170,23 @@ export async function saveCachedTotals(userAddress: string, version: string, tot
       version,
       rows: totals.length
     })
-    const BATCH_SIZE = 250
+    await Promise.all(
+      chunkItems(totals, 250).map((totalChunk) => {
+        const values = totalChunk.flatMap((total) => [userAddressHash, version, total.date, total.usdValue])
+        const placeholders = totalChunk.map((_total, index) => {
+          const paramIndex = index * 4 + 1
+          return `($${paramIndex}, $${paramIndex + 1}, $${paramIndex + 2}, $${paramIndex + 3})`
+        })
+        const query = `
+          INSERT INTO holdings_totals (user_address_hash, version, date, usd_value)
+          VALUES ${placeholders.join(', ')}
+          ON CONFLICT (user_address_hash, version, date)
+          DO UPDATE SET usd_value = EXCLUDED.usd_value, updated_at = NOW()
+        `
 
-    for (let i = 0; i < totals.length; i += BATCH_SIZE) {
-      const batch = totals.slice(i, i + BATCH_SIZE)
-      const values: unknown[] = []
-      const placeholders: string[] = []
-      let paramIndex = 1
-
-      for (const total of batch) {
-        placeholders.push(`($${paramIndex}, $${paramIndex + 1}, $${paramIndex + 2}, $${paramIndex + 3})`)
-        values.push(userAddressHash, version, total.date, total.usdValue)
-        paramIndex += 4
-      }
-
-      const query = `
-        INSERT INTO holdings_totals (user_address_hash, version, date, usd_value)
-        VALUES ${placeholders.join(', ')}
-        ON CONFLICT (user_address_hash, version, date)
-        DO UPDATE SET usd_value = EXCLUDED.usd_value, updated_at = NOW()
-      `
-
-      await pool.query(query, values)
-    }
+        return pool.query(query, values, { disableOnFailure: false })
+      })
+    )
     debugLog('cache', 'saved cached totals', { rows: totals.length })
     return true
   } catch (error) {
@@ -109,10 +196,478 @@ export async function saveCachedTotals(userAddress: string, version: string, tot
   }
 }
 
+export async function getCachedPrices(
+  tokenKeys: string[],
+  timestamps: number[]
+): Promise<Map<string, Map<number, number>>> {
+  return getCachedPricesForTokenTimestamps(tokenKeys.map((tokenKey) => ({ tokenKey, timestamps })))
+}
+
+export async function getCachedPricesForTokenTimestamps(
+  lookups: CachedPriceLookup[]
+): Promise<Map<string, Map<number, number>>> {
+  const result = new Map<string, Map<number, number>>()
+  const normalizedLookups = normalizeCachedPriceLookups(lookups)
+  const pricePoints = countCachedPriceLookupPoints(normalizedLookups)
+
+  if (!isDatabaseEnabled() || normalizedLookups.length === 0 || pricePoints === 0) {
+    if (normalizedLookups.length > 0 && pricePoints > 0) {
+      debugLog('cache', 'skipping cached prices lookup because database is disabled', {
+        tokenKeys: normalizedLookups.length,
+        pricePoints
+      })
+    }
+    return result
+  }
+
+  const pool = await getPool()
+  if (!pool) {
+    debugLog('cache', 'skipping cached prices lookup because database pool is unavailable', {
+      tokenKeys: normalizedLookups.length,
+      pricePoints
+    })
+    return result
+  }
+
+  try {
+    debugLog('cache', 'loading cached prices', { tokenKeys: normalizedLookups.length, pricePoints })
+    const lookupPairs = normalizedLookups.flatMap((lookup) =>
+      lookup.timestamps.map((timestamp) => ({ tokenKey: lookup.tokenKey, timestamp }))
+    )
+
+    await chunkItems(lookupPairs, 5_000).reduce<Promise<void>>(async (previousPromise, batch) => {
+      await previousPromise
+
+      const tokenKeys = batch.map((pair) => pair.tokenKey)
+      const timestamps = batch.map((pair) => pair.timestamp)
+
+      const query = `
+        WITH requested AS (
+          SELECT *
+          FROM unnest($1::text[], $2::integer[]) AS requested(token_key, price_timestamp)
+        )
+        SELECT token_prices.token_key, token_prices.timestamp, token_prices.price
+        FROM token_prices
+        INNER JOIN requested
+          ON requested.token_key = token_prices.token_key
+          AND requested.price_timestamp = token_prices.timestamp
+      `
+
+      const queryResult = await pool.query<{ token_key: string; timestamp: number; price: string }>(query, [
+        tokenKeys,
+        timestamps
+      ])
+
+      queryResult.rows.forEach((row) => {
+        const tokenPrices = result.get(row.token_key) ?? new Map<number, number>()
+        tokenPrices.set(row.timestamp, parseFloat(row.price))
+        result.set(row.token_key, tokenPrices)
+      })
+    }, Promise.resolve())
+
+    const cachedPoints = Array.from(result.values()).reduce((total, priceMap) => total + priceMap.size, 0)
+    debugLog('cache', 'loaded cached prices', {
+      tokenKeys: result.size,
+      pricePoints: cachedPoints
+    })
+  } catch (error) {
+    console.error('[Cache] Failed to get cached prices:', error)
+    debugError('cache', 'cached prices lookup failed', error, {
+      tokenKeys: normalizedLookups.length,
+      pricePoints
+    })
+  }
+
+  return result
+}
+
+export async function getCachedPriceMisses(
+  tokenKeys: string[],
+  timestamps: number[]
+): Promise<Map<string, Set<number>>> {
+  return getCachedPriceMissesForTokenTimestamps(tokenKeys.map((tokenKey) => ({ tokenKey, timestamps })))
+}
+
+export async function getCachedPriceMissesForTokenTimestamps(
+  lookups: CachedPriceLookup[]
+): Promise<Map<string, Set<number>>> {
+  const result = new Map<string, Set<number>>()
+  const normalizedLookups = normalizeCachedPriceLookups(lookups)
+  const pricePoints = countCachedPriceLookupPoints(normalizedLookups)
+
+  if (!isDatabaseEnabled() || normalizedLookups.length === 0 || pricePoints === 0) {
+    if (normalizedLookups.length > 0 && pricePoints > 0) {
+      debugLog('cache', 'skipping cached price misses lookup because database is disabled', {
+        tokenKeys: normalizedLookups.length,
+        pricePoints
+      })
+    }
+    return result
+  }
+
+  const pool = await getPool()
+  if (!pool) {
+    debugLog('cache', 'skipping cached price misses lookup because database pool is unavailable', {
+      tokenKeys: normalizedLookups.length,
+      pricePoints
+    })
+    return result
+  }
+
+  try {
+    debugLog('cache', 'loading cached price misses', { tokenKeys: normalizedLookups.length, pricePoints })
+    const lookupPairs = normalizedLookups.flatMap((lookup) =>
+      lookup.timestamps.map((timestamp) => ({ tokenKey: lookup.tokenKey, timestamp }))
+    )
+
+    await chunkItems(lookupPairs, 5_000).reduce<Promise<void>>(async (previousPromise, batch) => {
+      await previousPromise
+
+      const tokenKeys = batch.map((pair) => pair.tokenKey)
+      const timestamps = batch.map((pair) => pair.timestamp)
+
+      const query = `
+        WITH requested AS (
+          SELECT *
+          FROM unnest($1::text[], $2::integer[]) AS requested(token_key, price_timestamp)
+        )
+        SELECT token_price_misses.token_key, token_price_misses.timestamp
+        FROM token_price_misses
+        INNER JOIN requested
+          ON requested.token_key = token_price_misses.token_key
+          AND requested.price_timestamp = token_price_misses.timestamp
+        WHERE token_price_misses.expires_at > NOW()
+      `
+
+      const queryResult = await pool.query<{ token_key: string; timestamp: number }>(query, [tokenKeys, timestamps])
+
+      queryResult.rows.forEach((row) => {
+        const tokenMisses = result.get(row.token_key) ?? new Set<number>()
+        tokenMisses.add(row.timestamp)
+        result.set(row.token_key, tokenMisses)
+      })
+    }, Promise.resolve())
+
+    const cachedMissPoints = Array.from(result.values()).reduce((total, timestampSet) => total + timestampSet.size, 0)
+    debugLog('cache', 'loaded cached price misses', {
+      tokenKeys: result.size,
+      missPoints: cachedMissPoints
+    })
+  } catch (error) {
+    console.error('[Cache] Failed to get cached price misses:', error)
+    debugError('cache', 'cached price misses lookup failed', error, {
+      tokenKeys: normalizedLookups.length,
+      pricePoints
+    })
+  }
+
+  return result
+}
+
+export async function saveCachedPrices(prices: CachedPrice[]): Promise<void> {
+  if (!isDatabaseEnabled() || prices.length === 0) {
+    if (prices.length > 0) {
+      debugLog('cache', 'skipping cached prices save because database is disabled', { rows: prices.length })
+    }
+    return
+  }
+
+  const pool = await getPool()
+  if (!pool) {
+    debugLog('cache', 'skipping cached prices save because database pool is unavailable', { rows: prices.length })
+    return
+  }
+
+  try {
+    debugLog('cache', 'saving cached prices', { rows: prices.length })
+    await Promise.all(
+      chunkItems(prices, 1_000).map((priceChunk) => {
+        const values = priceChunk.flatMap((price) => [price.tokenKey, price.timestamp, price.price])
+        const placeholders = priceChunk.map((_price, index) => {
+          const paramIndex = index * 3 + 1
+          return `($${paramIndex}, $${paramIndex + 1}, $${paramIndex + 2})`
+        })
+        const query = `
+          INSERT INTO token_prices (token_key, timestamp, price)
+          VALUES ${placeholders.join(', ')}
+          ON CONFLICT (token_key, timestamp) DO NOTHING
+        `
+
+        return pool.query(query, values, { disableOnFailure: false })
+      })
+    )
+    debugLog('cache', 'saved cached prices', { rows: prices.length })
+  } catch (error) {
+    console.error('[Cache] Failed to save prices:', error)
+    debugError('cache', 'cached prices save failed', error, { rows: prices.length })
+  }
+}
+
+export async function saveCachedPriceMisses(priceMisses: CachedPriceMiss[]): Promise<void> {
+  if (!isDatabaseEnabled() || priceMisses.length === 0) {
+    if (priceMisses.length > 0) {
+      debugLog('cache', 'skipping cached price misses save because database is disabled', { rows: priceMisses.length })
+    }
+    return
+  }
+
+  const pool = await getPool()
+  if (!pool) {
+    debugLog('cache', 'skipping cached price misses save because database pool is unavailable', {
+      rows: priceMisses.length
+    })
+    return
+  }
+
+  try {
+    debugLog('cache', 'saving cached price misses', { rows: priceMisses.length })
+    const expiresAt = new Date(Date.now() + PRICE_MISS_TTL_MS)
+    await Promise.all(
+      chunkItems(priceMisses, 1_000).map((priceMissChunk) => {
+        const values = priceMissChunk.flatMap((priceMiss) => [priceMiss.tokenKey, priceMiss.timestamp, expiresAt])
+        const placeholders = priceMissChunk.map((_priceMiss, index) => {
+          const paramIndex = index * 3 + 1
+          return `($${paramIndex}, $${paramIndex + 1}, $${paramIndex + 2})`
+        })
+        const query = `
+          INSERT INTO token_price_misses (token_key, timestamp, expires_at)
+          VALUES ${placeholders.join(', ')}
+          ON CONFLICT (token_key, timestamp)
+          DO UPDATE SET expires_at = GREATEST(token_price_misses.expires_at, EXCLUDED.expires_at)
+        `
+
+        return pool.query(query, values, { disableOnFailure: false })
+      })
+    )
+    debugLog('cache', 'saved cached price misses', { rows: priceMisses.length })
+  } catch (error) {
+    console.error('[Cache] Failed to save price misses:', error)
+    debugError('cache', 'cached price misses save failed', error, { rows: priceMisses.length })
+  }
+}
+
+export async function getCachedProtocolReturnHistory<TResponse>(args: {
+  userAddress: string
+  version: VaultVersion
+  timeframe: string
+  vaultFilterKey: string
+  latestSettledTimestamp: number
+  maxAgeSeconds: number
+}): Promise<CachedProtocolReturnHistory<TResponse> | null> {
+  const userAddressHash = getUserAddressCacheKey(args.userAddress)
+  const vaultFilterHash = getProtocolReturnVaultFilterCacheKey(args.vaultFilterKey)
+  const memoryCacheKey = getProtocolReturnHistoryMemoryCacheKey({
+    userAddressHash,
+    version: args.version,
+    timeframe: args.timeframe,
+    vaultFilterHash,
+    latestSettledTimestamp: args.latestSettledTimestamp
+  })
+  const memoryEntry = protocolReturnHistoryMemoryCache.get(memoryCacheKey)
+  const memoryEntryAgeSeconds = memoryEntry ? (Date.now() - memoryEntry.updatedAt.getTime()) / 1_000 : Infinity
+
+  if (memoryEntry && memoryEntryAgeSeconds <= args.maxAgeSeconds) {
+    debugLog('cache', 'loaded cached protocol return history from memory', {
+      userAddressHash,
+      version: args.version,
+      timeframe: args.timeframe,
+      vaultFilterHash,
+      latestSettledTimestamp: args.latestSettledTimestamp,
+      updatedAt: memoryEntry.updatedAt.toISOString()
+    })
+    return {
+      response: memoryEntry.response as TResponse,
+      updatedAt: memoryEntry.updatedAt
+    }
+  }
+
+  if (protocolReturnHistoryPersistentCacheUnavailable) {
+    debugLog('cache', 'skipping protocol return history persistent cache lookup because table is unavailable')
+    return null
+  }
+
+  if (!isDatabaseEnabled()) {
+    debugLog('cache', 'skipping protocol return history cache lookup because database is disabled')
+    return null
+  }
+
+  const pool = await getPool()
+  if (!pool) {
+    debugLog('cache', 'skipping protocol return history cache lookup because database pool is unavailable')
+    return null
+  }
+
+  try {
+    debugLog('cache', 'loading cached protocol return history', {
+      userAddressHash,
+      version: args.version,
+      timeframe: args.timeframe,
+      vaultFilterHash,
+      latestSettledTimestamp: args.latestSettledTimestamp
+    })
+    const result = await pool.query<{ response_json: TResponse | string; updated_at: Date | string }>(
+      `SELECT response_json, updated_at
+       FROM protocol_return_history
+       WHERE user_address_hash = $1
+         AND version = $2
+         AND timeframe = $3
+         AND vault_filter_hash = $4
+         AND latest_settled_timestamp = $5
+         AND updated_at >= NOW() - ($6::integer * INTERVAL '1 second')
+       LIMIT 1`,
+      [userAddressHash, args.version, args.timeframe, vaultFilterHash, args.latestSettledTimestamp, args.maxAgeSeconds]
+    )
+
+    const row = result.rows[0]
+    if (!row) {
+      debugLog('cache', 'cached protocol return history miss', {
+        userAddressHash,
+        version: args.version,
+        timeframe: args.timeframe,
+        vaultFilterHash,
+        latestSettledTimestamp: args.latestSettledTimestamp
+      })
+      return null
+    }
+
+    const response =
+      typeof row.response_json === 'string' ? (JSON.parse(row.response_json) as TResponse) : row.response_json
+    const updatedAt = parseCacheTimestamp(row.updated_at)
+
+    debugLog('cache', 'loaded cached protocol return history', {
+      userAddressHash,
+      version: args.version,
+      timeframe: args.timeframe,
+      vaultFilterHash,
+      latestSettledTimestamp: args.latestSettledTimestamp,
+      updatedAt: updatedAt.toISOString()
+    })
+    protocolReturnHistoryMemoryCache.set(memoryCacheKey, {
+      response,
+      updatedAt,
+      latestSettledTimestamp: args.latestSettledTimestamp
+    })
+    return { response, updatedAt }
+  } catch (error) {
+    if (isMissingProtocolReturnHistoryTableError(error)) {
+      protocolReturnHistoryPersistentCacheUnavailable = true
+    }
+    console.error('[Cache] Failed to get cached protocol return history:', error)
+    debugError('cache', 'cached protocol return history lookup failed', error, {
+      userAddressHash: getUserAddressCacheKey(args.userAddress),
+      version: args.version,
+      timeframe: args.timeframe,
+      latestSettledTimestamp: args.latestSettledTimestamp
+    })
+    return null
+  }
+}
+
+export async function saveCachedProtocolReturnHistory<TResponse>(args: {
+  userAddress: string
+  version: VaultVersion
+  timeframe: string
+  vaultFilterKey: string
+  latestSettledTimestamp: number
+  response: TResponse
+}): Promise<void> {
+  const userAddressHash = getUserAddressCacheKey(args.userAddress)
+  const vaultFilterHash = getProtocolReturnVaultFilterCacheKey(args.vaultFilterKey)
+  const updatedAt = new Date()
+  protocolReturnHistoryMemoryCache.set(
+    getProtocolReturnHistoryMemoryCacheKey({
+      userAddressHash,
+      version: args.version,
+      timeframe: args.timeframe,
+      vaultFilterHash,
+      latestSettledTimestamp: args.latestSettledTimestamp
+    }),
+    {
+      response: args.response,
+      updatedAt,
+      latestSettledTimestamp: args.latestSettledTimestamp
+    }
+  )
+
+  if (protocolReturnHistoryPersistentCacheUnavailable) {
+    debugLog('cache', 'skipping protocol return history persistent cache save because table is unavailable')
+    return
+  }
+
+  if (!isDatabaseEnabled()) {
+    debugLog('cache', 'skipping protocol return history cache save because database is disabled')
+    return
+  }
+
+  const pool = await getPool()
+  if (!pool) {
+    debugLog('cache', 'skipping protocol return history cache save because database pool is unavailable')
+    return
+  }
+
+  try {
+    debugLog('cache', 'saving cached protocol return history', {
+      userAddressHash,
+      version: args.version,
+      timeframe: args.timeframe,
+      vaultFilterHash,
+      latestSettledTimestamp: args.latestSettledTimestamp
+    })
+    await pool.query(
+      `INSERT INTO protocol_return_history (
+         user_address_hash,
+         version,
+         timeframe,
+         vault_filter_hash,
+         latest_settled_timestamp,
+         response_json,
+         updated_at
+       )
+       VALUES ($1, $2, $3, $4, $5, $6::jsonb, NOW())
+       ON CONFLICT (user_address_hash, version, timeframe, vault_filter_hash, latest_settled_timestamp)
+       DO UPDATE SET response_json = EXCLUDED.response_json, updated_at = NOW()`,
+      [
+        userAddressHash,
+        args.version,
+        args.timeframe,
+        vaultFilterHash,
+        args.latestSettledTimestamp,
+        JSON.stringify(args.response)
+      ],
+      { disableOnFailure: false }
+    )
+    debugLog('cache', 'saved cached protocol return history', {
+      userAddressHash,
+      version: args.version,
+      timeframe: args.timeframe,
+      vaultFilterHash,
+      latestSettledTimestamp: args.latestSettledTimestamp
+    })
+  } catch (error) {
+    if (isMissingProtocolReturnHistoryTableError(error)) {
+      protocolReturnHistoryPersistentCacheUnavailable = true
+    }
+    console.error('[Cache] Failed to save protocol return history:', error)
+    debugError('cache', 'cached protocol return history save failed', error, {
+      userAddressHash: getUserAddressCacheKey(args.userAddress),
+      version: args.version,
+      timeframe: args.timeframe,
+      latestSettledTimestamp: args.latestSettledTimestamp
+    })
+  }
+}
+
 export async function clearUserCache(userAddress: string, version?: string): Promise<number> {
+  const userAddressHash = getUserAddressCacheKey(userAddress)
+  Array.from(protocolReturnHistoryMemoryCache.keys())
+    .filter((cacheKey) => cacheKey.startsWith(`${userAddressHash}:`))
+    .forEach((cacheKey) => {
+      protocolReturnHistoryMemoryCache.delete(cacheKey)
+    })
+
   if (!isDatabaseEnabled()) {
     debugLog('cache', 'skipping user cache clear because database is disabled', {
-      userAddressHash: getUserAddressCacheKey(userAddress),
+      userAddressHash,
       version: version ?? null
     })
     return 0
@@ -121,14 +676,13 @@ export async function clearUserCache(userAddress: string, version?: string): Pro
   const pool = await getPool()
   if (!pool) {
     debugLog('cache', 'skipping user cache clear because database pool is unavailable', {
-      userAddressHash: getUserAddressCacheKey(userAddress),
+      userAddressHash,
       version: version ?? null
     })
     return 0
   }
 
   try {
-    const userAddressHash = getUserAddressCacheKey(userAddress)
     const result = version
       ? await pool.query('DELETE FROM holdings_totals WHERE user_address_hash = $1 AND version = $2', [
           userAddressHash,

--- a/api/lib/holdings/services/defillama.test.ts
+++ b/api/lib/holdings/services/defillama.test.ts
@@ -6,7 +6,9 @@ import {
   getChainPrefix,
   getHistoricalPriceFetchFailedBatches,
   getPriceAtTimestamp,
-  parseDefiLlamaResponse
+  parseDefiLlamaResponse,
+  resetDefiLlamaProApiAvailabilityForTests,
+  resetHistoricalPriceInflightRequestsForTests
 } from './defillama'
 
 function createBatchResponse(response: DefiLlamaBatchResponse): Response {
@@ -17,6 +19,8 @@ function createBatchResponse(response: DefiLlamaBatchResponse): Response {
 }
 
 afterEach(() => {
+  resetDefiLlamaProApiAvailabilityForTests()
+  resetHistoricalPriceInflightRequestsForTests()
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
   vi.unstubAllEnvs()
@@ -77,6 +81,33 @@ describe('parseDefiLlamaResponse', () => {
     expect(priceMap?.get(1773260095)).toBe(0.9966185770862551)
     expect(priceMap?.get(1700000102)).toBe(0.999211)
     expect(getPriceAtTimestamp(priceMap ?? new Map(), 1773260546)).toBe(0.9966185770862551)
+  })
+
+  it('deduplicates overlapping in-flight historical price requests', async () => {
+    const tokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+    const tokenKey = `ethereum:${tokenAddress}`
+    const timestamp = 1700000000
+    const fetchStub = vi.fn(async () =>
+      createBatchResponse({
+        coins: {
+          [tokenKey]: {
+            symbol: 'USDC',
+            prices: [{ timestamp, price: 1.002, confidence: 0.99 }]
+          }
+        }
+      })
+    )
+
+    vi.stubGlobal('fetch', fetchStub)
+
+    const [firstPrices, secondPrices] = await Promise.all([
+      fetchHistoricalPricesForTokenTimestamps([{ chainId: 1, address: tokenAddress, timestamps: [timestamp] }]),
+      fetchHistoricalPricesForTokenTimestamps([{ chainId: 1, address: tokenAddress, timestamps: [timestamp] }])
+    ])
+
+    expect(fetchStub).toHaveBeenCalledTimes(1)
+    expect(firstPrices.get(tokenKey)?.get(timestamp)).toBe(1.002)
+    expect(secondPrices.get(tokenKey)?.get(timestamp)).toBe(1.002)
   })
 
   it('uses yearn-prices when selected and maps UTC day-end prices back to requested timestamps', async () => {
@@ -678,6 +709,35 @@ describe('parseDefiLlamaResponse', () => {
     )
     expect(secondRequestInit).toEqual({ signal: expect.any(AbortSignal) })
     expect(prices.get('ethereum:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')?.get(1700000000)).toBe(1)
+  })
+
+  it('skips paid DefiLlama requests after an authorization failure', async () => {
+    vi.stubEnv('DEFILLAMA_API_KEY', 'test-llama-key')
+
+    const tokenAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'
+    const fetchStub = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 402 }))
+      .mockImplementation(() =>
+        createBatchResponse({
+          coins: {
+            [`ethereum:${tokenAddress}`]: {
+              symbol: 'USDC',
+              prices: [{ timestamp: 1700000000, price: 1, confidence: 0.99 }]
+            }
+          }
+        })
+      )
+
+    vi.stubGlobal('fetch', fetchStub)
+
+    await fetchHistoricalPrices([{ chainId: 1, address: tokenAddress }], [1700000000])
+    await fetchHistoricalPrices([{ chainId: 1, address: tokenAddress }], [1700000000])
+
+    expect(fetchStub).toHaveBeenCalledTimes(3)
+    expect(new URL(String(fetchStub.mock.calls[0]?.[0])).origin).toBe('https://pro-api.llama.fi')
+    expect(new URL(String(fetchStub.mock.calls[1]?.[0])).origin).toBe('https://coins.llama.fi')
+    expect(new URL(String(fetchStub.mock.calls[2]?.[0])).origin).toBe('https://coins.llama.fi')
   })
 
   it('splits paid GET batches before the request URL grows beyond the configured limit', async () => {

--- a/api/lib/holdings/services/defillama.ts
+++ b/api/lib/holdings/services/defillama.ts
@@ -38,6 +38,8 @@ const YEARN_PRICES_MAX_RANGE_DAYS = 366
 const MAX_REQUESTED_PRICE_DISTANCE_SECONDS = 60 * 60
 const MAX_DAILY_PRICE_DISTANCE_SECONDS = 60 * 60 * 24
 const SPLITTABLE_GET_STATUS_CODES = new Set([414, 431, 505])
+const DISABLE_PRO_API_STATUS_CODES = new Set([401, 402, 403])
+const defillamaProApiAvailability = { isDisabled: false }
 
 type TCoinRequest = { chain: string; address: string; timestamps: number[] }
 type TDefiLlamaFetchTuning = {
@@ -77,10 +79,87 @@ const HISTORICAL_PRICE_FETCH_FAILED_BATCHES = Symbol('historicalPriceFetchFailed
 type THistoricalPriceResult = Map<string, Map<number, number>> & {
   [HISTORICAL_PRICE_FETCH_FAILED_BATCHES]?: number
 }
+type TPendingHistoricalPrice = {
+  promise: Promise<number | null>
+  resolve: (price: number | null) => void
+}
+
+const pendingHistoricalPrices = new Map<string, TPendingHistoricalPrice>()
 
 export function getChainPrefix(chainId: number): string {
   const chain = SUPPORTED_CHAINS.find((c) => c.id === chainId)
   return chain?.defillamaPrefix || 'ethereum'
+}
+
+export function resetDefiLlamaProApiAvailabilityForTests(): void {
+  defillamaProApiAvailability.isDisabled = false
+}
+
+export function resetHistoricalPriceInflightRequestsForTests(): void {
+  pendingHistoricalPrices.forEach((pendingPrice) => {
+    pendingPrice.resolve(null)
+  })
+  pendingHistoricalPrices.clear()
+}
+
+function createPendingHistoricalPrice(): TPendingHistoricalPrice {
+  let resolvePendingPrice: (price: number | null) => void = () => {}
+  const promise = new Promise<number | null>((resolve) => {
+    resolvePendingPrice = resolve
+  })
+
+  return { promise, resolve: resolvePendingPrice }
+}
+
+function getPendingHistoricalPriceKey(tokenKey: string, timestamp: number): string {
+  return `${tokenKey}:${timestamp}`
+}
+
+function claimMissingHistoricalPrices(coins: TCoinRequest[]): {
+  claimedCoins: TCoinRequest[]
+  claimedKeys: string[]
+  pendingPrices: Array<{ tokenKey: string; timestamp: number; promise: Promise<number | null> }>
+} {
+  const claimedKeys: string[] = []
+  const pendingPrices: Array<{ tokenKey: string; timestamp: number; promise: Promise<number | null> }> = []
+  const claimedCoins = coins
+    .map((coin) => {
+      const tokenKey = `${coin.chain}:${coin.address.toLowerCase()}`
+      const claimedTimestamps = coin.timestamps.filter((timestamp) => {
+        const pendingKey = getPendingHistoricalPriceKey(tokenKey, timestamp)
+        const pendingPrice = pendingHistoricalPrices.get(pendingKey)
+
+        if (pendingPrice) {
+          pendingPrices.push({ tokenKey, timestamp, promise: pendingPrice.promise })
+          return false
+        }
+
+        pendingHistoricalPrices.set(pendingKey, createPendingHistoricalPrice())
+        claimedKeys.push(pendingKey)
+        return true
+      })
+
+      return { ...coin, timestamps: claimedTimestamps }
+    })
+    .filter((coin) => coin.timestamps.length > 0)
+
+  return { claimedCoins, claimedKeys, pendingPrices }
+}
+
+function settleClaimedHistoricalPrices(claimedKeys: string[], result: Map<string, Map<number, number>>): void {
+  claimedKeys.forEach((pendingKey) => {
+    const pendingPrice = pendingHistoricalPrices.get(pendingKey)
+
+    if (!pendingPrice) {
+      return
+    }
+
+    const [tokenKey, timestampValue] = pendingKey.split(/:(?=\d+$)/)
+    const timestamp = Number(timestampValue)
+    const price = Number.isFinite(timestamp) ? result.get(tokenKey)?.get(timestamp) : null
+    pendingPrice.resolve(price ?? null)
+    pendingHistoricalPrices.delete(pendingKey)
+  })
 }
 
 function normalizeToUtcDayEnd(timestamp: number): number {
@@ -503,7 +582,7 @@ function buildBatchHistoricalRequests(coins: TCoinRequest[], tuning: TDefiLlamaF
     ]
   }
 
-  if (holdingsConfig.defillamaApiKey.length === 0) {
+  if (holdingsConfig.defillamaApiKey.length === 0 || !tuning.useProApi) {
     return [
       {
         url: buildBatchHistoricalUrl(coins),
@@ -564,6 +643,12 @@ function isSplittableGetError(error: unknown): boolean {
   return status !== null && SPLITTABLE_GET_STATUS_CODES.has(status)
 }
 
+function shouldDisableDefiLlamaProApi(error: unknown): boolean {
+  const errorStatus = (error as Partial<TDefiLlamaError>)?.status
+  const status = typeof errorStatus === 'number' ? errorStatus : null
+  return status !== null && DISABLE_PRO_API_STATUS_CODES.has(status)
+}
+
 function shouldSplitBatchAfterRequestError(error: unknown, tuning: TDefiLlamaFetchTuning): boolean {
   return isSplittableGetError(error) || (tuning.provider === 'yearn-prices' && isTimeoutError(error))
 }
@@ -612,7 +697,7 @@ function getDefiLlamaFetchTuning(providerConfig: THistoricalPriceProviderConfig)
     }
   }
 
-  if (holdingsConfig.defillamaApiKey.length > 0) {
+  if (holdingsConfig.defillamaApiKey.length > 0 && !defillamaProApiAvailability.isDisabled) {
     return {
       provider: 'defillama',
       useProApi: true,
@@ -710,6 +795,21 @@ async function fetchBatch(
           const data = (await response.json()) as DefiLlamaBatchResponse
           return parseDefiLlamaResponse(data, uniqueTimestamps)
         } catch (error) {
+          if (request.variant === 'pro_get' && shouldDisableDefiLlamaProApi(error)) {
+            defillamaProApiAvailability.isDisabled = true
+            debugError('prices', 'disabling DefiLlama Pro API after authorization failure', error, {
+              attempt: attempt + 1,
+              provider: tuning.provider,
+              tokenCount: coinBatch.length,
+              timestampCount: uniqueTimestamps.length,
+              pricePointCount: requestedPricePoints,
+              ...batchDebugSummary,
+              requestVariant: request.variant,
+              requestMethod: request.init.method ?? 'GET',
+              requestUrlLength: request.url.length
+            })
+          }
+
           if (shouldSplitBatchAfterRequestError(error, tuning)) {
             const splitBatch = splitCoinBatch(coinBatch)
 
@@ -845,6 +945,16 @@ export async function fetchHistoricalPricesForTokenTimestamps(
     return result
   }
 
+  const { claimedCoins, claimedKeys, pendingPrices } = claimMissingHistoricalPrices(coins)
+  if (pendingPrices.length > 0) {
+    debugLog('prices', 'waiting on in-flight historical prices', {
+      provider: providerConfig.provider,
+      pendingPoints: pendingPrices.length,
+      claimedPoints: claimedKeys.length,
+      resolution
+    })
+  }
+
   const fetchStats = { successfulBatches: 0, failedBatches: 0 }
   const fetchPriceGroup = async (coinsToFetch: TCoinRequest[]): Promise<void> => {
     const shouldUseRangeRequests = tuning.provider === 'yearn-prices' && shouldUseYearnPricesRangeRequest(coinsToFetch)
@@ -926,7 +1036,26 @@ export async function fetchHistoricalPricesForTokenTimestamps(
     }, Promise.resolve())
   }
 
-  await fetchPriceGroup(coins)
+  try {
+    await fetchPriceGroup(claimedCoins)
+  } finally {
+    settleClaimedHistoricalPrices(claimedKeys, result)
+  }
+
+  if (pendingPrices.length > 0) {
+    const pendingResults = await Promise.all(pendingPrices.map((pendingPrice) => pendingPrice.promise))
+    pendingPrices.forEach((pendingPrice, index) => {
+      const price = pendingResults[index]
+
+      if (price === null) {
+        return
+      }
+
+      const tokenPrices = result.get(pendingPrice.tokenKey) ?? new Map<number, number>()
+      tokenPrices.set(pendingPrice.timestamp, price)
+      result.set(pendingPrice.tokenKey, tokenPrices)
+    })
+  }
 
   if (fetchStats.successfulBatches === 0 && countPricePoints(result) === 0) {
     throw new Error(`Failed to fetch token prices from ${providerConfig.label}`)

--- a/api/lib/holdings/services/pnlSimple.ts
+++ b/api/lib/holdings/services/pnlSimple.ts
@@ -1,6 +1,7 @@
 import { formatUnits } from 'viem'
 import { holdingsConfig } from '../config'
 import type { VaultMetadata } from '../types'
+import { getCachedProtocolReturnHistory, saveCachedProtocolReturnHistory } from './cache'
 import { debugError, debugLog, reportHoldingsProgress } from './debug'
 import {
   fetchHistoricalPricesForTokenTimestamps,
@@ -39,6 +40,7 @@ type TProtocolReturnReceiptKind = 'deposit' | 'transfer_in'
 type TProtocolReturnExitKind = 'withdrawal' | 'transfer_out'
 
 const RECEIPT_PRICE_BUCKET_SECONDS = 24 * 60 * 60
+const PROTOCOL_RETURN_HISTORY_CACHE_MAX_AGE_SECONDS = 60 * 60
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 const ETHEREUM_WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'
 const ETHEREUM_WETH_PRICE_KEY = `${getChainPrefix(1)}:${ETHEREUM_WETH_ADDRESS.toLowerCase()}`
@@ -454,6 +456,22 @@ export function buildReceiptPriceRequests(args: {
 
 function countReceiptPricePoints(requests: TSimpleReceiptPriceRequest[]): number {
   return requests.reduce((total, request) => total + request.timestamps.length, 0)
+}
+
+function getProtocolReturnVaultFilterCacheKey(vaultFilters: TProtocolReturnVaultFilter[] | undefined): string {
+  if (!vaultFilters || vaultFilters.length === 0) {
+    return 'all'
+  }
+
+  return vaultFilters
+    .map((vault) => `${vault.chainId}:${vault.vaultAddress.toLowerCase()}`)
+    .sort()
+    .join(',')
+}
+
+function getLatestSettledProtocolReturnTimestamp(): number {
+  const settledTimestamps = generateDailyTimestamps(1, 1)
+  return toSettledDayTimestamp(settledTimestamps[0] ?? 0)
 }
 
 async function fetchReceiptPrices(requests: TSimpleReceiptPriceRequest[]): Promise<Map<string, Map<number, number>>> {
@@ -1547,17 +1565,28 @@ function getProtocolReturnTimestamps(events: TRawPnlEvent[], timeframe: '1y' | '
 }
 
 function buildTransactionHashesByChain(events: TRawPnlEvent[]): Map<number, string[]> {
-  return events.reduce<Map<number, string[]>>((grouped, event) => {
+  const seenByChain = new Map<number, Set<string>>()
+  const grouped = events.reduce<Map<number, string[]>>((result, event) => {
     const transactionHash = lowerCaseAddress(event.transactionHash)
-    const existing = grouped.get(event.chainId) ?? []
+    const seen = seenByChain.get(event.chainId) ?? new Set<string>()
 
-    if (existing.includes(transactionHash)) {
-      return grouped
+    if (seen.has(transactionHash)) {
+      return result
     }
 
-    grouped.set(event.chainId, [...existing, transactionHash])
-    return grouped
+    if (!seenByChain.has(event.chainId)) {
+      seenByChain.set(event.chainId, seen)
+    }
+
+    seen.add(transactionHash)
+
+    const transactionHashes = result.get(event.chainId) ?? []
+    transactionHashes.push(transactionHash)
+    result.set(event.chainId, transactionHashes)
+    return result
   }, new Map())
+
+  return grouped
 }
 
 async function enrichSimpleHistoryRawEvents(args: {
@@ -1754,73 +1783,76 @@ export function materializeProtocolReturnVaults(args: {
   metadata: Map<string, VaultMetadata>
   ppsData: Map<string, Map<number, number>>
   currentTimestamp: number
+  selectedVaultKeys?: Set<string>
 }): HoldingsPnLSimpleVault[] {
-  return Array.from(args.ledgers.values()).map((ledger) => {
-    const vaultKey = toVaultKey(ledger.chainId, ledger.vaultAddress)
-    const metadata = args.metadata.get(vaultKey)
-    const shareDecimals = metadata?.decimals ?? 18
-    const ppsMap = args.ppsData.get(vaultKey)
-    const currentPps = ppsMap ? getPPS(ppsMap, args.currentTimestamp) : null
-    const currentShares = ledger.lots.reduce((total, lot) => total + lot.shares, ZERO)
-    const sharesFormatted = formatAmount(currentShares, shareDecimals)
-    const currentUnderlying = currentPps === null ? 0 : sharesFormatted * currentPps
-    const unrealizedBaselineUnderlying = ledger.lots.reduce((total, lot) => total + lot.baselineUnderlying, 0)
-    const unrealizedBaselineWeightUsd = ledger.lots.reduce(
-      (total, lot) => total + lot.baselineUnderlying * lot.receiptPriceUsd,
-      0
-    )
-    const currentWeightUsd = ledger.lots.reduce(
-      (total, lot) => total + scaleNumber(currentUnderlying, lot.shares, currentShares) * lot.receiptPriceUsd,
-      0
-    )
-    const unrealizedGrowthUnderlying = currentUnderlying - unrealizedBaselineUnderlying
-    const unrealizedGrowthWeightUsd = currentWeightUsd - unrealizedBaselineWeightUsd
-    const baselineExposureUnderlyingYears = ledger.baselineExposureUnderlyingSeconds / SECONDS_PER_YEAR
-    const baselineExposureWeightUsdYears = ledger.baselineExposureWeightUsdSeconds / SECONDS_PER_YEAR
-    const baselineWeightUsd = ledger.realizedBaselineWeightUsd + unrealizedBaselineWeightUsd
-    const growthWeightUsd = ledger.realizedGrowthWeightUsd + unrealizedGrowthWeightUsd
-    const issues = ledgerIssues({ ledger, metadata, currentPps })
-    const status = vaultStatus(issues)
+  return Array.from(args.ledgers.entries())
+    .filter(([vaultKey]) => (args.selectedVaultKeys ? args.selectedVaultKeys.has(vaultKey) : true))
+    .map(([, ledger]) => {
+      const vaultKey = toVaultKey(ledger.chainId, ledger.vaultAddress)
+      const metadata = args.metadata.get(vaultKey)
+      const shareDecimals = metadata?.decimals ?? 18
+      const ppsMap = args.ppsData.get(vaultKey)
+      const currentPps = ppsMap ? getPPS(ppsMap, args.currentTimestamp) : null
+      const currentShares = ledger.lots.reduce((total, lot) => total + lot.shares, ZERO)
+      const sharesFormatted = formatAmount(currentShares, shareDecimals)
+      const currentUnderlying = currentPps === null ? 0 : sharesFormatted * currentPps
+      const unrealizedBaselineUnderlying = ledger.lots.reduce((total, lot) => total + lot.baselineUnderlying, 0)
+      const unrealizedBaselineWeightUsd = ledger.lots.reduce(
+        (total, lot) => total + lot.baselineUnderlying * lot.receiptPriceUsd,
+        0
+      )
+      const currentWeightUsd = ledger.lots.reduce(
+        (total, lot) => total + scaleNumber(currentUnderlying, lot.shares, currentShares) * lot.receiptPriceUsd,
+        0
+      )
+      const unrealizedGrowthUnderlying = currentUnderlying - unrealizedBaselineUnderlying
+      const unrealizedGrowthWeightUsd = currentWeightUsd - unrealizedBaselineWeightUsd
+      const baselineExposureUnderlyingYears = ledger.baselineExposureUnderlyingSeconds / SECONDS_PER_YEAR
+      const baselineExposureWeightUsdYears = ledger.baselineExposureWeightUsdSeconds / SECONDS_PER_YEAR
+      const baselineWeightUsd = ledger.realizedBaselineWeightUsd + unrealizedBaselineWeightUsd
+      const growthWeightUsd = ledger.realizedGrowthWeightUsd + unrealizedGrowthWeightUsd
+      const issues = ledgerIssues({ ledger, metadata, currentPps })
+      const status = vaultStatus(issues)
 
-    return {
-      chainId: ledger.chainId,
-      vaultAddress: ledger.vaultAddress,
-      status,
-      issues,
-      shares: currentShares.toString(),
-      sharesFormatted,
-      pricePerShare: currentPps ?? 0,
-      currentUnderlying,
-      baselineUnderlying: ledger.realizedBaselineUnderlying + unrealizedBaselineUnderlying,
-      baselineExposureUnderlyingYears,
-      baselineExposureWeightUsdYears,
-      realizedBaselineUnderlying: ledger.realizedBaselineUnderlying,
-      unrealizedBaselineUnderlying,
-      realizedGrowthUnderlying: ledger.realizedGrowthUnderlying,
-      unrealizedGrowthUnderlying,
-      growthUnderlying: ledger.realizedGrowthUnderlying + unrealizedGrowthUnderlying,
-      baselineWeightUsd,
-      growthWeightUsd,
-      realizedGrowthWeightUsd: ledger.realizedGrowthWeightUsd,
-      unrealizedGrowthWeightUsd,
-      protocolReturnPct: protocolReturnPct(growthWeightUsd, baselineWeightUsd),
-      annualizedProtocolReturnPct: annualizedProtocolReturnPct(growthWeightUsd, baselineExposureWeightUsdYears),
-      receiptCount: ledger.receiptCount,
-      exitCount: ledger.exitCount,
-      deposits: ledger.deposits,
-      withdrawals: ledger.withdrawals,
-      transfersIn: ledger.transfersIn,
-      transfersOut: ledger.transfersOut,
-      unmatchedExitShares: ledger.unmatchedExitShares.toString(),
-      unmatchedExitSharesFormatted: formatAmount(ledger.unmatchedExitShares, shareDecimals),
-      metadata: {
-        symbol: metadata?.token.symbol ?? null,
-        decimals: metadata?.decimals ?? 18,
-        assetDecimals: metadata?.token.decimals ?? 18,
-        tokenAddress: metadata?.token.address ?? null
+      return {
+        chainId: ledger.chainId,
+        vaultAddress: ledger.vaultAddress,
+        status,
+        issues,
+        shares: currentShares.toString(),
+        sharesFormatted,
+        pricePerShare: currentPps ?? 0,
+        currentUnderlying,
+        baselineUnderlying: ledger.realizedBaselineUnderlying + unrealizedBaselineUnderlying,
+        baselineExposureUnderlyingYears,
+        baselineExposureWeightUsdYears,
+        realizedBaselineUnderlying: ledger.realizedBaselineUnderlying,
+        unrealizedBaselineUnderlying,
+        realizedGrowthUnderlying: ledger.realizedGrowthUnderlying,
+        unrealizedGrowthUnderlying,
+        growthUnderlying: ledger.realizedGrowthUnderlying + unrealizedGrowthUnderlying,
+        baselineWeightUsd,
+        growthWeightUsd,
+        realizedGrowthWeightUsd: ledger.realizedGrowthWeightUsd,
+        unrealizedGrowthWeightUsd,
+        protocolReturnPct: protocolReturnPct(growthWeightUsd, baselineWeightUsd),
+        annualizedProtocolReturnPct: annualizedProtocolReturnPct(growthWeightUsd, baselineExposureWeightUsdYears),
+        receiptCount: ledger.receiptCount,
+        exitCount: ledger.exitCount,
+        deposits: ledger.deposits,
+        withdrawals: ledger.withdrawals,
+        transfersIn: ledger.transfersIn,
+        transfersOut: ledger.transfersOut,
+        unmatchedExitShares: ledger.unmatchedExitShares.toString(),
+        unmatchedExitSharesFormatted: formatAmount(ledger.unmatchedExitShares, shareDecimals),
+        metadata: {
+          symbol: metadata?.token.symbol ?? null,
+          decimals: metadata?.decimals ?? 18,
+          assetDecimals: metadata?.token.decimals ?? 18,
+          tokenAddress: metadata?.token.address ?? null
+        }
       }
-    }
-  })
+    })
 }
 
 function buildSummary(vaults: HoldingsPnLSimpleVault[]): HoldingsPnLSimpleResponse['summary'] {
@@ -1877,6 +1909,8 @@ export function buildProtocolReturnHistorySeries(args: {
   let previousGrowthWeightUsd = 0
   let previousExposureWeightUsdYears = 0
   let growthIndex: number | null = null
+  const selectedVaultKeys = args.selectedVaultKeys ?? (args.selectedVaultKey ? [args.selectedVaultKey] : [])
+  const selectedVaultKeySet = new Set(selectedVaultKeys)
 
   return args.timestamps.map((timestamp) => {
     while (
@@ -1908,8 +1942,6 @@ export function buildProtocolReturnHistorySeries(args: {
       ppsData: args.ppsData,
       currentTimestamp: timestamp
     })
-    const selectedVaultKeys = args.selectedVaultKeys ?? (args.selectedVaultKey ? [args.selectedVaultKey] : [])
-    const selectedVaultKeySet = new Set(selectedVaultKeys)
     const selectedVaults = selectedVaultKeys.length
       ? vaults.filter((vault) => selectedVaultKeySet.has(toVaultKey(vault.chainId, vault.vaultAddress)))
       : []
@@ -2031,7 +2063,8 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
         ledgers,
         metadata: args.metadata,
         ppsData: args.ppsData,
-        currentTimestamp: timestamp
+        currentTimestamp: timestamp,
+        selectedVaultKeys
       }).map((vault) => [toVaultKey(vault.chainId, vault.vaultAddress), vault] as const)
     )
 
@@ -2105,6 +2138,34 @@ export async function getHoldingsProtocolReturnHistory(
   reportHoldingsProgress(12, 'Fetching historical user data', 'Starting protocol return history')
 
   const requestedVaults = normalizeProtocolReturnVaultFilters(requestedVaultFilters, legacyVaultChainId)
+  const vaultFilterCacheKey = getProtocolReturnVaultFilterCacheKey(requestedVaults)
+  const latestSettledTimestamp = getLatestSettledProtocolReturnTimestamp()
+  const cachedHistory = await getCachedProtocolReturnHistory<HoldingsPnLSimpleHistoryResponse>({
+    userAddress,
+    version,
+    timeframe,
+    vaultFilterKey: vaultFilterCacheKey,
+    latestSettledTimestamp,
+    maxAgeSeconds: PROTOCOL_RETURN_HISTORY_CACHE_MAX_AGE_SECONDS
+  })
+
+  if (cachedHistory) {
+    reportHoldingsProgress(
+      94,
+      'Loaded cached protocol return history',
+      `${cachedHistory.response.dataPoints.length} chart points`
+    )
+    debugLog('protocol-return-history', 'serving cached holdings protocol return history', {
+      version,
+      timeframe,
+      latestSettledTimestamp,
+      updatedAt: cachedHistory.updatedAt.toISOString(),
+      points: cachedHistory.response.dataPoints.length,
+      families: cachedHistory.response.familySeries.length
+    })
+    return cachedHistory.response
+  }
+
   const singleRequestedVault = requestedVaults?.length === 1 ? requestedVaults[0] : undefined
   const settledContext = await getSettledVersionedPpsContext({
     userAddress,
@@ -2254,7 +2315,7 @@ export async function getHoldingsProtocolReturnHistory(
     recommendedGrowthDisplayReason
   })
 
-  return {
+  const response = {
     address: lowerCaseAddress(userAddress),
     version,
     timeframe,
@@ -2271,4 +2332,15 @@ export async function getHoldingsProtocolReturnHistory(
     dataPoints: history,
     familySeries
   }
+
+  saveCachedProtocolReturnHistory({
+    userAddress,
+    version,
+    timeframe,
+    vaultFilterKey: vaultFilterCacheKey,
+    latestSettledTimestamp,
+    response
+  }).catch(() => {})
+
+  return response
 }

--- a/api/lib/holdings/services/progress.test.ts
+++ b/api/lib/holdings/services/progress.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getPoolMock = vi.fn()
+const isDatabaseEnabledMock = vi.fn()
+
+vi.mock('../db/connection', () => ({
+  getPool: getPoolMock,
+  isDatabaseEnabled: isDatabaseEnabledMock
+}))
+
+const PROGRESS_ID = 'portfolio-history:0x0000000000000000000000000000000000000001:usd:1y'
+const WALLET_ADDRESS = '0x0000000000000000000000000000000000000001'
+const MISSING_PROGRESS_TABLE_ERROR = Object.assign(new Error('relation "holdings_progress" does not exist'), {
+  code: '42P01'
+})
+
+function emptyQueryResult() {
+  return { rows: [], rowCount: 0 }
+}
+
+describe('holdings progress persistence', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    isDatabaseEnabledMock.mockReturnValue(true)
+  })
+
+  it('initializes progress storage before reading progress rows', async () => {
+    const state = { schemaInitialized: false }
+    const queryMock = vi.fn(async (queryText: string) => {
+      if (queryText.includes('CREATE TABLE IF NOT EXISTS holdings_progress')) {
+        state.schemaInitialized = true
+        return emptyQueryResult()
+      }
+
+      if (!state.schemaInitialized && queryText.includes('holdings_progress')) {
+        throw MISSING_PROGRESS_TABLE_ERROR
+      }
+
+      if (queryText.includes('SELECT id, route, address, status, progress')) {
+        return {
+          rows: [
+            {
+              id: PROGRESS_ID,
+              route: 'history',
+              address: WALLET_ADDRESS,
+              status: 'running',
+              progress: 42,
+              message: 'Loading portfolio history',
+              detail: null,
+              started_at: new Date('2026-05-13T00:00:00Z'),
+              updated_at: new Date('2026-05-13T00:00:01Z'),
+              logs: []
+            }
+          ],
+          rowCount: 1
+        }
+      }
+
+      return emptyQueryResult()
+    })
+    getPoolMock.mockResolvedValue({ query: queryMock, end: vi.fn() })
+
+    const { getHoldingsProgress } = await import('./progress')
+    const result = await getHoldingsProgress(PROGRESS_ID)
+
+    expect(result?.progress).toBe(42)
+    expect(result?.message).toBe('Loading portfolio history')
+    expect(queryMock.mock.calls[0]?.[0]).toContain('CREATE TABLE IF NOT EXISTS holdings_progress')
+  })
+
+  it('treats a missing progress table as non-fatal when polling progress', async () => {
+    const queryMock = vi.fn(async (queryText: string) => {
+      if (queryText.includes('CREATE TABLE IF NOT EXISTS holdings_progress')) {
+        return emptyQueryResult()
+      }
+
+      if (queryText.includes('holdings_progress')) {
+        throw MISSING_PROGRESS_TABLE_ERROR
+      }
+
+      return emptyQueryResult()
+    })
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    getPoolMock.mockResolvedValue({ query: queryMock, end: vi.fn() })
+
+    const { getHoldingsProgress } = await import('./progress')
+    const result = await getHoldingsProgress(PROGRESS_ID)
+
+    expect(result).toBeNull()
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1)
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('holdings_progress table is unavailable'))
+
+    consoleErrorSpy.mockRestore()
+    consoleWarnSpy.mockRestore()
+  })
+})

--- a/api/lib/holdings/services/progress.ts
+++ b/api/lib/holdings/services/progress.ts
@@ -39,6 +39,26 @@ const PROGRESS_TTL_INTERVAL = '10 minutes'
 const PERSISTED_PROGRESS_CLEANUP_INTERVAL_MS = 60 * 1000
 const MAX_PROGRESS_LOGS = 20
 const persistedProgressCleanupState = { lastCleanupAt: 0 }
+const progressStorageWarningState = { didWarnMissingTable: false }
+const progressSchemaInitializationState: { promise: Promise<boolean> | null } = { promise: null }
+type HoldingsProgressPool = NonNullable<Awaited<ReturnType<typeof getPool>>>
+
+const PROGRESS_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS holdings_progress (
+    id VARCHAR(160) PRIMARY KEY,
+    route VARCHAR(64) NOT NULL,
+    address VARCHAR(42) NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    progress INTEGER NOT NULL,
+    message TEXT NOT NULL,
+    detail TEXT,
+    started_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    logs JSONB NOT NULL DEFAULT '[]'::jsonb
+  );
+
+  CREATE INDEX IF NOT EXISTS idx_holdings_progress_updated_at ON holdings_progress(updated_at);
+`
 
 function isValidProgressId(id: string | null | undefined): id is string {
   return Boolean(id && /^[a-zA-Z0-9:_-]{1,160}$/.test(id))
@@ -51,6 +71,57 @@ function clampProgress(progress: number): number {
   return Math.max(0, Math.min(100, Math.round(progress)))
 }
 
+function isMissingProgressTableError(error: unknown): boolean {
+  const databaseError = error as { code?: unknown; message?: unknown }
+  const code = typeof databaseError.code === 'string' ? databaseError.code : null
+  const message =
+    typeof databaseError.message === 'string'
+      ? databaseError.message
+      : error instanceof Error
+        ? error.message
+        : String(error)
+
+  return code === '42P01' && message.includes('holdings_progress')
+}
+
+function logProgressStorageError(action: string, error: unknown): void {
+  if (isMissingProgressTableError(error)) {
+    if (!progressStorageWarningState.didWarnMissingTable) {
+      progressStorageWarningState.didWarnMissingTable = true
+      console.warn(
+        '[Holdings Progress] holdings_progress table is unavailable; progress polling will return 404 until storage is initialized'
+      )
+    }
+    return
+  }
+
+  console.error(`[Holdings Progress] Failed to ${action}:`, error)
+}
+
+async function getPersistedProgressPool(): Promise<HoldingsProgressPool | null> {
+  if (!isDatabaseEnabled()) {
+    return null
+  }
+
+  const pool = await getPool()
+  if (!pool) {
+    return null
+  }
+
+  if (!progressSchemaInitializationState.promise) {
+    progressSchemaInitializationState.promise = pool
+      .query(PROGRESS_SCHEMA_SQL, undefined, { disableOnFailure: false })
+      .then(() => true)
+      .catch((error) => {
+        progressSchemaInitializationState.promise = null
+        logProgressStorageError('initialize progress storage', error)
+        return false
+      })
+  }
+
+  return (await progressSchemaInitializationState.promise) ? pool : null
+}
+
 async function cleanupPersistedProgressRecords(): Promise<void> {
   const now = Date.now()
   if (now - persistedProgressCleanupState.lastCleanupAt < PERSISTED_PROGRESS_CLEANUP_INTERVAL_MS) {
@@ -58,19 +129,14 @@ async function cleanupPersistedProgressRecords(): Promise<void> {
   }
   persistedProgressCleanupState.lastCleanupAt = now
 
-  if (!isDatabaseEnabled()) {
-    return
-  }
-
-  const pool = await getPool()
+  const pool = await getPersistedProgressPool()
   if (!pool) {
     return
   }
-
   try {
     await pool.query(`DELETE FROM holdings_progress WHERE updated_at < NOW() - INTERVAL '${PROGRESS_TTL_INTERVAL}'`)
   } catch (error) {
-    console.error('[Holdings Progress] Failed to delete stale progress rows:', error)
+    logProgressStorageError('delete stale progress rows', error)
   }
 }
 
@@ -117,15 +183,10 @@ function rowToProgressRecord(row: HoldingsProgressRow): HoldingsProgressRecord {
 }
 
 async function persistProgressRecord(record: HoldingsProgressRecord): Promise<boolean> {
-  if (!isDatabaseEnabled()) {
-    return false
-  }
-
-  const pool = await getPool()
+  const pool = await getPersistedProgressPool()
   if (!pool) {
     return false
   }
-
   try {
     await pool.query(
       `INSERT INTO holdings_progress (
@@ -161,21 +222,16 @@ async function persistProgressRecord(record: HoldingsProgressRecord): Promise<bo
     )
     return true
   } catch (error) {
-    console.error('[Holdings Progress] Failed to save progress row:', error)
+    logProgressStorageError('save progress row', error)
     return false
   }
 }
 
 async function getPersistedProgressRecord(id: string): Promise<HoldingsProgressRecord | null> {
-  if (!isDatabaseEnabled()) {
-    return null
-  }
-
-  const pool = await getPool()
+  const pool = await getPersistedProgressPool()
   if (!pool) {
     return null
   }
-
   try {
     const result = await pool.query<HoldingsProgressRow>(
       `SELECT id, route, address, status, progress, message, detail, started_at, updated_at, logs
@@ -186,7 +242,7 @@ async function getPersistedProgressRecord(id: string): Promise<HoldingsProgressR
     const row = result.rows[0]
     return row ? rowToProgressRecord(row) : null
   } catch (error) {
-    console.error('[Holdings Progress] Failed to get progress row:', error)
+    logProgressStorageError('get progress row', error)
     return null
   }
 }

--- a/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -335,6 +335,7 @@ function PortfolioHistoryChartLoading({
 }): ReactElement {
   const displayedMessage = serverProgress?.message ?? 'Building portfolio history'
   const detail = serverProgress?.detail
+  const isDeterminate = Boolean(serverProgress)
 
   return (
     <div
@@ -345,21 +346,22 @@ function PortfolioHistoryChartLoading({
       <YearnLogoSpinner className={'size-12'} logoClassName={'size-8'} />
       <span>{displayedMessage}</span>
       {detail ? <span className={'text-xs text-text-tertiary'}>{detail}</span> : null}
-      {serverProgress ? (
+      <div
+        className={'h-1.5 w-full max-w-[240px] overflow-hidden rounded-full bg-border'}
+        role={'progressbar'}
+        aria-label={displayedMessage}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={serverProgress?.progress}
+      >
         <div
-          className={'h-1.5 w-full max-w-[240px] overflow-hidden rounded-full bg-border'}
-          role={'progressbar'}
-          aria-label={displayedMessage}
-          aria-valuemin={0}
-          aria-valuemax={100}
-          aria-valuenow={serverProgress.progress}
-        >
-          <div
-            className={'h-full rounded-full bg-primary transition-[width] duration-700 ease-out'}
-            style={{ width: `${serverProgress.progress}%` }}
-          />
-        </div>
-      ) : null}
+          className={cl(
+            'h-full rounded-full bg-primary',
+            isDeterminate ? 'transition-[width] duration-700 ease-out' : 'w-1/2 animate-pulse opacity-70'
+          )}
+          style={serverProgress ? { width: `${serverProgress.progress}%` } : undefined}
+        />
+      </div>
     </div>
   )
 }

--- a/src/components/pages/portfolio/hooks/portfolioDisplayState.test.ts
+++ b/src/components/pages/portfolio/hooks/portfolioDisplayState.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { getPortfolioHistoryDisplayState } from './portfolioDisplayState'
+
+describe('getPortfolioHistoryDisplayState', () => {
+  it('keeps the history chart deferred while holdings are still loading', () => {
+    expect(
+      getPortfolioHistoryDisplayState({
+        isActive: true,
+        isHoldingsLoading: true,
+        hasHoldings: false,
+        balanceHistoryIsLoading: false,
+        balanceHistoryIsEmpty: true,
+        protocolReturnHistoryIsLoading: false,
+        protocolReturnHistoryIsEmpty: true
+      })
+    ).toEqual({
+      hasResolvedNoYearnPositions: false,
+      shouldDeferHistoryChart: true
+    })
+  })
+
+  it('requires both history sources to resolve before showing the no-positions state', () => {
+    expect(
+      getPortfolioHistoryDisplayState({
+        isActive: true,
+        isHoldingsLoading: false,
+        hasHoldings: false,
+        balanceHistoryIsLoading: false,
+        balanceHistoryIsEmpty: true,
+        protocolReturnHistoryIsLoading: false,
+        protocolReturnHistoryIsEmpty: true
+      })
+    ).toEqual({
+      hasResolvedNoYearnPositions: true,
+      shouldDeferHistoryChart: false
+    })
+  })
+
+  it('waits for protocol-return history when holdings exist', () => {
+    expect(
+      getPortfolioHistoryDisplayState({
+        isActive: true,
+        isHoldingsLoading: false,
+        hasHoldings: true,
+        balanceHistoryIsLoading: false,
+        balanceHistoryIsEmpty: false,
+        protocolReturnHistoryIsLoading: true,
+        protocolReturnHistoryIsEmpty: true
+      }).shouldDeferHistoryChart
+    ).toBe(true)
+  })
+})

--- a/src/components/pages/portfolio/hooks/portfolioDisplayState.ts
+++ b/src/components/pages/portfolio/hooks/portfolioDisplayState.ts
@@ -1,0 +1,48 @@
+type TPortfolioHistoryDisplayStateParams = {
+  isActive: boolean
+  isHoldingsLoading: boolean
+  hasHoldings: boolean
+  balanceHistoryIsLoading: boolean
+  balanceHistoryIsEmpty: boolean
+  protocolReturnHistoryIsLoading: boolean
+  protocolReturnHistoryIsEmpty: boolean
+}
+
+export type TPortfolioHistoryDisplayState = {
+  hasResolvedNoYearnPositions: boolean
+  shouldDeferHistoryChart: boolean
+}
+
+export function getPortfolioHistoryDisplayState({
+  isActive,
+  isHoldingsLoading,
+  hasHoldings,
+  balanceHistoryIsLoading,
+  balanceHistoryIsEmpty,
+  protocolReturnHistoryIsLoading,
+  protocolReturnHistoryIsEmpty
+}: TPortfolioHistoryDisplayStateParams): TPortfolioHistoryDisplayState {
+  const hasResolvedNoYearnPositions =
+    isActive &&
+    !isHoldingsLoading &&
+    !hasHoldings &&
+    !balanceHistoryIsLoading &&
+    !protocolReturnHistoryIsLoading &&
+    balanceHistoryIsEmpty &&
+    protocolReturnHistoryIsEmpty
+
+  const isAwaitingNoPositionsConfirmation =
+    !hasHoldings &&
+    !hasResolvedNoYearnPositions &&
+    (balanceHistoryIsLoading || protocolReturnHistoryIsLoading || balanceHistoryIsEmpty || protocolReturnHistoryIsEmpty)
+  const shouldWaitForPositionStats = hasHoldings && protocolReturnHistoryIsLoading
+  const shouldDeferHistoryChart =
+    isActive &&
+    !hasResolvedNoYearnPositions &&
+    (isHoldingsLoading || isAwaitingNoPositionsConfirmation || shouldWaitForPositionStats)
+
+  return {
+    hasResolvedNoYearnPositions,
+    shouldDeferHistoryChart
+  }
+}

--- a/src/components/pages/portfolio/hooks/usePortfolioModel.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioModel.ts
@@ -122,6 +122,7 @@ export function usePortfolioModel(): TPortfolioModel {
     cumulatedValueInV2Vaults,
     cumulatedValueInV3Vaults,
     isLoading: isWalletLoading,
+    isBalanceDiscoveryLoading,
     getBalance,
     getVaultHoldingsUsd,
     balances
@@ -252,7 +253,8 @@ export function usePortfolioModel(): TPortfolioModel {
   }, [visibleHoldingsVaults])
 
   const isSearchingBalances =
-    (isActive || isUserConnecting) && (isWalletLoading || isUserConnecting || isIdentityLoading)
+    (isActive || isUserConnecting) &&
+    (isWalletLoading || isBalanceDiscoveryLoading || isUserConnecting || isIdentityLoading)
   const isHoldingsLoading = (isLoadingVaultList && isActive) || isSearchingBalances
 
   const suggestedVaultCandidates = useMemo(

--- a/src/components/pages/portfolio/index.tsx
+++ b/src/components/pages/portfolio/index.tsx
@@ -1330,7 +1330,10 @@ function PortfolioPage(): ReactElement {
     protocolReturnHistoryIsEmpty: protocolReturnHistoryEmpty
   })
   const displayedHistoryChartTab = hasResolvedNoYearnPositions ? 'balance' : historyChartTab
-  const historyChartProgress = displayedHistoryChartTab === 'balance' ? historyProgress : protocolReturnHistoryProgress
+  const historyChartProgress =
+    displayedHistoryChartTab === 'balance'
+      ? (historyProgress ?? protocolReturnHistoryProgress)
+      : (protocolReturnHistoryProgress ?? historyProgress)
   const historyChartElement = (
     <PortfolioHistoryChart
       balanceData={historyData}

--- a/src/components/pages/portfolio/index.tsx
+++ b/src/components/pages/portfolio/index.tsx
@@ -53,6 +53,7 @@ import {
   resolvePortfolioGrowthDisplayMode
 } from './components/PortfolioHistoryChart'
 import type { TPortfolioVaultGrowthChartMode } from './components/PortfolioVaultGrowthChart'
+import { getPortfolioHistoryDisplayState } from './hooks/portfolioDisplayState'
 import { usePortfolioActivity } from './hooks/usePortfolioActivity'
 import { usePortfolioHistory } from './hooks/usePortfolioHistory'
 import { usePortfolioProtocolReturnHistory } from './hooks/usePortfolioProtocolReturnHistory'
@@ -1319,8 +1320,16 @@ function PortfolioPage(): ReactElement {
     protocolReturnHistoryData
   )
   const isEthGrowthAvailable = Boolean(protocolReturnHistoryData?.some((point) => point.growthWeightEth !== null))
-  const hasNoYearnPositions = model.isActive && !model.isHoldingsLoading && !model.hasHoldings
-  const displayedHistoryChartTab = hasNoYearnPositions ? 'balance' : historyChartTab
+  const { hasResolvedNoYearnPositions, shouldDeferHistoryChart } = getPortfolioHistoryDisplayState({
+    isActive: model.isActive,
+    isHoldingsLoading: model.isHoldingsLoading,
+    hasHoldings: model.hasHoldings,
+    balanceHistoryIsLoading: historyLoading,
+    balanceHistoryIsEmpty: historyEmpty,
+    protocolReturnHistoryIsLoading: protocolReturnHistoryLoading,
+    protocolReturnHistoryIsEmpty: protocolReturnHistoryEmpty
+  })
+  const displayedHistoryChartTab = hasResolvedNoYearnPositions ? 'balance' : historyChartTab
   const historyChartProgress = displayedHistoryChartTab === 'balance' ? historyProgress : protocolReturnHistoryProgress
   const historyChartElement = (
     <PortfolioHistoryChart
@@ -1335,17 +1344,19 @@ function PortfolioPage(): ReactElement {
       onGrowthDisplayModeOverrideChange={setHistoryGrowthDisplayModeOverride}
       vaultGrowthMode={historyVaultGrowthMode}
       onVaultGrowthModeChange={setHistoryVaultGrowthMode}
-      balanceIsLoading={historyLoading}
+      balanceIsLoading={historyLoading || shouldDeferHistoryChart}
       balanceIsEmpty={historyEmpty}
       balanceError={historyError}
-      protocolReturnIsLoading={protocolReturnHistoryLoading}
+      protocolReturnIsLoading={protocolReturnHistoryLoading || shouldDeferHistoryChart}
       protocolReturnIsEmpty={protocolReturnHistoryEmpty}
       protocolReturnError={protocolReturnHistoryError}
       embedded
-      reserveControlSpace={!hasNoYearnPositions}
+      reserveControlSpace={!hasResolvedNoYearnPositions}
       loadingProgress={historyChartProgress}
       className={
-        hasNoYearnPositions ? 'h-full min-h-0 bg-linear-to-b from-surface to-surface-secondary/20' : 'min-h-0 flex-1'
+        hasResolvedNoYearnPositions
+          ? 'h-full min-h-0 bg-linear-to-b from-surface to-surface-secondary/20'
+          : 'min-h-0 flex-1'
       }
     />
   )
@@ -1421,7 +1432,7 @@ function PortfolioPage(): ReactElement {
             {model.isActive ? (
               <div className="flex flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-[0_1px_0_rgba(15,23,42,0.02)]">
                 <div className="grid items-stretch min-[920px]:grid-cols-[minmax(640px,1fr)_minmax(200px,340px)]">
-                  {hasNoYearnPositions ? (
+                  {hasResolvedNoYearnPositions ? (
                     historyChartElement
                   ) : (
                     <PortfolioHistoryChartControls
@@ -1466,7 +1477,7 @@ function PortfolioPage(): ReactElement {
               setSortDirection={model.setSortDirection}
               vaultFlags={model.vaultFlags}
             />
-            <PortfolioSuggestedSection suggestedRows={model.suggestedRows} />
+            {!model.isHoldingsLoading ? <PortfolioSuggestedSection suggestedRows={model.suggestedRows} /> : null}
           </div>
         )
       case 'activity':

--- a/src/components/shared/components/Breadcrumbs.tsx
+++ b/src/components/shared/components/Breadcrumbs.tsx
@@ -20,7 +20,7 @@ export function Breadcrumbs({ items, className }: TBreadcrumbsProps): ReactEleme
     <nav aria-label={'Breadcrumb'} className={cl('flex items-center gap-2 text-sm text-text-secondary', className)}>
       {items.map((item, index) => {
         const isCurrent = item.isCurrent ?? index === lastIndex
-        const key = item.href ?? item.label
+        const itemKey = item.href ? `href-${item.href}` : `label-${item.label}-${isCurrent ? 'current' : 'static'}`
         const content =
           item.href && !isCurrent ? (
             <Link to={item.href} className={'transition-colors hover:text-text-primary'}>
@@ -36,7 +36,7 @@ export function Breadcrumbs({ items, className }: TBreadcrumbsProps): ReactEleme
           )
 
         return (
-          <span key={key} className={'flex items-center gap-2'}>
+          <span key={itemKey} className={'flex items-center gap-2'}>
             {content}
             {index < lastIndex ? <span>{'>'}</span> : null}
           </span>

--- a/src/components/shared/contexts/useWallet.tsx
+++ b/src/components/shared/contexts/useWallet.tsx
@@ -37,6 +37,7 @@ type TWalletContext = {
   getVaultHoldingsUsd: (vault: TKongVaultInput) => number
   balances: TChainTokens
   isLoading: boolean
+  isBalanceDiscoveryLoading: boolean
   cumulatedValueInV2Vaults: number
   cumulatedValueInV3Vaults: number
   onRefresh: (
@@ -52,6 +53,7 @@ const defaultProps = {
   getVaultHoldingsUsd: (): number => 0,
   balances: {},
   isLoading: true,
+  isBalanceDiscoveryLoading: true,
   cumulatedValueInV2Vaults: 0,
   cumulatedValueInV3Vaults: 0,
   onRefresh: async (): Promise<TChainTokens> => ({})
@@ -83,6 +85,7 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
     data: tokensRaw, // Expected to be TDict<TNormalizedBN | undefined>
     onUpdate,
     onUpdateSome,
+    status: balanceStatus,
     isLoading
   } = useBalancesHook({
     tokens: allTokens,
@@ -115,10 +118,13 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
   }, [deferredTokensRaw])
   const isBalancesPending = deferredTokensRaw !== visibleTokensRaw
   const hasVisibleBalances = hasWalletBalanceSnapshot(visibleTokensRaw)
+  const isBalanceQueryPending =
+    Boolean(userAddress) && (isLoadingVaultList || allTokens.length === 0 || balanceStatus === 'unknown')
+  const isBalanceDiscoveryLoading = Boolean(userAddress) && (isLoading || isBalancesPending || isBalanceQueryPending)
   const isWalletLoading = shouldExposeWalletLoading({
     userAddress,
     hasVisibleBalances,
-    isLoading,
+    isLoading: isLoading || isBalanceQueryPending,
     isBalancesPending
   })
 
@@ -279,6 +285,7 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
       getVaultHoldingsUsd,
       balances,
       isLoading: isWalletLoading,
+      isBalanceDiscoveryLoading,
       onRefresh,
       cumulatedValueInV2Vaults,
       cumulatedValueInV3Vaults
@@ -289,6 +296,7 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
       getVaultHoldingsUsd,
       balances,
       isWalletLoading,
+      isBalanceDiscoveryLoading,
       onRefresh,
       cumulatedValueInV2Vaults,
       cumulatedValueInV3Vaults

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,15 +1,14 @@
+import PortfolioPage from '@pages/portfolio/index'
+import VaultsPage from '@pages/vaults/index'
 import type { ReactElement } from 'react'
 import { lazy, Suspense } from 'react'
 import { Navigate, Route, Routes as RouterRoutes } from 'react-router'
 
 // Lazy load all page components
 const HomePage = lazy(() => import('@pages/landing'))
-const PortfolioPage = lazy(() => import('@pages/portfolio/index'))
-const VaultsPage = lazy(() => import('@pages/vaults/index'))
 const VaultsDetailPage = lazy(() => import('@pages/vaults/[chainID]/[address]'))
 const IconListPage = lazy(() => import('@pages/icon-list/index'))
 
-// Loading component
 const PageLoader = (): ReactElement => (
   <div className={'relative flex min-h-dvh flex-col px-4 text-center'}>
     <div className={'mt-[20%] flex h-10 items-center justify-center'}>


### PR DESCRIPTION
## Summary
- Port compatible speed-up work from `45a5cdb3e09d4b5942a92f0d688a14bc507d5200` onto `speed-up` for `feat/progress`.
- Add DB schema/options for non-fatal cache writes plus token price, price-miss, and protocol-return history cache tables.
- Add DefiLlama Pro auth fallback, in-flight historical price de-duplication, protocol-return response caching, and selected-family materialization.
- Keep portfolio loading in balance discovery until holdings/history are resolved, hide suggestions while holdings load, and eager-load portfolio/vault list routes.

## Validation
- `bun run lint:fix`
- `bun run tslint`
- `bunx vitest run api/lib/holdings/services/cache.test.ts api/lib/holdings/services/defillama.test.ts api/lib/holdings/services/pnlSimpleHistory.test.ts src/components/pages/portfolio/hooks/portfolioDisplayState.test.ts`
- `bun run test` was attempted; it failed in untouched existing areas: `YvUsdWithdraw.helpers.test.ts`, `SuggestedVaultCard.test.tsx`, `YearnApps.test.ts`, `VaultVersionToggle.test.tsx` package resolution for `@plausible-analytics/tracker`, plus missing `jsdom` errors.