### PR TITLE
Change link from weth-2 to weth-1

### DIFF
--- a/src/components/pages/landing/components/sections/Vaults.tsx
+++ b/src/components/pages/landing/components/sections/Vaults.tsx
@@ -53,8 +53,8 @@ const vaultsRows = [
   {
     symbol: 'ETH',
     icon: '/landing/vaults/eth.png',
-    href: '/vaults/1/0xAc37729B76db6438CE62042AE1270ee574CA7571',
-    address: '0xAc37729B76db6438CE62042AE1270ee574CA7571'
+    href: '/vaults/1/0xc56413869c6CDf96496f2b1eF801fEDBdFA7dDB0',
+    address: '0xc56413869c6CDf96496f2b1eF801fEDBdFA7dDB0'
   },
   {
     symbol: 'USDS',


### PR DESCRIPTION
As requested in tg chat - 

<img width="1249" height="541" alt="image" src="https://github.com/user-attachments/assets/c9df0a65-cdc3-4240-a116-139a1fce50ea" />
