### PR TITLE
[codex] Avoid 404s for missing holdings progress

### DIFF
--- a/api/holdings/progress.test.ts
+++ b/api/holdings/progress.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getHoldingsProgressMock = vi.fn()
+
+vi.mock('../lib/holdings/services/progress', () => ({
+  getHoldingsProgress: getHoldingsProgressMock
+}))
+
+type TMockResponse = {
+  statusCode: number
+  headers: Record<string, string>
+  body: unknown
+  setHeader: (name: string, value: string) => void
+  status: (code: number) => TMockResponse
+  json: (payload: unknown) => TMockResponse
+  end: () => TMockResponse
+}
+
+function createMockResponse(): TMockResponse {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: null,
+    setHeader(name: string, value: string) {
+      this.headers[name] = value
+    },
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      return this
+    },
+    end() {
+      return this
+    }
+  }
+}
+
+describe('holdings progress route', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('returns no content when a progress record is not available', async () => {
+    getHoldingsProgressMock.mockResolvedValue(null)
+
+    const { default: handler } = await import('./progress')
+    const req = {
+      method: 'GET',
+      query: {
+        id: 'portfolio-history:usd:1y:test'
+      }
+    } as any
+    const res = createMockResponse()
+
+    await handler(req, res as any)
+
+    expect(res.statusCode).toBe(204)
+    expect(res.body).toBeNull()
+    expect(res.headers['Cache-Control']).toBe('no-store')
+  })
+
+  it('returns the persisted progress record', async () => {
+    const progress = {
+      id: 'portfolio-history:usd:1y:test',
+      route: 'history',
+      addressHash: 'hash',
+      status: 'running',
+      progress: 40,
+      message: 'Fetched prices',
+      detail: null,
+      startedAt: 1,
+      updatedAt: 2,
+      logs: []
+    }
+    getHoldingsProgressMock.mockResolvedValue(progress)
+
+    const { default: handler } = await import('./progress')
+    const req = {
+      method: 'GET',
+      query: {
+        id: progress.id
+      }
+    } as any
+    const res = createMockResponse()
+
+    await handler(req, res as any)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual(progress)
+    expect(res.headers['Cache-Control']).toBe('no-store')
+  })
+})

--- a/api/holdings/progress.ts
+++ b/api/holdings/progress.ts
@@ -17,10 +17,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const id = req.query.id
   const progress = await getHoldingsProgress(typeof id === 'string' ? id : null)
 
+  res.setHeader('Cache-Control', 'no-store')
+
   if (!progress) {
-    return res.status(404).json({ error: 'Progress not found' })
+    return res.status(204).end()
   }
 
-  res.setHeader('Cache-Control', 'no-store')
   return res.status(200).json(progress)
 }

--- a/api/lib/holdings/README.md
+++ b/api/lib/holdings/README.md
@@ -198,7 +198,7 @@ Response:
 }
 ```
 
-Progress records expire after 10 minutes. The route returns `404` when the ID is invalid, expired, missing, or Redis progress is unavailable, and it always sends `Cache-Control: no-store`.
+Progress records expire after 10 minutes. The route returns `204` when the ID is invalid, expired, missing, or Redis progress is unavailable, and it always sends `Cache-Control: no-store`.
 
 ### `GET /api/holdings/breakdown`
 

--- a/api/server.ts
+++ b/api/server.ts
@@ -161,7 +161,12 @@ async function handleHoldingsProgress(req: Request): Promise<Response> {
   const progress = await getHoldingsProgress(url.searchParams.get('id'))
 
   if (!progress) {
-    return Response.json({ error: 'Progress not found', status: 404 }, { status: 404 })
+    return new Response(null, {
+      status: 204,
+      headers: {
+        'Cache-Control': 'no-store'
+      }
+    })
   }
 
   return Response.json(progress, {

--- a/src/components/pages/portfolio/hooks/usePortfolioHistoryProgress.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioHistoryProgress.ts
@@ -39,7 +39,7 @@ export function usePortfolioHistoryProgress(
     enabled: Boolean(endpoint) && enabled,
     queryFn: async () => {
       const response = await globalThis.fetch(endpoint as string, { headers: { Accept: 'application/json' } })
-      if (response.status === 404) {
+      if (response.status === 204 || response.status === 404) {
         return null
       }
       if (!response.ok) {


### PR DESCRIPTION
@w84april I missed a small fix for the redis PR that I found when testing. I was getting 404s from the progress endpoint.

## Summary
- Return `204 No Content` when holdings progress polling has no Redis record yet instead of emitting a normal `404`.
- Keep the portfolio progress hook compatible with both new `204` and existing `404` responses.
- Add serverless handler coverage for missing and persisted progress records.

## Root Cause
The frontend can poll `/api/holdings/progress` before the long-running holdings request creates its Redis progress row. The old `404` response was expected by the hook, but it still surfaced as a noisy failed network request in the console.

## Validation
- `bun run test api/holdings/progress.test.ts api/lib/holdings/services/progress.test.ts`
- `bunx biome check api/holdings/progress.ts api/holdings/progress.test.ts api/server.ts src/components/pages/portfolio/hooks/usePortfolioHistoryProgress.ts api/lib/holdings/README.md`
- `bun run build`
- Husky pre-commit lint-staged formatting/lint and `tsc -p tsconfig.json --noEmit`