### PR TITLE
Prefer Katana estimated APR in vault display

### DIFF
--- a/src/components/pages/vaults/domain/kongVaultSelectors.test.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.test.ts
@@ -1,3 +1,4 @@
+import { calculateVaultEstimatedAPY } from '@shared/utils/vaultApy'
 import { describe, expect, it } from 'vitest'
 import { getVaultAPR, getVaultStaking, getVaultStrategies, getVaultTVL } from './kongVaultSelectors'
 
@@ -272,6 +273,134 @@ describe('getVaultAPR', () => {
     } as any)
 
     expect(apr.forwardAPR.netAPR).toBe(0.03431466938555827)
+  })
+
+  it('prefers Katana estimated APY over oracle APY for vault forward APR values', () => {
+    const apr = getVaultAPR({
+      ...BASE_LIST_VAULT,
+      performance: {
+        estimated: {
+          apr: 0.049,
+          apy: 0.051,
+          type: 'katana-estimated-apr',
+          components: {}
+        },
+        oracle: {
+          apr: 0.029,
+          apy: 0.03,
+          netAPR: 0.028,
+          netAPY: 0.03
+        },
+        historical: {
+          net: 0.01,
+          weeklyNet: 0.01,
+          monthlyNet: 0.01,
+          inceptionNet: 0.01
+        }
+      }
+    } as any)
+
+    expect(apr.forwardAPR.netAPR).toBe(0.051)
+  })
+
+  it('uses Katana estimated APR before oracle values when estimated APY is absent', () => {
+    const apr = getVaultAPR({
+      ...BASE_LIST_VAULT,
+      performance: {
+        estimated: {
+          apr: 0.05,
+          type: 'katana-estimated-apr',
+          components: {}
+        },
+        oracle: {
+          apr: 0.029,
+          apy: 0.03,
+          netAPR: 0.028,
+          netAPY: 0.03
+        },
+        historical: {
+          net: 0.01,
+          weeklyNet: 0.01,
+          monthlyNet: 0.01,
+          inceptionNet: 0.01
+        }
+      }
+    } as any)
+
+    expect(apr.forwardAPR.netAPR).toBe(0.05)
+  })
+
+  it('prefers snapshot Katana estimated values over list estimated values', () => {
+    const apr = getVaultAPR(
+      {
+        ...BASE_LIST_VAULT,
+        performance: {
+          estimated: {
+            apr: 0.04,
+            apy: 0.045,
+            type: 'katana-estimated-apr',
+            components: {}
+          },
+          oracle: {
+            apr: 0.03,
+            apy: 0.031
+          },
+          historical: {
+            net: 0.01,
+            weeklyNet: 0.01,
+            monthlyNet: 0.01,
+            inceptionNet: 0.01
+          }
+        }
+      } as any,
+      {
+        performance: {
+          estimated: {
+            apr: 0.06,
+            apy: 0.07,
+            type: 'katana-estimated-apr',
+            components: {}
+          },
+          oracle: {
+            apr: 0.035,
+            apy: 0.036
+          }
+        }
+      } as any
+    )
+
+    expect(apr.forwardAPR.type).toBe('estimated')
+    expect(apr.forwardAPR.netAPR).toBe(0.07)
+  })
+
+  it('adds Katana app rewards on top of the selected estimated APY', () => {
+    const apy = calculateVaultEstimatedAPY({
+      ...BASE_LIST_VAULT,
+      performance: {
+        estimated: {
+          apr: 0.049,
+          apy: 0.051,
+          type: 'katana-estimated-apr',
+          components: {
+            katanaAppRewardsAPR: 0.02
+          }
+        },
+        oracle: {
+          apr: 0.029,
+          apy: 0.03,
+          netAPR: 0.028,
+          netAPY: 0.03
+        },
+        historical: {
+          net: 0.01,
+          weeklyNet: 0.01,
+          monthlyNet: 0.01,
+          inceptionNet: 0.01
+        }
+      }
+    } as any)
+
+    expect(apy).toBeCloseTo(0.071, 6)
   })
 })
 

