### PR TITLE
fix wallet connect connector dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "yearnfi",
@@ -49,6 +50,9 @@
         "vitest": "1.6.1",
       },
     },
+  },
+  "overrides": {
+    "qr": "0.5.5",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
@@ -1415,7 +1419,7 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "qr": ["qr@0.6.0", "", {}, "sha512-P23VoX7SipHALdiIYG+D+LT/6n22dNKwV92FAb3d+Nlki/5WisSsfLt0UDFz2XEBtuwrECTznvu+chKKFCSYhA=="],
+    "qr": ["qr@0.5.5", "", {}, "sha512-iQBvKj7MRKO+co+MY0IZpyLO+ezvttxsmV86WywrgPuAmgBkv0pytyi03wourniSoPgzffeBW6cBgIkpqcvjTg=="],
 
     "qrcode": ["qrcode@1.5.3", "", { "dependencies": { "dijkstrajs": "^1.0.1", "encode-utf8": "^1.0.3", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg=="],
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "wagmi": "2.18.2",
     "zod": "4.3.6"
   },
+  "overrides": {
+    "qr": "0.5.5"
+  },
   "devDependencies": {
     "@biomejs/biome": "2.4.14",
     "@tailwindcss/postcss": "4.1.18",


### PR DESCRIPTION
## Description

This fix pins an older version of the qr dependency that the rainbowkit wallet connect qr code needs in the connection modal. This is a known issue with wevm's QR code library. Once it is fixed upsteam in that library we can remove this pinned dependency.

## Related Issue

https://github.com/wevm/cuer/issues/12
https://github.com/wevm/cuer/pull/11

## Motivation and Context

wallet connect connector is broken

## How Has This Been Tested?

tested locally. To test, open the preview site and try connecting a wallet via wallet connect. The QR code should load successfully.
