### PR TITLE
Fix: Token-list logoURI values are rendered directly as image sources

### DIFF
--- a/src/components/pages/vaults/components/widget/TokenSelector.test.tsx
+++ b/src/components/pages/vaults/components/widget/TokenSelector.test.tsx
@@ -71,7 +71,7 @@ describe('TokenSelector', () => {
           buildToken({
             name: 'Override Token',
             symbol: 'OVR',
-            logoURI: 'https://example.com/override.png'
+            logoURI: 'https://tokens.1inch.io/override.png'
           })
         ]}
       />
@@ -79,7 +79,8 @@ describe('TokenSelector', () => {
 
     expect(html).toContain('Override Token')
     expect(html).toContain('OVR')
-    expect(html).toContain('https://example.com/override.png')
+    expect(html).toContain('https://tokens.1inch.io/override.png')
+    expect(html).toContain('referrerPolicy="no-referrer"')
     expect(html).not.toContain('Base Token')
   })
 
@@ -188,19 +189,19 @@ describe('TokenSelector', () => {
             address: BASE_TOKEN_ADDRESS,
             name: 'Base Token',
             symbol: 'BASE',
-            logoURI: 'https://example.com/base.png'
+            logoURI: 'https://tokens.1inch.io/base.png'
           }),
           [VAULT_TOKEN_ADDRESS]: buildToken({
             address: VAULT_TOKEN_ADDRESS,
             name: 'Vault Token',
             symbol: 'vBASE',
-            logoURI: 'https://example.com/vault.png'
+            logoURI: 'https://tokens.1inch.io/vault.png'
           }),
           [STAKING_TOKEN_ADDRESS]: buildToken({
             address: STAKING_TOKEN_ADDRESS,
             name: 'Staking Token',
             symbol: 'stBASE',
-            logoURI: 'https://example.com/staking.png'
+            logoURI: 'https://tokens.1inch.io/staking.png'
           })
         }
       },
@@ -210,7 +211,7 @@ describe('TokenSelector', () => {
             address: BASE_TOKEN_ADDRESS,
             name: 'Base Token',
             symbol: 'BASE',
-            logoURI: 'https://example.com/base.png'
+            logoURI: 'https://tokens.1inch.io/base.png'
           })
         }
         if (address === VAULT_TOKEN_ADDRESS) {
@@ -218,14 +219,14 @@ describe('TokenSelector', () => {
             address: VAULT_TOKEN_ADDRESS,
             name: 'Vault Token',
             symbol: 'vBASE',
-            logoURI: 'https://example.com/vault.png'
+            logoURI: 'https://tokens.1inch.io/vault.png'
           })
         }
         return buildToken({
           address: STAKING_TOKEN_ADDRESS,
           name: 'Staking Token',
           symbol: 'stBASE',
-          logoURI: 'https://example.com/staking.png'
+          logoURI: 'https://tokens.1inch.io/staking.png'
         })
       }
     })
