### PR TITLE
fix: usdt approve

### DIFF
--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -20,6 +20,7 @@ type TxState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'success' | 'er
 interface ApprovalOverlayProps {
   isOpen: boolean
   onClose: () => void
+  onAllowanceUpdated?: (amount: bigint) => void
   tokenSymbol: string
   tokenAddress: `0x${string}`
   tokenDecimals: number
@@ -32,6 +33,7 @@ interface ApprovalOverlayProps {
 export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   isOpen,
   onClose,
+  onAllowanceUpdated,
   tokenSymbol,
   tokenAddress,
   spenderAddress,
@@ -41,6 +43,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
 }) => {
   const [txState, setTxState] = useState<TxState>('idle')
   const [errorMessage, setErrorMessage] = useState('')
+  const [submittedAmount, setSubmittedAmount] = useState<bigint | undefined>()
 
   const { address: account, chain, connector } = useAccount()
   const currentChainId = useChainId()
@@ -82,6 +85,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
     if (!isOpen) {
       setTxState('idle')
       setErrorMessage('')
+      setSubmittedAmount(undefined)
       reset()
     }
   }, [isOpen, reset])
@@ -90,9 +94,12 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   useEffect(() => {
     if (receipt.isSuccess && (txState === 'pending' || txState === 'submitted')) {
       setTxState('success')
+      if (submittedAmount !== undefined) {
+        onAllowanceUpdated?.(submittedAmount)
+      }
       reset()
     }
-  }, [receipt.isSuccess, txState, reset])
+  }, [onAllowanceUpdated, receipt.isSuccess, submittedAmount, txState, reset])
 
   useEffect(() => {
     const nextTxState = resolveApprovalOverlayPendingSafeState({
@@ -111,6 +118,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
     if (nextTxState === 'error') {
       setTxState('error')
       setErrorMessage('Transaction failed in Safe. Please review your Safe queue and try again.')
+      setSubmittedAmount(undefined)
       reset()
     }
   }, [
@@ -127,6 +135,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
     if (receipt.isError && (txState === 'pending' || txState === 'submitted')) {
       setTxState('error')
       setErrorMessage('Transaction failed')
+      setSubmittedAmount(undefined)
       reset()
     }
   }, [receipt.isError, txState, reset])
@@ -166,6 +175,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
       }
 
       try {
+        setSubmittedAmount(amount)
         await writeContractAsync({
           address: tokenAddress,
           abi: getApproveAbi(tokenAddress),
@@ -182,8 +192,10 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
 
         if (isUserRejection) {
           setTxState('idle')
+          setSubmittedAmount(undefined)
         } else {
           setTxState('error')
+          setSubmittedAmount(undefined)
           setErrorMessage('Failed to submit transaction')
         }
       }

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -233,6 +233,12 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
                   <span className="font-semibold text-text-primary">{tokenSymbol}</span> up to a set limit. This is
                   required before depositing.
                 </p>
+                {disableSetUnlimited && (
+                  <p className="text-sm text-text-secondary">
+                    Unlike most tokens, {tokenSymbol} cannot change a non-zero approval directly. Revoke sets the{' '}
+                    {spenderName} allowance to zero; then you can approve again.
+                  </p>
+                )}
               </div>
             </div>
 
@@ -244,8 +250,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
                 </p>
                 {disableSetUnlimited ? (
                   <p className="text-sm text-text-secondary">
-                    Set Unlimited is unavailable because {tokenSymbol} cannot change a non-zero approval directly.
-                    Revoke first; once it confirms, you can approve again or set unlimited.
+                    Set Unlimited is unavailable until the current approval is revoked.
                   </p>
                 ) : (
                   <p className="text-sm text-text-secondary">

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -220,7 +220,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   const isInTransaction = txState !== 'idle'
 
   return (
-    <InfoOverlay isOpen={isOpen} onClose={onClose} title="Token Approval" hideButton>
+    <InfoOverlay isOpen={isOpen} onClose={onClose} title="Manage approval" hideButton>
       <div className="flex flex-col h-full">
         {/* Idle state - show info and actions */}
         {txState === 'idle' && (

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -20,7 +20,7 @@ type TxState = 'idle' | 'confirming' | 'pending' | 'submitted' | 'success' | 'er
 interface ApprovalOverlayProps {
   isOpen: boolean
   onClose: () => void
-  onAllowanceUpdated?: (amount: bigint) => void
+  onDone?: () => Promise<void> | void
   tokenSymbol: string
   tokenAddress: `0x${string}`
   tokenDecimals: number
@@ -33,7 +33,7 @@ interface ApprovalOverlayProps {
 export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   isOpen,
   onClose,
-  onAllowanceUpdated,
+  onDone,
   tokenSymbol,
   tokenAddress,
   spenderAddress,
@@ -43,7 +43,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
 }) => {
   const [txState, setTxState] = useState<TxState>('idle')
   const [errorMessage, setErrorMessage] = useState('')
-  const [submittedAmount, setSubmittedAmount] = useState<bigint | undefined>()
+  const [isDoneRefreshing, setIsDoneRefreshing] = useState(false)
 
   const { address: account, chain, connector } = useAccount()
   const currentChainId = useChainId()
@@ -85,7 +85,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
     if (!isOpen) {
       setTxState('idle')
       setErrorMessage('')
-      setSubmittedAmount(undefined)
+      setIsDoneRefreshing(false)
       reset()
     }
   }, [isOpen, reset])
@@ -94,12 +94,9 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   useEffect(() => {
     if (receipt.isSuccess && (txState === 'pending' || txState === 'submitted')) {
       setTxState('success')
-      if (submittedAmount !== undefined) {
-        onAllowanceUpdated?.(submittedAmount)
-      }
       reset()
     }
-  }, [onAllowanceUpdated, receipt.isSuccess, submittedAmount, txState, reset])
+  }, [receipt.isSuccess, txState, reset])
 
   useEffect(() => {
     const nextTxState = resolveApprovalOverlayPendingSafeState({
@@ -118,7 +115,6 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
     if (nextTxState === 'error') {
       setTxState('error')
       setErrorMessage('Transaction failed in Safe. Please review your Safe queue and try again.')
-      setSubmittedAmount(undefined)
       reset()
     }
   }, [
@@ -135,10 +131,24 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
     if (receipt.isError && (txState === 'pending' || txState === 'submitted')) {
       setTxState('error')
       setErrorMessage('Transaction failed')
-      setSubmittedAmount(undefined)
       reset()
     }
   }, [receipt.isError, txState, reset])
+
+  const handleDone = useCallback(async () => {
+    if (isDoneRefreshing) return
+
+    setIsDoneRefreshing(true)
+    try {
+      await onDone?.()
+      onClose()
+    } catch (error) {
+      console.warn('[ApprovalOverlay] Failed to refresh after approval update', error)
+      onClose()
+    } finally {
+      setIsDoneRefreshing(false)
+    }
+  }, [isDoneRefreshing, onClose, onDone])
 
   const handleApprove = useCallback(
     async (amount: bigint) => {
@@ -175,7 +185,6 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
       }
 
       try {
-        setSubmittedAmount(amount)
         await writeContractAsync({
           address: tokenAddress,
           abi: getApproveAbi(tokenAddress),
@@ -192,10 +201,8 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
 
         if (isUserRejection) {
           setTxState('idle')
-          setSubmittedAmount(undefined)
         } else {
           setTxState('error')
-          setSubmittedAmount(undefined)
           setErrorMessage('Failed to submit transaction')
         }
       }
@@ -287,8 +294,10 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
                 <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Approval updated</h3>
                 <p className="text-sm text-text-secondary mb-6">Your token allowance has been changed</p>
                 <Button
-                  onClick={onClose}
-                  variant="filled"
+                  onClick={handleDone}
+                  variant={isDoneRefreshing ? 'busy' : 'filled'}
+                  isBusy={isDoneRefreshing}
+                  disabled={isDoneRefreshing}
                   className="w-full max-w-xs"
                   classNameOverride="yearn--button--nextgen w-full"
                 >
@@ -306,8 +315,10 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
 Execution may happen separately after the required confirmations are collected.`}
                 </p>
                 <Button
-                  onClick={onClose}
-                  variant="filled"
+                  onClick={handleDone}
+                  variant={isDoneRefreshing ? 'busy' : 'filled'}
+                  isBusy={isDoneRefreshing}
+                  disabled={isDoneRefreshing}
                   className="w-full max-w-xs"
                   classNameOverride="yearn--button--nextgen w-full"
                 >

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -21,6 +21,7 @@ interface ApprovalOverlayProps {
   isOpen: boolean
   onClose: () => void
   onDone?: () => Promise<void> | void
+  disableSetUnlimited?: boolean
   tokenSymbol: string
   tokenAddress: `0x${string}`
   tokenDecimals: number
@@ -34,6 +35,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   isOpen,
   onClose,
   onDone,
+  disableSetUnlimited = false,
   tokenSymbol,
   tokenAddress,
   spenderAddress,
@@ -214,7 +216,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   const handleSetUnlimited = useCallback(() => handleApprove(maxUint256), [handleApprove])
 
   const isRevokeDisabled = !account || currentAllowance === '0.00' || currentAllowance === '0'
-  const isUnlimitedDisabled = !account || currentAllowance === 'Unlimited'
+  const isUnlimitedDisabled = disableSetUnlimited || !account || currentAllowance === 'Unlimited'
   const isInTransaction = txState !== 'idle'
 
   return (
@@ -240,10 +242,16 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
                   Hit <span className="font-semibold text-text-primary">Revoke</span> to set {spenderName} allowance to
                   zero.
                 </p>
-                <p className="text-sm text-text-secondary">
-                  Hit <span className="font-semibold text-text-primary">Set Unlimited</span> if you don't want to
-                  approve this token again for future deposits.
-                </p>
+                {disableSetUnlimited ? (
+                  <p className="text-sm text-text-secondary">
+                    Set Unlimited is unavailable until the current {spenderName} allowance is revoked.
+                  </p>
+                ) : (
+                  <p className="text-sm text-text-secondary">
+                    Hit <span className="font-semibold text-text-primary">Set Unlimited</span> if you don't want to
+                    approve this token again for future deposits.
+                  </p>
+                )}
               </div>
               <div className="flex gap-2">
                 <Button
@@ -260,7 +268,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
                   variant="filled"
                   disabled={isUnlimitedDisabled}
                   className="flex-1"
-                  classNameOverride="yearn--button--nextgen flex-1"
+                  classNameOverride={`yearn--button--nextgen flex-1 ${isUnlimitedDisabled ? 'opacity-40' : ''}`}
                 >
                   Set Unlimited
                 </Button>

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -244,7 +244,8 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
                 </p>
                 {disableSetUnlimited ? (
                   <p className="text-sm text-text-secondary">
-                    Set Unlimited is unavailable until the current {spenderName} allowance is revoked.
+                    Set Unlimited is unavailable because {tokenSymbol} cannot change a non-zero approval directly.
+                    Revoke first; once it confirms, you can approve again or set unlimited.
                   </p>
                 ) : (
                   <p className="text-sm text-text-secondary">

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalResetWarning.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalResetWarning.tsx
@@ -6,23 +6,14 @@ type TApprovalResetWarningProps = {
   onManageApproval: () => void
 }
 
-export function ApprovalResetWarning({
-  tokenSymbol,
-  spenderName,
-  onManageApproval
-}: TApprovalResetWarningProps): ReactElement {
+export function ApprovalResetWarning({ tokenSymbol, onManageApproval }: TApprovalResetWarningProps): ReactElement {
   const resolvedTokenSymbol = tokenSymbol || 'This token'
-  const resolvedSpenderName = spenderName || 'spender'
 
   return (
     <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm leading-5 text-red-500">
-          <span className="font-semibold">{resolvedTokenSymbol} approval needs revoke.</span>
-          <span className="block">
-            Unlike most tokens, {resolvedTokenSymbol} cannot change a non-zero approval directly. Revoke sets the{' '}
-            {resolvedSpenderName} allowance to zero; then approve again.
-          </span>
+          <span className="font-semibold">{resolvedTokenSymbol} approval must be revoked.</span>
         </p>
         <button
           type="button"

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalResetWarning.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalResetWarning.tsx
@@ -1,0 +1,36 @@
+import type { ReactElement } from 'react'
+
+type TApprovalResetWarningProps = {
+  tokenSymbol?: string
+  spenderName?: string
+  onManageApproval: () => void
+}
+
+export function ApprovalResetWarning({
+  tokenSymbol,
+  spenderName,
+  onManageApproval
+}: TApprovalResetWarningProps): ReactElement {
+  const resolvedTokenSymbol = tokenSymbol || 'This token'
+  const resolvedSpenderName = spenderName || 'spender'
+
+  return (
+    <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm leading-5 text-red-500">
+          <span className="font-semibold">{resolvedTokenSymbol} approval needs reset.</span>
+          <span className="block">
+            Revoke the current {resolvedSpenderName} approval before approving again or setting unlimited.
+          </span>
+        </p>
+        <button
+          type="button"
+          onClick={onManageApproval}
+          className="shrink-0 self-start text-sm font-semibold text-red-500 underline transition-colors hover:text-red-400 sm:self-center"
+        >
+          Manage approval
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalResetWarning.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalResetWarning.tsx
@@ -18,9 +18,10 @@ export function ApprovalResetWarning({
     <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <p className="text-sm leading-5 text-red-500">
-          <span className="font-semibold">{resolvedTokenSymbol} approval needs reset.</span>
+          <span className="font-semibold">{resolvedTokenSymbol} approval needs revoke.</span>
           <span className="block">
-            Revoke the current {resolvedSpenderName} approval before approving again or setting unlimited.
+            Unlike most tokens, {resolvedTokenSymbol} cannot change a non-zero approval directly. Revoke sets the{' '}
+            {resolvedSpenderName} allowance to zero; then approve again.
           </span>
         </p>
         <button

--- a/src/components/pages/vaults/components/widget/deposit/approvalReset.test.ts
+++ b/src/components/pages/vaults/components/widget/deposit/approvalReset.test.ts
@@ -12,6 +12,7 @@ describe('shouldBlockDepositApprovalForAllowanceReset', () => {
         depositToken: USDT,
         currentAllowance: 100n,
         requiredAmount: 200n,
+        availableBalance: 200n,
         needsApproval: true
       })
     ).toBe(true)
@@ -23,6 +24,7 @@ describe('shouldBlockDepositApprovalForAllowanceReset', () => {
         depositToken: USDT,
         currentAllowance: 0n,
         requiredAmount: 200n,
+        availableBalance: 200n,
         needsApproval: true
       })
     ).toBe(false)
@@ -32,6 +34,7 @@ describe('shouldBlockDepositApprovalForAllowanceReset', () => {
         depositToken: USDT,
         currentAllowance: 200n,
         requiredAmount: 200n,
+        availableBalance: 200n,
         needsApproval: false
       })
     ).toBe(false)
@@ -43,6 +46,19 @@ describe('shouldBlockDepositApprovalForAllowanceReset', () => {
         depositToken: DAI,
         currentAllowance: 100n,
         requiredAmount: 200n,
+        availableBalance: 200n,
+        needsApproval: true
+      })
+    ).toBe(false)
+  })
+
+  it('does not block when the user balance is below the input amount', () => {
+    expect(
+      shouldBlockDepositApprovalForAllowanceReset({
+        depositToken: USDT,
+        currentAllowance: 100n,
+        requiredAmount: 200n,
+        availableBalance: 199n,
         needsApproval: true
       })
     ).toBe(false)

--- a/src/components/pages/vaults/components/widget/deposit/approvalReset.test.ts
+++ b/src/components/pages/vaults/components/widget/deposit/approvalReset.test.ts
@@ -1,0 +1,50 @@
+import type { Address } from 'viem'
+import { describe, expect, it } from 'vitest'
+import { shouldBlockDepositApprovalForAllowanceReset } from './approvalReset'
+
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7' as Address
+const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F' as Address
+
+describe('shouldBlockDepositApprovalForAllowanceReset', () => {
+  it('blocks mainnet USDT approvals when allowance is non-zero but insufficient', () => {
+    expect(
+      shouldBlockDepositApprovalForAllowanceReset({
+        depositToken: USDT,
+        currentAllowance: 100n,
+        requiredAmount: 200n,
+        needsApproval: true
+      })
+    ).toBe(true)
+  })
+
+  it('does not block if the current allowance is zero or already sufficient', () => {
+    expect(
+      shouldBlockDepositApprovalForAllowanceReset({
+        depositToken: USDT,
+        currentAllowance: 0n,
+        requiredAmount: 200n,
+        needsApproval: true
+      })
+    ).toBe(false)
+
+    expect(
+      shouldBlockDepositApprovalForAllowanceReset({
+        depositToken: USDT,
+        currentAllowance: 200n,
+        requiredAmount: 200n,
+        needsApproval: false
+      })
+    ).toBe(false)
+  })
+
+  it('does not block standard approval tokens', () => {
+    expect(
+      shouldBlockDepositApprovalForAllowanceReset({
+        depositToken: DAI,
+        currentAllowance: 100n,
+        requiredAmount: 200n,
+        needsApproval: true
+      })
+    ).toBe(false)
+  })
+})

--- a/src/components/pages/vaults/components/widget/deposit/approvalReset.ts
+++ b/src/components/pages/vaults/components/widget/deposit/approvalReset.ts
@@ -5,6 +5,7 @@ type TShouldBlockDepositApprovalForAllowanceReset = {
   depositToken?: Address
   currentAllowance: bigint
   requiredAmount: bigint
+  availableBalance: bigint
   needsApproval: boolean
 }
 
@@ -12,12 +13,14 @@ export function shouldBlockDepositApprovalForAllowanceReset({
   depositToken,
   currentAllowance,
   requiredAmount,
+  availableBalance,
   needsApproval
 }: TShouldBlockDepositApprovalForAllowanceReset): boolean {
   return (
     needsApproval &&
     requiresAllowanceResetBeforeApproval(depositToken) &&
     requiredAmount > 0n &&
+    availableBalance >= requiredAmount &&
     currentAllowance > 0n &&
     currentAllowance < requiredAmount
   )

--- a/src/components/pages/vaults/components/widget/deposit/approvalReset.ts
+++ b/src/components/pages/vaults/components/widget/deposit/approvalReset.ts
@@ -1,0 +1,24 @@
+import { requiresAllowanceResetBeforeApproval } from '@shared/utils/approve'
+import type { Address } from 'viem'
+
+type TShouldBlockDepositApprovalForAllowanceReset = {
+  depositToken?: Address
+  currentAllowance: bigint
+  requiredAmount: bigint
+  needsApproval: boolean
+}
+
+export function shouldBlockDepositApprovalForAllowanceReset({
+  depositToken,
+  currentAllowance,
+  requiredAmount,
+  needsApproval
+}: TShouldBlockDepositApprovalForAllowanceReset): boolean {
+  return (
+    needsApproval &&
+    requiresAllowanceResetBeforeApproval(depositToken) &&
+    requiredAmount > 0n &&
+    currentAllowance > 0n &&
+    currentAllowance < requiredAmount
+  )
+}

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -1135,7 +1135,8 @@ export function WidgetDeposit({
       !currentStep.prepare.isSuccess &&
       !currentStep.prepare.isError
   )
-  const isDepositButtonBusy = activeFlow.periphery.isLoadingRoute || isCurrentStepWaitingForPrepare
+  const isDepositButtonBusy =
+    !shouldBlockApprovalForAllowanceReset && (activeFlow.periphery.isLoadingRoute || isCurrentStepWaitingForPrepare)
   const isDepositButtonDisabled =
     !!effectiveDepositError ||
     depositAmount.bn === 0n ||

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -645,6 +645,7 @@ export function WidgetDeposit({
       depositToken,
       currentAllowance: activeFlow.periphery.allowance,
       requiredAmount: depositAmount.debouncedBn,
+      availableBalance: inputToken?.balance.raw ?? 0n,
       needsApproval
     })
   const approvalFlowKey = useMemo(

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -827,10 +827,16 @@ export function WidgetDeposit({
     [approvalFlowKey]
   )
 
-  const handleApprovalOverlayAllowanceUpdated = useCallback(() => {
+  const refetchActiveAllowance = activeFlow.periphery.refetchAllowance
+  const handleApprovalOverlayDone = useCallback(async () => {
+    try {
+      await refetchActiveAllowance?.()
+    } catch (error) {
+      console.warn('[WidgetDeposit] Failed to refetch allowance after approval update', error)
+    }
     setCompletedApprovalFlowKey(null)
     setApprovalRouteRefreshKey((current) => current + 1)
-  }, [])
+  }, [refetchActiveAllowance])
 
   const handleDepositSuccess = useCallback(() => {
     const amountToDeposit = formatUnits(depositAmount.bn, inputToken?.decimals ?? 18)
@@ -1329,7 +1335,7 @@ export function WidgetDeposit({
       <ApprovalOverlay
         isOpen={showApprovalOverlay}
         onClose={() => setShowApprovalOverlay(false)}
-        onAllowanceUpdated={handleApprovalOverlayAllowanceUpdated}
+        onDone={handleApprovalOverlayDone}
         tokenSymbol={inputToken?.symbol || ''}
         tokenAddress={toAddress(depositToken)}
         tokenDecimals={inputToken?.decimals ?? 18}

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -28,6 +28,8 @@ import { WidgetLoadingSkeleton } from '../shared/WidgetLoadingSkeleton'
 import { DEPOSIT_COMMON_TOKENS_BY_CHAIN } from '../withdraw/constants'
 import { AnnualReturnOverlay } from './AnnualReturnOverlay'
 import { ApprovalOverlay } from './ApprovalOverlay'
+import { ApprovalResetWarning } from './ApprovalResetWarning'
+import { shouldBlockDepositApprovalForAllowanceReset } from './approvalReset'
 import { getDepositApprovalSpender } from './approvalSpender'
 import { DepositDetails } from './DepositDetails'
 import { getStructurallyExcludedDepositTokenAddresses } from './tokenSelectorFiltering'
@@ -194,6 +196,7 @@ export function WidgetDeposit({
   const [isDetailsPanelOpen, setIsDetailsPanelOpen] = useState(false)
   const [isYBoldAutoStakeWarningDismissing, setIsYBoldAutoStakeWarningDismissing] = useState(false)
   const [isYBoldAutoStakeWarningExiting, setIsYBoldAutoStakeWarningExiting] = useState(false)
+  const [approvalRouteRefreshKey, setApprovalRouteRefreshKey] = useState(0)
   const yBoldAutoStakeWarningTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const yBoldAutoStakeWarningExitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -335,6 +338,7 @@ export function WidgetDeposit({
     vaultDecimals: vault?.decimals ?? 18,
     slippage: ensoQuoteSlippage,
     ensoRoutingStrategy: isWalletSafe ? 'router' : undefined,
+    routeRefreshKey: approvalRouteRefreshKey,
     stakingSource
   })
 
@@ -634,6 +638,15 @@ export function WidgetDeposit({
   })
   const formattedDepositAmount = formatTAmount({ value: depositAmount.bn, decimals: inputToken?.decimals ?? 18 })
   const needsApproval = !isNativeToken && !activeFlow.periphery.isAllowanceSufficient
+  const hasSyncedDepositAmount = !depositAmount.isDebouncing && depositAmount.bn === depositAmount.debouncedBn
+  const shouldBlockApprovalForAllowanceReset =
+    hasSyncedDepositAmount &&
+    shouldBlockDepositApprovalForAllowanceReset({
+      depositToken,
+      currentAllowance: activeFlow.periphery.allowance,
+      requiredAmount: depositAmount.debouncedBn,
+      needsApproval
+    })
   const approvalFlowKey = useMemo(
     () =>
       [routeType, depositToken, destinationToken, sourceChainId, chainId, depositAmount.debouncedBn.toString()].join(
@@ -813,6 +826,11 @@ export function WidgetDeposit({
     },
     [approvalFlowKey]
   )
+
+  const handleApprovalOverlayAllowanceUpdated = useCallback(() => {
+    setCompletedApprovalFlowKey(null)
+    setApprovalRouteRefreshKey((current) => current + 1)
+  }, [])
 
   const handleDepositSuccess = useCallback(() => {
     const amountToDeposit = formatUnits(depositAmount.bn, inputToken?.decimals ?? 18)
@@ -1044,6 +1062,13 @@ export function WidgetDeposit({
       hasAmount={depositAmount.bn > 0n}
     />
   )
+  const approvalResetWarning = shouldBlockApprovalForAllowanceReset ? (
+    <ApprovalResetWarning
+      tokenSymbol={inputToken?.symbol}
+      spenderName={approvalSpenderName}
+      onManageApproval={() => setShowApprovalOverlay(true)}
+    />
+  ) : null
   const shouldRenderYBoldAutoStakeWarning = showYBoldAutoStakeWarning || isYBoldAutoStakeWarningDismissing
   const isYBoldAutoStakeToggleOn = isAutoStakingEnabled || isYBoldAutoStakeWarningDismissing
   const yBoldAutoStakeWarning = shouldRenderYBoldAutoStakeWarning ? (
@@ -1096,17 +1121,29 @@ export function WidgetDeposit({
     routeType,
     actionLabelOverride
   )
+  const isCurrentStepWaitingForPrepare = Boolean(
+    currentStep &&
+      currentStep.isEnabled !== false &&
+      !currentStep.batch &&
+      !currentStep.isPermit &&
+      !currentStep.prepare.isSuccess &&
+      !currentStep.prepare.isError
+  )
+  const isDepositButtonBusy = activeFlow.periphery.isLoadingRoute || isCurrentStepWaitingForPrepare
   const isDepositButtonDisabled =
     !!effectiveDepositError ||
     depositAmount.bn === 0n ||
     isLoadingQuote ||
     depositAmount.isDebouncing ||
+    shouldBlockApprovalForAllowanceReset ||
+    isCurrentStepWaitingForPrepare ||
     (effectiveNeedsApproval && !activeFlow.periphery.prepareApproveEnabled) ||
     (!effectiveNeedsApproval && !activeFlow.periphery.prepareDepositEnabled) ||
     (ensoRouteHasSwap && (priceImpactInfo.isBlocking || priceImpactInfo.isAboveTolerance))
 
   const actionRow = showActionRow ? (
     <div className="flex flex-col gap-3">
+      {approvalResetWarning}
       {priceImpactWarning}
       {contentAboveButton}
       {yBoldAutoStakeWarning}
@@ -1124,8 +1161,8 @@ export function WidgetDeposit({
           ) : (
             <Button
               onClick={() => setShowTransactionOverlay(true)}
-              variant={activeFlow.periphery.isLoadingRoute ? 'busy' : 'filled'}
-              isBusy={activeFlow.periphery.isLoadingRoute}
+              variant={isDepositButtonBusy ? 'busy' : 'filled'}
+              isBusy={isDepositButtonBusy}
               disabled={isDepositButtonDisabled}
               className="w-full"
               classNameOverride="yearn--button--nextgen w-full"
@@ -1292,6 +1329,7 @@ export function WidgetDeposit({
       <ApprovalOverlay
         isOpen={showApprovalOverlay}
         onClose={() => setShowApprovalOverlay(false)}
+        onAllowanceUpdated={handleApprovalOverlayAllowanceUpdated}
         tokenSymbol={inputToken?.symbol || ''}
         tokenAddress={toAddress(depositToken)}
         tokenDecimals={inputToken?.decimals ?? 18}

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -10,6 +10,7 @@ import { IconCross } from '@shared/icons/IconCross'
 import { IconSettings } from '@shared/icons/IconSettings'
 import type { TToken } from '@shared/types'
 import { cl, formatTAmount, toAddress } from '@shared/utils'
+import { requiresAllowanceResetBeforeApproval } from '@shared/utils/approve'
 import { ETH_TOKEN_ADDRESS } from '@shared/utils/constants'
 import { PLAUSIBLE_EVENTS } from '@shared/utils/plausible'
 import { calculateRemainingEnsoSlippagePercentage, ZAP_SLIPPAGE_HARD_CAP } from '@shared/utils/slippage'
@@ -192,6 +193,7 @@ export function WidgetDeposit({
   const [showVaultShareValueModal, setShowVaultShareValueModal] = useState(false)
   const [showAnnualReturnModal, setShowAnnualReturnModal] = useState(false)
   const [showApprovalOverlay, setShowApprovalOverlay] = useState(false)
+  const [disableApprovalOverlaySetUnlimited, setDisableApprovalOverlaySetUnlimited] = useState(false)
   const [showTransactionOverlay, setShowTransactionOverlay] = useState(false)
   const [isDetailsPanelOpen, setIsDetailsPanelOpen] = useState(false)
   const [isYBoldAutoStakeWarningDismissing, setIsYBoldAutoStakeWarningDismissing] = useState(false)
@@ -638,6 +640,8 @@ export function WidgetDeposit({
   })
   const formattedDepositAmount = formatTAmount({ value: depositAmount.bn, decimals: inputToken?.decimals ?? 18 })
   const needsApproval = !isNativeToken && !activeFlow.periphery.isAllowanceSufficient
+  const shouldDisableSetUnlimitedForAllowanceReset =
+    !isNativeToken && activeFlow.periphery.allowance > 0n && requiresAllowanceResetBeforeApproval(depositToken)
   const hasSyncedDepositAmount = !depositAmount.isDebouncing && depositAmount.bn === depositAmount.debouncedBn
   const shouldBlockApprovalForAllowanceReset =
     hasSyncedDepositAmount &&
@@ -838,6 +842,21 @@ export function WidgetDeposit({
     setCompletedApprovalFlowKey(null)
     setApprovalRouteRefreshKey((current) => current + 1)
   }, [refetchActiveAllowance])
+
+  const openApprovalOverlay = useCallback(() => {
+    setDisableApprovalOverlaySetUnlimited(shouldDisableSetUnlimitedForAllowanceReset)
+    setShowApprovalOverlay(true)
+  }, [shouldDisableSetUnlimitedForAllowanceReset])
+
+  const openApprovalResetOverlay = useCallback(() => {
+    setDisableApprovalOverlaySetUnlimited(true)
+    setShowApprovalOverlay(true)
+  }, [])
+
+  const closeApprovalOverlay = useCallback(() => {
+    setShowApprovalOverlay(false)
+    setDisableApprovalOverlaySetUnlimited(false)
+  }, [])
 
   const handleDepositSuccess = useCallback(() => {
     const amountToDeposit = formatUnits(depositAmount.bn, inputToken?.decimals ?? 18)
@@ -1054,7 +1073,7 @@ export function WidgetDeposit({
       allowanceTokenSymbol={!isNativeToken ? inputToken?.symbol : undefined}
       approvalSpenderName={approvalSpenderName}
       onAllowanceClick={onAllowanceClick}
-      onShowApprovalOverlay={!isNativeToken ? () => setShowApprovalOverlay(true) : undefined}
+      onShowApprovalOverlay={!isNativeToken ? openApprovalOverlay : undefined}
     />
   )
 
@@ -1073,7 +1092,7 @@ export function WidgetDeposit({
     <ApprovalResetWarning
       tokenSymbol={inputToken?.symbol}
       spenderName={approvalSpenderName}
-      onManageApproval={() => setShowApprovalOverlay(true)}
+      onManageApproval={openApprovalResetOverlay}
     />
   ) : null
   const shouldRenderYBoldAutoStakeWarning = showYBoldAutoStakeWarning || isYBoldAutoStakeWarningDismissing
@@ -1336,8 +1355,9 @@ export function WidgetDeposit({
 
       <ApprovalOverlay
         isOpen={showApprovalOverlay}
-        onClose={() => setShowApprovalOverlay(false)}
+        onClose={closeApprovalOverlay}
         onDone={handleApprovalOverlayDone}
+        disableSetUnlimited={disableApprovalOverlaySetUnlimited}
         tokenSymbol={inputToken?.symbol || ''}
         tokenAddress={toAddress(depositToken)}
         tokenDecimals={inputToken?.decimals ?? 18}

--- a/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
@@ -37,6 +37,7 @@ interface UseDepositFlowProps {
   // Settings
   slippage: number
   ensoRoutingStrategy?: EnsoRoutingStrategy
+  routeRefreshKey?: number
   stakingSource?: string
 }
 
@@ -90,6 +91,7 @@ export const useDepositFlow = ({
   vaultDecimals,
   slippage,
   ensoRoutingStrategy,
+  routeRefreshKey,
   stakingSource
 }: UseDepositFlowProps): DepositFlowResult => {
   // Determine routing type
@@ -162,7 +164,8 @@ export const useDepositFlow = ({
     decimalsOut: vaultDecimals,
     enabled: routeType === 'ENSO' && !!depositToken && amount > 0n && currentAmount > 0n,
     slippage: toBasisPoints(slippage),
-    routingStrategy: ensoRoutingStrategy
+    routingStrategy: ensoRoutingStrategy,
+    routeRefreshKey
   })
 
   // Select active flow based on routing type

--- a/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
@@ -70,6 +70,7 @@ export interface DepositFlowResult {
       }
       gas?: string
       error?: unknown
+      refetchAllowance?: () => Promise<unknown>
     }
   }
 }

--- a/src/components/pages/vaults/hooks/actions/useDirectDeposit.ts
+++ b/src/components/pages/vaults/hooks/actions/useDirectDeposit.ts
@@ -19,7 +19,7 @@ interface UseDirectDepositParams {
 
 export function useDirectDeposit(params: UseDirectDepositParams): UseWidgetDepositFlowReturn {
   // Check current allowance using shared hook
-  const { allowance = 0n } = useTokenAllowance({
+  const { allowance = 0n, refetch: refetchAllowance } = useTokenAllowance({
     account: params.account,
     token: params.assetAddress,
     spender: params.vaultAddress,
@@ -79,7 +79,8 @@ export function useDirectDeposit(params: UseDirectDepositParams): UseWidgetDepos
       minExpectedOut: expectedOut,
       isLoadingRoute: false,
       isCrossChain: false,
-      error
+      error,
+      refetchAllowance
     }
   }
 }

--- a/src/components/pages/vaults/hooks/actions/useDirectStake.ts
+++ b/src/components/pages/vaults/hooks/actions/useDirectStake.ts
@@ -18,7 +18,7 @@ interface UseDirectStakeParams {
 
 export function useDirectStake(params: UseDirectStakeParams): UseWidgetDepositFlowReturn {
   // Check current allowance (vault tokens → staking contract)
-  const { allowance = 0n } = useTokenAllowance({
+  const { allowance = 0n, refetch: refetchAllowance } = useTokenAllowance({
     account: params.account,
     token: params.vaultAddress,
     spender: params.stakingAddress,
@@ -88,7 +88,8 @@ export function useDirectStake(params: UseDirectStakeParams): UseWidgetDepositFl
       minExpectedOut: expectedOut,
       isLoadingRoute: false,
       isCrossChain: false,
-      error: undefined
+      error: undefined,
+      refetchAllowance
     }
   }
 }

--- a/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
+++ b/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
@@ -17,6 +17,7 @@ interface UseEnsoDepositParams {
   enabled: boolean
   slippage?: number
   routingStrategy?: EnsoRoutingStrategy
+  routeRefreshKey?: number
 }
 
 export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFlowReturn {
@@ -29,7 +30,8 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
         params.vaultAddress,
         params.account ?? 'no-account',
         params.slippage ?? 'default',
-        params.routingStrategy ?? 'default-strategy'
+        params.routingStrategy ?? 'default-strategy',
+        params.routeRefreshKey ?? 0
       ].join(':'),
     [
       params.chainId,
@@ -38,7 +40,8 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
       params.vaultAddress,
       params.account,
       params.slippage,
-      params.routingStrategy
+      params.routingStrategy,
+      params.routeRefreshKey
     ]
   )
 

--- a/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
+++ b/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
@@ -107,7 +107,8 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
         routerAddress: ensoFlow.periphery.routerAddress,
         error: ensoFlow.periphery.error?.message,
         tx: ensoFlow.periphery.route?.tx,
-        gas: ensoFlow.periphery.route?.gas
+        gas: ensoFlow.periphery.route?.gas,
+        refetchAllowance: ensoFlow.periphery.refetchAllowance
       }
     }),
     [ensoFlow, prepareEnsoOrder, params.amount, isEnsoAllowanceSufficient]

--- a/src/components/pages/vaults/hooks/actions/useYBoldZapperDeposit.ts
+++ b/src/components/pages/vaults/hooks/actions/useYBoldZapperDeposit.ts
@@ -15,7 +15,7 @@ interface UseYBoldZapperDepositParams {
 }
 
 export function useYBoldZapperDeposit(params: UseYBoldZapperDepositParams): UseWidgetDepositFlowReturn {
-  const { allowance = 0n } = useTokenAllowance({
+  const { allowance = 0n, refetch: refetchAllowance } = useTokenAllowance({
     account: params.account,
     token: BOLD_ADDRESS,
     spender: YBOLD_ZAPPER_ADDRESS,
@@ -71,7 +71,8 @@ export function useYBoldZapperDeposit(params: UseYBoldZapperDepositParams): UseW
       isLoadingRoute: false,
       isCrossChain: false,
       routerAddress: YBOLD_ZAPPER_ADDRESS,
-      error: undefined
+      error: undefined,
+      refetchAllowance
     }
   }
 }

--- a/src/components/pages/vaults/hooks/actions/useYvUsdLockedZapDeposit.ts
+++ b/src/components/pages/vaults/hooks/actions/useYvUsdLockedZapDeposit.ts
@@ -16,7 +16,7 @@ interface UseYvUsdLockedZapDepositParams {
 }
 
 export function useYvUsdLockedZapDeposit(params: UseYvUsdLockedZapDepositParams): UseWidgetDepositFlowReturn {
-  const { allowance = 0n } = useTokenAllowance({
+  const { allowance = 0n, refetch: refetchAllowance } = useTokenAllowance({
     account: params.account,
     token: params.depositToken,
     spender: YVUSD_LOCKED_ZAP_ADDRESS,
@@ -72,7 +72,8 @@ export function useYvUsdLockedZapDeposit(params: UseYvUsdLockedZapDepositParams)
       isLoadingRoute: false,
       isCrossChain: false,
       routerAddress: YVUSD_LOCKED_ZAP_ADDRESS,
-      error: undefined
+      error: undefined,
+      refetchAllowance
     }
   }
 }

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
@@ -52,6 +52,7 @@ interface UseSolverEnsoReturn {
     isLoadingAllowance: boolean
     isCrossChain: boolean
     routerAddress: Address | undefined
+    refetchAllowance: () => Promise<unknown>
   }
   methods: {
     getRoute: () => Promise<void>
@@ -92,7 +93,11 @@ export const useSolverEnso = ({
   const knownRouterAddress = ENSO_ROUTER_ADDRESSES[chainId]
   const allowanceSpender = routerAddress || knownRouterAddress
 
-  const { allowance = 0n, isLoading: isLoadingAllowance } = useTokenAllowance({
+  const {
+    allowance = 0n,
+    isLoading: isLoadingAllowance,
+    refetch: refetchAllowance
+  } = useTokenAllowance({
     account: fromAddress,
     token: tokenIn,
     spender: allowanceSpender,
@@ -273,7 +278,8 @@ export const useSolverEnso = ({
       isLoadingRoute: isLoadingCurrentRequest,
       isLoadingAllowance,
       isCrossChain,
-      routerAddress
+      routerAddress,
+      refetchAllowance
     },
     methods: {
       getRoute,

--- a/src/components/pages/vaults/types/index.ts
+++ b/src/components/pages/vaults/types/index.ts
@@ -79,6 +79,7 @@ export type UseWidgetDepositFlowReturn = T<
     gas?: string
     routerAddress?: TAddress
     error?: string
+    refetchAllowance?: () => Promise<unknown>
   }
 >
 

--- a/src/components/shared/utils/approve.ts
+++ b/src/components/shared/utils/approve.ts
@@ -1,14 +1,23 @@
 import { usdtAbi } from '@shared/contracts/abi/usdt.abi'
-import { toAddress } from '@shared/utils/tools.address'
-import type { Address } from 'viem'
-import { erc20Abi } from 'viem'
+import { type Address, erc20Abi, getAddress } from 'viem'
 
-const TOKENS_WITH_NON_STANDARD_APPROVE_ABI = new Set([toAddress('0xdAC17F958D2ee523a2206206994597C13D831ec7')])
+const MAINNET_USDT_ADDRESS = getAddress('0xdAC17F958D2ee523a2206206994597C13D831ec7')
+
+const TOKENS_WITH_NON_STANDARD_APPROVE_ABI = new Set([MAINNET_USDT_ADDRESS])
+const TOKENS_REQUIRING_ALLOWANCE_RESET_BEFORE_APPROVAL = new Set([MAINNET_USDT_ADDRESS])
 
 export function getApproveAbi(tokenAddress?: Address) {
   if (!tokenAddress) {
     return erc20Abi
   }
 
-  return TOKENS_WITH_NON_STANDARD_APPROVE_ABI.has(toAddress(tokenAddress)) ? usdtAbi : erc20Abi
+  return TOKENS_WITH_NON_STANDARD_APPROVE_ABI.has(getAddress(tokenAddress)) ? usdtAbi : erc20Abi
+}
+
+export function requiresAllowanceResetBeforeApproval(tokenAddress?: Address): boolean {
+  if (!tokenAddress) {
+    return false
+  }
+
+  return TOKENS_REQUIRING_ALLOWANCE_RESET_BEFORE_APPROVAL.has(getAddress(tokenAddress))
 }


### PR DESCRIPTION
## Description

USDT on Mainnet doesn't allow setting allowance if current allowance is not 0:
```
require(!((_value != 0) && (allowed[msg.sender][_spender] != 0)));
```

added a special message explaining that and cta

to test:
1. In any vault other than USDT enter amount that is bigger than your enso allowance
2. Message should appear
3. Click manage approval
4. Click revoke
5. Widget should refresh and it should be possible to deposit

<img width="842" height="1146" alt="image" src="https://github.com/user-attachments/assets/1e628107-6819-4f14-a314-5b25e40107ce" />