--- a/src/components/pages/vaults/domain/kongVaultSelectors.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.ts
@@ -599,6 +599,10 @@ export const getVaultAPR = (vault: TKongVaultInput, snapshot?: TKongVaultSnapsho
 
   const forwardNet = isKatanaVault
     ? pickNumber(
+        snapshot?.performance?.estimated?.apy,
+        snapshot?.performance?.estimated?.apr,
+        vault.performance?.estimated?.apy,
+        vault.performance?.estimated?.apr,
         snapshot?.performance?.oracle?.netAPY,
         snapshot?.performance?.oracle?.apy,
         snapshot?.performance?.oracle?.netAPR,
@@ -606,9 +610,6 @@ export const getVaultAPR = (vault: TKongVaultInput, snapshot?: TKongVaultSnapsho
         vault.performance?.oracle?.netAPY,
         vault.performance?.oracle?.apy,
         vault.performance?.oracle?.netAPR,
-        snapshot?.performance?.estimated?.apy,
-        snapshot?.performance?.estimated?.apr,
-        vault.performance?.estimated?.apy,
         vault.performance?.historical?.net,
         historical?.net
       )

--- a/src/components/pages/vaults/domain/kongVaultSelectors.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.ts
@@ -531,7 +531,7 @@ export const getVaultTVL = (vault: TKongVaultInput, snapshot?: TKongVaultSnapsho
   const totalAssetsRaw = snapshot?.totalAssets ?? '0'
   const totalAssets = toBigIntValue(totalAssetsRaw)
   const normalizedAssets = toNormalizedBN(totalAssets, token.decimals).normalized
-  const tvl = pickNumber(snapshot?.tvl?.close ?? null, vault.tvl)
+  const tvl = pickNumber(vault.tvl, snapshot?.tvl?.close ?? null)
   const price = Number.isFinite(tvl) && tvl > 0 && normalizedAssets > 0 ? tvl / normalizedAssets : 0
 
   return {

--- a/src/components/shared/utils/vaultApy.test.ts
+++ b/src/components/shared/utils/vaultApy.test.ts
@@ -127,7 +127,7 @@ describe('vaultApy Katana calculations', () => {
 
   it('calculates Katana estimated APY from list data using native plus app rewards', () => {
     const apy = calculateVaultEstimatedAPY(withComponents(BASE_VAULT))
-    expect(apy).toBeCloseTo(0.1316, 6)
+    expect(apy).toBeCloseTo(0.1596, 6)
   })
 
   it('calculates full Katana estimate on snapshot-backed vault details', () => {
@@ -135,9 +135,9 @@ describe('vaultApy Katana calculations', () => {
     expect(apy).toBeCloseTo(0.1596, 6)
   })
 
-  it('falls back to Kong forward APY when list-level Katana components are absent', () => {
+  it('uses Kong estimated APY when list-level Katana components are absent', () => {
     const apy = calculateVaultEstimatedAPY(BASE_VAULT)
-    expect(apy).toBeCloseTo(0.04, 6)
+    expect(apy).toBeCloseTo(0.068, 6)
   })
 
   it('calculates Katana 30 day APY from historical base + app rewards', () => {


### PR DESCRIPTION
### Summary
Update Katana vault APR selection so vault-level display prefers Kong estimated APY/APR values before oracle values. This lets Katana vaults use the fee-adjusted estimated APY emitted through Kong while keeping strategy-level KAT reward semantics unchanged.

Closes #1307

### How to review
Start with `src/components/pages/vaults/domain/kongVaultSelectors.ts`, especially the Katana `forwardAPR.netAPR` precedence in `getVaultAPR`.

Then review the regression tests in:
- `src/components/pages/vaults/domain/kongVaultSelectors.test.ts`
- `src/components/shared/utils/vaultApy.test.ts`

The PR also includes a small selector correction so list TVL remains preferred over stale snapshot TVL, matching the existing selector tests.

### Test plan
- [ ] Automated: `bunx vitest run src/components/pages/vaults/domain/kongVaultSelectors.test.ts src/components/shared/utils/vaultApy.test.ts`
- [ ] Automated: `bun run lint:fix`
- [ ] Automated: `bun run tslint`
- [ ] Automated: `bun run test` mostly passes, but one unrelated existing failure remains in `scripts/tenderly-vnet.test.ts` for unwritable path validation.

### Risk / impact
Low UI data-selection risk. The change is limited to vault selector behavior and tests, with no new API calls, contracts, migrations, or display components. Non-Katana vault selection is unchanged; Katana strategy rows still treat `estimated.apr` as KAT rewards unless an explicit strategy `estimated.apy` exists.
