### PR TITLE
[codex] Add portfolio Merkl claim all

### DIFF
--- a/src/components/pages/portfolio/index.tsx
+++ b/src/components/pages/portfolio/index.tsx
@@ -33,11 +33,13 @@ import {
   getVaultToken,
   type TKongVault
 } from '@pages/vaults/domain/kongVaultSelectors'
-import { useMerkleRewards } from '@pages/vaults/hooks/rewards/useMerkleRewards'
+import { useClaimMerkleRewards } from '@pages/vaults/hooks/rewards/useClaimMerkleRewards'
+import { buildMerkleRewardKey, useMerkleRewards } from '@pages/vaults/hooks/rewards/useMerkleRewards'
 import { useStakingRewards } from '@pages/vaults/hooks/rewards/useStakingRewards'
 import type { TPossibleSortBy } from '@pages/vaults/hooks/useSortVaults'
 import { resolveNextSingleChainSelection } from '@pages/vaults/utils/chainSelection'
 import { Breadcrumbs } from '@shared/components/Breadcrumbs'
+import { Button } from '@shared/components/Button'
 import { METRIC_VALUE_CLASS, MetricHeader, type TMetricBlock } from '@shared/components/MetricsCard'
 import { SearchBar } from '@shared/components/SearchBar'
 import { SwitchChainPrompt } from '@shared/components/SwitchChainPrompt'
