### PR TITLE
Update 30d APY chart to use 30d interval by default

### DIFF
--- a/src/components/pages/vaults/components/detail/VaultChartsSection.tsx
+++ b/src/components/pages/vaults/components/detail/VaultChartsSection.tsx
@@ -42,7 +42,7 @@ export const VAULT_CHART_TIMEFRAME_OPTIONS = [
 ] as const
 
 export type TVaultChartTimeframe = (typeof VAULT_CHART_TIMEFRAME_OPTIONS)[number]['value']
-export const DEFAULT_VAULT_CHART_TIMEFRAME: TVaultChartTimeframe = '30d'
+const DEFAULT_VAULT_CHART_TIMEFRAME: TVaultChartTimeframe = '1y'
 
 type TBaseVaultChartTab = 'historical-pps' | 'historical-apy' | 'historical-tvl'
 type TUserVaultChartTab = 'user-position'

--- a/src/components/pages/vaults/components/detail/VaultChartsSection.tsx
+++ b/src/components/pages/vaults/components/detail/VaultChartsSection.tsx
@@ -42,6 +42,7 @@ export const VAULT_CHART_TIMEFRAME_OPTIONS = [
 ] as const
 
 export type TVaultChartTimeframe = (typeof VAULT_CHART_TIMEFRAME_OPTIONS)[number]['value']
+export const DEFAULT_VAULT_CHART_TIMEFRAME: TVaultChartTimeframe = '30d'
 
 type TBaseVaultChartTab = 'historical-pps' | 'historical-apy' | 'historical-tvl'
 type TUserVaultChartTab = 'user-position'
@@ -117,7 +118,8 @@ export function VaultChartsSection({
   const transformed = useMemo(() => transformVaultChartData(data), [data])
 
   const [uncontrolledTab, setUncontrolledTab] = useState<TVaultChartTab>('historical-apy')
-  const [uncontrolledTimeframe, setUncontrolledTimeframe] = useState<TVaultChartTimeframe>('1y')
+  const [uncontrolledTimeframe, setUncontrolledTimeframe] =
+    useState<TVaultChartTimeframe>(DEFAULT_VAULT_CHART_TIMEFRAME)
 
   const activeTab = chartTab ?? uncontrolledTab
   const activeTimeframe = timeframe ?? uncontrolledTimeframe

--- a/src/components/pages/vaults/components/detail/YvUsdChartsSection.tsx
+++ b/src/components/pages/vaults/components/detail/YvUsdChartsSection.tsx
@@ -9,12 +9,7 @@ import ChartSkeleton from './charts/ChartSkeleton'
 import ChartsLoader from './charts/ChartsLoader'
 import { FixedHeightChartContainer } from './charts/FixedHeightChartContainer'
 import { YvUsdApyChart, YvUsdChartLegend, YvUsdPerformanceChart, YvUsdTvlChart } from './charts/YvUsdDualLineChart'
-import {
-  DEFAULT_VAULT_CHART_TIMEFRAME,
-  VAULT_CHART_TABS,
-  type VAULT_CHART_TIMEFRAME_OPTIONS,
-  VaultChartTimeframeDropdown
-} from './VaultChartsSection'
+import { VAULT_CHART_TABS, type VAULT_CHART_TIMEFRAME_OPTIONS, VaultChartTimeframeDropdown } from './VaultChartsSection'
 
 const VaultTvlGrowthChart = lazy(() =>
   import('./charts/VaultTvlGrowthChart').then((m) => ({ default: m.VaultTvlGrowthChart }))
@@ -23,6 +18,7 @@ const VaultTvlGrowthChart = lazy(() =>
 type TYvUsdUserChartTab = 'user-position'
 export type TYvUsdChartTab = (typeof VAULT_CHART_TABS)[number]['id'] | TYvUsdUserChartTab
 export type TYvUsdChartTimeframe = (typeof VAULT_CHART_TIMEFRAME_OPTIONS)[number]['value']
+const DEFAULT_YVUSD_CHART_TIMEFRAME: TYvUsdChartTimeframe = '90d'
 
 type YvUsdChartsSectionProps = {
   chartTab?: TYvUsdChartTab
@@ -93,7 +89,7 @@ export function YvUsdChartsSection({
 
   const [uncontrolledTab, setUncontrolledTab] = useState<TYvUsdChartTab>('historical-apy')
   const [uncontrolledTimeframe, setUncontrolledTimeframe] =
-    useState<TYvUsdChartTimeframe>(DEFAULT_VAULT_CHART_TIMEFRAME)
+    useState<TYvUsdChartTimeframe>(DEFAULT_YVUSD_CHART_TIMEFRAME)
 
   const activeTab = chartTab ?? uncontrolledTab
   const activeTimeframe = timeframe ?? uncontrolledTimeframe

--- a/src/components/pages/vaults/components/detail/YvUsdChartsSection.tsx
+++ b/src/components/pages/vaults/components/detail/YvUsdChartsSection.tsx
@@ -9,7 +9,12 @@ import ChartSkeleton from './charts/ChartSkeleton'
 import ChartsLoader from './charts/ChartsLoader'
 import { FixedHeightChartContainer } from './charts/FixedHeightChartContainer'
 import { YvUsdApyChart, YvUsdChartLegend, YvUsdPerformanceChart, YvUsdTvlChart } from './charts/YvUsdDualLineChart'
-import { VAULT_CHART_TABS, type VAULT_CHART_TIMEFRAME_OPTIONS, VaultChartTimeframeDropdown } from './VaultChartsSection'
+import {
+  DEFAULT_VAULT_CHART_TIMEFRAME,
+  VAULT_CHART_TABS,
+  type VAULT_CHART_TIMEFRAME_OPTIONS,
+  VaultChartTimeframeDropdown
+} from './VaultChartsSection'
 
 const VaultTvlGrowthChart = lazy(() =>
   import('./charts/VaultTvlGrowthChart').then((m) => ({ default: m.VaultTvlGrowthChart }))
@@ -87,7 +92,8 @@ export function YvUsdChartsSection({
   const { apyData, performanceData, tvlData, isLoading, error } = useYvUsdCharts()
 
   const [uncontrolledTab, setUncontrolledTab] = useState<TYvUsdChartTab>('historical-apy')
-  const [uncontrolledTimeframe, setUncontrolledTimeframe] = useState<TYvUsdChartTimeframe>('1y')
+  const [uncontrolledTimeframe, setUncontrolledTimeframe] =
+    useState<TYvUsdChartTimeframe>(DEFAULT_VAULT_CHART_TIMEFRAME)
 
   const activeTab = chartTab ?? uncontrolledTab
   const activeTimeframe = timeframe ?? uncontrolledTimeframe


### PR DESCRIPTION
## Description

Update 30d APY chart to use 30d interval by default
<img width="785" height="536" alt="image" src="https://github.com/user-attachments/assets/92c9b1d7-f037-4676-9741-557737b7a2fc" />
