### PR TITLE
Fix Enso protected quote slippage

### DIFF
--- a/src/components/pages/vaults/components/widget/MobileDrawerSettingsButton.tsx
+++ b/src/components/pages/vaults/components/widget/MobileDrawerSettingsButton.tsx
@@ -72,7 +72,8 @@ export const MobileDrawerSettingsButton: FC = () => {
           <div className="space-y-1">
             <h4 className="font-medium text-text-primary">Transaction Settings</h4>
             <p className="text-xs text-text-secondary">
-              Applies site-wide across all vaults. Price impact covers both quote quality and execution buffer.
+              Applies site-wide across all vaults. Route impact consumes part of this tolerance; the remainder is used
+              as execution buffer.
             </p>
           </div>
 
@@ -80,7 +81,7 @@ export const MobileDrawerSettingsButton: FC = () => {
             <div className="space-y-2">
               <div className="flex items-center justify-between">
                 <label htmlFor={slippageId} className="text-sm text-text-primary">
-                  Price Impact Tolerance
+                  Slippage & Price Impact
                 </label>
                 <span className="text-sm text-text-secondary">{sanitizedSlippage}%</span>
               </div>
@@ -130,12 +131,12 @@ export const MobileDrawerSettingsButton: FC = () => {
                 />
               </div>
               <p className="text-xs text-text-secondary">
-                Default is 0.50%. Transactions with total price impact at or above 5.00% are blocked.
+                Default is 0.50%. Routes with worst-case impact at or above 5.00% are blocked.
               </p>
               {needsRiskAcknowledgement ? (
                 <div className="space-y-2 rounded-md border border-red-500/30 bg-red-500/5 p-3">
                   <label htmlFor={riskAcknowledgementId} className="block text-xs font-medium text-red-500">
-                    Type this sentence exactly to save price impact above 1.00%
+                    Type this sentence exactly to save tolerance above 1.00%
                   </label>
                   <p className="text-xs text-text-primary">"{ZAP_SLIPPAGE_RISK_ACKNOWLEDGEMENT_TEXT}"</p>
                   <input
@@ -151,7 +152,7 @@ export const MobileDrawerSettingsButton: FC = () => {
                   {riskAcknowledgementMessage ? (
                     <p className="text-xs text-red-500">{riskAcknowledgementMessage}</p>
                   ) : (
-                    <p className="text-xs text-green-500">High price impact tolerance will save when settings close.</p>
+                    <p className="text-xs text-green-500">High tolerance will save when settings close.</p>
                   )}
                 </div>
               ) : null}

--- a/src/components/pages/vaults/components/widget/SettingsPanel.tsx
+++ b/src/components/pages/vaults/components/widget/SettingsPanel.tsx
@@ -77,7 +77,8 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({ isActive, onClose, varia
           <div className="flex flex-col gap-1">
             <h3 className="text-base font-semibold text-text-primary">Transaction Settings</h3>
             <p className="text-xs text-text-secondary">
-              Applies site-wide across all vaults. Price impact covers both quote quality and execution buffer.
+              Applies site-wide across all vaults. Route impact consumes part of this tolerance; the remainder is used
+              as execution buffer.
             </p>
           </div>
           {onClose ? (
@@ -97,7 +98,7 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({ isActive, onClose, varia
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <label htmlFor={slippageId} className="text-sm text-text-primary">
-                    Price Impact Tolerance
+                    Slippage & Price Impact
                   </label>
                   <span className="text-sm text-text-secondary">{sanitizedSlippage}%</span>
                 </div>
@@ -147,12 +148,12 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({ isActive, onClose, varia
                   />
                 </div>
                 <p className="text-xs text-text-secondary">
-                  Default is 0.50%. Transactions with total price impact at or above 5.00% are blocked.
+                  Default is 0.50%. Routes with worst-case impact at or above 5.00% are blocked.
                 </p>
                 {needsRiskAcknowledgement ? (
                   <div className="space-y-2 rounded-md border border-red-500/30 bg-red-500/5 p-3">
                     <label htmlFor={riskAcknowledgementId} className="block text-xs font-medium text-red-500">
-                      Type this sentence exactly to save price impact above 1.00%
+                      Type this sentence exactly to save tolerance above 1.00%
                     </label>
                     <p className="text-xs text-text-primary">"{ZAP_SLIPPAGE_RISK_ACKNOWLEDGEMENT_TEXT}"</p>
                     <input
@@ -168,9 +169,7 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({ isActive, onClose, varia
                     {riskAcknowledgementMessage ? (
                       <p className="text-xs text-red-500">{riskAcknowledgementMessage}</p>
                     ) : (
-                      <p className="text-xs text-green-500">
-                        High price impact tolerance will save when settings close.
-                      </p>
+                      <p className="text-xs text-green-500">High tolerance will save when settings close.</p>
                     )}
                   </div>
                 ) : null}

--- a/src/components/pages/vaults/components/widget/deposit/DepositDetails.test.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/DepositDetails.test.tsx
@@ -125,4 +125,50 @@ describe('DepositDetails', () => {
     expect(html).toContain('+5.00%')
     expect(html).toContain('+2.00%')
   })
+
+  it('masks existing approval details while an ENSO quote is loading', () => {
+    const html = renderToStaticMarkup(
+      <DepositDetails
+        depositAmountBn={10n * ONE_ETHER}
+        inputTokenSymbol="BOLD"
+        inputTokenDecimals={18}
+        inputTokenUsdPrice={1}
+        routeType="ENSO"
+        isSwap
+        usesMinExpectedOut
+        isLoadingQuote
+        isApprovalLoading
+        isQuoteStale={false}
+        expectedOutInAsset={10n * ONE_ETHER}
+        minExpectedOutInAsset={9n * ONE_ETHER}
+        assetTokenSymbol="yvUSDC"
+        assetTokenDecimals={18}
+        expectedVaultShares={9n * ONE_ETHER}
+        vaultDecimals={18}
+        sharesDisplayDecimals={18}
+        pricePerShare={ONE_ETHER}
+        assetUsdPrice={1}
+        vaultShareValueInAsset={9n * ONE_ETHER}
+        vaultShareValueUsdRaw={9}
+        expectedPriceImpactPercentage={0}
+        priceImpactPercentage={10}
+        shouldHighlightPriceImpact
+        willReceiveStakedShares={false}
+        onShowVaultSharesModal={() => undefined}
+        onShowVaultShareValueModal={() => undefined}
+        estimatedAnnualReturn={1}
+        onShowAnnualReturnModal={() => undefined}
+        allowance={123n * ONE_ETHER}
+        allowanceTokenDecimals={18}
+        allowanceTokenSymbol="BOLD"
+        approvalSpenderName="Enso Router"
+        onShowApprovalOverlay={() => undefined}
+      />
+    )
+
+    expect(html).not.toContain('Existing Approval')
+    expect(html).not.toContain('Enso Router')
+    expect(html).not.toContain('123')
+    expect(html).toContain('animate-pulse')
+  })
 })

--- a/src/components/pages/vaults/components/widget/deposit/DepositDetails.test.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/DepositDetails.test.tsx
@@ -14,6 +14,7 @@ describe('DepositDetails', () => {
         inputTokenUsdPrice={1}
         routeType="ENSO"
         isSwap
+        usesMinExpectedOut
         isLoadingQuote={false}
         isQuoteStale={false}
         expectedOutInAsset={10n * ONE_ETHER}
@@ -56,6 +57,7 @@ describe('DepositDetails', () => {
         inputTokenUsdPrice={1}
         routeType="ENSO"
         isSwap={false}
+        usesMinExpectedOut
         isLoadingQuote={false}
         isQuoteStale={false}
         expectedOutInAsset={10n * ONE_ETHER}
@@ -81,8 +83,9 @@ describe('DepositDetails', () => {
     )
 
     expect(html).toContain('You Will Deposit')
+    expect(html).toContain('You Will Receive at least')
     expect(html).not.toContain('For expected / at least')
-    expect(html).not.toContain('Est. / Worst price impact')
+    expect(html).toContain('Est. / Worst price impact')
   })
 
   it('shows positive slippage for favorable swap quotes', () => {
@@ -94,6 +97,7 @@ describe('DepositDetails', () => {
         inputTokenUsdPrice={1}
         routeType="ENSO"
         isSwap
+        usesMinExpectedOut
         isLoadingQuote={false}
         isQuoteStale={false}
         expectedOutInAsset={10n * ONE_ETHER}

--- a/src/components/pages/vaults/components/widget/deposit/DepositDetails.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/DepositDetails.tsx
@@ -41,6 +41,7 @@ interface DepositDetailsProps {
   allowanceTokenDecimals?: number
   allowanceTokenSymbol?: string
   approvalSpenderName?: string
+  isApprovalLoading?: boolean
   onAllowanceClick?: () => void
   onShowApprovalOverlay?: () => void
 }
@@ -75,6 +76,7 @@ export const DepositDetails: FC<DepositDetailsProps> = ({
   allowanceTokenDecimals,
   allowanceTokenSymbol,
   approvalSpenderName,
+  isApprovalLoading = false,
   onAllowanceClick,
   onShowApprovalOverlay
 }) => {
@@ -95,6 +97,8 @@ export const DepositDetails: FC<DepositDetailsProps> = ({
     return 'Deposit'
   }
   const allowanceDisplay = formatWidgetAllowance(allowance, allowanceTokenDecimals)
+  const shouldShowAllowanceRow = isApprovalLoading || allowanceDisplay !== null
+  const renderedAllowanceDisplay = allowanceDisplay ?? '0'
   const vaultShareValueDisplay = formatWidgetValue(vaultShareValueInAsset, assetTokenDecimals)
   const vaultShareValueUsd = formatWidgetValue(vaultShareValueUsdRaw)
   const shouldUseHighlight = !isQuoteStale && !isLoadingQuote && shouldHighlightPriceImpact
@@ -105,7 +109,13 @@ export const DepositDetails: FC<DepositDetailsProps> = ({
       <div className="flex flex-col gap-2">
         {/* You will deposit/swap/stake */}
         <div className="flex items-center justify-between h-5">
-          <p className="text-sm text-text-secondary">{'You Will ' + getActionVerb()}</p>
+          <p className="text-sm text-text-secondary">
+            {isLoadingQuote ? (
+              <span className="inline-block h-4 w-24 bg-surface-secondary rounded animate-pulse" />
+            ) : (
+              'You Will ' + getActionVerb()
+            )}
+          </p>
           <p className="text-sm text-text-primary">
             <span className="font-semibold">
               {depositAmountBn > 0n ? formatWidgetValue(depositAmountBn, inputTokenDecimals) : '0'}
@@ -226,9 +236,13 @@ export const DepositDetails: FC<DepositDetailsProps> = ({
         </div>
 
         {/* Approved allowance */}
-        {allowanceDisplay && (
+        {shouldShowAllowanceRow && (
           <div className="flex items-center justify-between h-5">
-            {onShowApprovalOverlay ? (
+            {isApprovalLoading ? (
+              <p className="text-sm text-text-secondary">
+                <span className="inline-block h-4 w-36 bg-surface-secondary rounded animate-pulse" />
+              </p>
+            ) : onShowApprovalOverlay ? (
               <button
                 type="button"
                 onClick={onShowApprovalOverlay}
@@ -241,21 +255,23 @@ export const DepositDetails: FC<DepositDetailsProps> = ({
                 Existing Approval{approvalSpenderName ? ` (${approvalSpenderName})` : ''}
               </p>
             )}
-            {onAllowanceClick && allowanceDisplay !== 'Unlimited' ? (
+            {isApprovalLoading ? (
+              <span className="inline-block h-4 w-20 bg-surface-secondary rounded animate-pulse" />
+            ) : onAllowanceClick && renderedAllowanceDisplay !== 'Unlimited' ? (
               <button
                 type="button"
                 onClick={onAllowanceClick}
                 className="text-sm text-text-primary hover:text-blue-500 transition-colors cursor-pointer"
               >
                 <span className="font-normal">
-                  <span className={'font-semibold'}>{allowanceDisplay} </span>{' '}
+                  <span className={'font-semibold'}>{renderedAllowanceDisplay} </span>{' '}
                   <span> {allowanceTokenSymbol || ''}</span>
                 </span>
               </button>
             ) : (
               <p className="text-sm text-text-primary">
                 <span className="font-normal">
-                  <span className={'font-semibold'}>{allowanceDisplay} </span>{' '}
+                  <span className={'font-semibold'}>{renderedAllowanceDisplay} </span>{' '}
                   <span> {allowanceTokenSymbol || ''}</span>
                 </span>
               </p>

--- a/src/components/pages/vaults/components/widget/deposit/DepositDetails.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/DepositDetails.tsx
@@ -11,6 +11,7 @@ interface DepositDetailsProps {
   // Route info
   routeType: DepositRouteType
   isSwap: boolean
+  usesMinExpectedOut: boolean
   isLoadingQuote: boolean
   isQuoteStale: boolean
   expectedOutInAsset: bigint
@@ -50,6 +51,7 @@ export const DepositDetails: FC<DepositDetailsProps> = ({
   inputTokenDecimals,
   routeType,
   isSwap,
+  usesMinExpectedOut,
   isLoadingQuote,
   isQuoteStale,
   expectedOutInAsset,
@@ -96,7 +98,8 @@ export const DepositDetails: FC<DepositDetailsProps> = ({
   const vaultShareValueDisplay = formatWidgetValue(vaultShareValueInAsset, assetTokenDecimals)
   const vaultShareValueUsd = formatWidgetValue(vaultShareValueUsdRaw)
   const shouldUseHighlight = !isQuoteStale && !isLoadingQuote && shouldHighlightPriceImpact
-  const shouldShowWorstCasePriceImpact = isSwap && !isStake
+  const shouldShowWorstCasePriceImpact = usesMinExpectedOut && !isStake
+  const receiveLabel = usesMinExpectedOut ? 'You Will Receive at least' : 'You Will Receive'
   return (
     <div className="">
       <div className="flex flex-col gap-2">
@@ -143,7 +146,7 @@ export const DepositDetails: FC<DepositDetailsProps> = ({
             onClick={onShowVaultSharesModal}
             className="text-sm text-text-secondary hover:text-text-primary transition-colors yearn--link-dots"
           >
-            You Will Receive
+            {receiveLabel}
           </button>
           <p className="text-sm text-text-primary">
             {isLoadingQuote ? (

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -15,11 +15,6 @@ import { cl, formatTAmount, toAddress } from '@shared/utils'
 import { requiresAllowanceResetBeforeApproval } from '@shared/utils/approve'
 import { ETH_TOKEN_ADDRESS } from '@shared/utils/constants'
 import { PLAUSIBLE_EVENTS } from '@shared/utils/plausible'
-import {
-  calculateRemainingEnsoSlippagePercentage,
-  optionalBasisPointsToPercentage,
-  ZAP_SLIPPAGE_HARD_CAP
-} from '@shared/utils/slippage'
 import type { ReactElement, ReactNode } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { formatUnits, isAddressEqual } from 'viem'
@@ -28,6 +23,7 @@ import { SettingsPanel } from '../SettingsPanel'
 import { PriceImpactWarning } from '../shared/PriceImpactWarning'
 import { TokenSelectorOverlay } from '../shared/TokenSelectorOverlay'
 import { TransactionOverlay, type TransactionStep } from '../shared/TransactionOverlay'
+import { useProtectedEnsoQuoteState } from '../shared/useProtectedEnsoQuoteState'
 import { useResetEnsoSelection } from '../shared/useResetEnsoSelection'
 import { useWidgetContext } from '../shared/useWidgetContext'
 import { formatWidgetAllowance, formatWidgetValue } from '../shared/valueDisplay'
@@ -522,54 +518,54 @@ export function WidgetDeposit({
       assetTokenPrice
     ]
   )
-  const ensoPriceImpactPercentage = isEnsoRoute
-    ? optionalBasisPointsToPercentage(activeFlow.periphery.priceImpact)
-    : undefined
-  const estimatedPriceImpactPercentage =
-    isEnsoRoute && ensoPriceImpactPercentage !== undefined
-      ? Math.max(depositValueInfo.priceImpactPercentage, ensoPriceImpactPercentage)
-      : depositValueInfo.priceImpactPercentage
-  const worstCaseRouteImpactPercentage =
-    isEnsoRoute && ensoPriceImpactPercentage !== undefined
-      ? Math.max(depositValueInfo.worstCasePriceImpactPercentage, ensoPriceImpactPercentage)
-      : depositValueInfo.worstCasePriceImpactPercentage
-  const desiredEnsoQuoteSlippage = useMemo(
-    () =>
-      isEnsoRoute
-        ? depositValueInfo.hasIncompleteUsdValuation && ensoPriceImpactPercentage === undefined
-          ? 0
-          : calculateRemainingEnsoSlippagePercentage({
-              userTolerancePercentage: zapSlippage,
-              quoteImpactPercentage: estimatedPriceImpactPercentage
-            })
-        : 0,
+  const depositQuoteDisplay = useMemo(
+    () => ({
+      expectedVaultShares: activeFlow.periphery.minExpectedOut,
+      vaultShareValueInAsset: depositValueInfo.minVaultShareValueInAsset,
+      vaultShareValueUsdRaw: depositValueInfo.minVaultShareValueUsdRaw,
+      convertedVaultShares: normalizedMinExpectedOut,
+      expectedOutInAsset,
+      minExpectedOutInAsset,
+      routeHasSwap: ensoRouteHasSwap
+    }),
     [
-      depositValueInfo.hasIncompleteUsdValuation,
-      ensoPriceImpactPercentage,
-      estimatedPriceImpactPercentage,
-      isEnsoRoute,
-      zapSlippage
+      activeFlow.periphery.minExpectedOut,
+      depositValueInfo.minVaultShareValueInAsset,
+      depositValueInfo.minVaultShareValueUsdRaw,
+      ensoRouteHasSwap,
+      expectedOutInAsset,
+      minExpectedOutInAsset,
+      normalizedMinExpectedOut
     ]
   )
-
-  useEffect(() => {
-    if (
-      routeType !== 'ENSO' ||
-      ensoQuoteSlippage !== 0 ||
-      depositAmount.debouncedBn === 0n ||
-      isLoadingQuote ||
-      desiredEnsoQuoteSlippage <= 0
-    ) {
-      return
-    }
-
-    setEnsoQuoteSlippage(desiredEnsoQuoteSlippage)
-  }, [depositAmount.debouncedBn, desiredEnsoQuoteSlippage, ensoQuoteSlippage, isLoadingQuote, routeType])
-
-  const hasBootstrapEnsoQuote =
-    isEnsoRoute && ensoQuoteSlippage === 0 && activeFlow.periphery.expectedOut > 0n && depositAmount.debouncedBn > 0n
-  const isWaitingForProtectedEnsoQuote = hasBootstrapEnsoQuote && desiredEnsoQuoteSlippage > 0
-  const isPreparingEnsoQuote = isLoadingQuote || isWaitingForProtectedEnsoQuote
+  const protectedEnsoQuote = useProtectedEnsoQuoteState({
+    stateKey: ensoSlippageCalibrationKey,
+    isEnsoRoute,
+    amount: depositAmount.debouncedBn,
+    requestedSlippage: ensoQuoteSlippage,
+    setRequestedSlippage: setEnsoQuoteSlippage,
+    isLoadingQuote,
+    userTolerancePercentage: zapSlippage,
+    localPriceImpactPercentage: depositValueInfo.priceImpactPercentage,
+    localWorstCasePriceImpactPercentage: depositValueInfo.worstCasePriceImpactPercentage,
+    hasIncompleteUsdValuation: depositValueInfo.hasIncompleteUsdValuation,
+    ensoPriceImpact: activeFlow.periphery.priceImpact,
+    expectedOut: activeFlow.periphery.expectedOut,
+    minExpectedOut: activeFlow.periphery.minExpectedOut,
+    tx: activeFlow.periphery.tx,
+    display: depositQuoteDisplay
+  })
+  const {
+    desiredSlippage: desiredEnsoQuoteSlippage,
+    ensoPriceImpactPercentage,
+    estimatedPriceImpactPercentage,
+    worstCaseRouteImpactPercentage,
+    priceImpactInfo,
+    isPreparing: isPreparingEnsoQuote,
+    isDisplayLoading: isDisplayLoadingEnsoQuote,
+    isWaitingForProtectedQuote: isWaitingForProtectedEnsoQuote,
+    executableTx: executableEnsoTx
+  } = protectedEnsoQuote
 
   useEffect(() => {
     if (
@@ -662,29 +658,8 @@ export function WidgetDeposit({
     zapSlippage
   ])
 
-  // Calculate worst-case route impact for warning and blocking.
-  const priceImpactInfo = useMemo(() => {
-    if (!isEnsoRoute) {
-      return {
-        percentage: 0,
-        isAboveTolerance: false,
-        isBlocking: false
-      }
-    }
-
-    return {
-      percentage: worstCaseRouteImpactPercentage,
-      isAboveTolerance: worstCaseRouteImpactPercentage > zapSlippage,
-      isBlocking: worstCaseRouteImpactPercentage >= ZAP_SLIPPAGE_HARD_CAP
-    }
-  }, [isEnsoRoute, worstCaseRouteImpactPercentage, zapSlippage])
   const unpricedEnsoDepositError =
-    isEnsoRoute &&
-    ensoPriceImpactPercentage === undefined &&
-    depositValueInfo.hasIncompleteUsdValuation &&
-    depositAmount.debouncedBn > 0n &&
-    !depositAmount.isDebouncing &&
-    !isPreparingEnsoQuote
+    protectedEnsoQuote.hasUnpricedQuoteError && !depositAmount.isDebouncing
       ? 'Unable to estimate zap price impact for the selected token. Use the base asset flow or swap elsewhere.'
       : null
   const effectiveDepositError = depositError || unpricedEnsoDepositError
@@ -726,7 +701,6 @@ export function WidgetDeposit({
   const [completedApprovalFlowKey, setCompletedApprovalFlowKey] = useState<string | null>(null)
   const hasCompletedApprovalInActiveFlow = completedApprovalFlowKey === approvalFlowKey
   const effectiveNeedsApproval = needsApproval && !hasCompletedApprovalInActiveFlow
-  const executableEnsoTx = isWaitingForProtectedEnsoQuote ? undefined : activeFlow.periphery.tx
   const safeDepositBatch = useMemo(() => {
     if (!isWalletSafe || !needsApproval) {
       return undefined
@@ -1086,20 +1060,24 @@ export function WidgetDeposit({
         }
       : undefined
   const displayedExpectedVaultShares = isEnsoRoute
-    ? activeFlow.periphery.minExpectedOut
+    ? protectedEnsoQuote.display.expectedVaultShares
     : activeFlow.periphery.expectedOut
   const displayedVaultShareValueInAsset = isEnsoRoute
-    ? depositValueInfo.minVaultShareValueInAsset
+    ? protectedEnsoQuote.display.vaultShareValueInAsset
     : depositValueInfo.vaultShareValueInAsset
   const displayedVaultShareValueUsdRaw = isEnsoRoute
-    ? depositValueInfo.minVaultShareValueUsdRaw
+    ? protectedEnsoQuote.display.vaultShareValueUsdRaw
     : depositValueInfo.vaultShareValueUsdRaw
   const displayedPriceImpactPercentage = isEnsoRoute
     ? worstCaseRouteImpactPercentage
     : depositValueInfo.priceImpactPercentage
   const displayedShouldHighlightPriceImpact =
     isEnsoRoute && (priceImpactInfo.isAboveTolerance || priceImpactInfo.isBlocking)
-  const displayedConvertedVaultShares = isEnsoRoute ? normalizedMinExpectedOut : normalizedExpectedOut
+  const displayedConvertedVaultShares = isEnsoRoute
+    ? protectedEnsoQuote.display.convertedVaultShares
+    : normalizedExpectedOut
+  const displayedEnsoRouteHasSwap = isEnsoRoute ? protectedEnsoQuote.display.routeHasSwap : false
+  const shouldRevealEnsoRouteDetails = !isEnsoRoute || !isDisplayLoadingEnsoQuote
   const shouldShowShareConversion =
     willReceiveStakedShares && displayedExpectedVaultShares !== displayedConvertedVaultShares
 
@@ -1112,12 +1090,12 @@ export function WidgetDeposit({
       inputTokenDecimals={inputToken?.decimals ?? 18}
       inputTokenUsdPrice={inputTokenPrice}
       routeType={routeType}
-      isSwap={ensoRouteHasSwap}
+      isSwap={shouldRevealEnsoRouteDetails && displayedEnsoRouteHasSwap}
       usesMinExpectedOut={isEnsoRoute}
-      isLoadingQuote={isPreparingEnsoQuote}
+      isLoadingQuote={isEnsoRoute ? isDisplayLoadingEnsoQuote : isLoadingQuote}
       isQuoteStale={depositAmount.isDebouncing || depositAmount.bn !== depositAmount.debouncedBn}
-      expectedOutInAsset={expectedOutInAsset}
-      minExpectedOutInAsset={minExpectedOutInAsset}
+      expectedOutInAsset={isEnsoRoute ? protectedEnsoQuote.display.expectedOutInAsset : expectedOutInAsset}
+      minExpectedOutInAsset={isEnsoRoute ? protectedEnsoQuote.display.minExpectedOutInAsset : minExpectedOutInAsset}
       assetTokenSymbol={assetToken?.symbol}
       assetTokenDecimals={assetToken?.decimals ?? 18}
       expectedVaultShares={displayedExpectedVaultShares}
@@ -1140,6 +1118,7 @@ export function WidgetDeposit({
       allowanceTokenDecimals={!isNativeToken ? (inputToken?.decimals ?? 18) : undefined}
       allowanceTokenSymbol={!isNativeToken ? inputToken?.symbol : undefined}
       approvalSpenderName={approvalSpenderName}
+      isApprovalLoading={isEnsoRoute && isDisplayLoadingEnsoQuote && !isNativeToken}
       onAllowanceClick={onAllowanceClick}
       onShowApprovalOverlay={!isNativeToken && approvalSpenderAddress ? openApprovalOverlay : undefined}
     />
@@ -1150,7 +1129,7 @@ export function WidgetDeposit({
       percentage={priceImpactInfo.percentage}
       userTolerancePercentage={zapSlippage}
       isBlocking={priceImpactInfo.isBlocking}
-      isLoading={isPreparingEnsoQuote}
+      isLoading={isEnsoRoute ? isDisplayLoadingEnsoQuote : isLoadingQuote}
       isDebouncing={depositAmount.isDebouncing}
       isAmountSynced={depositAmount.bn === depositAmount.debouncedBn}
       hasAmount={depositAmount.bn > 0n}

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -15,7 +15,11 @@ import { cl, formatTAmount, toAddress } from '@shared/utils'
 import { requiresAllowanceResetBeforeApproval } from '@shared/utils/approve'
 import { ETH_TOKEN_ADDRESS } from '@shared/utils/constants'
 import { PLAUSIBLE_EVENTS } from '@shared/utils/plausible'
-import { calculateRemainingEnsoSlippagePercentage, ZAP_SLIPPAGE_HARD_CAP } from '@shared/utils/slippage'
+import {
+  calculateRemainingEnsoSlippagePercentage,
+  optionalBasisPointsToPercentage,
+  ZAP_SLIPPAGE_HARD_CAP
+} from '@shared/utils/slippage'
 import type { ReactElement, ReactNode } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { formatUnits, isAddressEqual } from 'viem'
@@ -373,6 +377,8 @@ export function WidgetDeposit({
   })
 
   const isCrossChain = sourceChainId !== chainId
+  const isEnsoRoute = routeType === 'ENSO'
+  const ensoRouteHasSwap = isEnsoRoute && Boolean(activeFlow.periphery.routeHasSwap)
   const { approveNotificationParams, depositNotificationParams } = useDepositNotifications({
     inputToken,
     vault,
@@ -385,10 +391,7 @@ export function WidgetDeposit({
     sourceChainId,
     chainId,
     depositAmount: depositAmount.debouncedBn,
-    expectedShareAmount:
-      routeType === 'ENSO' && activeFlow.periphery.routeHasSwap
-        ? activeFlow.periphery.minExpectedOut
-        : activeFlow.periphery.expectedOut,
+    expectedShareAmount: isEnsoRoute ? activeFlow.periphery.minExpectedOut : activeFlow.periphery.expectedOut,
     routeType,
     routerAddress: activeFlow.periphery.routerAddress,
     isCrossChain
@@ -519,17 +522,34 @@ export function WidgetDeposit({
       assetTokenPrice
     ]
   )
-  const ensoRouteHasSwap = routeType === 'ENSO' && Boolean(activeFlow.periphery.routeHasSwap)
-
+  const ensoPriceImpactPercentage = isEnsoRoute
+    ? optionalBasisPointsToPercentage(activeFlow.periphery.priceImpact)
+    : undefined
+  const estimatedPriceImpactPercentage =
+    isEnsoRoute && ensoPriceImpactPercentage !== undefined
+      ? Math.max(depositValueInfo.priceImpactPercentage, ensoPriceImpactPercentage)
+      : depositValueInfo.priceImpactPercentage
+  const worstCaseRouteImpactPercentage =
+    isEnsoRoute && ensoPriceImpactPercentage !== undefined
+      ? Math.max(depositValueInfo.worstCasePriceImpactPercentage, ensoPriceImpactPercentage)
+      : depositValueInfo.worstCasePriceImpactPercentage
   const desiredEnsoQuoteSlippage = useMemo(
     () =>
-      routeType === 'ENSO' && activeFlow.periphery.routeHasSwap !== false
-        ? calculateRemainingEnsoSlippagePercentage({
-            userTolerancePercentage: zapSlippage,
-            quoteImpactPercentage: depositValueInfo.priceImpactPercentage
-          })
+      isEnsoRoute
+        ? depositValueInfo.hasIncompleteUsdValuation && ensoPriceImpactPercentage === undefined
+          ? 0
+          : calculateRemainingEnsoSlippagePercentage({
+              userTolerancePercentage: zapSlippage,
+              quoteImpactPercentage: estimatedPriceImpactPercentage
+            })
         : 0,
-    [activeFlow.periphery.routeHasSwap, depositValueInfo.priceImpactPercentage, routeType, zapSlippage]
+    [
+      depositValueInfo.hasIncompleteUsdValuation,
+      ensoPriceImpactPercentage,
+      estimatedPriceImpactPercentage,
+      isEnsoRoute,
+      zapSlippage
+    ]
   )
 
   useEffect(() => {
@@ -545,6 +565,11 @@ export function WidgetDeposit({
 
     setEnsoQuoteSlippage(desiredEnsoQuoteSlippage)
   }, [depositAmount.debouncedBn, desiredEnsoQuoteSlippage, ensoQuoteSlippage, isLoadingQuote, routeType])
+
+  const hasBootstrapEnsoQuote =
+    isEnsoRoute && ensoQuoteSlippage === 0 && activeFlow.periphery.expectedOut > 0n && depositAmount.debouncedBn > 0n
+  const isWaitingForProtectedEnsoQuote = hasBootstrapEnsoQuote && desiredEnsoQuoteSlippage > 0
+  const isPreparingEnsoQuote = isLoadingQuote || isWaitingForProtectedEnsoQuote
 
   useEffect(() => {
     if (
@@ -570,8 +595,11 @@ export function WidgetDeposit({
       normalizedMinExpectedOutRaw: normalizedMinExpectedOut.toString(),
       expectedOutInAssetRaw: expectedOutInAsset.toString(),
       minExpectedOutInAssetRaw: minExpectedOutInAsset.toString(),
-      expectedPriceImpactPercentage: depositValueInfo.priceImpactPercentage,
-      worstCasePriceImpactPercentage: depositValueInfo.worstCasePriceImpactPercentage,
+      localPriceImpactPercentage: depositValueInfo.priceImpactPercentage,
+      ensoPriceImpactPercentage,
+      selectedPriceImpactPercentage: estimatedPriceImpactPercentage,
+      localWorstCasePriceImpactPercentage: depositValueInfo.worstCasePriceImpactPercentage,
+      selectedWorstCasePriceImpactPercentage: worstCaseRouteImpactPercentage,
       inputTokenSymbol: inputToken?.symbol,
       destinationTokenSymbol: assetToken?.symbol
     }
@@ -608,7 +636,7 @@ export function WidgetDeposit({
     console.log('[ENSO][deposit] protected quote comparison', {
       bootstrapQuote: bootstrapEnsoQuoteDebugRef.current,
       protectedQuote: quoteSummary,
-      note: 'expectedPriceImpactPercentage comes from amountOut; worstCasePriceImpactPercentage comes from minAmountOut; widget warnings currently use worstCasePriceImpactPercentage.'
+      note: 'localPriceImpactPercentage comes from amountOut; localWorstCasePriceImpactPercentage comes from minAmountOut; selected values also include Enso priceImpact when Enso is stricter.'
     })
   }, [
     activeFlow.periphery.expectedOut,
@@ -619,8 +647,10 @@ export function WidgetDeposit({
     depositValueInfo.priceImpactPercentage,
     depositValueInfo.worstCasePriceImpactPercentage,
     desiredEnsoQuoteSlippage,
+    ensoPriceImpactPercentage,
     ensoQuoteSlippage,
     ensoSlippageCalibrationKey,
+    estimatedPriceImpactPercentage,
     expectedOutInAsset,
     inputToken?.symbol,
     isLoadingQuote,
@@ -628,12 +658,13 @@ export function WidgetDeposit({
     normalizedExpectedOut,
     normalizedMinExpectedOut,
     routeType,
+    worstCaseRouteImpactPercentage,
     zapSlippage
   ])
 
-  // Calculate total price impact for warning and blocking.
+  // Calculate worst-case route impact for warning and blocking.
   const priceImpactInfo = useMemo(() => {
-    if (!ensoRouteHasSwap) {
+    if (!isEnsoRoute) {
       return {
         percentage: 0,
         isAboveTolerance: false,
@@ -642,18 +673,18 @@ export function WidgetDeposit({
     }
 
     return {
-      percentage: depositValueInfo.worstCasePriceImpactPercentage,
-      isAboveTolerance: depositValueInfo.worstCasePriceImpactPercentage > zapSlippage,
-      isBlocking: depositValueInfo.worstCasePriceImpactPercentage >= ZAP_SLIPPAGE_HARD_CAP
+      percentage: worstCaseRouteImpactPercentage,
+      isAboveTolerance: worstCaseRouteImpactPercentage > zapSlippage,
+      isBlocking: worstCaseRouteImpactPercentage >= ZAP_SLIPPAGE_HARD_CAP
     }
-  }, [depositValueInfo.worstCasePriceImpactPercentage, ensoRouteHasSwap, zapSlippage])
+  }, [isEnsoRoute, worstCaseRouteImpactPercentage, zapSlippage])
   const unpricedEnsoDepositError =
-    routeType === 'ENSO' &&
-    ensoRouteHasSwap &&
+    isEnsoRoute &&
+    ensoPriceImpactPercentage === undefined &&
     depositValueInfo.hasIncompleteUsdValuation &&
     depositAmount.debouncedBn > 0n &&
     !depositAmount.isDebouncing &&
-    !isLoadingQuote
+    !isPreparingEnsoQuote
       ? 'Unable to estimate zap price impact for the selected token. Use the base asset flow or swap elsewhere.'
       : null
   const effectiveDepositError = depositError || unpricedEnsoDepositError
@@ -695,6 +726,7 @@ export function WidgetDeposit({
   const [completedApprovalFlowKey, setCompletedApprovalFlowKey] = useState<string | null>(null)
   const hasCompletedApprovalInActiveFlow = completedApprovalFlowKey === approvalFlowKey
   const effectiveNeedsApproval = needsApproval && !hasCompletedApprovalInActiveFlow
+  const executableEnsoTx = isWaitingForProtectedEnsoQuote ? undefined : activeFlow.periphery.tx
   const safeDepositBatch = useMemo(() => {
     if (!isWalletSafe || !needsApproval) {
       return undefined
@@ -712,11 +744,11 @@ export function WidgetDeposit({
       stakingSource,
       approvalSpenderAddress: approvalWarning ? undefined : approvalSpenderAddress,
       routerAddress: activeFlow.periphery.routerAddress ? toAddress(activeFlow.periphery.routerAddress) : undefined,
-      ensoTx: activeFlow.periphery.tx
+      ensoTx: executableEnsoTx
         ? {
-            to: toAddress(activeFlow.periphery.tx.to),
-            data: activeFlow.periphery.tx.data,
-            value: activeFlow.periphery.tx.value
+            to: toAddress(executableEnsoTx.to),
+            data: executableEnsoTx.data,
+            value: executableEnsoTx.value
           }
         : undefined
     })
@@ -724,7 +756,6 @@ export function WidgetDeposit({
     account,
     activeFlow.periphery.allowance,
     activeFlow.periphery.routerAddress,
-    activeFlow.periphery.tx,
     approvalSpenderAddress,
     approvalWarning,
     chainId,
@@ -732,6 +763,7 @@ export function WidgetDeposit({
     depositToken,
     isWalletSafe,
     needsApproval,
+    executableEnsoTx,
     routeType,
     sourceChainId,
     stakingDepositAddress,
@@ -752,7 +784,10 @@ export function WidgetDeposit({
         successMessage: isCrossChain
           ? `Your cross-chain ${actionLabel.toLowerCase()} has been submitted.\nIt may take a few minutes to complete on the destination chain.`
           : `You have ${pastTenseLabel} ${formattedDepositAmount} ${inputToken?.symbol || ''} into ${vaultSymbol}.`,
-        isEnabled: activeFlow.periphery.prepareApproveEnabled && safeDepositBatch.calls.length > 0,
+        isEnabled:
+          !isWaitingForProtectedEnsoQuote &&
+          activeFlow.periphery.prepareApproveEnabled &&
+          safeDepositBatch.calls.length > 0,
         completesFlow: true,
         showConfetti: true,
         notification: depositNotificationParams
@@ -766,7 +801,7 @@ export function WidgetDeposit({
         confirmMessage: `Approving ${formattedDepositAmount} ${inputToken?.symbol || ''}`,
         successTitle: 'Approval successful',
         successMessage: `Approved ${formattedDepositAmount} ${inputToken?.symbol || ''}.\nReady to deposit.`,
-        isEnabled: activeFlow.periphery.prepareApproveEnabled,
+        isEnabled: !isWaitingForProtectedEnsoQuote && activeFlow.periphery.prepareApproveEnabled,
         completesFlow: false,
         notification: approveNotificationParams
       }
@@ -779,7 +814,7 @@ export function WidgetDeposit({
         confirmMessage: `${progressLabel} ${formattedDepositAmount} ${inputToken?.symbol || ''}`,
         successTitle: 'Transaction Submitted',
         successMessage: `Your cross-chain ${actionLabel.toLowerCase()} has been submitted.\nIt may take a few minutes to complete on the destination chain.`,
-        isEnabled: activeFlow.periphery.prepareDepositEnabled,
+        isEnabled: !isWaitingForProtectedEnsoQuote && activeFlow.periphery.prepareDepositEnabled,
         completesFlow: true,
         showConfetti: true,
         notification: depositNotificationParams
@@ -792,7 +827,7 @@ export function WidgetDeposit({
       confirmMessage: `${progressLabel} ${formattedDepositAmount} ${inputToken?.symbol || ''}`,
       successTitle: `${actionLabel} successful!`,
       successMessage: `You have ${pastTenseLabel} ${formattedDepositAmount} ${inputToken?.symbol || ''} into ${vaultSymbol}.`,
-      isEnabled: activeFlow.periphery.prepareDepositEnabled,
+      isEnabled: !isWaitingForProtectedEnsoQuote && activeFlow.periphery.prepareDepositEnabled,
       completesFlow: true,
       showConfetti: true,
       notification: depositNotificationParams
@@ -810,7 +845,8 @@ export function WidgetDeposit({
     routeType,
     approveNotificationParams,
     depositNotificationParams,
-    isCrossChain
+    isCrossChain,
+    isWaitingForProtectedEnsoQuote
   ])
 
   const { fetchMaxQuote, isFetching: isFetchingMaxQuote } = useFetchMaxQuote({
@@ -1049,24 +1085,21 @@ export function WidgetDeposit({
           setDepositInput(formatUnits(activeFlow.periphery.allowance, inputToken?.decimals ?? 18))
         }
       : undefined
-  const displayedExpectedVaultShares =
-    routeType === 'ENSO' && ensoRouteHasSwap ? activeFlow.periphery.minExpectedOut : activeFlow.periphery.expectedOut
-  const displayedVaultShareValueInAsset =
-    routeType === 'ENSO' && ensoRouteHasSwap
-      ? depositValueInfo.minVaultShareValueInAsset
-      : depositValueInfo.vaultShareValueInAsset
-  const displayedVaultShareValueUsdRaw =
-    routeType === 'ENSO' && ensoRouteHasSwap
-      ? depositValueInfo.minVaultShareValueUsdRaw
-      : depositValueInfo.vaultShareValueUsdRaw
-  const displayedPriceImpactPercentage =
-    routeType === 'ENSO' && ensoRouteHasSwap
-      ? depositValueInfo.worstCasePriceImpactPercentage
-      : depositValueInfo.priceImpactPercentage
+  const displayedExpectedVaultShares = isEnsoRoute
+    ? activeFlow.periphery.minExpectedOut
+    : activeFlow.periphery.expectedOut
+  const displayedVaultShareValueInAsset = isEnsoRoute
+    ? depositValueInfo.minVaultShareValueInAsset
+    : depositValueInfo.vaultShareValueInAsset
+  const displayedVaultShareValueUsdRaw = isEnsoRoute
+    ? depositValueInfo.minVaultShareValueUsdRaw
+    : depositValueInfo.vaultShareValueUsdRaw
+  const displayedPriceImpactPercentage = isEnsoRoute
+    ? worstCaseRouteImpactPercentage
+    : depositValueInfo.priceImpactPercentage
   const displayedShouldHighlightPriceImpact =
-    routeType === 'ENSO' && ensoRouteHasSwap && (priceImpactInfo.isAboveTolerance || priceImpactInfo.isBlocking)
-  const displayedConvertedVaultShares =
-    routeType === 'ENSO' && ensoRouteHasSwap ? normalizedMinExpectedOut : normalizedExpectedOut
+    isEnsoRoute && (priceImpactInfo.isAboveTolerance || priceImpactInfo.isBlocking)
+  const displayedConvertedVaultShares = isEnsoRoute ? normalizedMinExpectedOut : normalizedExpectedOut
   const shouldShowShareConversion =
     willReceiveStakedShares && displayedExpectedVaultShares !== displayedConvertedVaultShares
 
@@ -1080,7 +1113,8 @@ export function WidgetDeposit({
       inputTokenUsdPrice={inputTokenPrice}
       routeType={routeType}
       isSwap={ensoRouteHasSwap}
-      isLoadingQuote={isLoadingQuote}
+      usesMinExpectedOut={isEnsoRoute}
+      isLoadingQuote={isPreparingEnsoQuote}
       isQuoteStale={depositAmount.isDebouncing || depositAmount.bn !== depositAmount.debouncedBn}
       expectedOutInAsset={expectedOutInAsset}
       minExpectedOutInAsset={minExpectedOutInAsset}
@@ -1093,7 +1127,7 @@ export function WidgetDeposit({
       assetUsdPrice={assetTokenPrice}
       vaultShareValueInAsset={displayedVaultShareValueInAsset}
       vaultShareValueUsdRaw={displayedVaultShareValueUsdRaw}
-      expectedPriceImpactPercentage={depositValueInfo.priceImpactPercentage}
+      expectedPriceImpactPercentage={estimatedPriceImpactPercentage}
       priceImpactPercentage={displayedPriceImpactPercentage}
       shouldHighlightPriceImpact={displayedShouldHighlightPriceImpact}
       willReceiveStakedShares={willReceiveStakedShares}
@@ -1116,7 +1150,7 @@ export function WidgetDeposit({
       percentage={priceImpactInfo.percentage}
       userTolerancePercentage={zapSlippage}
       isBlocking={priceImpactInfo.isBlocking}
-      isLoading={isLoadingQuote}
+      isLoading={isPreparingEnsoQuote}
       isDebouncing={depositAmount.isDebouncing}
       isAmountSynced={depositAmount.bn === depositAmount.debouncedBn}
       hasAmount={depositAmount.bn > 0n}
@@ -1176,7 +1210,7 @@ export function WidgetDeposit({
   const showActionRow = !hideActionButton || !!onOpenSettings
   const showSettingsButton = !!account && !!onOpenSettings
   const depositButtonLabel = getDepositButtonLabel(
-    isLoadingQuote,
+    isPreparingEnsoQuote,
     effectiveNeedsApproval,
     routeType,
     actionLabelOverride
@@ -1190,17 +1224,17 @@ export function WidgetDeposit({
       !currentStep.prepare.isError
   )
   const isDepositButtonBusy =
-    !shouldBlockApprovalForAllowanceReset && (activeFlow.periphery.isLoadingRoute || isCurrentStepWaitingForPrepare)
+    !shouldBlockApprovalForAllowanceReset && (isPreparingEnsoQuote || isCurrentStepWaitingForPrepare)
   const isDepositButtonDisabled =
     !!effectiveDepositError ||
     depositAmount.bn === 0n ||
-    isLoadingQuote ||
+    isPreparingEnsoQuote ||
     depositAmount.isDebouncing ||
     shouldBlockApprovalForAllowanceReset ||
     isCurrentStepWaitingForPrepare ||
     (effectiveNeedsApproval && !activeFlow.periphery.prepareApproveEnabled) ||
     (!effectiveNeedsApproval && !activeFlow.periphery.prepareDepositEnabled) ||
-    (ensoRouteHasSwap && (priceImpactInfo.isBlocking || priceImpactInfo.isAboveTolerance))
+    (isEnsoRoute && (priceImpactInfo.isBlocking || priceImpactInfo.isAboveTolerance))
 
   const actionRow = showActionRow ? (
     <div className="flex flex-col gap-3">

--- a/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
@@ -55,6 +55,7 @@ export interface DepositFlowResult {
       allowance: bigint
       expectedOut: bigint
       minExpectedOut: bigint
+      priceImpact?: number | null
       normalizedExpectedOut: bigint
       normalizedMinExpectedOut: bigint
       routeHasSwap?: boolean

--- a/src/components/pages/vaults/components/widget/shared/PriceImpactWarning.test.tsx
+++ b/src/components/pages/vaults/components/widget/shared/PriceImpactWarning.test.tsx
@@ -16,7 +16,7 @@ describe('PriceImpactWarning', () => {
       />
     )
 
-    expect(html).toContain('Total price impact is')
+    expect(html).toContain('Worst-case route impact is')
     expect(html).toContain('2.50%')
     expect(html).toContain('Price impact details')
     expect(html).not.toContain(

--- a/src/components/pages/vaults/components/widget/shared/PriceImpactWarning.tsx
+++ b/src/components/pages/vaults/components/widget/shared/PriceImpactWarning.tsx
@@ -54,7 +54,7 @@ export function PriceImpactWarning({
     <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2">
       <div className="flex items-center justify-between gap-2">
         <p className="text-sm text-red-500">
-          Total price impact is <span className="font-semibold">{percentage.toFixed(2)}%</span>.
+          Worst-case route impact is <span className="font-semibold">{percentage.toFixed(2)}%</span>.
         </p>
         <Tooltip
           className="h-auto shrink-0 gap-0"

--- a/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { type ProtectedQuoteSnapshot, resolveProtectedEnsoQuoteView } from './useProtectedEnsoQuoteState'
+
+const TX = {
+  to: '0x0000000000000000000000000000000000000001',
+  data: '0x',
+  value: '0',
+  from: '0x0000000000000000000000000000000000000002'
+} as const
+
+type Display = {
+  amount: bigint
+  routeHasSwap: boolean
+}
+
+function snapshot(amount: bigint, routeHasSwap = false): ProtectedQuoteSnapshot<Display> {
+  return {
+    display: { amount, routeHasSwap },
+    expectedOut: amount,
+    minExpectedOut: amount,
+    estimatedPriceImpactPercentage: 0.3,
+    worstCaseRouteImpactPercentage: 0.3
+  }
+}
+
+describe('resolveProtectedEnsoQuoteView', () => {
+  it('keeps bootstrap quotes out of display and execution state while protecting', () => {
+    const view = resolveProtectedEnsoQuoteView({
+      isEnsoRoute: true,
+      amount: 1000n,
+      requestedSlippage: 0,
+      isLoadingQuote: false,
+      hasCurrentQuote: true,
+      currentSnapshot: snapshot(1000n, true),
+      desiredSlippage: 0.2,
+      userTolerancePercentage: 0.5,
+      fallbackDisplay: { amount: 0n, routeHasSwap: false },
+      fallbackEstimatedPriceImpactPercentage: 0,
+      fallbackWorstCaseRouteImpactPercentage: 0,
+      tx: TX
+    })
+
+    expect(view.routeState).toBe('protecting')
+    expect(view.isPreparing).toBe(true)
+    expect(view.isDisplayLoading).toBe(true)
+    expect(view.display.amount).toBe(0n)
+    expect(view.display.routeHasSwap).toBe(false)
+    expect(view.executableTx).toBeUndefined()
+  })
+
+  it('keeps the quote view loading while a protected quote refetches, even with a cached display', () => {
+    const view = resolveProtectedEnsoQuoteView({
+      isEnsoRoute: true,
+      amount: 1000n,
+      requestedSlippage: 0.2,
+      isLoadingQuote: true,
+      hasCurrentQuote: false,
+      currentSnapshot: snapshot(0n),
+      cachedSnapshot: snapshot(995n, true),
+      desiredSlippage: 0.2,
+      userTolerancePercentage: 0.5,
+      fallbackDisplay: { amount: 0n, routeHasSwap: false },
+      fallbackEstimatedPriceImpactPercentage: 0,
+      fallbackWorstCaseRouteImpactPercentage: 0,
+      tx: TX
+    })
+
+    expect(view.routeState).toBe('protecting')
+    expect(view.isPreparing).toBe(true)
+    expect(view.isDisplayLoading).toBe(true)
+    expect(view.display.amount).toBe(995n)
+    expect(view.display.routeHasSwap).toBe(true)
+    expect(view.executableTx).toBeUndefined()
+  })
+})

--- a/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.ts
+++ b/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.ts
@@ -1,0 +1,236 @@
+import type { TAddress } from '@shared/types'
+import {
+  calculateRemainingEnsoSlippagePercentage,
+  optionalBasisPointsToPercentage,
+  ZAP_SLIPPAGE_HARD_CAP
+} from '@shared/utils/slippage'
+import { useEffect, useMemo, useRef } from 'react'
+import type { Hex } from 'viem'
+
+export type ProtectedEnsoRouteState = 'idle' | 'loading' | 'protecting' | 'ready' | 'blocked'
+
+export type ProtectedEnsoTx = {
+  to: TAddress
+  data: Hex
+  value: string
+  from: TAddress
+}
+
+export type ProtectedQuoteSnapshot<TDisplay> = {
+  display: TDisplay
+  expectedOut: bigint
+  minExpectedOut: bigint
+  estimatedPriceImpactPercentage: number
+  worstCaseRouteImpactPercentage: number
+}
+
+type UseProtectedEnsoQuoteStateParams<TDisplay> = {
+  stateKey: string
+  isEnsoRoute: boolean
+  amount: bigint
+  requestedSlippage: number
+  setRequestedSlippage: (value: number) => void
+  isLoadingQuote: boolean
+  userTolerancePercentage: number
+  localPriceImpactPercentage: number
+  localWorstCasePriceImpactPercentage: number
+  hasIncompleteUsdValuation: boolean
+  ensoPriceImpact?: number | null
+  expectedOut: bigint
+  minExpectedOut: bigint
+  tx?: ProtectedEnsoTx
+  display: TDisplay
+}
+
+export function resolveProtectedEnsoQuoteView<TDisplay>({
+  isEnsoRoute,
+  amount,
+  requestedSlippage,
+  isLoadingQuote,
+  hasCurrentQuote,
+  currentSnapshot,
+  cachedSnapshot,
+  desiredSlippage,
+  userTolerancePercentage,
+  fallbackDisplay,
+  fallbackEstimatedPriceImpactPercentage,
+  fallbackWorstCaseRouteImpactPercentage,
+  tx
+}: {
+  isEnsoRoute: boolean
+  amount: bigint
+  requestedSlippage: number
+  isLoadingQuote: boolean
+  hasCurrentQuote: boolean
+  currentSnapshot: ProtectedQuoteSnapshot<TDisplay>
+  cachedSnapshot?: ProtectedQuoteSnapshot<TDisplay>
+  desiredSlippage: number
+  userTolerancePercentage: number
+  fallbackDisplay: TDisplay
+  fallbackEstimatedPriceImpactPercentage: number
+  fallbackWorstCaseRouteImpactPercentage: number
+  tx?: ProtectedEnsoTx
+}) {
+  const isWaitingForProtectedQuote =
+    isEnsoRoute &&
+    amount > 0n &&
+    ((requestedSlippage === 0 && hasCurrentQuote && desiredSlippage > 0) || (requestedSlippage > 0 && isLoadingQuote))
+  const canDisplayCurrentQuote = hasCurrentQuote && !isWaitingForProtectedQuote && !isLoadingQuote
+  const snapshot = canDisplayCurrentQuote ? currentSnapshot : cachedSnapshot
+  const isPreparing = isLoadingQuote || isWaitingForProtectedQuote
+  const isDisplayLoading = isEnsoRoute && amount > 0n && isPreparing
+  const displayedEstimatedPriceImpactPercentage =
+    snapshot?.estimatedPriceImpactPercentage ?? fallbackEstimatedPriceImpactPercentage
+  const displayedWorstCaseRouteImpactPercentage =
+    snapshot?.worstCaseRouteImpactPercentage ?? fallbackWorstCaseRouteImpactPercentage
+
+  const priceImpactInfo = !isEnsoRoute
+    ? {
+        percentage: 0,
+        isAboveTolerance: false,
+        isBlocking: false
+      }
+    : {
+        percentage: displayedWorstCaseRouteImpactPercentage,
+        isAboveTolerance: displayedWorstCaseRouteImpactPercentage > userTolerancePercentage,
+        isBlocking: displayedWorstCaseRouteImpactPercentage >= ZAP_SLIPPAGE_HARD_CAP
+      }
+
+  const routeState: ProtectedEnsoRouteState =
+    !isEnsoRoute || amount === 0n
+      ? 'idle'
+      : isWaitingForProtectedQuote
+        ? 'protecting'
+        : isDisplayLoading
+          ? 'loading'
+          : priceImpactInfo.isBlocking || priceImpactInfo.isAboveTolerance
+            ? 'blocked'
+            : hasCurrentQuote
+              ? 'ready'
+              : 'loading'
+
+  return {
+    routeState,
+    display: snapshot?.display ?? fallbackDisplay,
+    isPreparing,
+    isDisplayLoading,
+    isWaitingForProtectedQuote,
+    canDisplayCurrentQuote,
+    estimatedPriceImpactPercentage: displayedEstimatedPriceImpactPercentage,
+    worstCaseRouteImpactPercentage: displayedWorstCaseRouteImpactPercentage,
+    priceImpactInfo,
+    executableTx: isEnsoRoute && isPreparing ? undefined : tx
+  }
+}
+
+export function useProtectedEnsoQuoteState<TDisplay>({
+  stateKey,
+  isEnsoRoute,
+  amount,
+  requestedSlippage,
+  setRequestedSlippage,
+  isLoadingQuote,
+  userTolerancePercentage,
+  localPriceImpactPercentage,
+  localWorstCasePriceImpactPercentage,
+  hasIncompleteUsdValuation,
+  ensoPriceImpact,
+  expectedOut,
+  minExpectedOut,
+  tx,
+  display
+}: UseProtectedEnsoQuoteStateParams<TDisplay>) {
+  const resetKey = isEnsoRoute && amount > 0n ? stateKey : 'inactive'
+  const resetKeyRef = useRef(resetKey)
+  const snapshotRef = useRef<ProtectedQuoteSnapshot<TDisplay> | undefined>(undefined)
+
+  if (resetKeyRef.current !== resetKey) {
+    resetKeyRef.current = resetKey
+    snapshotRef.current = undefined
+  }
+
+  const ensoPriceImpactPercentage = isEnsoRoute ? optionalBasisPointsToPercentage(ensoPriceImpact) : undefined
+  const estimatedPriceImpactPercentage =
+    isEnsoRoute && ensoPriceImpactPercentage !== undefined
+      ? Math.max(localPriceImpactPercentage, ensoPriceImpactPercentage)
+      : localPriceImpactPercentage
+  const worstCaseRouteImpactPercentage =
+    isEnsoRoute && ensoPriceImpactPercentage !== undefined
+      ? Math.max(localWorstCasePriceImpactPercentage, ensoPriceImpactPercentage)
+      : localWorstCasePriceImpactPercentage
+
+  const desiredSlippage = useMemo(
+    () =>
+      isEnsoRoute
+        ? hasIncompleteUsdValuation && ensoPriceImpactPercentage === undefined
+          ? 0
+          : calculateRemainingEnsoSlippagePercentage({
+              userTolerancePercentage,
+              quoteImpactPercentage: estimatedPriceImpactPercentage
+            })
+        : 0,
+    [
+      ensoPriceImpactPercentage,
+      estimatedPriceImpactPercentage,
+      hasIncompleteUsdValuation,
+      isEnsoRoute,
+      userTolerancePercentage
+    ]
+  )
+
+  const hasCurrentQuote = isEnsoRoute && amount > 0n && expectedOut > 0n
+  const currentSnapshot = useMemo(
+    (): ProtectedQuoteSnapshot<TDisplay> => ({
+      display,
+      expectedOut,
+      minExpectedOut,
+      estimatedPriceImpactPercentage,
+      worstCaseRouteImpactPercentage
+    }),
+    [display, estimatedPriceImpactPercentage, expectedOut, minExpectedOut, worstCaseRouteImpactPercentage]
+  )
+
+  useEffect(() => {
+    if (!isEnsoRoute || requestedSlippage !== 0 || amount === 0n || isLoadingQuote || !hasCurrentQuote) {
+      return
+    }
+
+    if (desiredSlippage > 0) {
+      setRequestedSlippage(desiredSlippage)
+    }
+  }, [amount, desiredSlippage, hasCurrentQuote, isEnsoRoute, isLoadingQuote, requestedSlippage, setRequestedSlippage])
+
+  const view = resolveProtectedEnsoQuoteView({
+    isEnsoRoute,
+    amount,
+    requestedSlippage,
+    isLoadingQuote,
+    hasCurrentQuote,
+    currentSnapshot,
+    cachedSnapshot: snapshotRef.current,
+    desiredSlippage,
+    userTolerancePercentage,
+    fallbackDisplay: display,
+    fallbackEstimatedPriceImpactPercentage: estimatedPriceImpactPercentage,
+    fallbackWorstCaseRouteImpactPercentage: worstCaseRouteImpactPercentage,
+    tx
+  })
+
+  useEffect(() => {
+    if (view.canDisplayCurrentQuote) {
+      snapshotRef.current = currentSnapshot
+    }
+  }, [currentSnapshot, view.canDisplayCurrentQuote])
+
+  return {
+    ...view,
+    desiredSlippage,
+    ensoPriceImpactPercentage,
+    hasUnpricedQuoteError:
+      isEnsoRoute &&
+      ensoPriceImpactPercentage === undefined &&
+      hasIncompleteUsdValuation &&
+      amount > 0n &&
+      !view.isPreparing
+  }
+}

--- a/src/components/pages/vaults/components/widget/withdraw/WithdrawDetails.test.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/WithdrawDetails.test.tsx
@@ -26,7 +26,7 @@ describe('WithdrawDetails', () => {
         expectedPriceImpactPercentage={0}
         priceImpactPercentage={0}
         shouldHighlightPriceImpact={false}
-        hasSwap
+        usesMinExpectedOut
         onShowDetailsModal={() => undefined}
       />
     )
@@ -55,7 +55,7 @@ describe('WithdrawDetails', () => {
         expectedPriceImpactPercentage={0}
         priceImpactPercentage={10}
         shouldHighlightPriceImpact
-        hasSwap
+        usesMinExpectedOut
         onShowDetailsModal={() => undefined}
       />
     )
@@ -66,7 +66,7 @@ describe('WithdrawDetails', () => {
     expect(html).toContain('text-red-500')
   })
 
-  it('uses receive copy for routed ENSO withdrawals without swaps', () => {
+  it('uses protected receive copy for routed ENSO withdrawals without swaps', () => {
     const html = renderToStaticMarkup(
       <WithdrawDetails
         actionLabel="You will redeem"
@@ -87,14 +87,15 @@ describe('WithdrawDetails', () => {
         expectedPriceImpactPercentage={0}
         priceImpactPercentage={0}
         shouldHighlightPriceImpact={false}
-        hasSwap={false}
+        usesMinExpectedOut
         onShowDetailsModal={() => undefined}
       />
     )
 
     expect(html).toContain('You will receive')
-    expect(html).not.toContain('You will receive at least')
-    expect(html).not.toContain('Est. / Worst price impact')
+    expect(html).toContain('You will receive at least')
+    expect(html).not.toContain('You will swap')
+    expect(html).toContain('Est. / Worst price impact')
   })
 
   it('shows positive slippage for favorable zap withdrawals', () => {
@@ -118,7 +119,7 @@ describe('WithdrawDetails', () => {
         expectedPriceImpactPercentage={-6}
         priceImpactPercentage={-3}
         shouldHighlightPriceImpact={false}
-        hasSwap
+        usesMinExpectedOut
         onShowDetailsModal={() => undefined}
       />
     )

--- a/src/components/pages/vaults/components/widget/withdraw/WithdrawDetails.test.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/WithdrawDetails.test.tsx
@@ -127,4 +127,42 @@ describe('WithdrawDetails', () => {
     expect(html).toContain('+6.00%')
     expect(html).toContain('+3.00%')
   })
+
+  it('masks existing approval details while an ENSO quote is loading', () => {
+    const html = renderToStaticMarkup(
+      <WithdrawDetails
+        actionLabel="You will redeem"
+        requiredShares={10n * ONE_ETHER}
+        sharesDecimals={18}
+        isLoadingQuote
+        isApprovalLoading
+        isQuoteStale={false}
+        expectedOut={9n * ONE_ETHER}
+        outputDecimals={18}
+        outputSymbol="USDC"
+        showSwapRow
+        withdrawAmountSimple="10"
+        withdrawAmountBn={10n * ONE_ETHER}
+        assetDecimals={18}
+        assetUsdPrice={1}
+        assetSymbol="yvUSD"
+        outputUsdPrice={1}
+        expectedPriceImpactPercentage={0}
+        priceImpactPercentage={10}
+        shouldHighlightPriceImpact
+        usesMinExpectedOut
+        onShowDetailsModal={() => undefined}
+        allowance={123n * ONE_ETHER}
+        allowanceTokenDecimals={18}
+        allowanceTokenSymbol="yvUSD"
+        approvalSpenderName="Enso Router"
+        onShowApprovalOverlay={() => undefined}
+      />
+    )
+
+    expect(html).not.toContain('Existing Approval')
+    expect(html).not.toContain('Enso Router')
+    expect(html).not.toContain('123')
+    expect(html).toContain('animate-pulse')
+  })
 })

--- a/src/components/pages/vaults/components/widget/withdraw/WithdrawDetails.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/WithdrawDetails.tsx
@@ -27,7 +27,7 @@ interface WithdrawDetailsProps {
   expectedPriceImpactPercentage: number
   priceImpactPercentage: number
   shouldHighlightPriceImpact: boolean
-  hasSwap: boolean
+  usesMinExpectedOut: boolean
   // Modal trigger
   onShowDetailsModal: () => void
   // Approval info (for zap withdrawals)
@@ -62,7 +62,7 @@ export function WithdrawDetails({
   expectedPriceImpactPercentage,
   priceImpactPercentage,
   shouldHighlightPriceImpact,
-  hasSwap,
+  usesMinExpectedOut,
   onShowDetailsModal,
   allowance,
   allowanceTokenDecimals,
@@ -83,8 +83,8 @@ export function WithdrawDetails({
   const withdrawUsdDisplay = formatCounterValue(formatUnits(withdrawAmountBn, assetDecimals), assetUsdPrice)
   const expectedOutUsdDisplay = formatCounterValue(formatUnits(expectedOut, outputDecimals), outputUsdPrice)
   const shouldShowWithdrawUsdBadge = showSwapRow && assetUsdPrice > 0 && withdrawAmountBn > 0n
-  const shouldShowExpectedOutUsdBadge = hasSwap && outputUsdPrice > 0 && expectedOut > 0n
-  const shouldShowWorstCasePriceImpact = showSwapRow && hasSwap
+  const shouldShowExpectedOutUsdBadge = usesMinExpectedOut && outputUsdPrice > 0 && expectedOut > 0n
+  const shouldShowWorstCasePriceImpact = usesMinExpectedOut
   const shouldUseHighlight = !isQuoteStale && !isLoadingQuote && shouldHighlightPriceImpact
   return (
     <div>
@@ -126,7 +126,7 @@ export function WithdrawDetails({
 
         {/* You will receive */}
         <div className="flex items-center justify-between h-5">
-          <p className="text-sm text-text-secondary">You will receive{hasSwap ? ' at least' : ''}</p>
+          <p className="text-sm text-text-secondary">You will receive{usesMinExpectedOut ? ' at least' : ''}</p>
           <div className="flex items-center gap-1">
             <p className={`text-sm ${shouldUseHighlight ? 'text-red-500' : 'text-text-primary'}`}>
               {isLoadingQuote ? (

--- a/src/components/pages/vaults/components/widget/withdraw/WithdrawDetails.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/WithdrawDetails.tsx
@@ -35,6 +35,7 @@ interface WithdrawDetailsProps {
   allowanceTokenDecimals?: number
   allowanceTokenSymbol?: string
   approvalSpenderName?: string
+  isApprovalLoading?: boolean
   onAllowanceClick?: () => void
   onShowApprovalOverlay?: () => void
 }
@@ -68,10 +69,13 @@ export function WithdrawDetails({
   allowanceTokenDecimals,
   allowanceTokenSymbol,
   approvalSpenderName,
+  isApprovalLoading = false,
   onAllowanceClick,
   onShowApprovalOverlay
 }: WithdrawDetailsProps): ReactElement {
   const allowanceDisplay = formatWidgetAllowance(allowance, allowanceTokenDecimals)
+  const shouldShowAllowanceRow = isApprovalLoading || allowanceDisplay !== null
+  const renderedAllowanceDisplay = allowanceDisplay ?? '0'
   const approvalLabel = getApprovalLabel(approvalSpenderName)
   const formatSignedSlippage = (percentage: number) => {
     if (percentage === 0) {
@@ -170,9 +174,13 @@ export function WithdrawDetails({
         )}
 
         {/* Approved allowance (for zap withdrawals) */}
-        {allowanceDisplay && (
+        {shouldShowAllowanceRow && (
           <div className="flex items-center justify-between h-5">
-            {onShowApprovalOverlay ? (
+            {isApprovalLoading ? (
+              <p className="text-sm text-text-secondary">
+                <span className="inline-block h-4 w-36 bg-surface-secondary rounded animate-pulse" />
+              </p>
+            ) : onShowApprovalOverlay ? (
               <button
                 type="button"
                 onClick={onShowApprovalOverlay}
@@ -183,22 +191,24 @@ export function WithdrawDetails({
             ) : (
               <p className="text-sm text-text-secondary">{approvalLabel}</p>
             )}
-            {onAllowanceClick && allowanceDisplay !== 'Unlimited' ? (
+            {isApprovalLoading ? (
+              <span className="inline-block h-4 w-20 bg-surface-secondary rounded animate-pulse" />
+            ) : onAllowanceClick && renderedAllowanceDisplay !== 'Unlimited' ? (
               <button
                 type="button"
                 onClick={onAllowanceClick}
                 className="text-sm text-text-primary hover:text-blue-500 transition-colors cursor-pointer"
               >
                 <span className="font-semibold">
-                  {allowanceDisplay}
-                  {allowanceDisplay !== 'Unlimited' && allowanceTokenSymbol ? ` ${allowanceTokenSymbol}` : ''}
+                  {renderedAllowanceDisplay}
+                  {renderedAllowanceDisplay !== 'Unlimited' && allowanceTokenSymbol ? ` ${allowanceTokenSymbol}` : ''}
                 </span>
               </button>
             ) : (
               <p className="text-sm text-text-primary">
                 <span className="font-semibold">
-                  {allowanceDisplay}
-                  {allowanceDisplay !== 'Unlimited' && allowanceTokenSymbol ? ` ${allowanceTokenSymbol}` : ''}
+                  {renderedAllowanceDisplay}
+                  {renderedAllowanceDisplay !== 'Unlimited' && allowanceTokenSymbol ? ` ${allowanceTokenSymbol}` : ''}
                 </span>
               </p>
             )}

--- a/src/components/pages/vaults/components/widget/withdraw/WithdrawDetailsOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/WithdrawDetailsOverlay.tsx
@@ -19,6 +19,7 @@ interface WithdrawDetailsOverlayProps {
   routeType: WithdrawRouteType
   isZap: boolean
   hasSwap: boolean
+  usesMinExpectedOut: boolean
   isLoadingQuote: boolean
 }
 
@@ -34,7 +35,8 @@ export const WithdrawDetailsOverlay: FC<WithdrawDetailsOverlayProps> = ({
   withdrawalSource,
   routeType,
   isZap,
-  hasSwap
+  hasSwap,
+  usesMinExpectedOut
 }) => {
   const isFromStaking = withdrawalSource === 'staking'
   const isUnstake = routeType === 'DIRECT_UNSTAKE'
@@ -69,7 +71,7 @@ export const WithdrawDetailsOverlay: FC<WithdrawDetailsOverlayProps> = ({
     return <span className="font-semibold text-text-primary">{outputTokenSymbol}</span>
   }
 
-  const receiveLabel = isZap && hasSwap && hasInputValue ? "You'll receive at least:" : "You'll receive:"
+  const receiveLabel = isZap && usesMinExpectedOut && hasInputValue ? "You'll receive at least:" : "You'll receive:"
 
   return (
     <InfoOverlay isOpen={isOpen} onClose={onClose} title="Withdrawal Details">

--- a/src/components/pages/vaults/components/widget/withdraw/index.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/index.tsx
@@ -7,7 +7,12 @@ import { IconCross } from '@shared/icons/IconCross'
 import { IconSettings } from '@shared/icons/IconSettings'
 import { cl, formatTAmount, toAddress, toNormalizedBN } from '@shared/utils'
 import { PLAUSIBLE_EVENTS } from '@shared/utils/plausible'
-import { calculateRemainingEnsoSlippagePercentage, toBasisPoints, ZAP_SLIPPAGE_HARD_CAP } from '@shared/utils/slippage'
+import {
+  calculateRemainingEnsoSlippagePercentage,
+  optionalBasisPointsToPercentage,
+  toBasisPoints,
+  ZAP_SLIPPAGE_HARD_CAP
+} from '@shared/utils/slippage'
 import type { ReactElement, ReactNode } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { formatUnits } from 'viem'
@@ -395,11 +400,12 @@ export function WidgetWithdraw({
   ])
 
   const isCrossChain = destinationChainId !== chainId
-  const ensoRouteHasSwap = routeType === 'ENSO' && Boolean(activeFlow.periphery.routeHasSwap)
+  const isEnsoRoute = routeType === 'ENSO'
+  const ensoRouteHasSwap = isEnsoRoute && Boolean(activeFlow.periphery.routeHasSwap)
   const effectiveSourceShares = activeFlow.periphery.shareAmount ?? effectiveRequiredShares
   const effectiveExpectedOut = expectedOutOverride ?? activeFlow.periphery.expectedOut
   const effectiveMinExpectedOut = expectedOutOverride ?? activeFlow.periphery.minExpectedOut
-  const displayedExpectedOut = routeType === 'ENSO' && ensoRouteHasSwap ? effectiveMinExpectedOut : effectiveExpectedOut
+  const displayedExpectedOut = isEnsoRoute ? effectiveMinExpectedOut : effectiveExpectedOut
   const { approveNotificationParams, unstakeNotificationParams, withdrawNotificationParams } = useWithdrawNotifications(
     {
       vault,
@@ -552,22 +558,33 @@ export function WidgetWithdraw({
       withdrawAmount.bn
     ]
   )
+  const ensoPriceImpactPercentage = isEnsoRoute
+    ? optionalBasisPointsToPercentage(activeFlow.periphery.priceImpact)
+    : undefined
+  const estimatedPriceImpactPercentage =
+    isEnsoRoute && ensoPriceImpactPercentage !== undefined
+      ? Math.max(withdrawValueInfo.priceImpactPercentage, ensoPriceImpactPercentage)
+      : withdrawValueInfo.priceImpactPercentage
+  const worstCaseRouteImpactPercentage =
+    isEnsoRoute && ensoPriceImpactPercentage !== undefined
+      ? Math.max(withdrawValueInfo.worstCasePriceImpactPercentage, ensoPriceImpactPercentage)
+      : withdrawValueInfo.worstCasePriceImpactPercentage
 
   const desiredEnsoQuoteSlippage = useMemo(
     () =>
-      routeType === 'ENSO' && activeFlow.periphery.routeHasSwap !== false
-        ? withdrawValueInfo.hasIncompleteUsdValuation
+      isEnsoRoute
+        ? withdrawValueInfo.hasIncompleteUsdValuation && ensoPriceImpactPercentage === undefined
           ? 0
           : calculateRemainingEnsoSlippagePercentage({
               userTolerancePercentage: zapSlippage,
-              quoteImpactPercentage: withdrawValueInfo.priceImpactPercentage
+              quoteImpactPercentage: estimatedPriceImpactPercentage
             })
         : 0,
     [
-      activeFlow.periphery.routeHasSwap,
-      routeType,
+      ensoPriceImpactPercentage,
+      estimatedPriceImpactPercentage,
+      isEnsoRoute,
       withdrawValueInfo.hasIncompleteUsdValuation,
-      withdrawValueInfo.priceImpactPercentage,
       zapSlippage
     ]
   )
@@ -585,6 +602,11 @@ export function WidgetWithdraw({
 
     setEnsoQuoteSlippage(desiredEnsoQuoteSlippage)
   }, [desiredEnsoQuoteSlippage, ensoQuoteSlippage, flowRequiredShares, isFetchingQuote, routeType])
+
+  const hasBootstrapEnsoQuote =
+    isEnsoRoute && ensoQuoteSlippage === 0 && activeFlow.periphery.expectedOut > 0n && flowRequiredShares > 0n
+  const isWaitingForProtectedEnsoQuote = hasBootstrapEnsoQuote && desiredEnsoQuoteSlippage > 0
+  const isPreparingEnsoQuote = isFetchingQuote || isWaitingForProtectedEnsoQuote
 
   useEffect(() => {
     if (
@@ -606,8 +628,11 @@ export function WidgetWithdraw({
       inputAmountRaw: flowRequiredShares.toString(),
       expectedOutRaw: activeFlow.periphery.expectedOut.toString(),
       minExpectedOutRaw: activeFlow.periphery.minExpectedOut.toString(),
-      expectedPriceImpactPercentage: withdrawValueInfo.priceImpactPercentage,
-      worstCasePriceImpactPercentage: withdrawValueInfo.worstCasePriceImpactPercentage,
+      localPriceImpactPercentage: withdrawValueInfo.priceImpactPercentage,
+      ensoPriceImpactPercentage,
+      selectedPriceImpactPercentage: estimatedPriceImpactPercentage,
+      localWorstCasePriceImpactPercentage: withdrawValueInfo.worstCasePriceImpactPercentage,
+      selectedWorstCasePriceImpactPercentage: worstCaseRouteImpactPercentage,
       sourceTokenSymbol: assetToken?.symbol,
       destinationTokenSymbol: outputToken?.symbol
     }
@@ -644,15 +669,17 @@ export function WidgetWithdraw({
     console.log('[ENSO][withdraw] protected quote comparison', {
       bootstrapQuote: bootstrapEnsoQuoteDebugRef.current,
       protectedQuote: quoteSummary,
-      note: 'expectedPriceImpactPercentage comes from amountOut; worstCasePriceImpactPercentage comes from minAmountOut; widget warnings currently use worstCasePriceImpactPercentage.'
+      note: 'localPriceImpactPercentage comes from amountOut; localWorstCasePriceImpactPercentage comes from minAmountOut; selected values also include Enso priceImpact when Enso is stricter.'
     })
   }, [
     activeFlow.periphery.expectedOut,
     activeFlow.periphery.minExpectedOut,
     assetToken?.symbol,
     desiredEnsoQuoteSlippage,
+    ensoPriceImpactPercentage,
     ensoQuoteSlippage,
     ensoSlippageCalibrationKey,
+    estimatedPriceImpactPercentage,
     flowRequiredShares,
     isFetchingQuote,
     outputToken?.symbol,
@@ -661,12 +688,13 @@ export function WidgetWithdraw({
     withdrawAmount.isDebouncing,
     withdrawValueInfo.priceImpactPercentage,
     withdrawValueInfo.worstCasePriceImpactPercentage,
+    worstCaseRouteImpactPercentage,
     zapSlippage
   ])
 
-  // Calculate total price impact for warning and blocking.
+  // Calculate worst-case route impact for warning and blocking.
   const priceImpactInfo = useMemo(() => {
-    if (!ensoRouteHasSwap) {
+    if (!isEnsoRoute) {
       return {
         percentage: 0,
         isAboveTolerance: false,
@@ -675,18 +703,18 @@ export function WidgetWithdraw({
     }
 
     return {
-      percentage: withdrawValueInfo.worstCasePriceImpactPercentage,
-      isAboveTolerance: withdrawValueInfo.worstCasePriceImpactPercentage > zapSlippage,
-      isBlocking: withdrawValueInfo.worstCasePriceImpactPercentage >= ZAP_SLIPPAGE_HARD_CAP
+      percentage: worstCaseRouteImpactPercentage,
+      isAboveTolerance: worstCaseRouteImpactPercentage > zapSlippage,
+      isBlocking: worstCaseRouteImpactPercentage >= ZAP_SLIPPAGE_HARD_CAP
     }
-  }, [ensoRouteHasSwap, withdrawValueInfo.worstCasePriceImpactPercentage, zapSlippage])
+  }, [isEnsoRoute, worstCaseRouteImpactPercentage, zapSlippage])
   const unpricedEnsoWithdrawError =
-    routeType === 'ENSO' &&
-    ensoRouteHasSwap &&
+    isEnsoRoute &&
+    ensoPriceImpactPercentage === undefined &&
     withdrawValueInfo.hasIncompleteUsdValuation &&
     withdrawAmount.debouncedBn > 0n &&
     !withdrawAmount.isDebouncing &&
-    !isFetchingQuote
+    !isPreparingEnsoQuote
       ? 'Unable to estimate zap price impact for the selected token. Withdraw the base asset or swap elsewhere.'
       : null
   const effectiveWithdrawError = baseWithdrawError || unpricedEnsoWithdrawError
@@ -698,12 +726,11 @@ export function WidgetWithdraw({
     enableTokenListFetch()
     setShowTokenSelector(true)
   }
-  const displayedPriceImpactPercentage =
-    routeType === 'ENSO' && ensoRouteHasSwap
-      ? withdrawValueInfo.worstCasePriceImpactPercentage
-      : withdrawValueInfo.priceImpactPercentage
+  const displayedPriceImpactPercentage = isEnsoRoute
+    ? worstCaseRouteImpactPercentage
+    : withdrawValueInfo.priceImpactPercentage
   const shouldHighlightDisplayedPriceImpact =
-    routeType === 'ENSO' && ensoRouteHasSwap && (priceImpactInfo.isAboveTolerance || priceImpactInfo.isBlocking)
+    isEnsoRoute && (priceImpactInfo.isAboveTolerance || priceImpactInfo.isBlocking)
 
   const zapToken = useMemo(() => {
     if (!shouldShowZapUi) return undefined
@@ -726,7 +753,7 @@ export function WidgetWithdraw({
       expectedAmount: getExpectedAmount(),
       expectedAmountRaw: isUnstake ? effectiveRequiredShares : displayedExpectedOut,
       expectedAmountDecimals: isUnstake ? (vault?.decimals ?? 18) : (outputToken?.decimals ?? 18),
-      isLoading: isUnstake ? false : isFetchingQuote
+      isLoading: isUnstake ? false : isPreparingEnsoQuote
     }
   }, [
     shouldShowZapUi,
@@ -734,7 +761,7 @@ export function WidgetWithdraw({
     effectiveRequiredShares,
     vault?.decimals,
     displayedExpectedOut,
-    isFetchingQuote,
+    isPreparingEnsoQuote,
     outputToken?.symbol,
     outputToken?.address,
     outputToken?.chainID,
@@ -748,6 +775,7 @@ export function WidgetWithdraw({
   })
   const formattedRequiredShares = formatTAmount({ value: effectiveRequiredShares, decimals: sharesDecimals })
   const formattedApprovalAmount = formatTAmount({ value: effectiveSourceShares, decimals: sharesDecimals })
+  const executableEnsoTx = isWaitingForProtectedEnsoQuote ? undefined : activeFlow.periphery.tx
   const safeWithdrawBatch = useMemo(() => {
     if (!isWalletSafe || !approvalState.needsApproval) {
       return undefined
@@ -763,11 +791,11 @@ export function WidgetWithdraw({
       approvalSpenderAddress: approvalState.spenderAddress,
       routerAddress: activeFlow.periphery.routerAddress ? toAddress(activeFlow.periphery.routerAddress) : undefined,
       maxLoss: BigInt(toBasisPoints(zapSlippage)),
-      ensoTx: activeFlow.periphery.tx
+      ensoTx: executableEnsoTx
         ? {
-            to: toAddress(activeFlow.periphery.tx.to),
-            data: activeFlow.periphery.tx.data,
-            value: activeFlow.periphery.tx.value
+            to: toAddress(executableEnsoTx.to),
+            data: executableEnsoTx.data,
+            value: executableEnsoTx.value
           }
         : undefined
     })
@@ -775,11 +803,11 @@ export function WidgetWithdraw({
     account,
     activeFlow.periphery.allowance,
     activeFlow.periphery.routerAddress,
-    activeFlow.periphery.tx,
     approvalState.needsApproval,
     approvalState.spenderAddress,
     chainId,
     effectiveSourceShares,
+    executableEnsoTx,
     isWalletSafe,
     routeType,
     sourceToken,
@@ -808,8 +836,8 @@ export function WidgetWithdraw({
         unstakeNotificationParams,
         withdrawNotificationParams,
         safeWithdrawBatch,
-        prepareApproveEnabled: Boolean(activeFlow.periphery.prepareApproveEnabled),
-        prepareWithdrawEnabled: Boolean(activeFlow.periphery.prepareWithdrawEnabled),
+        prepareApproveEnabled: !isWaitingForProtectedEnsoQuote && Boolean(activeFlow.periphery.prepareApproveEnabled),
+        prepareWithdrawEnabled: !isWaitingForProtectedEnsoQuote && Boolean(activeFlow.periphery.prepareWithdrawEnabled),
         directUnstakePrepareEnabled: Boolean(directUnstakeFlow.periphery.prepareWithdrawEnabled),
         directWithdrawPrepareEnabled: Boolean(directWithdrawFlow.periphery.prepareWithdrawEnabled)
       }),
@@ -836,7 +864,8 @@ export function WidgetWithdraw({
       withdrawNotificationParams,
       safeWithdrawBatch,
       activeFlow.periphery.prepareApproveEnabled,
-      activeFlow.periphery.prepareWithdrawEnabled
+      activeFlow.periphery.prepareWithdrawEnabled,
+      isWaitingForProtectedEnsoQuote
     ]
   )
 
@@ -978,7 +1007,7 @@ export function WidgetWithdraw({
       actionLabel={actionLabel}
       requiredShares={effectiveRequiredShares}
       sharesDecimals={sharesDecimals}
-      isLoadingQuote={isFetchingQuote}
+      isLoadingQuote={isPreparingEnsoQuote}
       isQuoteStale={withdrawAmount.isDebouncing || withdrawAmount.bn !== withdrawAmount.debouncedBn}
       expectedOut={displayedExpectedOut}
       outputDecimals={outputToken?.decimals ?? 18}
@@ -992,10 +1021,10 @@ export function WidgetWithdraw({
       assetUsdPrice={assetTokenPrice}
       assetSymbol={assetToken?.symbol}
       outputUsdPrice={outputTokenPrice}
-      expectedPriceImpactPercentage={withdrawValueInfo.priceImpactPercentage}
+      expectedPriceImpactPercentage={estimatedPriceImpactPercentage}
       priceImpactPercentage={displayedPriceImpactPercentage}
       shouldHighlightPriceImpact={shouldHighlightDisplayedPriceImpact}
-      hasSwap={ensoRouteHasSwap}
+      usesMinExpectedOut={isEnsoRoute}
       onShowDetailsModal={() => setShowWithdrawDetailsModal(true)}
       allowance={approvalState.hasApprovalStep ? activeFlow.periphery.allowance : undefined}
       allowanceTokenDecimals={approvalState.hasApprovalStep ? approvalState.tokenDecimals : undefined}
@@ -1011,7 +1040,7 @@ export function WidgetWithdraw({
       percentage={priceImpactInfo.percentage}
       userTolerancePercentage={zapSlippage}
       isBlocking={priceImpactInfo.isBlocking}
-      isLoading={isFetchingQuote}
+      isLoading={isPreparingEnsoQuote}
       isDebouncing={withdrawAmount.isDebouncing}
       isAmountSynced={withdrawAmount.bn === withdrawAmount.debouncedBn}
       hasAmount={withdrawAmount.bn > 0n}
@@ -1020,7 +1049,7 @@ export function WidgetWithdraw({
 
   const showSettingsButton = !!account && !!onOpenSettings
   const withdrawButtonLabel = getWithdrawCtaLabel({
-    isFetchingQuote,
+    isFetchingQuote: isPreparingEnsoQuote,
     showApprove: approvalState.hasApprovalStep,
     isAllowanceSufficient: approvalState.isAllowanceSufficient,
     transactionName
@@ -1029,14 +1058,14 @@ export function WidgetWithdraw({
     isWithdrawCtaDisabled({
       hasError: !!effectiveWithdrawError || isActionDisabled,
       withdrawAmountRaw: withdrawAmount.bn,
-      isFetchingQuote,
+      isFetchingQuote: isPreparingEnsoQuote,
       isDebouncing: withdrawAmount.isDebouncing,
       showApprove: approvalState.hasApprovalStep,
       isAllowanceSufficient: approvalState.isAllowanceSufficient,
       prepareApproveEnabled: Boolean(activeFlow.periphery.prepareApproveEnabled),
       prepareWithdrawEnabled: Boolean(activeFlow.periphery.prepareWithdrawEnabled)
     }) ||
-    (ensoRouteHasSwap && (priceImpactInfo.isBlocking || priceImpactInfo.isAboveTolerance))
+    (isEnsoRoute && (priceImpactInfo.isBlocking || priceImpactInfo.isAboveTolerance))
 
   const actionRow = (
     <div className="flex flex-col gap-3">
@@ -1055,8 +1084,8 @@ export function WidgetWithdraw({
           ) : (
             <Button
               onClick={handleOpenTransactionOverlay}
-              variant={isFetchingQuote ? 'busy' : 'filled'}
-              isBusy={isFetchingQuote}
+              variant={isPreparingEnsoQuote ? 'busy' : 'filled'}
+              isBusy={isPreparingEnsoQuote}
               disabled={isWithdrawButtonDisabled}
               className="w-full"
               classNameOverride="yearn--button--nextgen w-full"
@@ -1211,7 +1240,8 @@ export function WidgetWithdraw({
         routeType={routeType}
         isZap={routeType === 'ENSO' && shouldShowZapUi}
         hasSwap={ensoRouteHasSwap}
-        isLoadingQuote={isFetchingQuote}
+        usesMinExpectedOut={isEnsoRoute}
+        isLoadingQuote={isPreparingEnsoQuote}
       />
 
       <ApprovalOverlay

--- a/src/components/pages/vaults/components/widget/withdraw/index.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/index.tsx
@@ -7,12 +7,7 @@ import { IconCross } from '@shared/icons/IconCross'
 import { IconSettings } from '@shared/icons/IconSettings'
 import { cl, formatTAmount, toAddress, toNormalizedBN } from '@shared/utils'
 import { PLAUSIBLE_EVENTS } from '@shared/utils/plausible'
-import {
-  calculateRemainingEnsoSlippagePercentage,
-  optionalBasisPointsToPercentage,
-  toBasisPoints,
-  ZAP_SLIPPAGE_HARD_CAP
-} from '@shared/utils/slippage'
+import { toBasisPoints } from '@shared/utils/slippage'
 import type { ReactElement, ReactNode } from 'react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { formatUnits } from 'viem'
@@ -23,6 +18,7 @@ import { SettingsPanel } from '../SettingsPanel'
 import { PriceImpactWarning } from '../shared/PriceImpactWarning'
 import { TokenSelectorOverlay } from '../shared/TokenSelectorOverlay'
 import { TransactionOverlay, type TransactionStep } from '../shared/TransactionOverlay'
+import { useProtectedEnsoQuoteState } from '../shared/useProtectedEnsoQuoteState'
 import { useResetEnsoSelection } from '../shared/useResetEnsoSelection'
 import { useWidgetContext } from '../shared/useWidgetContext'
 import { formatWidgetAllowance, formatWidgetPreciseValue, formatWidgetValue } from '../shared/valueDisplay'
@@ -405,7 +401,7 @@ export function WidgetWithdraw({
   const effectiveSourceShares = activeFlow.periphery.shareAmount ?? effectiveRequiredShares
   const effectiveExpectedOut = expectedOutOverride ?? activeFlow.periphery.expectedOut
   const effectiveMinExpectedOut = expectedOutOverride ?? activeFlow.periphery.minExpectedOut
-  const displayedExpectedOut = isEnsoRoute ? effectiveMinExpectedOut : effectiveExpectedOut
+  const currentDisplayedExpectedOut = isEnsoRoute ? effectiveMinExpectedOut : effectiveExpectedOut
   const { approveNotificationParams, unstakeNotificationParams, withdrawNotificationParams } = useWithdrawNotifications(
     {
       vault,
@@ -419,7 +415,7 @@ export function WidgetWithdraw({
       destinationChainId,
       withdrawAmount: withdrawAmount.debouncedBn,
       requiredShares: effectiveSourceShares,
-      expectedOut: displayedExpectedOut,
+      expectedOut: currentDisplayedExpectedOut,
       routeType,
       routerAddress: activeFlow.periphery.routerAddress,
       isCrossChain,
@@ -558,55 +554,41 @@ export function WidgetWithdraw({
       withdrawAmount.bn
     ]
   )
-  const ensoPriceImpactPercentage = isEnsoRoute
-    ? optionalBasisPointsToPercentage(activeFlow.periphery.priceImpact)
-    : undefined
-  const estimatedPriceImpactPercentage =
-    isEnsoRoute && ensoPriceImpactPercentage !== undefined
-      ? Math.max(withdrawValueInfo.priceImpactPercentage, ensoPriceImpactPercentage)
-      : withdrawValueInfo.priceImpactPercentage
-  const worstCaseRouteImpactPercentage =
-    isEnsoRoute && ensoPriceImpactPercentage !== undefined
-      ? Math.max(withdrawValueInfo.worstCasePriceImpactPercentage, ensoPriceImpactPercentage)
-      : withdrawValueInfo.worstCasePriceImpactPercentage
-
-  const desiredEnsoQuoteSlippage = useMemo(
-    () =>
-      isEnsoRoute
-        ? withdrawValueInfo.hasIncompleteUsdValuation && ensoPriceImpactPercentage === undefined
-          ? 0
-          : calculateRemainingEnsoSlippagePercentage({
-              userTolerancePercentage: zapSlippage,
-              quoteImpactPercentage: estimatedPriceImpactPercentage
-            })
-        : 0,
-    [
-      ensoPriceImpactPercentage,
-      estimatedPriceImpactPercentage,
-      isEnsoRoute,
-      withdrawValueInfo.hasIncompleteUsdValuation,
-      zapSlippage
-    ]
+  const withdrawQuoteDisplay = useMemo(
+    () => ({
+      expectedOut: currentDisplayedExpectedOut,
+      routeHasSwap: ensoRouteHasSwap
+    }),
+    [currentDisplayedExpectedOut, ensoRouteHasSwap]
   )
-
-  useEffect(() => {
-    if (
-      routeType !== 'ENSO' ||
-      ensoQuoteSlippage !== 0 ||
-      flowRequiredShares === 0n ||
-      isFetchingQuote ||
-      desiredEnsoQuoteSlippage <= 0
-    ) {
-      return
-    }
-
-    setEnsoQuoteSlippage(desiredEnsoQuoteSlippage)
-  }, [desiredEnsoQuoteSlippage, ensoQuoteSlippage, flowRequiredShares, isFetchingQuote, routeType])
-
-  const hasBootstrapEnsoQuote =
-    isEnsoRoute && ensoQuoteSlippage === 0 && activeFlow.periphery.expectedOut > 0n && flowRequiredShares > 0n
-  const isWaitingForProtectedEnsoQuote = hasBootstrapEnsoQuote && desiredEnsoQuoteSlippage > 0
-  const isPreparingEnsoQuote = isFetchingQuote || isWaitingForProtectedEnsoQuote
+  const protectedEnsoQuote = useProtectedEnsoQuoteState({
+    stateKey: ensoSlippageCalibrationKey,
+    isEnsoRoute,
+    amount: flowRequiredShares,
+    requestedSlippage: ensoQuoteSlippage,
+    setRequestedSlippage: setEnsoQuoteSlippage,
+    isLoadingQuote: isFetchingQuote,
+    userTolerancePercentage: zapSlippage,
+    localPriceImpactPercentage: withdrawValueInfo.priceImpactPercentage,
+    localWorstCasePriceImpactPercentage: withdrawValueInfo.worstCasePriceImpactPercentage,
+    hasIncompleteUsdValuation: withdrawValueInfo.hasIncompleteUsdValuation,
+    ensoPriceImpact: activeFlow.periphery.priceImpact,
+    expectedOut: activeFlow.periphery.expectedOut,
+    minExpectedOut: activeFlow.periphery.minExpectedOut,
+    tx: activeFlow.periphery.tx,
+    display: withdrawQuoteDisplay
+  })
+  const {
+    desiredSlippage: desiredEnsoQuoteSlippage,
+    ensoPriceImpactPercentage,
+    estimatedPriceImpactPercentage,
+    worstCaseRouteImpactPercentage,
+    priceImpactInfo,
+    isPreparing: isPreparingEnsoQuote,
+    isDisplayLoading: isDisplayLoadingEnsoQuote,
+    isWaitingForProtectedQuote: isWaitingForProtectedEnsoQuote,
+    executableTx: executableEnsoTx
+  } = protectedEnsoQuote
 
   useEffect(() => {
     if (
@@ -692,29 +674,8 @@ export function WidgetWithdraw({
     zapSlippage
   ])
 
-  // Calculate worst-case route impact for warning and blocking.
-  const priceImpactInfo = useMemo(() => {
-    if (!isEnsoRoute) {
-      return {
-        percentage: 0,
-        isAboveTolerance: false,
-        isBlocking: false
-      }
-    }
-
-    return {
-      percentage: worstCaseRouteImpactPercentage,
-      isAboveTolerance: worstCaseRouteImpactPercentage > zapSlippage,
-      isBlocking: worstCaseRouteImpactPercentage >= ZAP_SLIPPAGE_HARD_CAP
-    }
-  }, [isEnsoRoute, worstCaseRouteImpactPercentage, zapSlippage])
   const unpricedEnsoWithdrawError =
-    isEnsoRoute &&
-    ensoPriceImpactPercentage === undefined &&
-    withdrawValueInfo.hasIncompleteUsdValuation &&
-    withdrawAmount.debouncedBn > 0n &&
-    !withdrawAmount.isDebouncing &&
-    !isPreparingEnsoQuote
+    protectedEnsoQuote.hasUnpricedQuoteError && !withdrawAmount.isDebouncing
       ? 'Unable to estimate zap price impact for the selected token. Withdraw the base asset or swap elsewhere.'
       : null
   const effectiveWithdrawError = baseWithdrawError || unpricedEnsoWithdrawError
@@ -726,6 +687,9 @@ export function WidgetWithdraw({
     enableTokenListFetch()
     setShowTokenSelector(true)
   }
+  const displayedExpectedOut = isEnsoRoute ? protectedEnsoQuote.display.expectedOut : currentDisplayedExpectedOut
+  const displayedEnsoRouteHasSwap = isEnsoRoute ? protectedEnsoQuote.display.routeHasSwap : false
+  const shouldRevealEnsoRouteDetails = !isEnsoRoute || !isDisplayLoadingEnsoQuote
   const displayedPriceImpactPercentage = isEnsoRoute
     ? worstCaseRouteImpactPercentage
     : withdrawValueInfo.priceImpactPercentage
@@ -753,7 +717,7 @@ export function WidgetWithdraw({
       expectedAmount: getExpectedAmount(),
       expectedAmountRaw: isUnstake ? effectiveRequiredShares : displayedExpectedOut,
       expectedAmountDecimals: isUnstake ? (vault?.decimals ?? 18) : (outputToken?.decimals ?? 18),
-      isLoading: isUnstake ? false : isPreparingEnsoQuote
+      isLoading: isUnstake ? false : isEnsoRoute ? isDisplayLoadingEnsoQuote : isFetchingQuote
     }
   }, [
     shouldShowZapUi,
@@ -761,7 +725,9 @@ export function WidgetWithdraw({
     effectiveRequiredShares,
     vault?.decimals,
     displayedExpectedOut,
-    isPreparingEnsoQuote,
+    isDisplayLoadingEnsoQuote,
+    isEnsoRoute,
+    isFetchingQuote,
     outputToken?.symbol,
     outputToken?.address,
     outputToken?.chainID,
@@ -775,7 +741,6 @@ export function WidgetWithdraw({
   })
   const formattedRequiredShares = formatTAmount({ value: effectiveRequiredShares, decimals: sharesDecimals })
   const formattedApprovalAmount = formatTAmount({ value: effectiveSourceShares, decimals: sharesDecimals })
-  const executableEnsoTx = isWaitingForProtectedEnsoQuote ? undefined : activeFlow.periphery.tx
   const safeWithdrawBatch = useMemo(() => {
     if (!isWalletSafe || !approvalState.needsApproval) {
       return undefined
@@ -1007,12 +972,12 @@ export function WidgetWithdraw({
       actionLabel={actionLabel}
       requiredShares={effectiveRequiredShares}
       sharesDecimals={sharesDecimals}
-      isLoadingQuote={isPreparingEnsoQuote}
+      isLoadingQuote={isEnsoRoute ? isDisplayLoadingEnsoQuote : isFetchingQuote}
       isQuoteStale={withdrawAmount.isDebouncing || withdrawAmount.bn !== withdrawAmount.debouncedBn}
       expectedOut={displayedExpectedOut}
       outputDecimals={outputToken?.decimals ?? 18}
       outputSymbol={outputToken?.symbol}
-      showSwapRow={ensoRouteHasSwap && !isUnstake}
+      showSwapRow={shouldRevealEnsoRouteDetails && displayedEnsoRouteHasSwap && !isUnstake}
       withdrawAmountSimple={
         withdrawAmount.bn > 0n ? formatWidgetValue(withdrawAmount.bn, assetToken?.decimals ?? 18) : '0'
       }
@@ -1030,6 +995,7 @@ export function WidgetWithdraw({
       allowanceTokenDecimals={approvalState.hasApprovalStep ? approvalState.tokenDecimals : undefined}
       allowanceTokenSymbol={approvalState.hasApprovalStep ? approvalState.tokenSymbol : undefined}
       approvalSpenderName={approvalState.hasApprovalStep ? approvalState.spenderName : undefined}
+      isApprovalLoading={isEnsoRoute && isDisplayLoadingEnsoQuote && approvalState.hasApprovalStep}
       onAllowanceClick={onAllowanceClick}
       onShowApprovalOverlay={approvalState.hasApprovalStep ? () => setShowApprovalOverlay(true) : undefined}
     />
@@ -1040,7 +1006,7 @@ export function WidgetWithdraw({
       percentage={priceImpactInfo.percentage}
       userTolerancePercentage={zapSlippage}
       isBlocking={priceImpactInfo.isBlocking}
-      isLoading={isPreparingEnsoQuote}
+      isLoading={isEnsoRoute ? isDisplayLoadingEnsoQuote : isFetchingQuote}
       isDebouncing={withdrawAmount.isDebouncing}
       isAmountSynced={withdrawAmount.bn === withdrawAmount.debouncedBn}
       hasAmount={withdrawAmount.bn > 0n}
@@ -1239,9 +1205,9 @@ export function WidgetWithdraw({
         withdrawalSource={withdrawalSource}
         routeType={routeType}
         isZap={routeType === 'ENSO' && shouldShowZapUi}
-        hasSwap={ensoRouteHasSwap}
+        hasSwap={shouldRevealEnsoRouteDetails && displayedEnsoRouteHasSwap}
         usesMinExpectedOut={isEnsoRoute}
-        isLoadingQuote={isPreparingEnsoQuote}
+        isLoadingQuote={isEnsoRoute ? isDisplayLoadingEnsoQuote : isFetchingQuote}
       />
 
       <ApprovalOverlay

--- a/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
+++ b/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
@@ -101,6 +101,7 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
         allowance: ensoFlow.periphery.allowance,
         expectedOut: ensoFlow.periphery.expectedOut.raw,
         minExpectedOut: ensoFlow.periphery.minExpectedOut.raw,
+        priceImpact: ensoFlow.periphery.priceImpact,
         isLoadingRoute: ensoFlow.periphery.isLoadingRoute,
         isCrossChain: ensoFlow.periphery.isCrossChain,
         routeHasSwap: ensoFlow.periphery.routeHasSwap,

--- a/src/components/pages/vaults/hooks/actions/useEnsoWithdraw.ts
+++ b/src/components/pages/vaults/hooks/actions/useEnsoWithdraw.ts
@@ -97,6 +97,7 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
         allowance: ensoFlow.periphery.allowance,
         expectedOut: ensoFlow.periphery.expectedOut.raw,
         minExpectedOut: ensoFlow.periphery.minExpectedOut.raw,
+        priceImpact: ensoFlow.periphery.priceImpact,
         isLoadingRoute: ensoFlow.periphery.isLoadingRoute,
         isCrossChain: ensoFlow.periphery.isCrossChain,
         routeHasSwap: ensoFlow.periphery.routeHasSwap,

--- a/src/components/pages/vaults/hooks/solvers/ensoRoute.test.ts
+++ b/src/components/pages/vaults/hooks/solvers/ensoRoute.test.ts
@@ -57,6 +57,25 @@ describe('normalizeEnsoRouteResponse', () => {
     })
   })
 
+  it('keeps numeric and null Enso price impact values', () => {
+    const basePayload = {
+      tx: {
+        to: '0x0000000000000000000000000000000000000001',
+        data: '0x1234',
+        value: '0',
+        from: '0x0000000000000000000000000000000000000002',
+        chainId: 1
+      },
+      amountOut: '100',
+      minAmountOut: '95',
+      gas: '123456',
+      route: []
+    }
+
+    expect(normalizeEnsoRouteResponse({ ...basePayload, priceImpact: 12 }, 200).route?.priceImpact).toBe(12)
+    expect(normalizeEnsoRouteResponse({ ...basePayload, priceImpact: null }, 200).route?.priceImpact).toBeNull()
+  })
+
   it('treats 422 simulation failures without an error field as route errors', () => {
     expect(
       normalizeEnsoRouteResponse(

--- a/src/components/pages/vaults/hooks/solvers/ensoRoute.ts
+++ b/src/components/pages/vaults/hooks/solvers/ensoRoute.ts
@@ -17,6 +17,7 @@ export interface EnsoRouteResponse {
   }
   amountOut: string
   minAmountOut: string
+  priceImpact?: number | null
   gas: string
   route: EnsoRouteStep[]
 }
@@ -35,7 +36,8 @@ type EnsoRouteErrorPayload = {
   statusCode?: number
 }
 
-type EnsoRouteCandidate = Omit<EnsoRouteResponse, 'tx'> & {
+type EnsoRouteCandidate = Omit<EnsoRouteResponse, 'tx' | 'priceImpact'> & {
+  priceImpact?: unknown
   tx: Omit<EnsoRouteResponse['tx'], 'chainId'> & {
     chainId?: number
   }
@@ -85,6 +87,18 @@ function buildEnsoError(data: unknown, statusCode: number): EnsoError {
   }
 }
 
+function normalizeEnsoPriceImpact(value: unknown): number | null | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (value === null) {
+    return null
+  }
+
+  return undefined
+}
+
 export function normalizeEnsoRouteResponse(
   data: unknown,
   statusCode: number,
@@ -95,6 +109,8 @@ export function normalizeEnsoRouteResponse(
 } {
   if (isEnsoRouteCandidate(data)) {
     const resolvedChainId = typeof data.tx.chainId === 'number' ? data.tx.chainId : fallbackChainId
+    const priceImpact = normalizeEnsoPriceImpact(data.priceImpact)
+    const { priceImpact: _rawPriceImpact, tx, ...routeData } = data
 
     if (typeof resolvedChainId !== 'number') {
       return { error: buildEnsoError({ message: 'Enso route payload missing tx.chainId' }, statusCode) }
@@ -102,9 +118,10 @@ export function normalizeEnsoRouteResponse(
 
     return {
       route: {
-        ...data,
+        ...routeData,
+        ...(priceImpact !== undefined ? { priceImpact } : {}),
         tx: {
-          ...data.tx,
+          ...tx,
           chainId: resolvedChainId
         }
       }

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
@@ -39,6 +39,7 @@ interface UseSolverEnsoReturn {
     prepareApproveEnabled: boolean
     expectedOut: TNormalizedBN
     minExpectedOut: TNormalizedBN
+    priceImpact: number | null | undefined
     allowance: bigint
     isAllowanceSufficient: boolean
     route: EnsoRouteResponse | undefined
@@ -284,6 +285,7 @@ export const useSolverEnso = ({
       prepareApproveEnabled: !!prepareApproveEnabled,
       expectedOut,
       minExpectedOut,
+      priceImpact: visibleRoute?.priceImpact,
       allowance,
       isAllowanceSufficient,
       route: visibleRoute,

--- a/src/components/pages/vaults/types/index.ts
+++ b/src/components/pages/vaults/types/index.ts
@@ -67,6 +67,7 @@ export type UseWidgetDepositFlowReturn = T<
     allowance: bigint
     expectedOut: bigint
     minExpectedOut: bigint
+    priceImpact?: number | null
     isLoadingRoute: boolean
     isCrossChain: boolean
     routeHasSwap?: boolean
@@ -99,6 +100,7 @@ export type UseWidgetWithdrawFlowReturn = T<
     shareAmount?: bigint
     expectedOut: bigint
     minExpectedOut: bigint
+    priceImpact?: number | null
     isLoadingRoute: boolean
     isCrossChain: boolean
     routeHasSwap?: boolean

--- a/src/components/shared/utils/slippage.test.ts
+++ b/src/components/shared/utils/slippage.test.ts
@@ -3,6 +3,7 @@ import {
   calculateRemainingEnsoSlippagePercentage,
   clampZapSlippage,
   getZapSlippageSaveState,
+  optionalBasisPointsToPercentage,
   requiresZapSlippageRiskAcknowledgement,
   toBasisPoints,
   ZAP_SLIPPAGE_HARD_CAP,
@@ -42,6 +43,13 @@ describe('slippage utils', () => {
   it('converts percentages to basis points without rounding up', () => {
     expect(toBasisPoints(0.5)).toBe(50)
     expect(toBasisPoints(1.239)).toBe(123)
+  })
+
+  it('converts optional Enso basis points to percentage values', () => {
+    expect(optionalBasisPointsToPercentage(77)).toBe(0.77)
+    expect(optionalBasisPointsToPercentage(7778)).toBe(77.78)
+    expect(optionalBasisPointsToPercentage(null)).toBeUndefined()
+    expect(optionalBasisPointsToPercentage(undefined)).toBeUndefined()
   })
 
   it('allocates only the remaining tolerance to Enso execution slippage', () => {

--- a/src/components/shared/utils/slippage.ts
+++ b/src/components/shared/utils/slippage.ts
@@ -50,6 +50,10 @@ export function fromBasisPoints(value: number): number {
   return Math.max(0, sanitizeNumber(value) / 100)
 }
 
+export function optionalBasisPointsToPercentage(value: number | null | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? fromBasisPoints(value) : undefined
+}
+
 export function calculateRemainingEnsoSlippagePercentage({
   userTolerancePercentage,
   quoteImpactPercentage


### PR DESCRIPTION
### Summary
Preserves the existing double-fetch Enso quote flow while fixing the zero-slippage execution risk.

Previously, the widget fetched a `slippage=0` Enso quote for calibration and then re-quoted with remaining slippage, but parts of that flow were gated by `routeHasSwap`. That meant non-swap Enso routes could skip the protected re-quote path and potentially expose zero-slippage calldata. This PR makes the bootstrap quote non-executable, applies min-output and route-impact checks to all Enso routes, and keeps the old combined tolerance model.

### How to review
Start with the deposit and withdraw widget quote state:
- `src/components/pages/vaults/components/widget/deposit/index.tsx`
- `src/components/pages/vaults/components/widget/withdraw/index.tsx`

Key behavior:
- first Enso quote still starts with `slippage=0`
- the widget waits for a protected quote before enabling execution
- Safe batches do not include Enso tx data while only the bootstrap quote is available
- remaining Enso slippage is still derived from the user tolerance minus estimated route impact
- `routeHasSwap` is now only used for swap-specific UI copy, not route-quality gating

Also review:
- Enso `priceImpact` parsing in `ensoRoute.ts`
- min-output display changes in `DepositDetails` / `WithdrawDetails`
- settings and warning copy updates

### Test plan
- [x] Automated: `bun run lint:fix`
- [x] Automated: `bun run tslint`
- [x] Automated: `bun run test -- src/components/pages/vaults/hooks/solvers/ensoRoute.test.ts src/components/pages/vaults/components/widget/deposit/DepositDetails.test.tsx src/components/pages/vaults/components/widget/withdraw/WithdrawDetails.test.tsx src/components/pages/vaults/components/widget/shared/PriceImpactWarning.test.tsx src/components/shared/utils/slippage.test.ts`

Manual smoke test:
- Deposit/withdraw through an Enso route and confirm the Network tab shows a `slippage=0` bootstrap request followed by a protected request with remaining slippage.
- Confirm the action button stays in fetching/disabled state until the protected quote is ready.
- Confirm high worst-case route impact blocks the transaction and shows the warning.

### Risk / impact
Touches zap execution readiness and displayed route-impact numbers for deposit/withdraw. The main risk is being stricter than before on Enso routes, especially routes that previously bypassed checks because they had no swap step. Rollback is scoped to the widget quote-state and Enso route parsing changes.