### PR TITLE
[codex] Fix vault-state strategy validation

### DIFF
--- a/api/optimization/_lib/address.ts
+++ b/api/optimization/_lib/address.ts
@@ -1,0 +1,33 @@
+export const MAX_VAULT_STATE_STRATEGIES = 100
+
+const ETHEREUM_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/
+
+export function isValidEthereumAddress(address: string): boolean {
+  return ETHEREUM_ADDRESS_REGEX.test(address)
+}
+
+type TStrategyAddressParseResult =
+  | { error: 'Invalid strategy addresses' | 'No strategy addresses provided' | 'Too many strategy addresses' }
+  | { strategies: string[] }
+
+export function parseVaultStateStrategies(value: unknown): TStrategyAddressParseResult {
+  if (!Array.isArray(value)) {
+    return { error: 'No strategy addresses provided' }
+  }
+
+  if (value.length === 0) {
+    return { error: 'No strategy addresses provided' }
+  }
+
+  if (value.length > MAX_VAULT_STATE_STRATEGIES) {
+    return { error: 'Too many strategy addresses' }
+  }
+
+  if (
+    !value.every((strategy): strategy is string => typeof strategy === 'string' && isValidEthereumAddress(strategy))
+  ) {
+    return { error: 'Invalid strategy addresses' }
+  }
+
+  return { strategies: value }
+}

--- a/api/optimization/handlers.test.ts
+++ b/api/optimization/handlers.test.ts
@@ -52,6 +52,7 @@ vi.mock('./_lib/rpc', () => ({
   fetchVaultOnChainState: fetchVaultOnChainStateMock
 }))
 
+import { MAX_VAULT_STATE_STRATEGIES } from './_lib/address'
 import alignmentHandler from './alignment'
 import changeHandler from './change'
 import vaultStateHandler from './vault-state'
@@ -142,6 +143,49 @@ describe('optimization handlers', () => {
       },
       unallocatedBps: 6000
     })
