### PR TITLE
override kong snapshot TVL

### DIFF
--- a/src/components/pages/vaults/domain/kongVaultSelectors.test.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getVaultAPR, getVaultStaking, getVaultStrategies } from './kongVaultSelectors'
+import { getVaultAPR, getVaultStaking, getVaultStrategies, getVaultTVL } from './kongVaultSelectors'
 
 const LIST_REWARD = {
   address: '0x3333333333333333333333333333333333333333',
@@ -24,6 +24,114 @@ const SNAPSHOT_REWARD = {
   apr: 1.5,
   perWeek: 20
 }
+
+const BASE_LIST_VAULT = {
+  chainId: 747474,
+  address: '0x80c34BD3A3569E126e7055831036aa7b212cB159',
+  name: 'vbUSDC yVault',
+  symbol: 'yvvbUSDC',
+  decimals: 6,
+  asset: {
+    address: '0x203A662b0BD271A6ed5a60EdFbd04bFce608FD36',
+    name: 'Vault Bridge USDC',
+    symbol: 'vbUSDC',
+    decimals: 6
+  },
+  tvl: 12_592_341.595237955,
+  performance: null,
+  fees: null,
+  category: 'Stablecoin',
+  type: 'Yearn Vault',
+  kind: 'Multi Strategy',
+  v3: true,
+  yearn: true,
+  isRetired: false,
+  isHidden: false,
+  isBoosted: false,
+  isHighlighted: true,
+  strategiesCount: 7,
+  riskLevel: 1,
+  staking: null,
+  pricePerShare: '1020958'
+}
+
+describe('getVaultTVL', () => {
+  it('prefers list TVL over stale snapshot tvl.close while keeping snapshot totalAssets', () => {
+    const tvl = getVaultTVL(
+      BASE_LIST_VAULT as any,
+      {
+        totalAssets: '12593094416700',
+        tvl: {
+          close: 13_340_384.672131458
+        }
+      } as any
+    )
+
+    expect(tvl.totalAssets).toBe(12_593_094_416_700n)
+    expect(tvl.tvl).toBeCloseTo(12_592_341.595237955, 6)
+    expect(tvl.price).toBeCloseTo(0.9999402195014876, 12)
+  })
+
+  it('falls back to snapshot tvl.close when list TVL is missing', () => {
+    const tvl = getVaultTVL(
+      {
+        ...BASE_LIST_VAULT,
+        tvl: null
+      } as any,
+      {
+        totalAssets: '100000000',
+        tvl: {
+          close: 125
+        }
+      } as any
+    )
+
+    expect(tvl.tvl).toBe(125)
+    expect(tvl.price).toBe(1.25)
+  })
+
+  it('still prefers list TVL when snapshot totalAssets is missing', () => {
+    const tvl = getVaultTVL(
+      BASE_LIST_VAULT as any,
+      {
+        tvl: {
+          close: 500
+        }
+      } as any
+    )
+
+    expect(tvl.totalAssets).toBe(0n)
+    expect(tvl.tvl).toBe(12_592_341.595237955)
+    expect(tvl.price).toBe(0)
+  })
+
+  it('keeps list TVL when no snapshot is available', () => {
+    const tvl = getVaultTVL(BASE_LIST_VAULT as any)
+
+    expect(tvl.totalAssets).toBe(0n)
+    expect(tvl.tvl).toBe(12_592_341.595237955)
+    expect(tvl.price).toBe(0)
+  })
+
+  it('keeps an empty vault at zero when list TVL is zero', () => {
+    const tvl = getVaultTVL(
+      {
+        ...BASE_LIST_VAULT,
+        tvl: 0
+      } as any,
+      {
+        totalAssets: '0',
+        tvl: {
+          close: 100
+        }
+      } as any
+    )
+
+    expect(tvl.totalAssets).toBe(0n)
+    expect(tvl.tvl).toBe(0)
+    expect(tvl.price).toBe(0)
+  })
+})
 
 describe('getVaultStaking', () => {
   it('preserves list staking source and rewards when snapshot metadata is missing', () => {

--- a/src/components/pages/vaults/domain/kongVaultSelectors.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.ts
@@ -530,8 +530,11 @@ export const getVaultTVL = (vault: TKongVaultInput, snapshot?: TKongVaultSnapsho
   const token = getVaultToken(vault, snapshot)
   const totalAssetsRaw = snapshot?.totalAssets ?? '0'
   const totalAssets = toBigIntValue(totalAssetsRaw)
-  const tvl = pickNumber(snapshot?.tvl?.close ?? null, vault.tvl)
   const normalizedAssets = toNormalizedBN(totalAssets, token.decimals).normalized
+  /** this next line can be reverted to accept snapshot.tvl.close when kong issues are fixed.
+   * Check that snapshot.tvl.close matches vault.tvl before reverting.
+   */
+  const tvl = pickNumber(vault.tvl, snapshot?.tvl?.close ?? null)
   const price = Number.isFinite(tvl) && tvl > 0 && normalizedAssets > 0 ? tvl / normalizedAssets : 0
 
   return {


### PR DESCRIPTION
## Description

Issue: There are discrepancies between the TVL shown in the vault list for the katana yvvbUSDC vault and what is shown on the vault page. The vault list uses the /api/rest/list/vaults rest API data and returns a value that matches totalAssets (12,592,341.595). The vault page use the `tvl.close`value from the snapshot, and that is returning a much higher number (13,340,384.672). 

There is a confirmed kong issue with refresh timings that is being troubleshooted. In the meantime, we can read the TVL values straight from that main vault list instead of from the snapshot.

## Related Issue

none

## Motivation and Context

bug fix

## How Has This Been Tested?

To test: confirm that TVL values match between Vault list values and vault page values. The issue was noticed on the yvvbUSDC vault.

