### PR TITLE
fix nested fees display issue

### DIFF
--- a/src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
+++ b/src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
@@ -1,3 +1,7 @@
+import {
+  resolveStrategyDisplayFees,
+  type TStrategyDisplayFees
+} from '@pages/vaults/components/detail/strategyDisplayFees'
 import { ALL_VAULTSV3_KINDS_KEYS } from '@pages/vaults/constants'
 import {
   getVaultAPR,
@@ -30,10 +34,11 @@ const AllocationChart = lazy(() =>
 type TStrategyRow = TKongVaultStrategy & {
   name: string
   isVault: boolean
+  fees: TStrategyDisplayFees
 }
 
 export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVaultInput }): ReactElement {
-  const { vaults } = useYearn()
+  const { allVaults, vaults } = useYearn()
   const isDark = useDarkMode()
   const vaultVersion = getVaultVersion(currentVault)
   const vaultVariant = vaultVersion?.startsWith('3') || vaultVersion?.startsWith('~3') ? 'v3' : 'v2'
@@ -54,14 +59,22 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
 
   const mergedList = useMemo(() => {
     return strategies.map((strategy): TStrategyRow => {
-      const linkedVault = vaults[toAddress(strategy.address)]
+      const linkedVault = allVaults[toAddress(strategy.address)]
+      const catalogVault = vaults[toAddress(strategy.address)]
+      const linkedVaultFees = linkedVault ? getVaultAPR(linkedVault).fees : undefined
       return {
         ...strategy,
         name: strategy.name || (linkedVault ? getVaultName(linkedVault) : `Strategy ${strategy.address}`),
-        isVault: Boolean(linkedVault?.address)
+        isVault: Boolean(catalogVault?.address),
+        fees: resolveStrategyDisplayFees({
+          linkedVaultFees,
+          parentVaultFees: fees,
+          strategyPerformanceFee: strategy.details?.performanceFee,
+          variant: vaultVariant
+        })
       }
     })
-  }, [strategies, vaults])
+  }, [allVaults, fees, strategies, vaultVariant, vaults])
 
   const allocatedRatio = mergedList.reduce((acc, strategy) => acc + (strategy.details?.debtRatio || 0), 0)
   const unallocatedPercentage = Math.max(0, 10000 - allocatedRatio)
@@ -244,7 +257,7 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
                   apr={strategy.estimatedAPY}
                   netApr={strategy.netAPR}
                   katRewardsAPR={strategy.katRewardsAPR}
-                  fees={fees}
+                  fees={strategy.fees}
                 />
               ))}
             {unallocatedPercentage > 0 && unallocatedValue > 0n ? (
@@ -303,7 +316,7 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
                   apr={strategy.estimatedAPY}
                   netApr={strategy.netAPR}
                   katRewardsAPR={strategy.katRewardsAPR}
-                  fees={fees}
+                  fees={strategy.fees}
                 />
               ))}
           </div>

--- a/src/components/pages/vaults/components/detail/VaultsListStrategy.tsx
+++ b/src/components/pages/vaults/components/detail/VaultsListStrategy.tsx
@@ -1,4 +1,5 @@
-import type { TKongVaultApr, TKongVaultStrategy } from '@pages/vaults/domain/kongVaultSelectors'
+import type { TStrategyDisplayFees } from '@pages/vaults/components/detail/strategyDisplayFees'
+import type { TKongVaultStrategy } from '@pages/vaults/domain/kongVaultSelectors'
 import { TokenLogo } from '@shared/components/TokenLogo'
 import { Tooltip } from '@shared/components/Tooltip'
 import { IconChevron } from '@shared/icons/IconChevron'
