### PR TITLE
chore: remove fixed rate KAT rewards after program end

### DIFF
--- a/src/components/pages/vaults/components/table/KatanaApyTooltip.tsx
+++ b/src/components/pages/vaults/components/table/KatanaApyTooltip.tsx
@@ -6,7 +6,6 @@ import type { ReactElement } from 'react'
 
 type TKatanaTooltipProps = {
   katanaNativeYield: number
-  fixedRateKatanRewardsAPR: number
   katanaAppRewardsAPR: number
   steerPointsPerDollar?: number
   isEligibleForSpectraBoost?: boolean
@@ -51,7 +50,6 @@ function KatanaApyRow({ iconSrc, label, value }: TKatanaApyRowProps): ReactEleme
 
 export function KatanaApyTooltipContent({
   katanaNativeYield,
-  fixedRateKatanRewardsAPR,
   katanaAppRewardsAPR,
   steerPointsPerDollar,
   isEligibleForSpectraBoost,
@@ -66,7 +64,6 @@ export function KatanaApyTooltipContent({
   const tokenAddress = getVaultToken(currentVault).address.toLowerCase()
   const tokenLogoSrc = `${baseAssetsUrl}/tokens/${chainId}/${tokenAddress}/logo-32.png`
   const chainLogoSrc = `${baseAssetsUrl}/chains/${chainId}/logo-32.png`
-  const hasFixedRateRewards = fixedRateKatanRewardsAPR > 0
   const hasAppRewards = katanaAppRewardsAPR > 0
   const hasSteerPoints = (steerPointsPerDollar || 0) > 0
 
@@ -82,14 +79,6 @@ export function KatanaApyTooltipContent({
         <p className={'-mt-1 mb-2 w-full text-left text-xs text-text-secondary wrap-break-word'}>
           {'Yield Earned on Katana'}
         </p>
-        {hasFixedRateRewards ? (
-          <>
-            <KatanaApyRow iconSrc={chainLogoSrc} label={'Base Rewards APR '} value={fixedRateKatanRewardsAPR} />
-            <p className={'-mt-1 mb-2 w-full text-left text-xs text-text-secondary wrap-break-word'}>
-              {'Limited time KAT rewards'}
-            </p>
-          </>
-        ) : null}
         {hasAppRewards ? (
           <>
             <KatanaApyRow iconSrc={chainLogoSrc} label={'App Rewards APR '} value={katanaAppRewardsAPR} />

--- a/src/components/pages/vaults/components/table/apyDisplayConfig.test.tsx
+++ b/src/components/pages/vaults/components/table/apyDisplayConfig.test.tsx
@@ -31,7 +31,6 @@ const KATANA_APY_DATA = {
   hasKelp: false,
   hasKelpNEngenlayer: false,
   katanaExtras: {
-    fixedRateKatanaRewards: 4,
     katanaAppRewardsAPR: 3,
     steerPointsPerDollar: 0
   },

--- a/src/components/pages/vaults/components/table/apyDisplayConfig.tsx
+++ b/src/components/pages/vaults/components/table/apyDisplayConfig.tsx
@@ -280,7 +280,6 @@ export function resolveForwardApyDisplayConfig({
     const katanaDetails = (
       <KatanaApyTooltipContent
         katanaNativeYield={katanaBreakdownBaseApr}
-        fixedRateKatanRewardsAPR={katanaExtras?.fixedRateKatanaRewards ?? 0}
         katanaAppRewardsAPR={katanaExtras?.katanaAppRewardsAPR ?? 0}
         steerPointsPerDollar={katanaExtras?.steerPointsPerDollar}
         isEligibleForSpectraBoost={isEligibleForSpectraBoost}
@@ -628,7 +627,6 @@ export function resolveHistoricalApyDisplayConfig({
     shouldUseKatanaAPRs && katanaExtras ? (
       <KatanaApyTooltipContent
         katanaNativeYield={standardThirtyDayApr}
-        fixedRateKatanRewardsAPR={katanaExtras.fixedRateKatanaRewards ?? 0}
         katanaAppRewardsAPR={katanaExtras.katanaAppRewardsAPR ?? 0}
         steerPointsPerDollar={katanaExtras.steerPointsPerDollar}
         isEligibleForSpectraBoost={isEligibleForSpectraBoost}

--- a/src/components/pages/vaults/hooks/useVaultApyData.test.ts
+++ b/src/components/pages/vaults/hooks/useVaultApyData.test.ts
@@ -74,16 +74,15 @@ describe('useVaultApyData helpers', () => {
 
     expect(katanaExtras).toEqual({
       katanaAppRewardsAPR: 0.0916,
-      fixedRateKatanaRewards: 0.35,
       steerPointsPerDollar: 0.1883
     })
   })
 
-  it('computes the full Katana estimate using base + fixed + app rewards', () => {
+  it('computes the full Katana estimate using base + app rewards', () => {
     const katanaExtras = resolveKatanaExtras(DETAIL_VAULT_WITH_COMPONENTS as unknown as TKongVaultInput)
     const total = computeKatanaTotalApr(katanaExtras, DETAIL_VAULT_WITH_COMPONENTS.apr.forwardAPR.netAPR)
 
-    expect(total).toBeCloseTo(0.5096, 6)
+    expect(total).toBeCloseTo(0.1596, 6)
   })
 
   it('returns no Katana extras when APR extra has no Katana fields', () => {

--- a/src/components/shared/utils/vaultApy.test.ts
+++ b/src/components/shared/utils/vaultApy.test.ts
@@ -121,19 +121,18 @@ describe('vaultApy Katana calculations', () => {
 
     expect(katanaData).toEqual({
       katanaAppRewardsAPR: 0.0916,
-      fixedRateKatanaRewards: 0.35,
       steerPointsPerDollar: 0.1883
     })
   })
 
-  it('calculates Katana estimated APY from list data using native plus fixed and app rewards', () => {
+  it('calculates Katana estimated APY from list data using native plus app rewards', () => {
     const apy = calculateVaultEstimatedAPY(withComponents(BASE_VAULT))
-    expect(apy).toBeCloseTo(0.4816, 6)
+    expect(apy).toBeCloseTo(0.1316, 6)
   })
 
   it('calculates full Katana estimate on snapshot-backed vault details', () => {
     const apy = calculateVaultEstimatedAPY(DETAIL_VAULT_WITH_COMPONENTS)
-    expect(apy).toBeCloseTo(0.5096, 6)
+    expect(apy).toBeCloseTo(0.1596, 6)
   })
 
   it('falls back to Kong forward APY when list-level Katana components are absent', () => {
@@ -141,9 +140,9 @@ describe('vaultApy Katana calculations', () => {
     expect(apy).toBeCloseTo(0.04, 6)
   })
 
-  it('calculates Katana 30 day APY from historical base + fixed + app rewards', () => {
+  it('calculates Katana 30 day APY from historical base + app rewards', () => {
     const apy = calculateKatanaThirtyDayAPY(withComponents(BASE_VAULT))
-    expect(apy).toBeCloseTo(0.4616, 6)
+    expect(apy).toBeCloseTo(0.1116, 6)
   })
 
   it('falls back to monthly historical APY for Katana vaults when components are absent', () => {

--- a/src/components/shared/utils/vaultApy.ts
+++ b/src/components/shared/utils/vaultApy.ts
@@ -5,7 +5,6 @@ const KATANA_CHAIN_ID = 747474
 
 export type TKatanaAprData = {
   katanaAppRewardsAPR?: number
-  fixedRateKatanaRewards?: number
   steerPointsPerDollar?: number
 }
 
@@ -28,9 +27,9 @@ export function calculateKatanaTotalApr(
   }
 
   const appRewardsApr = katanaExtras.katanaAppRewardsAPR
-  const parts = [baseAprOverride, katanaExtras.fixedRateKatanaRewards, appRewardsApr].filter(
-    (value): value is number => typeof value === 'number' && !Number.isNaN(value)
-  )
+  const parts = [baseAprOverride, appRewardsApr].filter((value): value is number => {
+    return typeof value === 'number' && !Number.isNaN(value)
+  })
 
   if (parts.length === 0) {
     return undefined
@@ -45,12 +44,9 @@ export function getKatanaAprData(vault: TKongVaultInput): TKatanaAprData | undef
 
   const apr = getVaultAPR(vault)
   const katanaAppRewardsAPR = normalizeFiniteNumber(apr.extra.katanaAppRewardsAPR)
-  const fixedRateKatanaRewards = normalizeFiniteNumber(apr.extra.fixedRateKatanaRewards)
   const steerPointsPerDollar = normalizeFiniteNumber(apr.extra.steerPointsPerDollar)
 
-  const hasKatanaComponentData = [katanaAppRewardsAPR, fixedRateKatanaRewards, steerPointsPerDollar].some(
-    (value) => value !== undefined
-  )
+  const hasKatanaComponentData = [katanaAppRewardsAPR, steerPointsPerDollar].some((value) => value !== undefined)
 
   if (!hasKatanaComponentData) {
     return undefined
@@ -58,7 +54,6 @@ export function getKatanaAprData(vault: TKongVaultInput): TKatanaAprData | undef
 
   return {
     katanaAppRewardsAPR,
-    fixedRateKatanaRewards,
     steerPointsPerDollar
   }
 }


### PR DESCRIPTION
## Description

This PR removes the `Base Rewards APR` row from the Katana APY breakdown modals as that program has now ended. The only rewards are now the rewards that flow through underlying strategies.

## Related Issue

https://github.com/yearn/katana-apr-service/pull/41

## Motivation and Context

Fix to keep site accurate

## How Has This Been Tested?

To Test:
- Open preview site.
- Filter for katana vaults. click on apy value to get popover modal. confirm no Base Rewards APR row shows.
- Navigate to Katana vault page. click on estimated or historical APY value in header. make sure Base Rewards APR row does not show.

## Screenshots (if appropriate):
<img width="652" height="430" alt="image" src="https://github.com/user-attachments/assets/ad569121-7b17-4b35-b2c6-4aa6f3df4d6e" />