@@ -241,9 +242,9 @@ describe('TokenSelector', () => {
       />
     )
 
-    expect(html).toContain('https://example.com/base.png')
-    expect(html).not.toContain('https://example.com/vault.png')
-    expect(html).not.toContain('https://example.com/staking.png')
+    expect(html).toContain('https://tokens.1inch.io/base.png')
+    expect(html).not.toContain('https://tokens.1inch.io/vault.png')
+    expect(html).not.toContain('https://tokens.1inch.io/staking.png')
   })
 
   it('never shows hidden vault share or staking tokens', () => {

--- a/src/components/pages/vaults/components/widget/tokenLogo.utils.test.ts
+++ b/src/components/pages/vaults/components/widget/tokenLogo.utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { getTokenLogoSources } from './tokenLogo.utils'
+
+const TOKEN_ADDRESS = '0x0000000000000000000000000000000000000001'
+
+describe('getTokenLogoSources', () => {
+  it('uses an approved HTTPS logo URI as the primary source', () => {
+    const logoURI = 'https://tokens.1inch.io/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png'
+
+    expect(getTokenLogoSources({ address: TOKEN_ADDRESS, chainId: 1, logoURI })).toEqual({
+      src: logoURI,
+      altSrc: `${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/1/${TOKEN_ADDRESS}/logo-32.png`
+    })
+  })
+
+  it.each([
+    'https://example.com/logo.png',
+    'data:image/svg+xml,<svg></svg>',
+    'javascript:alert(1)',
+    'blob:test'
+  ])('falls back to the canonical Yearn asset for unsafe logo URI %s', (logoURI) => {
+    expect(getTokenLogoSources({ address: TOKEN_ADDRESS, chainId: 1, logoURI })).toEqual({
+      src: `${import.meta.env.VITE_BASE_YEARN_ASSETS_URI}/tokens/1/${TOKEN_ADDRESS}/logo-32.png`
+    })
+  })
+})

--- a/src/components/pages/vaults/components/widget/tokenLogo.utils.ts
+++ b/src/components/pages/vaults/components/widget/tokenLogo.utils.ts
@@ -1,3 +1,5 @@
+import { sanitizeTokenLogoURI } from '@shared/utils/tokenLogo'
+
 type TokenLogoSourceParams = {
   address?: string
   chainId?: number
@@ -23,12 +25,14 @@ export function getTokenLogoSources({ address, chainId, logoURI, size = 32 }: To
 } {
   const fallbackSrc = getDefaultTokenLogoSrc({ address, chainId, size }) ?? ''
 
-  if (!logoURI) {
+  const sanitizedLogoURI = sanitizeTokenLogoURI(logoURI)
+
+  if (!sanitizedLogoURI) {
     return { src: fallbackSrc }
   }
 
   return {
-    src: logoURI,
-    altSrc: fallbackSrc && fallbackSrc !== logoURI ? fallbackSrc : undefined
+    src: sanitizedLogoURI,
+    altSrc: fallbackSrc && fallbackSrc !== sanitizedLogoURI ? fallbackSrc : undefined
   }
 }

--- a/src/components/shared/components/TokenLogo.tsx
+++ b/src/components/shared/components/TokenLogo.tsx
@@ -167,6 +167,7 @@ function TokenLogo(props: TokenLogoProps): ReactElement {
             height={height}
             decoding="async"
             {...rest}
+            referrerPolicy="no-referrer"
           />
         ) : null}
       </div>

--- a/src/components/shared/contexts/WithTokenList.tsx
+++ b/src/components/shared/contexts/WithTokenList.tsx
@@ -7,6 +7,7 @@ import type { TAddress } from '../types/address'
 import type { TDict, TNDict, TToken, TTokenList } from '../types/mixed'
 import { DEFAULT_ERC20 } from '../utils'
 import { zeroNormalizedBN } from '../utils/format'
+import { sanitizeTokenLogoURI } from '../utils/tokenLogo'
 import { toAddress } from '../utils/tools.address'
 import { useWeb3 } from './useWeb3'
 
@@ -40,7 +41,7 @@ export function toTokenListToken(token: TToken): TTokenList['tokens'][0] {
     address: token.address,
     chainId: token.chainID,
     decimals: token.decimals,
-    logoURI: token.logoURI,
+    logoURI: sanitizeTokenLogoURI(token.logoURI),
     name: token.name,
     symbol: token.symbol
   }
@@ -54,7 +55,7 @@ export function toTToken(token: TTokenList['tokens'][0]): TToken {
     address: token.address,
     chainID: token.chainId,
     decimals: token.decimals,
-    logoURI: token.logoURI,
+    logoURI: sanitizeTokenLogoURI(token.logoURI),
     name: token.name,
     symbol: token.symbol,
     value: 0,
@@ -120,7 +121,7 @@ export const WithTokenList = ({
           symbol: eachToken.symbol,
           decimals: eachToken.decimals,
           chainID: eachToken.chainId,
-          logoURI: eachToken.logoURI,
+          logoURI: sanitizeTokenLogoURI(eachToken.logoURI),
           value: 0,
           balance: zeroNormalizedBN
         }
@@ -141,7 +142,7 @@ export const WithTokenList = ({
             symbol: eachToken.symbol,
             decimals: eachToken.decimals,
             chainID: 1337,
-            logoURI: eachToken.logoURI,
+            logoURI: sanitizeTokenLogoURI(eachToken.logoURI),
             value: 0,
             balance: zeroNormalizedBN
           }
@@ -182,7 +183,7 @@ export const WithTokenList = ({
               symbol: eachToken.symbol,
               decimals: eachToken.decimals,
               chainID: chainId,
-              logoURI: eachToken.logoURI,
+              logoURI: sanitizeTokenLogoURI(eachToken.logoURI),
               value: 0,
               balance: zeroNormalizedBN
             }
@@ -203,7 +204,7 @@ export const WithTokenList = ({
                 symbol: eachToken.symbol,
                 decimals: eachToken.decimals,
                 chainID: 1337,
-                logoURI: eachToken.logoURI,
+                logoURI: sanitizeTokenLogoURI(eachToken.logoURI),
                 value: 0,
                 balance: zeroNormalizedBN
               }
@@ -237,7 +238,7 @@ export const WithTokenList = ({
             symbol: eachToken.symbol,
             decimals: eachToken.decimals,
             chainID: eachToken.chainId,
-            logoURI: eachToken.logoURI,
+            logoURI: sanitizeTokenLogoURI(eachToken.logoURI),
             value: 0,
             balance: zeroNormalizedBN
           }
@@ -257,7 +258,7 @@ export const WithTokenList = ({
               symbol: eachToken.symbol,
               decimals: eachToken.decimals,
               chainID: 1337,
-              logoURI: eachToken.logoURI,
+              logoURI: sanitizeTokenLogoURI(eachToken.logoURI),
               value: 0,
               balance: zeroNormalizedBN
             }

--- a/src/components/shared/utils/tokenLogo.test.ts
+++ b/src/components/shared/utils/tokenLogo.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeTokenLogoURI } from './tokenLogo'
+
+describe('sanitizeTokenLogoURI', () => {
+  it('allows approved HTTPS token logo hosts', () => {
+    expect(sanitizeTokenLogoURI('https://tokens.1inch.io/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png')).toBe(
+      'https://tokens.1inch.io/0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee.png'
+    )
+    expect(sanitizeTokenLogoURI('https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/1/logo.png')).toBe(
+      'https://cdn.jsdelivr.net/gh/yearn/tokenassets@main/tokens/1/logo.png'
+    )
+  })
+
+  it.each([
+    'https://example.com/logo.png',
+    'http://tokens.1inch.io/logo.png',
+    'data:image/svg+xml,<svg></svg>',
+    'javascript:alert(1)',
+    'blob:https://tokens.1inch.io/logo',
+    '/tokens/1/logo.png',
+    'not a url',
+    '',
+    undefined
+  ])('rejects unsafe or unapproved logo URI %s', (logoURI) => {
+    expect(sanitizeTokenLogoURI(logoURI)).toBeUndefined()
+  })
+})

--- a/src/components/shared/utils/tokenLogo.ts
+++ b/src/components/shared/utils/tokenLogo.ts
@@ -1,0 +1,34 @@
+const APPROVED_TOKEN_LOGO_HOSTS = ['cdn.jsdelivr.net', 'token-assets.yearn.fi', 'tokens.1inch.io'] as const
+
+function getHostname(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  try {
+    return new URL(value).hostname.toLowerCase()
+  } catch {
+    return undefined
+  }
+}
+
+function getApprovedLogoHosts(): Set<string> {
+  const configuredAssetsHost = getHostname(import.meta.env.VITE_BASE_YEARN_ASSETS_URI)
+  return new Set([...APPROVED_TOKEN_LOGO_HOSTS, ...(configuredAssetsHost ? [configuredAssetsHost] : [])])
+}
+
+export function sanitizeTokenLogoURI(logoURI: string | undefined): string | undefined {
+  if (!logoURI) {
+    return undefined
+  }
+
+  try {
+    const url = new URL(logoURI)
+    if (url.protocol !== 'https:' || !getApprovedLogoHosts().has(url.hostname.toLowerCase())) {
+      return undefined
+    }
+    return url.toString()
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
Fixes vulnerability harness finding finding-10f9bd8dcc: Token-list logoURI values are rendered directly as image sources.

Summary:
The implementation appears to fix the supplied token-list logoURI image request issue. I did not make additional changes.

Review notes:
- Token-list metadata is sanitized in WithTokenList before entering shared token state, including default lists, extra token lists, extra tokens, forknet copies, and token conversion helpers.
- The widget logo source utility defensively re-sanitizes logoURI before returning an image src and falls back to the canonical Yearn asset path for unsafe, malformed, non-HTTPS, or unapproved-host values.
- TokenLogo now applies referrerPolicy="no-referrer" to the rendered token image element, including fallback altSrc loads on the same element.
- I found no path where the original untrusted token-list logoURI can still flow into TokenSelector/InputTokenAmount image rendering as a direct arbitrary remote src.

Tests:
- bun run lint:fix
- bun run tslint
- bunx vitest run src/components/shared/utils/tokenLogo.test.ts src/components/pages/vaults/components/widget/tokenLogo.utils.test.ts src/components/pages/vaults/components/widget/TokenSelector.test.tsx
- API_PORT=5464 PORT=4191 HOST=127.0.0.1 bun run build
- bunx vitest run src/components/shared/utils/tokenLogo.test.ts src/components/pages/vaults/components/widget/tokenLogo.utils.test.ts src/components/pages/vaults/components/widget/TokenSelector.test.tsx: passed, 23 tests
- bun run tslint: passed
- bun run lint: passed