@@ -43,7 +44,7 @@ export function VaultsListStrategy({
   apr: number | null | undefined
   netApr: number | null | undefined
   katRewardsAPR?: number | null
-  fees: TKongVaultApr['fees']
+  fees: TStrategyDisplayFees
   totalValueUsd: number
 }): ReactElement {
   const [isExpanded, setIsExpanded] = useState(false)
@@ -194,11 +195,11 @@ export function VaultsListStrategy({
           <div className={'flex flex-col gap-1 text-sm pt-2'}>
             <div className={'flex flex-col items-start gap-1 md:flex-row md:items-center md:gap-3'}>
               <span className={'w-full text-text-secondary md:w-36'}>Management Fee:</span>
-              <span>{formatStrategiesPercent((fees?.management || 0) * 100)}</span>
+              <span>{formatStrategiesPercent(fees.management * 100)}</span>
             </div>
             <div className={'flex flex-col items-start gap-1 md:flex-row md:items-center md:gap-3'}>
               <span className={'w-full text-text-secondary md:w-36'}>Performance Fee:</span>
-              <span>{formatStrategiesPercent((details?.performanceFee || 0) / 100)}</span>
+              <span>{formatStrategiesPercent(fees.performance * 100)}</span>
             </div>
             <div className={'flex flex-col items-start gap-1 md:flex-row md:items-center md:gap-3'}>
               <span className={'w-full text-text-secondary md:w-36'}>Last Report:</span>

--- a/src/components/pages/vaults/components/detail/strategyDisplayFees.test.ts
+++ b/src/components/pages/vaults/components/detail/strategyDisplayFees.test.ts
@@ -1,0 +1,35 @@
+import { resolveStrategyDisplayFees } from '@pages/vaults/components/detail/strategyDisplayFees'
+import { describe, expect, it } from 'vitest'
+
+describe('resolveStrategyDisplayFees', () => {
+  it('uses linked vault fees when a strategy address is another vault', () => {
+    expect(
+      resolveStrategyDisplayFees({
+        linkedVaultFees: { management: 0, performance: 0.1 },
+        parentVaultFees: { management: 0.02, performance: 0.2 },
+        strategyPerformanceFee: 0,
+        variant: 'v3'
+      })
+    ).toEqual({ management: 0, performance: 0.1 })
+  })
+
+  it('falls back to parent vault performance fees for v3 strategy rows when strategy fee is unset', () => {
+    expect(
+      resolveStrategyDisplayFees({
+        parentVaultFees: { management: 0, performance: 0.1 },
+        strategyPerformanceFee: 0,
+        variant: 'v3'
+      })
+    ).toEqual({ management: 0, performance: 0.1 })
+  })
+
+  it('preserves explicit v2 strategy performance fees', () => {
+    expect(
+      resolveStrategyDisplayFees({
+        parentVaultFees: { management: 0.02, performance: 0.1 },
+        strategyPerformanceFee: 500,
+        variant: 'v2'
+      })
+    ).toEqual({ management: 0.02, performance: 0.05 })
+  })
+})

--- a/src/components/pages/vaults/components/detail/strategyDisplayFees.ts
+++ b/src/components/pages/vaults/components/detail/strategyDisplayFees.ts
@@ -1,0 +1,37 @@
+import type { TKongVaultApr } from '@pages/vaults/domain/kongVaultSelectors'
+
+export type TStrategyDisplayFees = Pick<TKongVaultApr['fees'], 'management' | 'performance'>
+
+const normalizeFee = (value: number | null | undefined): number => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return 0
+  }
+  if (value > 1) {
+    return value / 10000
+  }
+  return value
+}
+
+export function resolveStrategyDisplayFees({
+  linkedVaultFees,
+  parentVaultFees,
+  strategyPerformanceFee,
+  variant
+}: {
+  linkedVaultFees?: TStrategyDisplayFees
+  parentVaultFees: TStrategyDisplayFees
+  strategyPerformanceFee: number | null | undefined
+  variant: 'v2' | 'v3'
+}): TStrategyDisplayFees {
+  if (linkedVaultFees) {
+    return linkedVaultFees
+  }
+
+  const normalizedStrategyPerformanceFee = normalizeFee(strategyPerformanceFee)
+  const shouldUseStrategyPerformanceFee = variant === 'v2' || normalizedStrategyPerformanceFee > 0
+
+  return {
+    management: parentVaultFees.management,
+    performance: shouldUseStrategyPerformanceFee ? normalizedStrategyPerformanceFee : parentVaultFees.performance
+  }
+}


### PR DESCRIPTION
## Description
Allocator Vaults attached as strategies are showing incorrect fee data in the strategies section when expanded on the current site. 

The strategy row was reading performanceFee from DAI-2’s strategy/debt record, where Kong reports performanceFee: "0". But both the DAI-2 vault record and the linked DAI-1 vault record report fees.performanceFee: 1000, meaning 10%. So the row was showing bookkeeping data for the allocation instead of the linked vault’s fee schedule.

Changed:
VaultStrategiesSection.tsx: resolves per-row display fees, preferring the linked vault’s fees when the strategy address is itself a known vault.
VaultsListStrategy.tsx: displays the resolved fee values.
strategyDisplayFees.ts + test: captures the v3 fallback and linked-vault behavior.

## Motivation and Context

fix bug

## How Has This Been Tested?

Check that the preview shows correct fee values for nested allocator vaults.
- Navigate to the WETH-2 vault.
- scroll down to the strategies tab and expand the WETH-1 yVault entry.
- Performance fee should show 10%

## Screenshots (if appropriate):
<img width="801" height="636" alt="image" src="https://github.com/user-attachments/assets/7f59aa0f-7a1a-4d39-bfb8-6d8e2fcc35fe" />
<img width="926" height="637" alt="image" src="https://github.com/user-attachments/assets/0d42796c-0350-4c4a-bb18-b371c6b5c605" />