@@ -76,6 +78,7 @@ import { getNetwork } from '@shared/utils/wagmi'
 import type { CSSProperties, ReactElement } from 'react'
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router'
+import { useWriteContract } from 'wagmi'
 import Link from '/src/components/Link'
 import type {
   TGrowthDisplayMode,
@@ -109,6 +112,7 @@ const headingTooltipClassName =
   'rounded-lg border border-border bg-surface-secondary px-2 py-1 text-xs text-text-primary'
 const metricTooltipContentClassName = 'flex max-w-[280px] flex-col gap-1 leading-relaxed'
 const metricCardClassName = 'bg-surface px-5 py-3 md:px-5 md:py-2.5'
+const portfolioRewardClaimButtonClassName = 'w-full md:w-[112px]'
 const PORTFOLIO_TABS = [
   { key: 'positions', label: 'Account Overview' },
   { key: 'activity', label: 'Activity' },
@@ -2261,6 +2265,86 @@ function ChainMerkleRewardsFetcher({
   return null
 }
 
+function getMerkleRewardKeys(groupedRewards: TGroupedMerkleReward[]): string[] {
+  return groupedRewards.flatMap((groupedReward) =>
+    groupedReward.rewards.map((reward) => buildMerkleRewardKey(reward.root, reward.token.address))
+  )
+}
+
+function getMerkleRewardTokenCount(groupedRewards: TGroupedMerkleReward[]): number {
+  return groupedRewards.filter((groupedReward) => groupedReward.totalUnclaimed > 0n).length
+}
+
+function MerkleClaimAllButton({
+  chainData,
+  userAddress,
+  onStartClaim,
+  onSwitchChain
+}: {
+  chainData: TChainRewardData
+  userAddress: `0x${string}`
+  onStartClaim: (step: TransactionStep, merkleRewardKeys: string[], chainId: number) => void
+  onSwitchChain: () => void
+}): ReactElement | null {
+  const currentChainId = useChainId()
+  const { isPending } = useWriteContract()
+  const merkleRewardTokenCount = getMerkleRewardTokenCount(chainData.merkleRewards)
+  const isWrongChain = currentChainId !== chainData.chainId
+
+  const { prepare } = useClaimMerkleRewards({
+    groupedRewards: chainData.merkleRewards,
+    userAddress,
+    chainId: chainData.chainId,
+    enabled: merkleRewardTokenCount > 1
+  })
+
+  const step = useMemo((): TransactionStep | undefined => {
+    if (!prepare.isSuccess || !prepare.data?.request) {
+      return undefined
+    }
+
+    return {
+      prepare,
+      label: 'Claim',
+      confirmMessage: 'Claim all Merkl rewards',
+      successTitle: 'Rewards Claimed',
+      successMessage: 'You claimed all Merkl rewards',
+      showConfetti: true
+    }
+  }, [prepare])
+
+  const handleClaimAll = useCallback(() => {
+    if (isWrongChain) {
+      onSwitchChain()
+      return
+    }
+    if (!step) return
+
+    onStartClaim(step, getMerkleRewardKeys(chainData.merkleRewards), chainData.chainId)
+  }, [chainData.chainId, chainData.merkleRewards, isWrongChain, onStartClaim, onSwitchChain, step])
+
+  if (merkleRewardTokenCount < 2) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="h-px w-full bg-border" />
+      <div className="mt-3 flex justify-end">
+        <Button
+          onClick={handleClaimAll}
+          isDisabled={!isWrongChain && !step}
+          isBusy={isPending}
+          variant={isWrongChain || !step ? 'light' : 'filled'}
+          classNameOverride={cl('yearn--button--nextgen min-h-[36px] px-3', portfolioRewardClaimButtonClassName)}
+        >
+          {isWrongChain ? 'Switch Chain' : 'Claim all'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
 function PortfolioClaimRewardsSection({ isActive, openLoginModal }: TPortfolioClaimRewardsProps): ReactElement {
   const { address: userAddress } = useWeb3()
   const { vaults } = useYearn()
@@ -2491,6 +2575,7 @@ function PortfolioClaimRewardsSection({ isActive, openLoginModal }: TPortfolioCl
                   isFirst={srIdx === 0 && rewardIdx === 0}
                   isAllChainsView={isAllChainsView}
                   onSwitchChain={() => switchChainAsync({ chainId: chainData.chainId })}
+                  claimButtonClassName={portfolioRewardClaimButtonClassName}
                 />
               ))
             )}
@@ -2504,8 +2589,15 @@ function PortfolioClaimRewardsSection({ isActive, openLoginModal }: TPortfolioCl
                 isFirst={idx === 0 && chainData.stakingRewards.length === 0}
                 isAllChainsView={isAllChainsView}
                 onSwitchChain={() => switchChainAsync({ chainId: chainData.chainId })}
+                claimButtonClassName={portfolioRewardClaimButtonClassName}
               />
             ))}
+            <MerkleClaimAllButton
+              chainData={chainData}
+              userAddress={userAddress!}
+              onStartClaim={handleStartClaim}
+              onSwitchChain={() => switchChainAsync({ chainId: chainData.chainId })}
+            />
             {needsSwitchChain(chainData) && (
               <SwitchChainPrompt
                 chainId={chainData.chainId}

--- a/src/components/pages/vaults/components/widget/rewards/MerkleRewardRow.tsx
+++ b/src/components/pages/vaults/components/widget/rewards/MerkleRewardRow.tsx
@@ -17,10 +17,20 @@ type TMerkleRewardRowProps = {
   isFirst?: boolean
   isAllChainsView?: boolean
   onSwitchChain?: () => void
+  claimButtonClassName?: string
 }
 
 export function MerkleRewardRow(props: TMerkleRewardRowProps): ReactElement {
-  const { groupedReward, userAddress, chainId, onStartClaim, isFirst, isAllChainsView, onSwitchChain } = props
+  const {
+    groupedReward,
+    userAddress,
+    chainId,
+    onStartClaim,
+    isFirst,
+    isAllChainsView,
+    onSwitchChain,
+    claimButtonClassName
+  } = props
 
   const currentChainId = useChainId()
   const { isPending } = useWriteContract()
@@ -70,6 +80,7 @@ export function MerkleRewardRow(props: TMerkleRewardRowProps): ReactElement {
       isFirst={isFirst}
       isAllChainsView={isAllChainsView}
       onSwitchChain={onSwitchChain}
+      claimButtonClassName={claimButtonClassName}
     />
   )
 }

--- a/src/components/pages/vaults/components/widget/rewards/RewardRow.tsx
+++ b/src/components/pages/vaults/components/widget/rewards/RewardRow.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@shared/components/Button'
 import { TokenLogo } from '@shared/components/TokenLogo'
+import { cl } from '@shared/utils'
 import { formatAmount, formatUSD } from '@shared/utils/format'
 import type { ReactElement } from 'react'
 
@@ -16,6 +17,7 @@ type TRewardRowProps = {
   isFirst?: boolean
   isAllChainsView?: boolean
   onSwitchChain?: () => void
+  claimButtonClassName?: string
 }
 
 function getTokenLogoUrl(chainId: number, tokenAddress: `0x${string}`): string {
@@ -35,7 +37,8 @@ export function RewardRow(props: TRewardRowProps): ReactElement {
     isClaimReady,
     isFirst,
     isAllChainsView,
-    onSwitchChain
+    onSwitchChain,
+    claimButtonClassName
   } = props
 
   const isWrongChain = currentChainId !== chainId
@@ -69,7 +72,7 @@ export function RewardRow(props: TRewardRowProps): ReactElement {
             isDisabled={!showSwitchChainButton && !canClaim}
             isBusy={isClaimPending}
             variant={buttonVariant}
-            classNameOverride="yearn--button--nextgen w-full md:w-auto"
+            classNameOverride={cl('yearn--button--nextgen w-full md:w-auto', claimButtonClassName)}
           >
             {showSwitchChainButton ? 'Switch Chain' : 'Claim'}
           </Button>

--- a/src/components/pages/vaults/components/widget/rewards/StakingRewardRow.tsx
+++ b/src/components/pages/vaults/components/widget/rewards/StakingRewardRow.tsx
@@ -17,11 +17,21 @@ type TStakingRewardRowProps = {
   isFirst?: boolean
   isAllChainsView?: boolean
   onSwitchChain?: () => void
+  claimButtonClassName?: string
 }
 
 export function StakingRewardRow(props: TStakingRewardRowProps): ReactElement {
-  const { reward, stakingAddress, stakingSource, chainId, onStartClaim, isFirst, isAllChainsView, onSwitchChain } =
-    props
+  const {
+    reward,
+    stakingAddress,
+    stakingSource,
+    chainId,
+    onStartClaim,
+    isFirst,
+    isAllChainsView,
+    onSwitchChain,
+    claimButtonClassName
+  } = props
 
   const currentChainId = useChainId()
   const { isPending } = useWriteContract()
@@ -69,6 +79,7 @@ export function StakingRewardRow(props: TStakingRewardRowProps): ReactElement {
       isFirst={isFirst}
       isAllChainsView={isAllChainsView}
       onSwitchChain={onSwitchChain}
+      claimButtonClassName={claimButtonClassName}
     />
   )
 }

--- a/src/components/pages/vaults/hooks/rewards/useClaimMerkleRewards.ts
+++ b/src/components/pages/vaults/hooks/rewards/useClaimMerkleRewards.ts
@@ -5,17 +5,19 @@ import { MERKLE_DISTRIBUTOR_ADDRESS } from '@shared/utils/constants'
 
 type UseClaimMerkleRewardsParams = {
   groupedReward?: TGroupedMerkleReward
+  groupedRewards?: TGroupedMerkleReward[]
   userAddress?: `0x${string}`
   chainId: number
   enabled?: boolean
 }
 
 export function useClaimMerkleRewards(params: UseClaimMerkleRewardsParams) {
-  const { groupedReward, userAddress, chainId, enabled = true } = params
+  const { groupedReward, groupedRewards, userAddress, chainId, enabled = true } = params
 
-  const hasClaimableRewards = !!groupedReward && groupedReward.totalUnclaimed > 0n
+  const rewardGroups = groupedRewards ?? (groupedReward ? [groupedReward] : [])
+  const rewards = rewardGroups.flatMap((group) => group.rewards)
+  const hasClaimableRewards = rewardGroups.some((group) => group.totalUnclaimed > 0n)
   const isEnabled = enabled && !!userAddress && hasClaimableRewards
-  const rewards = groupedReward?.rewards ?? []
 
   const prepare = useSimulateContract({
     address: MERKLE_DISTRIBUTOR_ADDRESS,


### PR DESCRIPTION
## Summary
- Add a per-chain Merkl Claim all action to the portfolio rewards view.
- Reuse the existing Merkl distributor claim simulation with multiple grouped rewards flattened into one claim payload.
- Align the row Claim buttons and Claim all button width, with a matching divider above Claim all.

## Validation
- bun run tslint
- bun run lint
- bun run build

<img width="1220" height="673" alt="image" src="https://github.com/user-attachments/assets/d4bde640-db19-43a1-837b-511a6e43ef48" />
