### PR TITLE
[codex] Harden Enso route execution

### DIFF
--- a/api/enso/route.ts
+++ b/api/enso/route.ts
@@ -1,4 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { isAddress } from 'viem'
+import { normalizeEnsoRouteResponse } from '../../src/components/pages/vaults/hooks/solvers/ensoRoute'
 
 const ENSO_API_BASE = 'https://api.enso.finance'
 
@@ -15,6 +17,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
   if (!chainId || typeof chainId !== 'string') {
     return res.status(400).json({ error: 'Missing or invalid chainId' })
+  }
+  const parsedChainId = Number(chainId)
+  if (!Number.isInteger(parsedChainId) || parsedChainId <= 0) {
+    return res.status(400).json({ error: 'Missing or invalid chainId' })
+  }
+  if (!isAddress(fromAddress, { strict: false })) {
+    return res.status(400).json({ error: 'Missing or invalid fromAddress' })
   }
   if (!tokenIn || typeof tokenIn !== 'string') {
     return res.status(400).json({ error: 'Missing or invalid tokenIn' })
@@ -67,7 +76,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(response.status).json(data)
     }
 
-    return res.status(200).json(data)
+    const normalizedResponse = normalizeEnsoRouteResponse(data, response.status, {
+      chainId: parsedChainId,
+      fromAddress
+    })
+
+    if (normalizedResponse.error) {
+      return res.status(502).json(normalizedResponse.error)
+    }
+
+    return res.status(200).json(normalizedResponse.route)
   } catch (error) {
     console.error('Error proxying Enso route request:', error)
     return res.status(500).json({ error: 'Internal server error' })

--- a/api/server.ts
+++ b/api/server.ts
@@ -1,4 +1,6 @@
 import { serve } from 'bun'
+import type { Address } from 'viem'
+import { normalizeEnsoRouteResponse } from '../src/components/pages/vaults/hooks/solvers/ensoRoute'
 import type {
   TTenderlyFundRequest,
   TTenderlyIncreaseTimeRequest,
@@ -513,6 +515,10 @@ async function handleEnsoRoute(req: Request): Promise<Response> {
   if (!fromAddress || !chainId || !tokenIn || !tokenOut || !amountIn) {
     return Response.json({ error: 'Missing required parameters' }, { status: 400 })
   }
+  const parsedChainId = Number(chainId)
+  if (!Number.isInteger(parsedChainId) || parsedChainId <= 0 || !isValidAddress(fromAddress)) {
+    return Response.json({ error: 'Missing required parameters' }, { status: 400 })
+  }
 
   const apiKey = process.env.ENSO_API_KEY
   if (!apiKey) {
@@ -555,7 +561,16 @@ async function handleEnsoRoute(req: Request): Promise<Response> {
       return Response.json(data, { status: response.status })
     }
 
-    return Response.json(data)
+    const normalizedResponse = normalizeEnsoRouteResponse(data, response.status, {
+      chainId: parsedChainId,
+      fromAddress: fromAddress as Address
+    })
+
+    if (normalizedResponse.error) {
+      return Response.json(normalizedResponse.error, { status: 502 })
+    }
+
+    return Response.json(normalizedResponse.route)
   } catch (error) {
     console.error('Error proxying Enso route request:', error)
     return Response.json({ error: 'Internal server error' }, { status: 500 })

--- a/src/components/pages/vaults/components/widget/deposit/useFetchMaxQuote.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useFetchMaxQuote.ts
@@ -96,7 +96,10 @@ export const useFetchMaxQuote = ({
 
       const response = await fetch(`${ENSO_ROUTE_PROXY}?${params}`)
       const data = await response.json()
-      const normalizedResponse = normalizeEnsoRouteResponse(data, response.status, sourceChainId)
+      const normalizedResponse = normalizeEnsoRouteResponse(data, response.status, {
+        chainId: sourceChainId,
+        fromAddress: account!
+      })
 
       if (normalizedResponse.error) {
         console.warn('[Enso] MAX quote error', {

--- a/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
+++ b/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
@@ -81,7 +81,8 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
   const { prepareEnsoOrder } = useEnsoOrder({
     getEnsoTransaction: ensoFlow.methods.getEnsoTransaction,
     enabled: canDeposit,
-    chainId: params.chainId
+    chainId: params.chainId,
+    account: params.account
   })
 
   // Adapt ensoFlow to UseWidgetDepositFlowReturn interface

--- a/src/components/pages/vaults/hooks/actions/useEnsoWithdraw.ts
+++ b/src/components/pages/vaults/hooks/actions/useEnsoWithdraw.ts
@@ -80,7 +80,8 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
   const { prepareEnsoOrder } = useEnsoOrder({
     getEnsoTransaction: ensoFlow.methods.getEnsoTransaction,
     enabled: canWithdraw,
-    chainId: params.chainId
+    chainId: params.chainId,
+    account: params.account
   })
 
   // Adapt ensoFlow to UseWidgetWithdrawFlowReturn interface

--- a/src/components/pages/vaults/hooks/solvers/ensoRoute.test.ts
+++ b/src/components/pages/vaults/hooks/solvers/ensoRoute.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeEnsoRouteResponse, routeHasSwapStep } from './ensoRoute'
+import { getEnsoRouteInvariantError, normalizeEnsoRouteResponse, routeHasSwapStep } from './ensoRoute'
+
+const ETHEREUM_ENSO_ROUTER = '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf'
+const ACCOUNT = '0x0000000000000000000000000000000000000002'
 
 describe('normalizeEnsoRouteResponse', () => {
   it('keeps valid Enso route payloads as routes', () => {
@@ -27,10 +30,10 @@ describe('normalizeEnsoRouteResponse', () => {
       normalizeEnsoRouteResponse(
         {
           tx: {
-            to: '0x0000000000000000000000000000000000000001',
+            to: ETHEREUM_ENSO_ROUTER,
             data: '0x1234',
             value: '0',
-            from: '0x0000000000000000000000000000000000000002'
+            from: ACCOUNT
           },
           amountOut: '100',
           minAmountOut: '95',
@@ -38,15 +41,15 @@ describe('normalizeEnsoRouteResponse', () => {
           route: []
         },
         200,
-        1
+        { chainId: 1, fromAddress: ACCOUNT }
       )
     ).toEqual({
       route: {
         tx: {
-          to: '0x0000000000000000000000000000000000000001',
+          to: ETHEREUM_ENSO_ROUTER,
           data: '0x1234',
           value: '0',
-          from: '0x0000000000000000000000000000000000000002',
+          from: ACCOUNT,
           chainId: 1
         },
         amountOut: '100',
@@ -55,6 +58,115 @@ describe('normalizeEnsoRouteResponse', () => {
         route: []
       }
     })
+  })
+
+  it('rejects route targets that do not match the expected Enso router', () => {
+    expect(
+      normalizeEnsoRouteResponse(
+        {
+          tx: {
+            to: '0x0000000000000000000000000000000000000001',
+            data: '0x1234',
+            value: '0',
+            from: ACCOUNT,
+            chainId: 1
+          },
+          amountOut: '100',
+          minAmountOut: '95',
+          gas: '123456',
+          route: []
+        },
+        200,
+        { chainId: 1, fromAddress: ACCOUNT }
+      )
+    ).toEqual({
+      error: {
+        error: 'Enso route target does not match the expected router',
+        message: 'Enso route target does not match the expected router',
+        requestId: undefined,
+        statusCode: 200
+      }
+    })
+  })
+
+  it('rejects route senders that do not match the request account', () => {
+    expect(
+      normalizeEnsoRouteResponse(
+        {
+          tx: {
+            to: ETHEREUM_ENSO_ROUTER,
+            data: '0x1234',
+            value: '0',
+            from: '0x0000000000000000000000000000000000000003',
+            chainId: 1
+          },
+          amountOut: '100',
+          minAmountOut: '95',
+          gas: '123456',
+          route: []
+        },
+        200,
+        { chainId: 1, fromAddress: ACCOUNT }
+      )
+    ).toEqual({
+      error: {
+        error: 'Enso route sender does not match the connected account',
+        message: 'Enso route sender does not match the connected account',
+        requestId: undefined,
+        statusCode: 200
+      }
+    })
+  })
+
+  it('rejects routes whose tx.chainId does not match the request chain', () => {
+    expect(
+      normalizeEnsoRouteResponse(
+        {
+          tx: {
+            to: ETHEREUM_ENSO_ROUTER,
+            data: '0x1234',
+            value: '0',
+            from: ACCOUNT,
+            chainId: 10
+          },
+          amountOut: '100',
+          minAmountOut: '95',
+          gas: '123456',
+          route: []
+        },
+        200,
+        { chainId: 1, fromAddress: ACCOUNT }
+      )
+    ).toEqual({
+      error: {
+        error: 'Enso route chain does not match the requested chain',
+        message: 'Enso route chain does not match the requested chain',
+        requestId: undefined,
+        statusCode: 200
+      }
+    })
+  })
+
+  it('rejects malformed executable transaction fields', () => {
+    expect(
+      normalizeEnsoRouteResponse(
+        {
+          tx: {
+            to: ETHEREUM_ENSO_ROUTER,
+            data: 'not-hex',
+            value: '-1',
+            from: ACCOUNT,
+            chainId: 1
+          },
+          amountOut: '100',
+          minAmountOut: '95',
+          gas: '123456',
+          route: []
+        },
+        200,
+        { chainId: 1, fromAddress: ACCOUNT }
+      ).error?.message
+    ).toBe('Unable to find route')
   })
 
   it('treats 422 simulation failures without an error field as route errors', () => {
@@ -136,5 +248,35 @@ describe('normalizeEnsoRouteResponse', () => {
     )
 
     expect(routeHasSwapStep(normalized.route)).toBe(false)
+  })
+
+  it('exposes the same invariant check for execution-time validation', () => {
+    expect(
+      getEnsoRouteInvariantError(
+        {
+          to: '0x0000000000000000000000000000000000000001',
+          data: '0x1234',
+          value: '0',
+          from: ACCOUNT,
+          chainId: 1
+        },
+        { chainId: 1, fromAddress: ACCOUNT }
+      )
+    ).toBe('Enso route target does not match the expected router')
+  })
+
+  it('revalidates executable transaction fields at execution time', () => {
+    expect(
+      getEnsoRouteInvariantError(
+        {
+          to: ETHEREUM_ENSO_ROUTER,
+          data: 'not-hex' as any,
+          value: '0',
+          from: ACCOUNT,
+          chainId: 1
+        },
+        { chainId: 1, fromAddress: ACCOUNT }
+      )
+    ).toBe('Enso route transaction fields are invalid')
   })
 })

--- a/src/components/pages/vaults/hooks/solvers/ensoRoute.ts
+++ b/src/components/pages/vaults/hooks/solvers/ensoRoute.ts
@@ -1,4 +1,13 @@
-import type { Address, Hex } from 'viem'
+import { type Address, type Hex, isAddress, isAddressEqual, isHex } from 'viem'
+
+export const ENSO_ROUTER_ADDRESSES: Record<number, Address> = {
+  1: '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf',
+  10: '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf',
+  137: '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf',
+  42161: '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf',
+  8453: '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf',
+  747474: '0x3067BDBa0e6628497d527bEF511c22DA8b32cA3F'
+}
 
 export interface EnsoError {
   error: string
@@ -41,6 +50,23 @@ type EnsoRouteCandidate = Omit<EnsoRouteResponse, 'tx'> & {
   }
 }
 
+export interface EnsoRouteValidationContext {
+  chainId: number
+  fromAddress: Address
+}
+
+export function getEnsoRouterAddress(chainId: number): Address | undefined {
+  return ENSO_ROUTER_ADDRESSES[chainId]
+}
+
+function isNonNegativeBigIntString(value: string): boolean {
+  try {
+    return BigInt(value) >= 0n
+  } catch {
+    return false
+  }
+}
+
 function isEnsoRouteCandidate(data: unknown): data is EnsoRouteCandidate {
   if (!data || typeof data !== 'object') {
     return false
@@ -53,9 +79,13 @@ function isEnsoRouteCandidate(data: unknown): data is EnsoRouteCandidate {
 
   return (
     typeof candidate.tx.to === 'string' &&
+    isAddress(candidate.tx.to, { strict: false }) &&
     typeof candidate.tx.data === 'string' &&
+    isHex(candidate.tx.data, { strict: true }) &&
     typeof candidate.tx.value === 'string' &&
+    isNonNegativeBigIntString(candidate.tx.value) &&
     typeof candidate.tx.from === 'string' &&
+    isAddress(candidate.tx.from, { strict: false }) &&
     typeof candidate.amountOut === 'string' &&
     typeof candidate.minAmountOut === 'string' &&
     typeof candidate.gas === 'string' &&
@@ -85,29 +115,72 @@ function buildEnsoError(data: unknown, statusCode: number): EnsoError {
   }
 }
 
+export function getEnsoRouteInvariantError(
+  tx: EnsoRouteResponse['tx'],
+  context: EnsoRouteValidationContext
+): string | undefined {
+  const expectedRouter = getEnsoRouterAddress(context.chainId)
+
+  if (
+    !isAddress(context.fromAddress, { strict: false }) ||
+    !isAddress(tx.to, { strict: false }) ||
+    !isAddress(tx.from, { strict: false }) ||
+    !isHex(tx.data, { strict: true }) ||
+    !isNonNegativeBigIntString(tx.value) ||
+    !Number.isInteger(tx.chainId)
+  ) {
+    return 'Enso route transaction fields are invalid'
+  }
+
+  if (!expectedRouter) {
+    return `Enso routes are not supported on chain ${context.chainId}`
+  }
+
+  if (tx.chainId !== context.chainId) {
+    return 'Enso route chain does not match the requested chain'
+  }
+
+  if (!isAddressEqual(tx.from, context.fromAddress)) {
+    return 'Enso route sender does not match the connected account'
+  }
+
+  if (!isAddressEqual(tx.to, expectedRouter)) {
+    return 'Enso route target does not match the expected router'
+  }
+
+  return undefined
+}
+
 export function normalizeEnsoRouteResponse(
   data: unknown,
   statusCode: number,
-  fallbackChainId?: number
+  context?: EnsoRouteValidationContext
 ): {
   error?: EnsoError
   route?: EnsoRouteResponse
 } {
   if (isEnsoRouteCandidate(data)) {
-    const resolvedChainId = typeof data.tx.chainId === 'number' ? data.tx.chainId : fallbackChainId
+    const resolvedChainId = typeof data.tx.chainId === 'number' ? data.tx.chainId : context?.chainId
 
     if (typeof resolvedChainId !== 'number') {
       return { error: buildEnsoError({ message: 'Enso route payload missing tx.chainId' }, statusCode) }
     }
 
-    return {
-      route: {
-        ...data,
-        tx: {
-          ...data.tx,
-          chainId: resolvedChainId
-        }
+    const route = {
+      ...data,
+      tx: {
+        ...data.tx,
+        chainId: resolvedChainId
       }
+    }
+    const invariantError = context ? getEnsoRouteInvariantError(route.tx, context) : undefined
+
+    if (invariantError) {
+      return { error: buildEnsoError({ message: invariantError }, statusCode) }
+    }
+
+    return {
+      route
     }
   }
 

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
@@ -5,20 +5,16 @@ import { getApproveAbi } from '@shared/utils/approve'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Address } from 'viem'
 import { useTokenAllowance } from '../useTokenAllowance'
-import { type EnsoError, type EnsoRouteResponse, normalizeEnsoRouteResponse, routeHasSwapStep } from './ensoRoute'
+import {
+  type EnsoError,
+  type EnsoRouteResponse,
+  getEnsoRouterAddress,
+  normalizeEnsoRouteResponse,
+  routeHasSwapStep
+} from './ensoRoute'
 
 const ENSO_ROUTE_PROXY = '/api/enso/route'
 export type EnsoRoutingStrategy = 'router' | 'delegate' | 'router-legacy' | 'delegate-legacy' | 'ensowallet'
-
-// Known Enso router addresses per chain for pre-fetching allowance
-const ENSO_ROUTER_ADDRESSES: Record<number, Address> = {
-  1: '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf', // Ethereum
-  10: '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf', // Optimism
-  137: '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf', // Polygon
-  42161: '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf', // Arbitrum
-  8453: '0xF75584eF6673aD213a685a1B58Cc0330B8eA22Cf', // Base
-  747474: '0x3067BDBa0e6628497d527bEF511c22DA8b32cA3F' // Katana
-}
 
 interface UseSolverEnsoProps {
   tokenIn: Address
@@ -89,7 +85,7 @@ export const useSolverEnso = ({
   const visibleRouteHasSwap = routeHasSwapStep(visibleRoute)
 
   // Use known Enso router for pre-fetching allowance, fall back to actual router from route
-  const knownRouterAddress = ENSO_ROUTER_ADDRESSES[chainId]
+  const knownRouterAddress = getEnsoRouterAddress(chainId)
   const allowanceSpender = routerAddress || knownRouterAddress
 
   const { allowance = 0n, isLoading: isLoadingAllowance } = useTokenAllowance({
@@ -135,7 +131,7 @@ export const useSolverEnso = ({
         return
       }
 
-      const normalizedResponse = normalizeEnsoRouteResponse(data, response.status, chainId)
+      const normalizedResponse = normalizeEnsoRouteResponse(data, response.status, { chainId, fromAddress })
       if (normalizedResponse.error) {
         console.warn('[Enso] Route error', {
           chainId,
@@ -236,7 +232,12 @@ export const useSolverEnso = ({
 
   const isValidInput = amountIn > 0n
   const canRequestRoute =
-    enabled && !!fromAddress && isValidInput && !isZeroAddress(tokenIn) && !isZeroAddress(tokenOut)
+    enabled &&
+    !!fromAddress &&
+    !!knownRouterAddress &&
+    isValidInput &&
+    !isZeroAddress(tokenIn) &&
+    !isZeroAddress(tokenOut)
   const hasCurrentRoute = resolvedRequestKey === requestKey
   const hasCurrentError = errorRequestKey === requestKey
   const isLoadingCurrentRequest = isLoadingRoute || (canRequestRoute && !hasCurrentRoute && !hasCurrentError)

--- a/src/components/pages/vaults/hooks/useEnsoOrder.ts
+++ b/src/components/pages/vaults/hooks/useEnsoOrder.ts
@@ -8,6 +8,7 @@ import type { Address, Hash, Hex } from 'viem'
 import { useWalletClient } from 'wagmi'
 import { supportedWalletChains } from '@/config/supportedChains'
 import { resolveExecutionChainId } from '@/config/tenderly'
+import { getEnsoRouteInvariantError } from './solvers/ensoRoute'
 
 interface EnsoTransaction {
   to: Address
@@ -21,6 +22,7 @@ interface UseEnsoOrderProps {
   getEnsoTransaction: () => EnsoTransaction | undefined
   enabled?: boolean
   chainId: number
+  account?: Address
 }
 
 interface UseEnsoOrderReturn {
@@ -33,7 +35,8 @@ interface UseEnsoOrderReturn {
 export const useEnsoOrder = ({
   getEnsoTransaction,
   enabled = true,
-  chainId
+  chainId,
+  account
 }: UseEnsoOrderProps): UseEnsoOrderReturn => {
   const [isExecuting, setIsExecuting] = useState(false)
   const [error, setError] = useState<Error | null>(null)
@@ -58,6 +61,10 @@ export const useEnsoOrder = ({
       if (!walletClient) throw new Error('No wallet client available')
       if (!publicClient) throw new Error('No public client available')
       if (!executionChainId) throw new Error(`No execution chain configured for chain ${chainId}`)
+      if (!account) throw new Error('No account available for Enso transaction')
+
+      const invariantError = getEnsoRouteInvariantError(ensoTx, { chainId, fromAddress: account })
+      if (invariantError) throw new Error(invariantError)
 
       // Note: Chain switching is handled by TransactionOverlay before calling executeOrder
       // We use the target chain from props, not walletClient.chain which may be stale
@@ -81,7 +88,7 @@ export const useEnsoOrder = ({
       setIsExecuting(false)
       throw err
     }
-  }, [chainId, executionChainId, getEnsoTransaction, walletClient, publicClient])
+  }, [account, chainId, executionChainId, getEnsoTransaction, walletClient, publicClient])
 
   const ensoTx = getEnsoTransaction()
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add shared Enso route invariants for executable route payloads
- Require route tx targets to match the known Enso router for the request chain
- Require route tx sender and chain ID to match the request context
- Recheck the same invariants immediately before wallet transaction execution
- Validate successful Enso proxy responses before returning them from both API route implementations

## Security rationale
Enso route responses previously became executable wallet transactions after only basic shape checks. A tampered or malicious upstream response could choose tx.to, tx.data, tx.value, and tx.from. This change treats the upstream response as untrusted until it matches local request context and the local Enso router allowlist.

## Validation
- bun run lint:fix
- bun run tslint
- bunx vitest run src/components/pages/vaults/hooks/solvers/ensoRoute.test.ts src/components/pages/vaults/components/widget/deposit/useFetchMaxQuote.test.ts
- bun run build
- bun --print "await import('./api/enso/route.ts'); 'api route import ok'"