### PR TITLE
Fix yvUSD holdings

### DIFF
--- a/src/components/pages/portfolio/hooks/usePortfolioModel.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioModel.ts
@@ -21,10 +21,9 @@ import { usePersistedShowHiddenVaults } from '@pages/vaults/hooks/vaultsFiltersS
 import { deriveListKind, isAllocatorVaultOverride } from '@pages/vaults/utils/vaultListFacets'
 import {
   getWeightedYvUsdApy,
-  getYvUsdSharePrice,
+  getYvUsdPositionValues,
   isYvUsdAddress,
   isYvUsdVault,
-  YVUSD_CHAIN_ID,
   YVUSD_LOCKED_ADDRESS,
   YVUSD_UNLOCKED_ADDRESS
 } from '@pages/vaults/utils/yvUsd'
@@ -172,7 +171,7 @@ function getStablecoinHoldingMatch(balances: ReturnType<typeof useWalletTokens>[
 }
 
 export function usePortfolioModel(): TPortfolioModel {
-  const { getBalance, balances } = useWalletTokens()
+  const { getToken, getBalance, balances } = useWalletTokens()
   const { getVaultHoldingsUsd } = useWalletHoldings()
   const { isLoading: isWalletLoading, hasCompletedBalanceLoad } = useWalletStatus()
   const { totalValue: totalPortfolioValue } = useWalletVaultTotals()
@@ -187,10 +186,12 @@ export function usePortfolioModel(): TPortfolioModel {
   const [sortDirection, setSortDirection] = useState<TSortDirection>('desc')
 
   const yvUsdPosition = useMemo<TYvUsdPortfolioPosition>(() => {
-    const unlockedBalance = getBalance({ address: YVUSD_UNLOCKED_ADDRESS, chainID: YVUSD_CHAIN_ID })
-    const lockedBalance = getBalance({ address: YVUSD_LOCKED_ADDRESS, chainID: YVUSD_CHAIN_ID })
-    const unlockedValue = unlockedBalance.normalized * getYvUsdSharePrice(yvUsdUnlockedVault)
-    const lockedValue = lockedBalance.normalized * getYvUsdSharePrice(yvUsdLockedVault)
+    const { unlockedValue, lockedValue, combinedValue, hasHoldings } = getYvUsdPositionValues({
+      unlockedVault: yvUsdUnlockedVault,
+      lockedVault: yvUsdLockedVault,
+      getToken,
+      getBalance
+    })
 
     return {
       blendedCurrentApy: getWeightedYvUsdApy({
@@ -205,10 +206,10 @@ export function usePortfolioModel(): TPortfolioModel {
         unlockedApy: getLatestYvUsdHistoricalApyValue(yvUsdHistoricalApyData, 'unlocked'),
         lockedApy: getLatestYvUsdHistoricalApyValue(yvUsdHistoricalApyData, 'locked')
       }),
-      combinedValue: unlockedValue + lockedValue,
-      hasHoldings: unlockedBalance.raw > 0n || lockedBalance.raw > 0n
+      combinedValue,
+      hasHoldings
     }
-  }, [getBalance, yvUsdHistoricalApyData, yvUsdLockedVault, yvUsdUnlockedVault])
+  }, [getBalance, getToken, yvUsdHistoricalApyData, yvUsdLockedVault, yvUsdUnlockedVault])
 
   const vaultLookup = useMemo(() => {
     const map = new Map<string, TKongVaultInput>()

--- a/src/components/pages/vaults/components/list/VaultsListRow.tsx
+++ b/src/components/pages/vaults/components/list/VaultsListRow.tsx
@@ -39,14 +39,7 @@ import {
   NOT_YEARN_TAG_DESCRIPTION,
   RETIRED_TAG_DESCRIPTION
 } from '@pages/vaults/utils/vaultTagCopy'
-import {
-  getYvUsdInfinifiPointsNote,
-  getYvUsdSharePrice,
-  isYvUsdAddress,
-  YVUSD_CHAIN_ID,
-  YVUSD_LOCKED_ADDRESS,
-  YVUSD_UNLOCKED_ADDRESS
-} from '@pages/vaults/utils/yvUsd'
+import { getYvUsdInfinifiPointsNote, getYvUsdPositionValues, isYvUsdAddress } from '@pages/vaults/utils/yvUsd'
 import { useMediaQuery } from '@react-hookz/web'
 import { RenderAmount } from '@shared/components/RenderAmount'
 import { TokenLogo } from '@shared/components/TokenLogo'
@@ -944,21 +937,23 @@ function VaultsListRowWithWallet(props: TVaultsListRowProps): ReactElement {
   const isYvUsd = isYvUsdAddress(vaultAddress)
   const yvUsdVaultsForRow = isYvUsd ? yvUsdVaults : undefined
   const { address } = useWeb3()
-  const { getBalance } = useWalletTokens()
+  const { getToken, getBalance } = useWalletTokens()
   const { getVaultHoldingsUsd } = useWalletHoldings()
   const { isLoading: isWalletLoading } = useWalletStatus()
   const holdingsValue = useMemo(() => {
     if (isYvUsd) {
-      const unlockedBalance = getBalance({ address: YVUSD_UNLOCKED_ADDRESS, chainID: YVUSD_CHAIN_ID }).normalized
-      const lockedBalance = getBalance({ address: YVUSD_LOCKED_ADDRESS, chainID: YVUSD_CHAIN_ID }).normalized
-      const unlockedSharePrice = getYvUsdSharePrice(yvUsdVaultsForRow?.unlockedVault)
-      const lockedSharePrice = getYvUsdSharePrice(yvUsdVaultsForRow?.lockedVault)
-      return unlockedBalance * unlockedSharePrice + lockedBalance * lockedSharePrice
+      return getYvUsdPositionValues({
+        unlockedVault: yvUsdVaultsForRow?.unlockedVault,
+        lockedVault: yvUsdVaultsForRow?.lockedVault,
+        getToken,
+        getBalance
+      }).combinedValue
     }
     return getVaultHoldingsUsd(currentVault)
   }, [
     currentVault,
     getBalance,
+    getToken,
     getVaultHoldingsUsd,
     isYvUsd,
     yvUsdVaultsForRow?.lockedVault,

--- a/src/components/pages/vaults/hooks/useSortVaults.ts
+++ b/src/components/pages/vaults/hooks/useSortVaults.ts
@@ -10,13 +10,7 @@ import {
   type TKongVaultStrategy
 } from '@pages/vaults/domain/kongVaultSelectors'
 import { useYvUsdVaults } from '@pages/vaults/hooks/useYvUsdVaults'
-import {
-  getYvUsdSharePrice,
-  isYvUsdVault,
-  YVUSD_CHAIN_ID,
-  YVUSD_LOCKED_ADDRESS,
-  YVUSD_UNLOCKED_ADDRESS
-} from '@pages/vaults/utils/yvUsd'
+import { getYvUsdPositionValues, isYvUsdVault } from '@pages/vaults/utils/yvUsd'
 import { useWalletHoldings, useWalletTokens } from '@shared/contexts/useWallet'
 import type { TSortDirection } from '@shared/types'
 import { normalizeApyDisplayValue, toAddress, toNormalizedBN } from '@shared/utils'
@@ -42,16 +36,17 @@ export function useSortVaults<TVault extends TKongVaultInput & { details?: TKong
   sortBy: TPossibleSortBy,
   sortDirection: TSortDirection
 ): TVault[] {
-  const { getBalance } = useWalletTokens()
+  const { getToken, getBalance } = useWalletTokens()
   const { getVaultHoldingsUsd } = useWalletHoldings()
   const { unlockedVault: yvUsdUnlockedVault, lockedVault: yvUsdLockedVault, metrics: yvUsdMetrics } = useYvUsdVaults()
   const yvUsdDepositedValue = useMemo((): number => {
-    const unlockedBalance = getBalance({ address: YVUSD_UNLOCKED_ADDRESS, chainID: YVUSD_CHAIN_ID }).normalized
-    const lockedBalance = getBalance({ address: YVUSD_LOCKED_ADDRESS, chainID: YVUSD_CHAIN_ID }).normalized
-    const unlockedSharePrice = getYvUsdSharePrice(yvUsdUnlockedVault)
-    const lockedSharePrice = getYvUsdSharePrice(yvUsdLockedVault)
-    return unlockedBalance * unlockedSharePrice + lockedBalance * lockedSharePrice
-  }, [getBalance, yvUsdLockedVault, yvUsdUnlockedVault])
+    return getYvUsdPositionValues({
+      unlockedVault: yvUsdUnlockedVault,
+      lockedVault: yvUsdLockedVault,
+      getToken,
+      getBalance
+    }).combinedValue
+  }, [getBalance, getToken, yvUsdLockedVault, yvUsdUnlockedVault])
 
   const yvUsdDisplayedApy = useMemo((): number => {
     const lockedApy = yvUsdMetrics.locked.apy

--- a/src/components/pages/vaults/hooks/useVaultsListModel.ts
+++ b/src/components/pages/vaults/hooks/useVaultsListModel.ts
@@ -18,7 +18,7 @@ import type { TVaultAggressiveness } from '@pages/vaults/utils/vaultListFacets'
 import type { TVaultType } from '@pages/vaults/utils/vaultTypeCopy'
 import { isYvBtcVault } from '@pages/vaults/utils/yvBtc'
 import {
-  getYvUsdSharePrice,
+  getYvUsdPositionValues,
   isYvUsdAddress,
   YVUSD_CHAIN_ID,
   YVUSD_LOCKED_ADDRESS,
@@ -176,7 +176,7 @@ export function useVaultsListModel({
       : undefined
   )
   const { listVault: yvUsdVault } = yvUsdVaults
-  const { getBalance } = useWalletTokens()
+  const { getToken, getBalance } = useWalletTokens()
   const { getVaultHoldingsUsd } = useWalletHoldings()
   const { isLoading: isWalletLoading } = useWalletStatus()
 
@@ -217,12 +217,13 @@ export function useVaultsListModel({
     return unlockedBalance > 0n || lockedBalance > 0n
   }, [getBalance])
   const yvUsdHoldingsValue = useMemo(() => {
-    const unlockedBalance = getBalance({ address: YVUSD_UNLOCKED_ADDRESS, chainID: YVUSD_CHAIN_ID }).normalized
-    const lockedBalance = getBalance({ address: YVUSD_LOCKED_ADDRESS, chainID: YVUSD_CHAIN_ID }).normalized
-    const unlockedSharePrice = getYvUsdSharePrice(yvUsdVaults.unlockedVault)
-    const lockedSharePrice = getYvUsdSharePrice(yvUsdVaults.lockedVault)
-    return unlockedBalance * unlockedSharePrice + lockedBalance * lockedSharePrice
-  }, [getBalance, yvUsdVaults.lockedVault, yvUsdVaults.unlockedVault])
+    return getYvUsdPositionValues({
+      unlockedVault: yvUsdVaults.unlockedVault,
+      lockedVault: yvUsdVaults.lockedVault,
+      getToken,
+      getBalance
+    }).combinedValue
+  }, [getBalance, getToken, yvUsdVaults.lockedVault, yvUsdVaults.unlockedVault])
   const yvUsdListVaults = useMemo(
     (): TYvUsdListVaults => ({
       metrics: yvUsdVaults.metrics,

--- a/src/components/pages/vaults/utils/yvUsd.test.ts
+++ b/src/components/pages/vaults/utils/yvUsd.test.ts
@@ -10,10 +10,14 @@ import {
   convertYvUsdVariantRawAmount,
   getWeightedYvUsdApy,
   getYvUsdLockedWithdrawDisplayMode,
+  getYvUsdPositionValues,
   getYvUsdUnderlyingPricePerShare,
+  YVUSD_CHAIN_ID,
   YVUSD_CUSTOM_RISK_SCORE,
   YVUSD_DECIMALS,
-  YVUSD_RISK_SCORE_ITEMS
+  YVUSD_LOCKED_ADDRESS,
+  YVUSD_RISK_SCORE_ITEMS,
+  YVUSD_UNLOCKED_ADDRESS
 } from './yvUsd'
 
 describe('yvUSD token metadata', () => {
@@ -76,6 +80,92 @@ describe('getWeightedYvUsdApy', () => {
         lockedApy: 0.09
       })
     ).toBeNull()
+  })
+})
+
+describe('getYvUsdPositionValues', () => {
+  const makeYvUsdVault = (price: number, pricePerShare: number) =>
+    ({
+      chainID: YVUSD_CHAIN_ID,
+      version: '3.0.4',
+      type: 'Automated Yearn Vault',
+      kind: 'Multi Strategy',
+      symbol: 'yvUSD',
+      name: 'yvUSD',
+      description: '',
+      category: 'Stablecoin',
+      decimals: YVUSD_DECIMALS,
+      token: {
+        address: YVUSD_UNLOCKED_ADDRESS,
+        name: 'USD yVault',
+        symbol: 'yvUSD',
+        decimals: YVUSD_DECIMALS
+      },
+      tvl: { price, tvl: 0, totalAssets: 0 },
+      apr: { pricePerShare: { today: pricePerShare, weekAgo: null, monthAgo: null } },
+      featuringScore: 0,
+      strategies: null,
+      staking: { address: '0x0000000000000000000000000000000000000000', available: false, rewards: [] },
+      migration: {},
+      info: {}
+    }) as any
+
+  it('uses Enso direct token values for unlocked and locked yvUSD holdings', () => {
+    const tokenValues = {
+      [YVUSD_UNLOCKED_ADDRESS]: 1.991627 * 1.018990889978977,
+      [YVUSD_LOCKED_ADDRESS]: 4.437947 * 1.062906287897898
+    }
+    const rawBalances = {
+      [YVUSD_UNLOCKED_ADDRESS]: 1_991_627n,
+      [YVUSD_LOCKED_ADDRESS]: 4_437_947n
+    }
+
+    const values = getYvUsdPositionValues({
+      getToken: ({ address }) => ({ value: tokenValues[address] ?? 0 }),
+      getBalance: ({ address, chainID }) => ({
+        raw: chainID === YVUSD_CHAIN_ID ? (rawBalances[address] ?? 0n) : 0n,
+        normalized: chainID === YVUSD_CHAIN_ID ? Number(rawBalances[address] ?? 0n) / 10 ** YVUSD_DECIMALS : 0
+      }),
+      unlockedVault: makeYvUsdVault(0, 0),
+      lockedVault: makeYvUsdVault(0, 0)
+    })
+
+    expect(values.unlockedValue).toBeCloseTo(2.02944976923616, 12)
+    expect(values.lockedValue).toBeCloseTo(4.717121771657613, 12)
+    expect(values.combinedValue).toBeCloseTo(6.746571540893774, 12)
+    expect(values.hasHoldings).toBe(true)
+  })
+
+  it('falls back to vault share prices when direct token values are unavailable', () => {
+    const values = getYvUsdPositionValues({
+      getToken: () => ({ value: 0 }),
+      getBalance: ({ address }) => ({
+        raw: address === YVUSD_UNLOCKED_ADDRESS ? 2_000_000n : 3_000_000n,
+        normalized: address === YVUSD_UNLOCKED_ADDRESS ? 2 : 3
+      }),
+      unlockedVault: makeYvUsdVault(1, 1.01),
+      lockedVault: makeYvUsdVault(1, 1.05)
+    })
+
+    expect(values.unlockedValue).toBeCloseTo(2.02, 8)
+    expect(values.lockedValue).toBeCloseTo(3.15, 8)
+    expect(values.combinedValue).toBeCloseTo(5.17, 8)
+    expect(values.hasHoldings).toBe(true)
+  })
+
+  it('ignores direct token values when no yvUSD raw balance is present', () => {
+    const values = getYvUsdPositionValues({
+      getToken: () => ({ value: 10 }),
+      getBalance: () => ({
+        raw: 0n,
+        normalized: 0
+      }),
+      unlockedVault: makeYvUsdVault(1, 1.01),
+      lockedVault: makeYvUsdVault(1, 1.05)
+    })
+
+    expect(values.combinedValue).toBe(0)
+    expect(values.hasHoldings).toBe(false)
   })
 })
 

--- a/src/components/pages/vaults/utils/yvUsd.ts
+++ b/src/components/pages/vaults/utils/yvUsd.ts
@@ -109,6 +109,73 @@ export function getYvUsdSharePrice(vault?: TKongVaultInput | null, fallbackAsset
   return assetPrice
 }
 
+type TYvUsdWalletValueGetter = (params: { address: Address; chainID: number }) => { value?: number }
+type TYvUsdWalletBalanceGetter = (params: { address: Address; chainID: number }) => {
+  raw: bigint
+  normalized: number
+}
+
+export type TYvUsdPositionValues = {
+  unlockedValue: number
+  lockedValue: number
+  combinedValue: number
+  hasHoldings: boolean
+}
+
+function getYvUsdWalletVariantValue({
+  address,
+  vault,
+  getToken,
+  getBalance
+}: {
+  address: Address
+  vault?: TKongVaultInput | null
+  getToken: TYvUsdWalletValueGetter
+  getBalance: TYvUsdWalletBalanceGetter
+}): { raw: bigint; value: number } {
+  const balance = getBalance({ address, chainID: YVUSD_CHAIN_ID })
+  const directValue = Number(getToken({ address, chainID: YVUSD_CHAIN_ID }).value || 0)
+
+  if (balance.raw > 0n && Number.isFinite(directValue) && directValue > 0) {
+    return { raw: balance.raw, value: directValue }
+  }
+
+  const fallbackValue = balance.normalized * getYvUsdSharePrice(vault)
+  return { raw: balance.raw, value: Number.isFinite(fallbackValue) ? fallbackValue : 0 }
+}
+
+export function getYvUsdPositionValues({
+  unlockedVault,
+  lockedVault,
+  getToken,
+  getBalance
+}: {
+  unlockedVault?: TKongVaultInput | null
+  lockedVault?: TKongVaultInput | null
+  getToken: TYvUsdWalletValueGetter
+  getBalance: TYvUsdWalletBalanceGetter
+}): TYvUsdPositionValues {
+  const unlocked = getYvUsdWalletVariantValue({
+    address: YVUSD_UNLOCKED_ADDRESS,
+    vault: unlockedVault,
+    getToken,
+    getBalance
+  })
+  const locked = getYvUsdWalletVariantValue({
+    address: YVUSD_LOCKED_ADDRESS,
+    vault: lockedVault,
+    getToken,
+    getBalance
+  })
+
+  return {
+    unlockedValue: unlocked.value,
+    lockedValue: locked.value,
+    combinedValue: unlocked.value + locked.value,
+    hasHoldings: unlocked.raw > 0n || locked.raw > 0n
+  }
+}
+
 export type TYvUsdHistoricalPricePerShare = {
   today?: number | null
   weekAgo?: number | null


### PR DESCRIPTION
### Summary
Fix yvUSD holdings display by valuing unlocked and locked yvUSD from the wallet token USD values returned by Enso, with the existing share-price calculation kept as a fallback.

This makes `/portfolio` and `/vaults` use the same yvUSD position value, including deposited sorting and row-level holdings display.

### How to review
Start with the shared yvUSD position valuation helper, then check the call sites in:
- portfolio holdings model
- vaults list model
- vault deposited sorting
- vault row wallet wrapper

### Test plan
- [ ] Manual: Connect the wallet above and verify yvUSD appears on `/portfolio`.
- [ ] Manual: Verify `/vaults` shows the same yvUSD holdings value and deposited sorting behaves consistently.
- [x] Automated: `bunx vitest run src/components/pages/vaults/utils/yvUsd.test.ts src/components/pages/vaults/hooks/useVaultsListModel.test.ts src/components/pages/vaults/components/list/VaultsListRow.test.tsx src/components/pages/portfolio/hooks/usePortfolioModel.helpers.test.ts`
- [x] Automated: `bun run lint:fix`
- [x] Automated: `bun run tslint`

### Risk / impact
Low risk and display-only. This does not change balance fetching, routing, deposits, withdrawals, or transaction logic. The fallback path still uses the existing share-price calculation when Enso direct values are unavailable.