### PR TITLE
Add partners link to menu

### DIFF
--- a/src/components/shared/components/HeaderNavMenu.tsx
+++ b/src/components/shared/components/HeaderNavMenu.tsx
@@ -1,6 +1,7 @@
 import { IconChevron } from '@shared/icons/IconChevron'
 import { IconDiscord } from '@shared/icons/IconDiscord'
 import { IconLinkOut } from '@shared/icons/IconLinkOut'
+import { IconStack } from '@shared/icons/IconStack'
 import { IconTelegram } from '@shared/icons/IconTelegram'
 import { IconTwitter } from '@shared/icons/IconTwitter'
 import { LogoCuration } from '@shared/icons/LogoCuration'
@@ -212,6 +213,12 @@ export function HeaderNavMenu({ isHomePage, isDarkTheme }: THeaderNavMenuProps):
   ]
 
   const communityItems: TNavTile[] = [
+    {
+      name: 'Partners',
+      href: 'https://partners.yearn.fi/',
+      description: 'Build on Yearn',
+      icon: <IconStack className={cl('size-5', neutralIconForeground)} />
+    },
     {
       name: 'Support',
       href: 'https://discord.gg/yearn',

--- a/src/components/shared/components/MobileNavMenu.tsx
+++ b/src/components/shared/components/MobileNavMenu.tsx
@@ -11,6 +11,7 @@ import { IconDiscord } from '@shared/icons/IconDiscord'
 import { IconLinkOut } from '@shared/icons/IconLinkOut'
 import { IconMoon } from '@shared/icons/IconMoon'
 import { IconSettings } from '@shared/icons/IconSettings'
+import { IconStack } from '@shared/icons/IconStack'
 import { IconSun } from '@shared/icons/IconSun'
 import { IconTwitter } from '@shared/icons/IconTwitter'
 import { IconWallet } from '@shared/icons/IconWallet'
@@ -359,6 +360,12 @@ export function MobileNavMenu({
   ]
 
   const resourceCommunityItems: TNavTile[] = [
+    {
+      name: 'Partners',
+      href: 'https://partners.yearn.fi/',
+      description: 'Build on Yearn',
+      icon: <IconStack className={cl('size-5', neutralIconForeground)} />
+    },
     {
       name: 'Support',
       href: 'https://discord.gg/yearn',


### PR DESCRIPTION
## Description

Add link to partners site from homepage menu

## Related Issue

N/A

## Motivation and Context

No link to partners site from Yearn page

## How Has This Been Tested?

`bun run dev`

## Screenshots (if appropriate):

<img width="937" height="525" alt="image" src="https://github.com/user-attachments/assets/b2ce64e8-2950-4b4f-8ca1-83063ee4ab53" />
