### PR TITLE
[codex] Fix duplicate yvUSD portfolio suggestions

### DIFF
--- a/scripts/tenderly-vnet-status.test.ts
+++ b/scripts/tenderly-vnet-status.test.ts
@@ -10,8 +10,6 @@ import {
   selectMatchingTenderlyVnet
 } from './tenderly-vnet-status'
 
-const TEST_TX_FROM_ADDRESS = process.env.TENDERLY_TEST_TX_FROM_ADDRESS ?? '0x2222222222222222222222222222222222222222'
-
 describe('tenderly-vnet-status', () => {
   it('defaults to the webops profile', () => {
     expect(
@@ -139,7 +137,7 @@ describe('tenderly-vnet-status', () => {
               createdAtAgeLabel: '8s',
               blockNumber: 24_735_515,
               txHash: '0xb00dc057e50c8926896495cb31717bfa7ab47608673789b4b7b478ec114080cb',
-              from: TEST_TX_FROM_ADDRESS,
+              from: '0x2222222222222222222222222222222222222222',
               to: '0xc56413869c6cdf96496f2b1ef801fedbdfa7ddb0'
             }
           ],

--- a/src/components/pages/portfolio/hooks/usePortfolioModel.helpers.test.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioModel.helpers.test.ts
@@ -1,6 +1,7 @@
+import type { TKongVaultInput } from '@pages/vaults/domain/kongVaultSelectors'
 import { YVUSD_CHAIN_ID, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { describe, expect, it } from 'vitest'
-import { hasYvUsdPortfolioHoldings } from './usePortfolioModel.helpers'
+import { hasYvUsdPortfolioHoldings, resolveYvUsdFollowOnSuggestionVault } from './usePortfolioModel.helpers'
 
 const getVaultKey = (address: string): string => `${YVUSD_CHAIN_ID}_${address}`
 
@@ -15,5 +16,34 @@ describe('hasYvUsdPortfolioHoldings', () => {
 
   it('ignores unrelated vault holdings', () => {
     expect(hasYvUsdPortfolioHoldings(new Set([getVaultKey('0x0000000000000000000000000000000000000001')]))).toBe(false)
+  })
+})
+
+describe('resolveYvUsdFollowOnSuggestionVault', () => {
+  const lockedVault = { chainId: YVUSD_CHAIN_ID, address: YVUSD_LOCKED_ADDRESS } as unknown as TKongVaultInput
+  const unlockedVault = { chainId: YVUSD_CHAIN_ID, address: YVUSD_UNLOCKED_ADDRESS } as unknown as TKongVaultInput
+  const daiVault = {
+    chainId: YVUSD_CHAIN_ID,
+    address: '0x0000000000000000000000000000000000000001'
+  } as unknown as TKongVaultInput
+
+  it('uses unlocked yvUSD when locked yvUSD is already pinned', () => {
+    expect(
+      resolveYvUsdFollowOnSuggestionVault({
+        pinnedVault: lockedVault,
+        candidateVault: lockedVault,
+        unlockedVault
+      })
+    ).toBe(unlockedVault)
+  })
+
+  it('keeps non-yvUSD suggestions unchanged', () => {
+    expect(
+      resolveYvUsdFollowOnSuggestionVault({
+        pinnedVault: lockedVault,
+        candidateVault: daiVault,
+        unlockedVault
+      })
+    ).toBe(daiVault)
   })
 })

--- a/src/components/pages/portfolio/hooks/usePortfolioModel.helpers.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioModel.helpers.ts
@@ -1,3 +1,4 @@
+import { getVaultAddress, type TKongVaultInput } from '@pages/vaults/domain/kongVaultSelectors'
 import { YVUSD_CHAIN_ID, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { toAddress } from '@shared/utils'
 
@@ -9,4 +10,23 @@ export function hasYvUsdPortfolioHoldings(holdingsKeySet: Set<string>): boolean 
   return [YVUSD_UNLOCKED_ADDRESS, YVUSD_LOCKED_ADDRESS].some((address) =>
     holdingsKeySet.has(getChainAddressKey(YVUSD_CHAIN_ID, address))
   )
+}
+
+export function resolveYvUsdFollowOnSuggestionVault({
+  pinnedVault,
+  candidateVault,
+  unlockedVault
+}: {
+  pinnedVault?: TKongVaultInput | null
+  candidateVault: TKongVaultInput
+  unlockedVault?: TKongVaultInput | null
+}): TKongVaultInput {
+  const pinnedAddress = pinnedVault ? getVaultAddress(pinnedVault) : null
+  const candidateAddress = getVaultAddress(candidateVault)
+
+  if (pinnedAddress === YVUSD_LOCKED_ADDRESS && candidateAddress === YVUSD_LOCKED_ADDRESS && unlockedVault) {
+    return unlockedVault
+  }
+
+  return candidateVault
 }

--- a/src/components/pages/portfolio/hooks/usePortfolioModel.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioModel.ts
@@ -39,7 +39,7 @@ import { calculateVaultEstimatedAPY, calculateVaultHistoricalAPY } from '@shared
 import { useCallback, useMemo, useState } from 'react'
 import type { TPortfolioLiveBalanceSnapshot } from '../types/api'
 import { filterVisiblePortfolioHoldings } from './portfolioVisibility'
-import { hasYvUsdPortfolioHoldings } from './usePortfolioModel.helpers'
+import { hasYvUsdPortfolioHoldings, resolveYvUsdFollowOnSuggestionVault } from './usePortfolioModel.helpers'
 
 type THoldingsRow = {
   key: string
@@ -51,13 +51,13 @@ export type TSuggestedItem =
   | {
       type: 'external'
       key: string
-      vault: TKongVault
+      vault: TKongVaultInput
       externalProtocol: string
       underlyingSymbol: string
       matchedChainID: number
     }
-  | { type: 'personalized'; key: string; vault: TKongVault; matchedSymbol: string; matchedChainID: number }
-  | { type: 'generic'; key: string; vault: TKongVault }
+  | { type: 'personalized'; key: string; vault: TKongVaultInput; matchedSymbol: string; matchedChainID: number }
+  | { type: 'generic'; key: string; vault: TKongVaultInput }
 
 export type TPortfolioBlendedMetrics = {
   blendedCurrentAPY: number | null
@@ -374,7 +374,7 @@ export function usePortfolioModel(): TPortfolioModel {
     () => sortedCandidates.filter((vault) => !holdingsKeySet.has(getVaultKey(vault))).slice(0, 4),
     [sortedCandidates, holdingsKeySet]
   )
-  const yvUsdSuggestedVault = allVaults[YVUSD_LOCKED_ADDRESS] ?? allVaults[YVUSD_UNLOCKED_ADDRESS]
+  const yvUsdSuggestedVault = yvUsdLockedVault ?? allVaults[YVUSD_LOCKED_ADDRESS] ?? allVaults[YVUSD_UNLOCKED_ADDRESS]
   const stablecoinHoldingMatch = useMemo(() => getStablecoinHoldingMatch(balances), [balances])
 
   const tokenSuggestions = useTokenSuggestions(holdingsKeySet)
@@ -413,19 +413,30 @@ export function usePortfolioModel(): TPortfolioModel {
           }
         : null
 
+    const getExternalVaultSuggestion = (vault: TKongVault): TKongVaultInput => {
+      return resolveYvUsdFollowOnSuggestionVault({
+        pinnedVault: yvUsdSuggestedVault,
+        candidateVault: vault,
+        unlockedVault: yvUsdUnlockedVault
+      })
+    }
+
     const candidates: { item: TSuggestedItem; vaultKey: string }[] = [
       ...(yvUsdSuggestion ? [yvUsdSuggestion] : []),
-      ...vaultSuggestions.slice(0, 2).map((ext) => ({
-        item: {
-          type: 'external' as const,
-          key: `ext-${getVaultKey(ext.vault)}`,
-          vault: ext.vault,
-          externalProtocol: ext.externalProtocol,
-          underlyingSymbol: ext.underlyingSymbol,
-          matchedChainID: ext.matchedChainID
-        },
-        vaultKey: getVaultKey(ext.vault)
-      })),
+      ...vaultSuggestions.slice(0, 2).map((ext) => {
+        const vault = getExternalVaultSuggestion(ext.vault)
+        return {
+          item: {
+            type: 'external' as const,
+            key: `ext-${getVaultKey(vault)}`,
+            vault,
+            externalProtocol: ext.externalProtocol,
+            underlyingSymbol: ext.underlyingSymbol,
+            matchedChainID: ext.matchedChainID
+          },
+          vaultKey: getVaultKey(vault)
+        }
+      }),
       ...tokenSuggestions.map((ps) => ({
         item: {
           type: 'personalized' as const,
@@ -451,7 +462,15 @@ export function usePortfolioModel(): TPortfolioModel {
       })
       .slice(0, 4)
       .map(({ item }) => item)
-  }, [vaultSuggestions, tokenSuggestions, genericVaults, yvUsdSuggestedVault, holdingsKeySet, stablecoinHoldingMatch])
+  }, [
+    vaultSuggestions,
+    tokenSuggestions,
+    genericVaults,
+    yvUsdSuggestedVault,
+    yvUsdUnlockedVault,
+    holdingsKeySet,
+    stablecoinHoldingMatch
+  ])
 
   const hasHoldings = sortedHoldings.length > 0
   const hasKatanaHoldings = useMemo(

--- a/src/components/pages/vaults/components/SuggestedVaultCard.test.tsx
+++ b/src/components/pages/vaults/components/SuggestedVaultCard.test.tsx
@@ -14,7 +14,8 @@ vi.mock('@pages/vaults/hooks/useVaultApyData', () => ({
 vi.mock('@pages/vaults/hooks/useYvUsdVaults', () => ({
   useYvUsdVaults: () => ({
     metrics: {
-      locked: { apy: 0.09 }
+      locked: { apy: 0.09 },
+      unlocked: { apy: 0.05 }
     }
   })
 }))
@@ -113,7 +114,40 @@ describe('SuggestedVaultCard', () => {
     expect(html).toContain('class="truncate')
   })
 
-  it('uses yvUSD locked presentation for yvUSD suggestions', () => {
+  it('uses yvUSD locked presentation for the locked yvUSD suggestion', () => {
+    vi.mocked(useVaultApyData).mockReturnValue({
+      mode: 'spot',
+      baseForwardApr: 0.1,
+      netApr: 0,
+      rewardsAprSum: 0,
+      isBoosted: false,
+      hasPendleArbRewards: false,
+      hasKelp: false,
+      hasKelpNEngenlayer: false,
+      katanaExtras: undefined,
+      katanaThirtyDayApr: undefined,
+      katanaEstApr: undefined
+    })
+
+    const html = renderCard({
+      ...baseVault,
+      address: YVUSD_LOCKED_ADDRESS,
+      name: 'yvUSD (Locked)',
+      token: {
+        address: YVUSD_UNLOCKED_ADDRESS,
+        symbol: 'yvUSD'
+      }
+    } as unknown as TKongVaultInput)
+
+    expect(html).toContain('yvUSD (14 day lock)')
+    expect(html).toContain('Locked APY')
+    expect(html).toContain('9.00%')
+    expect(html).toContain('/vaults/1/')
+    expect(html).toContain(YVUSD_LOCKED_ADDRESS)
+    expect(html).toContain('yvusd-128.png')
+  })
+
+  it('uses yvUSD unlocked presentation for the unlocked yvUSD suggestion', () => {
     vi.mocked(useVaultApyData).mockReturnValue({
       mode: 'spot',
       baseForwardApr: 0.1,
@@ -138,11 +172,10 @@ describe('SuggestedVaultCard', () => {
       }
     } as unknown as TKongVaultInput)
 
-    expect(html).toContain('yvUSD (14 day lock)')
-    expect(html).toContain('Locked APY')
-    expect(html).toContain('9.00%')
+    expect(html).toContain('yvUSD (Unlocked)')
+    expect(html).toContain('Unlocked APY')
+    expect(html).toContain('5.00%')
     expect(html).toContain('/vaults/1/')
-    expect(html).toContain(YVUSD_LOCKED_ADDRESS)
-    expect(html).toContain('yvusd-128.png')
+    expect(html).toContain(YVUSD_UNLOCKED_ADDRESS)
   })
 })

--- a/src/components/pages/vaults/components/SuggestedVaultCard.tsx
+++ b/src/components/pages/vaults/components/SuggestedVaultCard.tsx
@@ -44,8 +44,13 @@ export function SuggestedVaultCard({
   const vaultCategory = getVaultCategory(vault)
   const yvUsdVaults = useYvUsdVaults()
   const isYvUsd = isYvUsdVault(vault)
-  const vaultName = isYvUsd ? `yvUSD (${YVUSD_LOCKED_COOLDOWN_DAYS} day lock)` : getVaultName(vault)
-  const displayedVaultAddress = isYvUsd ? YVUSD_LOCKED_ADDRESS : vaultAddress
+  const isYvUsdLocked = isYvUsd && vaultAddress === YVUSD_LOCKED_ADDRESS
+  const vaultName = isYvUsd
+    ? isYvUsdLocked
+      ? `yvUSD (${YVUSD_LOCKED_COOLDOWN_DAYS} day lock)`
+      : 'yvUSD (Unlocked)'
+    : getVaultName(vault)
+  const yvUsdApy = isYvUsdLocked ? yvUsdVaults.metrics.locked.apy : yvUsdVaults.metrics.unlocked.apy
 
   const chain = getNetwork(chainID)
   const tokenIcon = isYvUsd
@@ -68,7 +73,7 @@ export function SuggestedVaultCard({
 
   return (
     <Link
-      to={`/vaults/${chainID}/${toAddress(displayedVaultAddress)}`}
+      to={`/vaults/${chainID}/${toAddress(vaultAddress)}`}
       className={
         'group flex h-fit min-h-[156px] flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-[0_12px_32px_rgba(4,8,32,0.05)] transition-all hover:-translate-y-0.5 hover:shadow-[0_18px_36px_rgba(4,8,32,0.12)]'
       }
@@ -109,13 +114,11 @@ export function SuggestedVaultCard({
         <div className={'flex items-end justify-between gap-4'}>
           <div>
             <p className={'text-mobile-label text-xs uppercase tracking-wide text-text-secondary'}>
-              {isYvUsd ? 'Locked APY' : apyLabel}
+              {isYvUsd ? (isYvUsdLocked ? 'Locked APY' : 'Unlocked APY') : apyLabel}
             </p>
             <div className={'mt-0'}>
               {isYvUsd ? (
-                <span className={'text-xl font-bold text-text-primary'}>
-                  {formatApyDisplay(yvUsdVaults.metrics.locked.apy)}
-                </span>
+                <span className={'text-xl font-bold text-text-primary'}>{formatApyDisplay(yvUsdApy)}</span>
               ) : (
                 <VaultForwardAPY
                   currentVault={vault}


### PR DESCRIPTION
## Summary

- keep pinned yvUSD as the locked variant on portfolio suggestions
- show the follow-on yvUSD match as unlocked instead of a second locked-looking card
- render locked and unlocked yvUSD suggestion cards with distinct labels, APY values, and links
- fix the Tenderly status test fixture so the release branch build can typecheck

## Root cause

Portfolio suggestions deduped by vault key, but locked and unlocked yvUSD use different addresses. The pinned card could therefore coexist with a matched yvUSD suggestion, while the card component rendered both variants as locked yvUSD.

## Validation

- bunx vitest run src/components/pages/vaults/components/SuggestedVaultCard.test.tsx
- bunx vitest run src/components/pages/portfolio/hooks/buildVaultSuggestions.test.ts src/components/pages/portfolio/hooks/usePortfolioModel.helpers.test.ts
- bun run build
- Husky lint-staged and tsc passed during commit

## Screenshots

Before:  
<img width="1261" height="258" alt="image" src="https://github.com/user-attachments/assets/6e768cb0-615f-409e-af7f-4e10c5f6584f" />

After: 
<img width="1229" height="257" alt="image" src="https://github.com/user-attachments/assets/74559c4b-4d22-4377-8fde-156c9ce2725a" />

