### PR TITLE
Harden server fetch upstreams

### DIFF
--- a/api/enso/balances.ts
+++ b/api/enso/balances.ts
@@ -2,6 +2,19 @@ import type { VercelRequest, VercelResponse } from '@vercel/node'
 import { ENSO_BALANCES_CACHE_CONTROL } from './cache'
 
 const ENSO_API_BASE = 'https://api.enso.finance'
+const ENSO_BALANCES_PATH = '/api/v1/wallet/balances'
+const ENSO_API_ORIGIN = new URL(ENSO_API_BASE).origin
+
+function buildEnsoBalancesUrl(params: URLSearchParams): URL {
+  const url = new URL(ENSO_BALANCES_PATH, ENSO_API_BASE)
+  url.search = params.toString()
+
+  if (url.protocol !== 'https:' || url.origin !== ENSO_API_ORIGIN || url.pathname !== ENSO_BALANCES_PATH) {
+    throw new Error('Invalid Enso balances upstream URL')
+  }
+
+  return url
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
@@ -27,9 +40,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       chainId: 'all'
     })
 
-    const url = `${ENSO_API_BASE}/api/v1/wallet/balances?${params}`
+    const ensoUrl = buildEnsoBalancesUrl(params)
 
-    const response = await fetch(url, {
+    const response = await fetch(ensoUrl, {
+      redirect: 'error',
       headers: {
         Authorization: `Bearer ${apiKey}`
       }

--- a/api/enso/route.ts
+++ b/api/enso/route.ts
@@ -1,6 +1,19 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
 
 const ENSO_API_BASE = 'https://api.enso.finance'
+const ENSO_ROUTE_PATH = '/api/v1/shortcuts/route'
+const ENSO_API_ORIGIN = new URL(ENSO_API_BASE).origin
+
+function buildEnsoRouteUrl(params: URLSearchParams): URL {
+  const url = new URL(ENSO_ROUTE_PATH, ENSO_API_BASE)
+  url.search = params.toString()
+
+  if (url.protocol !== 'https:' || url.origin !== ENSO_API_ORIGIN || url.pathname !== ENSO_ROUTE_PATH) {
+    throw new Error('Invalid Enso route upstream URL')
+  }
+
+  return url
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') {
@@ -52,9 +65,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       params.set('routingStrategy', routingStrategy)
     }
 
-    const url = `${ENSO_API_BASE}/api/v1/shortcuts/route?${params}`
+    const ensoUrl = buildEnsoRouteUrl(params)
 
-    const response = await fetch(url, {
+    const response = await fetch(ensoUrl, {
+      redirect: 'error',
       headers: {
         Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json'

--- a/api/lib/holdings/services/defillama.test.ts
+++ b/api/lib/holdings/services/defillama.test.ts
@@ -127,6 +127,7 @@ describe('parseDefiLlamaResponse', () => {
       headers: {
         Authorization: 'Bearer test-yearn-prices-key'
       },
+      redirect: 'error',
       signal: expect.any(AbortSignal)
     })
     expect(prices.get(tokenKey)?.get(requestedTimestamp)).toBe(1.002)
@@ -168,8 +169,30 @@ describe('parseDefiLlamaResponse', () => {
       headers: {
         Authorization: 'Bearer portfolio-test-key'
       },
+      redirect: 'error',
       signal: expect.any(AbortSignal)
     })
+  })
+
+  it('blocks non-HTTPS yearn-prices upstreams before fetching', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubEnv('HOLDINGS_PRICE_PROVIDER', 'yearn-prices')
+    vi.stubEnv('YEARN_PRICES_BASE_URL', 'http://127.0.0.1:8080')
+    vi.stubEnv('YEARN_PRICES_API_KEY', 'test-yearn-prices-key')
+
+    const fetchStub = vi.fn()
+    vi.stubGlobal('fetch', fetchStub)
+
+    await expect(
+      fetchHistoricalPricesForTokenTimestamps([
+        {
+          chainId: 1,
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          timestamps: [1700000000]
+        }
+      ])
+    ).rejects.toThrow('Failed to fetch token prices from yearn-prices')
+    expect(fetchStub).not.toHaveBeenCalled()
   })
 
   it('uses yearn-prices range requests for contiguous daily timestamp history', async () => {
@@ -236,6 +259,7 @@ describe('parseDefiLlamaResponse', () => {
       headers: {
         Authorization: 'Bearer portfolio-test-key'
       },
+      redirect: 'error',
       signal: expect.any(AbortSignal)
     })
     expect(prices.get(firstTokenKey)?.get(firstTimestamp)).toBe(1.001)
@@ -625,7 +649,7 @@ describe('parseDefiLlamaResponse', () => {
       expect(requestUrl.origin).toBe('https://pro-api.llama.fi')
       expect(requestUrl.pathname).toBe('/test-llama-key/coins/batchHistorical')
       expect(requestUrl.toString().length).toBeLessThanOrEqual(3_500)
-      expect(requestInit).toEqual({ signal: expect.any(AbortSignal) })
+      expect(requestInit).toEqual({ redirect: 'error', signal: expect.any(AbortSignal) })
       expect(Object.keys(requestCoinsParam).length).toBeGreaterThan(0)
     })
     expect(prices.size).toBe(90)
@@ -669,14 +693,14 @@ describe('parseDefiLlamaResponse', () => {
 
     expect(firstRequestUrl.origin).toBe('https://pro-api.llama.fi')
     expect(firstRequestUrl.pathname).toBe('/test-llama-key/coins/batchHistorical')
-    expect(firstRequestInit).toEqual({ signal: expect.any(AbortSignal) })
+    expect(firstRequestInit).toEqual({ redirect: 'error', signal: expect.any(AbortSignal) })
     expect(firstCoinsParam).toEqual({
       'ethereum:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48': [1700000000]
     })
     expect(String(secondRequestInput)).toBe(
       'https://coins.llama.fi/batchHistorical?coins=%7B%22ethereum%3A0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48%22%3A%5B1700000000%5D%7D'
     )
-    expect(secondRequestInit).toEqual({ signal: expect.any(AbortSignal) })
+    expect(secondRequestInit).toEqual({ redirect: 'error', signal: expect.any(AbortSignal) })
     expect(prices.get('ethereum:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')?.get(1700000000)).toBe(1)
   })
 
@@ -723,7 +747,7 @@ describe('parseDefiLlamaResponse', () => {
       expect(requestUrl.origin).toBe('https://pro-api.llama.fi')
       expect(requestUrl.pathname).toBe('/test-llama-key/coins/batchHistorical')
       expect(requestUrl.toString().length).toBeLessThanOrEqual(3_500)
-      expect(requestInit).toEqual({ signal: expect.any(AbortSignal) })
+      expect(requestInit).toEqual({ redirect: 'error', signal: expect.any(AbortSignal) })
     })
     expect(prices.size).toBe(20)
   })

--- a/api/lib/holdings/services/defillama.ts
+++ b/api/lib/holdings/services/defillama.ts
@@ -447,6 +447,61 @@ function buildRangeCoinsParam(coins: TCoinRequest[]): Record<string, [number, nu
   }, {})
 }
 
+function joinUrlPath(...segments: string[]): string {
+  const path = segments
+    .map((segment) => segment.replace(/^\/+|\/+$/g, ''))
+    .filter(Boolean)
+    .join('/')
+  return `/${path}`
+}
+
+function getYearnPricesApiBaseUrl(): string {
+  return holdingsConfig.yearnPricesBaseUrl.endsWith('/api')
+    ? holdingsConfig.yearnPricesBaseUrl
+    : `${holdingsConfig.yearnPricesBaseUrl}/api`
+}
+
+function assertHttpsUrl(url: URL): void {
+  if (url.protocol !== 'https:') {
+    throw new Error(`Blocked historical price request to non-HTTPS upstream: ${url.origin}`)
+  }
+}
+
+function assertExpectedUpstream(url: URL, baseUrl: string, expectedPath: string): void {
+  const base = new URL(baseUrl)
+  assertHttpsUrl(url)
+
+  if (url.origin !== base.origin || url.pathname !== joinUrlPath(base.pathname, expectedPath)) {
+    throw new Error(`Blocked historical price request to unexpected upstream: ${url.origin}${url.pathname}`)
+  }
+}
+
+function validateHistoricalPriceRequest(request: TDefiLlamaBatchRequest): URL {
+  const url = new URL(request.url)
+
+  if (request.variant === 'free_get') {
+    assertExpectedUpstream(url, holdingsConfig.defillamaBaseUrl, 'batchHistorical')
+    return url
+  }
+
+  if (request.variant === 'pro_get') {
+    assertExpectedUpstream(
+      url,
+      holdingsConfig.defillamaProBaseUrl,
+      `${holdingsConfig.defillamaApiKey}/coins/batchHistorical`
+    )
+    return url
+  }
+
+  if (request.variant === 'yearn_prices_get') {
+    assertExpectedUpstream(url, getYearnPricesApiBaseUrl(), 'prices/batchHistorical')
+    return url
+  }
+
+  assertExpectedUpstream(url, getYearnPricesApiBaseUrl(), 'prices/rangeHistorical')
+  return url
+}
+
 export function buildBatchHistoricalUrl(coins: TCoinRequest[]): string {
   const encodedCoins = encodeURIComponent(JSON.stringify(buildCoinsParam(coins)))
   return `${holdingsConfig.defillamaBaseUrl}/batchHistorical?coins=${encodedCoins}`
@@ -459,18 +514,12 @@ function buildProBatchHistoricalGetUrl(coins: TCoinRequest[]): string {
 
 function buildYearnPricesBatchHistoricalUrl(coins: TCoinRequest[]): string {
   const encodedCoins = encodeURIComponent(JSON.stringify(buildCoinsParam(coins, { normalizeTimestampsToDayEnd: true })))
-  const apiBaseUrl = holdingsConfig.yearnPricesBaseUrl.endsWith('/api')
-    ? holdingsConfig.yearnPricesBaseUrl
-    : `${holdingsConfig.yearnPricesBaseUrl}/api`
-  return `${apiBaseUrl}/prices/batchHistorical?coins=${encodedCoins}`
+  return `${getYearnPricesApiBaseUrl()}/prices/batchHistorical?coins=${encodedCoins}`
 }
 
 function buildYearnPricesRangeHistoricalUrl(coins: TCoinRequest[]): string {
   const encodedCoins = encodeURIComponent(JSON.stringify(buildRangeCoinsParam(coins)))
-  const apiBaseUrl = holdingsConfig.yearnPricesBaseUrl.endsWith('/api')
-    ? holdingsConfig.yearnPricesBaseUrl
-    : `${holdingsConfig.yearnPricesBaseUrl}/api`
-  return `${apiBaseUrl}/prices/rangeHistorical?coins=${encodedCoins}`
+  return `${getYearnPricesApiBaseUrl()}/prices/rangeHistorical?coins=${encodedCoins}`
 }
 
 function buildYearnPricesRequest(coins: TCoinRequest[]): Pick<TDefiLlamaBatchRequest, 'url' | 'variant'> {
@@ -696,8 +745,9 @@ async function fetchBatch(
         }
 
         try {
-          const response = await fetch(request.url, {
+          const response = await fetch(validateHistoricalPriceRequest(request), {
             ...request.init,
+            redirect: 'error',
             signal: AbortSignal.timeout(tuning.timeoutMs)
           })
 

--- a/api/server.ts
+++ b/api/server.ts
@@ -55,6 +55,9 @@ import {
 import { buildTenderlyAdminAccessDeniedResponse } from './tenderlyAccess'
 
 const ENSO_API_BASE = 'https://api.enso.finance'
+const ENSO_ROUTE_PATH = '/api/v1/shortcuts/route'
+const ENSO_BALANCES_PATH = '/api/v1/wallet/balances'
+const ENSO_API_ORIGIN = new URL(ENSO_API_BASE).origin
 const DEFAULT_API_PORT = 3001
 const YVUSD_APR_SERVICE_API = (
   process.env.YVUSD_APR_SERVICE_API || 'https://yearn-yvusd-apr-service.vercel.app/api/aprs'
@@ -498,6 +501,28 @@ function handleEnsoStatus(): Response {
   return Response.json({ configured: !!apiKey })
 }
 
+function buildEnsoRouteUrl(params: URLSearchParams): URL {
+  const ensoUrl = new URL(ENSO_ROUTE_PATH, ENSO_API_BASE)
+  ensoUrl.search = params.toString()
+
+  if (ensoUrl.protocol !== 'https:' || ensoUrl.origin !== ENSO_API_ORIGIN || ensoUrl.pathname !== ENSO_ROUTE_PATH) {
+    throw new Error('Invalid Enso route upstream URL')
+  }
+
+  return ensoUrl
+}
+
+function buildEnsoBalancesUrl(params: URLSearchParams): URL {
+  const ensoUrl = new URL(ENSO_BALANCES_PATH, ENSO_API_BASE)
+  ensoUrl.search = params.toString()
+
+  if (ensoUrl.protocol !== 'https:' || ensoUrl.origin !== ENSO_API_ORIGIN || ensoUrl.pathname !== ENSO_BALANCES_PATH) {
+    throw new Error('Invalid Enso balances upstream URL')
+  }
+
+  return ensoUrl
+}
+
 async function handleEnsoRoute(req: Request): Promise<Response> {
   const url = new URL(req.url)
   const fromAddress = url.searchParams.get('fromAddress')
@@ -539,10 +564,11 @@ async function handleEnsoRoute(req: Request): Promise<Response> {
     params.set('routingStrategy', routingStrategy)
   }
 
-  const ensoUrl = `${ENSO_API_BASE}/api/v1/shortcuts/route?${params}`
+  const ensoUrl = buildEnsoRouteUrl(params)
 
   try {
     const response = await fetch(ensoUrl, {
+      redirect: 'error',
       headers: {
         Authorization: `Bearer ${apiKey}`,
         'Content-Type': 'application/json'
@@ -583,10 +609,11 @@ async function handleEnsoBalances(req: Request): Promise<Response> {
     chainId: chainId || 'all'
   })
 
-  const ensoUrl = `${ENSO_API_BASE}/api/v1/wallet/balances?${params}`
+  const ensoUrl = buildEnsoBalancesUrl(params)
 
   try {
     const response = await fetch(ensoUrl, {
+      redirect: 'error',
       headers: {
         Authorization: `Bearer ${apiKey}`
       }


### PR DESCRIPTION
## Summary

- Validate Enso proxy URLs against fixed HTTPS upstream origins and paths before server-side fetches.
- Reject upstream redirects for Enso and historical price fetches.
- Validate DefiLlama and yearn-prices historical price requests against their configured HTTPS upstreams.
- Add regression coverage for blocking non-HTTPS yearn-prices upstreams before fetch.

## Validation

- bun run lint:fix
- bunx vitest run api/lib/holdings/services/defillama.test.ts
- bun run tslint
- bun run build
