### PR TITLE
ci: harden pr notification workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,11 +6,13 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout Repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -30,18 +32,19 @@ jobs:
           TELEGRAM_BOT_TOKEN: ${{ secrets.WEBOPS_TG_TOKEN }}
           CHAT_ID: ${{ secrets.WEBOPS_TG_CHAT_ID }}
           TOPIC_ID: ${{ secrets.WEBOPS_TG_PR_MESSAGE_THREAD_ID }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_STATE: ${{ github.event.pull_request.state }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          REVIEWER: ${{ github.event.requested_reviewer.login }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_URL="${{ github.event.pull_request.html_url }}"
-          PR_STATE="${{ github.event.pull_request.state }}"
-          PR_USER="${{ github.event.pull_request.user.login }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          REPO_NAME=$(echo "${{ github.repository }}" | cut -d'/' -f2)
+          REPO_NAME="${REPOSITORY#*/}"
 
-          EVENT_NAME="${{ github.event_name }}"
-          REVIEWER="${{ github.event.requested_reviewer.login }}"
-
-          if [ "$EVENT_NAME" = "pull_request" ] && [ "${{ github.event.action }}" = "review_requested" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$EVENT_ACTION" = "review_requested" ]; then
             STATE_MSG="Review requested from $REVIEWER"
           else
             STATE_MSG="${PR_STATE^}"


### PR DESCRIPTION
## Summary
- scope pull-requests: write to the dependency review job only
- pass PR metadata into the Telegram notification script through environment variables
- avoid direct shell interpolation of PR title/user/url/action fields

## Validation
- ruby YAML parse over changed workflow
- uvx zizmor --offline --min-severity medium on changed workflow: template-injection and excessive-permissions findings are cleared
- remaining zizmor finding is the existing checkout credential persistence warning