### PR TITLE
revert TVL changes to use snapshot

### DIFF
--- a/src/components/pages/vaults/domain/kongVaultSelectors.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.ts
@@ -531,10 +531,7 @@ export const getVaultTVL = (vault: TKongVaultInput, snapshot?: TKongVaultSnapsho
   const totalAssetsRaw = snapshot?.totalAssets ?? '0'
   const totalAssets = toBigIntValue(totalAssetsRaw)
   const normalizedAssets = toNormalizedBN(totalAssets, token.decimals).normalized
-  /** this next line can be reverted to accept snapshot.tvl.close when kong issues are fixed.
-   * Check that snapshot.tvl.close matches vault.tvl before reverting.
-   */
-  const tvl = pickNumber(vault.tvl, snapshot?.tvl?.close ?? null)
+  const tvl = pickNumber(snapshot?.tvl?.close ?? null, vault.tvl)
   const price = Number.isFinite(tvl) && tvl > 0 && normalizedAssets > 0 ? tvl / normalizedAssets : 0
 
   return {


### PR DESCRIPTION
## Description

This PR reverts the changes made in #1280 now that Kong's syncing issues have been fixed. `snapshot.tvl` is now used for TVL values on the vault pages.

## Related Issue

#1280 

## Motivation and Context

Revert now unnecessary fix

## How Has This Been Tested?

local spot checks. To check, run `bun run dev` and confirm TVL values match between vault list and pages