+  })
+
+  it('rejects invalid vault-state strategy addresses before fetching on-chain state', async () => {
+    const res = createMockResponse()
+
+    await vaultStateHandler(
+      {
+        body: {
+          chainId: 1,
+          strategies: ['not-an-address'],
+          vault: '0x1111111111111111111111111111111111111111'
+        },
+        method: 'POST'
+      } as VercelRequest,
+      res
+    )
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({ error: 'Invalid strategy addresses' })
+    expect(fetchVaultOnChainStateMock).not.toHaveBeenCalled()
+  })
+
+  it('caps vault-state strategy address count before fetching on-chain state', async () => {
+    const res = createMockResponse()
+
+    await vaultStateHandler(
+      {
+        body: {
+          chainId: 1,
+          strategies: Array.from(
+            { length: MAX_VAULT_STATE_STRATEGIES + 1 },
+            (_, index) => `0x${index.toString(16).padStart(40, '0')}`
+          ),
+          vault: '0x1111111111111111111111111111111111111111'
+        },
+        method: 'POST'
+      } as VercelRequest,
+      res
+    )
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toEqual({ error: 'Too many strategy addresses' })
+    expect(fetchVaultOnChainStateMock).not.toHaveBeenCalled()
   })
 
   it('keeps CORS headers on change Redis authentication failures', async () => {

--- a/api/optimization/vault-state.ts
+++ b/api/optimization/vault-state.ts
@@ -1,4 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { isValidEthereumAddress, parseVaultStateStrategies } from './_lib/address'
 import { OPTIMIZATION_POST_CORS_HEADERS, setCorsHeaders } from './_lib/cors'
 import { fetchVaultOnChainState } from './_lib/rpc'
 
@@ -18,22 +19,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const payload = req.body && typeof req.body === 'object' ? (req.body as Record<string, unknown>) : {}
   const vault = typeof payload.vault === 'string' ? payload.vault : null
   const chainId = typeof payload.chainId === 'number' ? payload.chainId : null
-  const strategies = Array.isArray(payload.strategies)
-    ? payload.strategies.filter((s: unknown): s is string => typeof s === 'string')
-    : []
+  const strategyResult = parseVaultStateStrategies(payload.strategies)
 
-  if (!vault || !/^0x[a-fA-F0-9]{40}$/.test(vault)) {
+  if (!vault || !isValidEthereumAddress(vault)) {
     return res.status(400).json({ error: 'Invalid vault address' })
   }
   if (chainId === null || !Number.isFinite(chainId)) {
     return res.status(400).json({ error: 'Invalid chainId' })
   }
-  if (strategies.length === 0) {
-    return res.status(400).json({ error: 'No strategy addresses provided' })
+  if ('error' in strategyResult) {
+    return res.status(400).json({ error: strategyResult.error })
   }
 
   try {
-    const state = await fetchVaultOnChainState(chainId, vault, strategies)
+    const state = await fetchVaultOnChainState(chainId, vault, strategyResult.strategies)
 
     const strategyDebts: Record<string, string> = {}
     for (const [addr, debt] of state.strategyDebts) {

--- a/api/server.ts
+++ b/api/server.ts
@@ -33,6 +33,7 @@ import {
 } from './lib/holdings/services/debug'
 import { fetchRecentAddressScopedActivityEvents } from './lib/holdings/services/graphql'
 import { getHoldingsProgress, startHoldingsProgress, updateHoldingsProgress } from './lib/holdings/services/progress'
+import { parseVaultStateStrategies } from './optimization/_lib/address'
 import { getVaultDecimals } from './optimization/_lib/assetLogos'
 import { fetchAlignedEvents } from './optimization/_lib/envio'
 import { parseExplainMetadata } from './optimization/_lib/explain-parse'
@@ -763,9 +764,7 @@ async function handleOptimizationVaultState(req: Request): Promise<Response> {
   const payload = body && typeof body === 'object' ? (body as Record<string, unknown>) : {}
   const vault = typeof payload.vault === 'string' ? payload.vault : null
   const chainId = typeof payload.chainId === 'number' ? payload.chainId : null
-  const strategies = Array.isArray(payload.strategies)
-    ? payload.strategies.filter((strategy: unknown): strategy is string => typeof strategy === 'string')
-    : []
+  const strategyResult = parseVaultStateStrategies(payload.strategies)
 
   if (!vault || !isValidAddress(vault)) {
     return Response.json({ error: 'Invalid vault address' }, { status: 400 })
@@ -775,12 +774,12 @@ async function handleOptimizationVaultState(req: Request): Promise<Response> {
     return Response.json({ error: 'Invalid chainId' }, { status: 400 })
   }
 
-  if (strategies.length === 0) {
-    return Response.json({ error: 'No strategy addresses provided' }, { status: 400 })
+  if ('error' in strategyResult) {
+    return Response.json({ error: strategyResult.error }, { status: 400 })
   }
 
   try {
-    const state = await fetchVaultOnChainState(chainId, vault, strategies)
+    const state = await fetchVaultOnChainState(chainId, vault, strategyResult.strategies)
     const strategyDebts = Object.fromEntries(
       [...state.strategyDebts].map(([strategyAddress, debt]) => [strategyAddress, debt.toString()])
     )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,14 @@ function resolveClientPort(env: Record<string, string>) {
   return Number.isInteger(configuredPort) && configuredPort > 0 ? configuredPort : 3000
 }
 
+function resolveAllowedHosts(env: Record<string, string>) {
+  const rawHosts = env.ALLOWED_HOSTS?.trim() || env.VITE_ALLOWED_HOSTS?.trim() || ''
+  return rawHosts
+    .split(',')
+    .map((host) => host.trim())
+    .filter(Boolean)
+}
+
 function buildProxy(apiProxyTarget: string) {
   return {
     '/api': {
@@ -99,6 +107,8 @@ export default defineConfig(({ mode }) => {
   const apiProxyTarget = resolveApiProxyTarget(env)
   const host = resolveClientHost(env)
   const port = resolveClientPort(env)
+  const allowedHosts = resolveAllowedHosts(env)
+  const allowedHostConfig = allowedHosts.length > 0 ? { allowedHosts } : {}
   const proxy = buildProxy(apiProxyTarget)
 
   return {
@@ -120,11 +130,13 @@ export default defineConfig(({ mode }) => {
     server: {
       host,
       port,
+      ...allowedHostConfig,
       proxy
     },
     preview: {
       host,
       port,
+      ...allowedHostConfig,
       proxy
     },
     build: {


### PR DESCRIPTION
## Summary
- Reject invalid strategy identifiers before vault-state RPC calldata is built
- Share strategy address validation between the Vercel handler and local Bun API route
- Cap vault-state strategy lists and cover invalid/oversized requests with focused tests
- Add env-driven allowed preview hosts for private preview serving

## Validation
- bun run lint:fix
- bun run tslint
- bunx vitest run api/optimization/handlers.test.ts api/optimization/_lib/rpc.test.ts