### PR TITLE
Show weighted yvUSD portfolio APY

### DIFF
--- a/src/components/pages/portfolio/hooks/usePortfolioModel.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioModel.ts
@@ -20,10 +20,11 @@ import { useYvUsdVaults } from '@pages/vaults/hooks/useYvUsdVaults'
 import { usePersistedShowHiddenVaults } from '@pages/vaults/hooks/vaultsFiltersStorage'
 import { deriveListKind, isAllocatorVaultOverride } from '@pages/vaults/utils/vaultListFacets'
 import {
-  getWeightedYvUsdApy,
+  getYvUsdPositionApyBreakdown,
   getYvUsdPositionValues,
   isYvUsdAddress,
   isYvUsdVault,
+  type TYvUsdPositionApyBreakdown,
   YVUSD_LOCKED_ADDRESS,
   YVUSD_UNLOCKED_ADDRESS
 } from '@pages/vaults/utils/yvUsd'
@@ -46,6 +47,7 @@ type THoldingsRow = {
   key: string
   vault: TKongVaultInput
   hrefOverride?: string
+  yvUsdPositionApy?: TYvUsdPositionApyBreakdown
 }
 
 export type TSuggestedItem =
@@ -87,7 +89,7 @@ export type TPortfolioModel = {
 
 type TSortStateSetter<T> = (value: T | ((previous: T) => T)) => void
 type TYvUsdPortfolioPosition = {
-  blendedCurrentApy: number | null
+  currentApyBreakdown: TYvUsdPositionApyBreakdown
   blendedHistoricalApy: number | null
   combinedValue: number
   hasHoldings: boolean
@@ -194,18 +196,18 @@ export function usePortfolioModel(): TPortfolioModel {
     })
 
     return {
-      blendedCurrentApy: getWeightedYvUsdApy({
+      currentApyBreakdown: getYvUsdPositionApyBreakdown({
         unlockedValue,
         lockedValue,
         unlockedApy: yvUsdUnlockedVault ? calculateVaultEstimatedAPY(yvUsdUnlockedVault) || null : null,
         lockedApy: yvUsdLockedVault ? calculateVaultEstimatedAPY(yvUsdLockedVault) || null : null
       }),
-      blendedHistoricalApy: getWeightedYvUsdApy({
+      blendedHistoricalApy: getYvUsdPositionApyBreakdown({
         unlockedValue,
         lockedValue,
         unlockedApy: getLatestYvUsdHistoricalApyValue(yvUsdHistoricalApyData, 'unlocked'),
         lockedApy: getLatestYvUsdHistoricalApyValue(yvUsdHistoricalApyData, 'locked')
-      }),
+      }).blendedApy,
       combinedValue,
       hasHoldings
     }
@@ -285,14 +287,14 @@ export function usePortfolioModel(): TPortfolioModel {
   const getVaultEstimatedAPY = useCallback(
     (vault: (typeof holdingsVaults)[number]): number | null => {
       if (isYvUsdVault(vault)) {
-        return yvUsdPosition.blendedCurrentApy
+        return yvUsdPosition.currentApyBreakdown.blendedApy
       }
 
       const apy = calculateVaultEstimatedAPY(vault)
       const hasHistoricalNet = 'performance' in vault && Boolean(vault.performance?.historical?.net)
       return apy === 0 && !hasHistoricalNet ? null : apy
     },
-    [yvUsdPosition.blendedCurrentApy]
+    [yvUsdPosition.currentApyBreakdown.blendedApy]
   )
 
   const getVaultHistoricalAPY = useCallback(
@@ -364,7 +366,9 @@ export function usePortfolioModel(): TPortfolioModel {
     [vaults]
   )
 
-  const sortedHoldings = useSortVaults(visibleHoldingsVaults, sortBy, sortDirection)
+  const sortedHoldings = useSortVaults(visibleHoldingsVaults, sortBy, sortDirection, {
+    yvUsdApyOverride: yvUsdPosition.currentApyBreakdown.blendedApy
+  })
   const sortedCandidates = useSortVaults(suggestedVaultCandidates, 'tvl', 'desc')
 
   const holdingsKeySet = useMemo(() => new Set(sortedHoldings.map((vault) => getVaultKey(vault))), [sortedHoldings])
@@ -384,9 +388,10 @@ export function usePortfolioModel(): TPortfolioModel {
       sortedHoldings.map((vault) => ({
         key: getVaultKey(vault),
         vault,
-        hrefOverride: getPortfolioRowHref(vault)
+        hrefOverride: getPortfolioRowHref(vault),
+        yvUsdPositionApy: isYvUsdVault(vault) ? yvUsdPosition.currentApyBreakdown : undefined
       })),
-    [sortedHoldings]
+    [sortedHoldings, yvUsdPosition.currentApyBreakdown]
   )
 
   const suggestedRows = useMemo((): TSuggestedItem[] => {

--- a/src/components/pages/portfolio/index.tsx
+++ b/src/components/pages/portfolio/index.tsx
@@ -2849,6 +2849,7 @@ function PortfolioHoldingsSection({
             currentVault={row.vault}
             flags={vaultFlags[row.key]}
             hrefOverride={row.hrefOverride}
+            yvUsdPositionApy={row.yvUsdPositionApy}
             showBoostDetails={false}
             activeProductType="all"
             showStrategies

--- a/src/components/pages/vaults/components/list/VaultsListRow.test.tsx
+++ b/src/components/pages/vaults/components/list/VaultsListRow.test.tsx
@@ -189,6 +189,50 @@ describe('VaultsListRow', () => {
     expect(html).not.toContain('style="width:48px;height:48px"')
   })
 
+  it('shows a portfolio user weighted APY instead of the generic yvUSD up-to APY', () => {
+    const vault = {
+      version: '3.0.0',
+      chainID: 1,
+      address: YVUSD_UNLOCKED_ADDRESS,
+      name: 'yvUSD',
+      symbol: 'yvUSD',
+      category: 'Stablecoin',
+      kind: 'Multi Strategy',
+      token: {
+        address: '0x0000000000000000000000000000000000000002',
+        symbol: 'USDC',
+        decimals: 6
+      },
+      apr: {
+        forwardAPR: { netAPR: 0.05 },
+        netAPR: 0.05
+      },
+      tvl: {
+        tvl: 350,
+        totalAssets: 350_000_000
+      },
+      info: {
+        riskLevel: 2
+      },
+      staking: {
+        address: '0x0000000000000000000000000000000000000000'
+      }
+    } as unknown as TKongVaultInput
+
+    const html = renderRowHtml(vault, {
+      yvUsdPositionApy: {
+        blendedApy: 0.07,
+        locked: { apy: 0.09, value: 100, weight: 0.5 },
+        unlocked: { apy: 0.05, value: 100, weight: 0.5 }
+      }
+    })
+
+    expect(html).toContain('7.00%')
+    expect(html).toContain('aria-label="View your yvUSD APY breakdown"')
+    expect(html).toContain('decoration-dotted')
+    expect(html).not.toContain('Up to')
+  })
+
   it('formats yvUSD locked APY with shared significant-digit rounding in the list row', () => {
     mockUseMediaQuery.mockReturnValue(true)
     mockUseYvUsdVaults.mockReturnValue({

--- a/src/components/pages/vaults/components/list/VaultsListRow.tsx
+++ b/src/components/pages/vaults/components/list/VaultsListRow.tsx
@@ -6,6 +6,7 @@ import { VaultTVL } from '@pages/vaults/components/table/VaultTVL'
 import {
   YvUsdApyDetailsContent,
   YvUsdApyTooltipContent,
+  YvUsdPositionApyTooltipContent,
   YvUsdTvlTooltipContent
 } from '@pages/vaults/components/yvUSD/YvUsdBreakdown'
 import {
@@ -39,7 +40,12 @@ import {
   NOT_YEARN_TAG_DESCRIPTION,
   RETIRED_TAG_DESCRIPTION
 } from '@pages/vaults/utils/vaultTagCopy'
-import { getYvUsdInfinifiPointsNote, getYvUsdPositionValues, isYvUsdAddress } from '@pages/vaults/utils/yvUsd'
+import {
+  getYvUsdInfinifiPointsNote,
+  getYvUsdPositionValues,
+  isYvUsdAddress,
+  type TYvUsdPositionApyBreakdown
+} from '@pages/vaults/utils/yvUsd'
 import { useMediaQuery } from '@react-hookz/web'
 import { RenderAmount } from '@shared/components/RenderAmount'
 import { TokenLogo } from '@shared/components/TokenLogo'
@@ -234,6 +240,7 @@ type TVaultsListRowProps = {
   mobileSecondaryMetric?: 'tvl' | 'holdings'
   expandedChartVariant?: 'default' | 'portfolio-user-tvl-overlay'
   yvUsdVaults?: TYvUsdListVaults
+  yvUsdPositionApy?: TYvUsdPositionApyBreakdown
   clickEventName?: TPlausibleEventName
 }
 
@@ -270,6 +277,7 @@ function VaultsListRowPresentationComponent({
   showAllocatorChip = true,
   expandedChartVariant = 'default',
   yvUsdVaults,
+  yvUsdPositionApy,
   clickEventName = PLAUSIBLE_EVENTS.VAULT_CLICK_LIST_ROW,
   hasWalletAddress = false,
   isWalletLoading = false,
@@ -351,6 +359,13 @@ function VaultsListRowPresentationComponent({
       {formatApyDisplay(resolvedYvUsdMetrics.lockedApy)}
     </>
   ) : null
+  const yvUsdPositionApyTooltip = yvUsdPositionApy ? (
+    <YvUsdPositionApyTooltipContent breakdown={yvUsdPositionApy} />
+  ) : undefined
+  const yvUsdPositionApyValue =
+    yvUsdPositionApy?.blendedApy === null || yvUsdPositionApy?.blendedApy === undefined
+      ? '—'
+      : formatApyDisplay(yvUsdPositionApy.blendedApy)
 
   const yvUsdTvlTooltip = resolvedYvUsdMetrics ? (
     <YvUsdTvlTooltipContent
@@ -728,7 +743,32 @@ function VaultsListRowPresentationComponent({
             <div className={'grid w-full grid-cols-2 gap-2 text-sm text-text-secondary'}>
               <div className={'flex items-center justify-center gap-2 whitespace-nowrap'}>
                 <span className={'text-text-primary/60'}>{'Est. APY:'}</span>
-                {resolvedYvUsdMetrics ? (
+                {yvUsdPositionApy ? (
+                  <Tooltip
+                    className={'apy-subline-tooltip gap-0 h-auto md:justify-end'}
+                    openDelayMs={150}
+                    tooltip={yvUsdPositionApyTooltip ?? ''}
+                    align={'center'}
+                    toggleOnClick
+                    zIndex={90}
+                  >
+                    <button
+                      type={'button'}
+                      onMouseEnter={() => handleInteractiveHoverChange(true)}
+                      onMouseLeave={() => handleInteractiveHoverChange(false)}
+                      className={'inline-flex items-center text-left'}
+                      aria-label={'View your yvUSD APY breakdown'}
+                    >
+                      <b
+                        className={
+                          'yearn--table-data-section-item-value text-lg font-semibold text-text-primary underline decoration-neutral-600/30 decoration-dotted underline-offset-4 transition-opacity hover:decoration-neutral-600'
+                        }
+                      >
+                        {yvUsdPositionApyValue}
+                      </b>
+                    </button>
+                  </Tooltip>
+                ) : resolvedYvUsdMetrics ? (
                   <Tooltip
                     className={'apy-subline-tooltip gap-0 h-auto md:justify-end'}
                     openDelayMs={150}
@@ -807,7 +847,36 @@ function VaultsListRowPresentationComponent({
           className={cl(rightColumnSpan, 'z-10 gap-4 mt-4', 'hidden md:mt-0 md:grid md:items-center', rightGridColumns)}
         >
           <div className={cl('yearn--table-data-section-item', apyColumnSpan)} datatype={'number'}>
-            {resolvedYvUsdMetrics ? (
+            {yvUsdPositionApy ? (
+              <div
+                className={'flex justify-end text-right'}
+                onMouseEnter={() => handleInteractiveHoverChange(true)}
+                onMouseLeave={() => handleInteractiveHoverChange(false)}
+              >
+                <Tooltip
+                  className={'apy-subline-tooltip gap-0 h-auto md:justify-end'}
+                  openDelayMs={150}
+                  tooltip={yvUsdPositionApyTooltip ?? ''}
+                  align={'center'}
+                  toggleOnClick
+                  zIndex={90}
+                >
+                  <button
+                    type={'button'}
+                    className={'inline-flex items-center text-right'}
+                    aria-label={'View your yvUSD APY breakdown'}
+                  >
+                    <b
+                      className={
+                        'yearn--table-data-section-item-value font-semibold text-text-primary underline decoration-neutral-600/30 decoration-dotted underline-offset-4 transition-opacity hover:decoration-neutral-600'
+                      }
+                    >
+                      {yvUsdPositionApyValue}
+                    </b>
+                  </button>
+                </Tooltip>
+              </div>
+            ) : resolvedYvUsdMetrics ? (
               <div
                 className={'flex justify-end text-right'}
                 onMouseEnter={() => handleInteractiveHoverChange(true)}
@@ -912,7 +981,7 @@ function VaultsListRowPresentationComponent({
             chartVariant={expandedChartVariant}
             apyDisplayVariant={apyDisplayVariant}
             showBoostDetails={showBoostDetails}
-            expandedApyTooltip={isYvUsd ? yvUsdApyTooltip : undefined}
+            expandedApyTooltip={isYvUsd ? (yvUsdPositionApyTooltip ?? yvUsdApyTooltip) : undefined}
           />
         </Suspense>
       ) : null}

--- a/src/components/pages/vaults/components/yvUSD/YvUsdBreakdown.test.tsx
+++ b/src/components/pages/vaults/components/yvUSD/YvUsdBreakdown.test.tsx
@@ -1,11 +1,33 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
-import { YvUsdApyDetailsContent } from './YvUsdBreakdown'
+import { YvUsdApyDetailsContent, YvUsdPositionApyTooltipContent } from './YvUsdBreakdown'
 
 describe('YvUsdApyDetailsContent', () => {
   it('describes the locked withdrawal window as 5 days', () => {
     const html = renderToStaticMarkup(<YvUsdApyDetailsContent lockedValue={0.09} unlockedValue={0.05} />)
 
     expect(html).toContain('Withdrawals are open for 5 days once the cooldown ends.')
+  })
+})
+
+describe('YvUsdPositionApyTooltipContent', () => {
+  it('shows each position weight, value, and APY', () => {
+    const html = renderToStaticMarkup(
+      <YvUsdPositionApyTooltipContent
+        breakdown={{
+          blendedApy: 0.07,
+          locked: { apy: 0.09, value: 100, weight: 0.5 },
+          unlocked: { apy: 0.05, value: 100, weight: 0.5 }
+        }}
+      />
+    )
+
+    expect(html).toContain('Your yvUSD APY breakdown')
+    expect(html).toContain('Locked')
+    expect(html).toContain('Unlocked')
+    expect(html).toContain('50.0% of position')
+    expect(html).toContain('$100.00')
+    expect(html).toContain('9.00%')
+    expect(html).toContain('5.00%')
   })
 })

--- a/src/components/pages/vaults/components/yvUSD/YvUsdBreakdown.tsx
+++ b/src/components/pages/vaults/components/yvUSD/YvUsdBreakdown.tsx
@@ -1,9 +1,14 @@
-import { YVUSD_DESCRIPTION, YVUSD_LOCKED_COOLDOWN_DAYS, YVUSD_WITHDRAW_WINDOW_DAYS } from '@pages/vaults/utils/yvUsd'
+import {
+  type TYvUsdPositionApyBreakdown,
+  YVUSD_DESCRIPTION,
+  YVUSD_LOCKED_COOLDOWN_DAYS,
+  YVUSD_WITHDRAW_WINDOW_DAYS
+} from '@pages/vaults/utils/yvUsd'
 import { RenderAmount } from '@shared/components/RenderAmount'
 import { IconInfinifiPoints } from '@shared/icons/IconInfinifiPoints'
 import { IconLock } from '@shared/icons/IconLock'
 import { IconLockOpen } from '@shared/icons/IconLockOpen'
-import { cl, formatAmount } from '@shared/utils'
+import { cl, formatAmount, formatApyDisplay, formatUSD } from '@shared/utils'
 import type { ReactElement } from 'react'
 
 type TYvUsdTooltipProps = {
@@ -80,6 +85,60 @@ export function YvUsdApyTooltipContent({
             </p>
           </div>
         ) : null}
+      </div>
+    </div>
+  )
+}
+
+function YvUsdPositionApyRow({
+  icon,
+  label,
+  position
+}: {
+  icon: ReactElement
+  label: string
+  position: TYvUsdPositionApyBreakdown['locked']
+}): ReactElement {
+  return (
+    <div className="flex items-center justify-between gap-6">
+      <div className="flex min-w-0 items-start gap-2">
+        <span className="mt-0.5 shrink-0">{icon}</span>
+        <span className="flex min-w-0 flex-col">
+          <span className="text-text-primary">{label}</span>
+          <span className="whitespace-nowrap text-[11px] text-text-secondary">
+            {`${formatApyDisplay(position.weight)} of position · ${formatUSD(position.value)}`}
+          </span>
+        </span>
+      </div>
+      <strong className="shrink-0 font-semibold text-text-primary">
+        {position.apy === null ? '—' : formatApyDisplay(position.apy)}
+      </strong>
+    </div>
+  )
+}
+
+export function YvUsdPositionApyTooltipContent({
+  breakdown,
+  className
+}: {
+  breakdown: TYvUsdPositionApyBreakdown
+  className?: string
+}): ReactElement {
+  return (
+    <div
+      className={cl(
+        'min-w-64 rounded-xl border border-border bg-surface-secondary p-3 text-xs text-text-primary',
+        className
+      )}
+    >
+      <p className="mb-2 font-semibold text-text-primary">{'Your yvUSD APY breakdown'}</p>
+      <div className="flex flex-col gap-2">
+        <YvUsdPositionApyRow icon={<IconLock className="size-3" />} label="Locked" position={breakdown.locked} />
+        <YvUsdPositionApyRow
+          icon={<IconLockOpen className="h-3 w-4" />}
+          label="Unlocked"
+          position={breakdown.unlocked}
+        />
       </div>
     </div>
   )

--- a/src/components/pages/vaults/hooks/useSortVaults.ts
+++ b/src/components/pages/vaults/hooks/useSortVaults.ts
@@ -34,7 +34,8 @@ export type TPossibleSortBy =
 export function useSortVaults<TVault extends TKongVaultInput & { details?: TKongVaultStrategy['details'] }>(
   vaultList: TVault[],
   sortBy: TPossibleSortBy,
-  sortDirection: TSortDirection
+  sortDirection: TSortDirection,
+  options?: { yvUsdApyOverride?: number | null }
 ): TVault[] {
   const { getToken, getBalance } = useWalletTokens()
   const { getVaultHoldingsUsd } = useWalletHoldings()
@@ -49,12 +50,15 @@ export function useSortVaults<TVault extends TKongVaultInput & { details?: TKong
   }, [getBalance, getToken, yvUsdLockedVault, yvUsdUnlockedVault])
 
   const yvUsdDisplayedApy = useMemo((): number => {
+    if (typeof options?.yvUsdApyOverride === 'number' && Number.isFinite(options.yvUsdApyOverride)) {
+      return options.yvUsdApyOverride
+    }
     const lockedApy = yvUsdMetrics.locked.apy
     if (lockedApy > 0 || yvUsdMetrics.unlocked.apy === 0) {
       return lockedApy
     }
     return yvUsdMetrics.unlocked.apy
-  }, [yvUsdMetrics.locked.apy, yvUsdMetrics.unlocked.apy])
+  }, [options?.yvUsdApyOverride, yvUsdMetrics.locked.apy, yvUsdMetrics.unlocked.apy])
   const isFeaturingScoreSortedDesc = useMemo((): boolean => {
     if (sortBy !== 'featuringScore' || sortDirection !== 'desc') {
       return false

--- a/src/components/pages/vaults/utils/yvUsd.test.ts
+++ b/src/components/pages/vaults/utils/yvUsd.test.ts
@@ -10,6 +10,7 @@ import {
   convertYvUsdVariantRawAmount,
   getWeightedYvUsdApy,
   getYvUsdLockedWithdrawDisplayMode,
+  getYvUsdPositionApyBreakdown,
   getYvUsdPositionValues,
   getYvUsdUnderlyingPricePerShare,
   YVUSD_CHAIN_ID,
@@ -78,6 +79,34 @@ describe('getWeightedYvUsdApy', () => {
         lockedApy: 0.09
       })
     ).toBeNull()
+  })
+})
+
+describe('getYvUsdPositionApyBreakdown', () => {
+  it('reports a 100% unlocked weight for an unlocked-only position', () => {
+    const breakdown = getYvUsdPositionApyBreakdown({
+      unlockedValue: 100,
+      lockedValue: 0,
+      unlockedApy: 0.05,
+      lockedApy: 0.09
+    })
+
+    expect(breakdown.blendedApy).toBeCloseTo(0.05, 6)
+    expect(breakdown.unlocked.weight).toBe(1)
+    expect(breakdown.locked.weight).toBe(0)
+  })
+
+  it('reports equal weights and the midpoint APY for a 50/50 position', () => {
+    const breakdown = getYvUsdPositionApyBreakdown({
+      unlockedValue: 100,
+      lockedValue: 100,
+      unlockedApy: 0.05,
+      lockedApy: 0.09
+    })
+
+    expect(breakdown.blendedApy).toBeCloseTo(0.07, 6)
+    expect(breakdown.unlocked.weight).toBe(0.5)
+    expect(breakdown.locked.weight).toBe(0.5)
   })
 })
 

--- a/src/components/pages/vaults/utils/yvUsd.ts
+++ b/src/components/pages/vaults/utils/yvUsd.ts
@@ -314,6 +314,55 @@ export function getWeightedYvUsdApy({
   return weightedApy / totalValue
 }
 
+export type TYvUsdPositionApyBreakdown = {
+  blendedApy: number | null
+  unlocked: {
+    apy: number | null
+    value: number
+    weight: number
+  }
+  locked: {
+    apy: number | null
+    value: number
+    weight: number
+  }
+}
+
+export function getYvUsdPositionApyBreakdown({
+  unlockedValue,
+  lockedValue,
+  unlockedApy,
+  lockedApy
+}: {
+  unlockedValue?: number | null
+  lockedValue?: number | null
+  unlockedApy?: number | null
+  lockedApy?: number | null
+}): TYvUsdPositionApyBreakdown {
+  const normalizedUnlockedValue = normalizeWeightedValue(unlockedValue)
+  const normalizedLockedValue = normalizeWeightedValue(lockedValue)
+  const totalValue = normalizedUnlockedValue + normalizedLockedValue
+
+  return {
+    blendedApy: getWeightedYvUsdApy({
+      unlockedValue: normalizedUnlockedValue,
+      lockedValue: normalizedLockedValue,
+      unlockedApy,
+      lockedApy
+    }),
+    unlocked: {
+      apy: isFiniteApy(unlockedApy) ? unlockedApy : null,
+      value: normalizedUnlockedValue,
+      weight: totalValue > 0 ? normalizedUnlockedValue / totalValue : 0
+    },
+    locked: {
+      apy: isFiniteApy(lockedApy) ? lockedApy : null,
+      value: normalizedLockedValue,
+      weight: totalValue > 0 ? normalizedLockedValue / totalValue : 0
+    }
+  }
+}
+
 export function convertYvUsdVariantRawAmount({
   amount,
   fromVariant,


### PR DESCRIPTION
## Summary

Keep locked and unlocked yvUSD deposits combined in one portfolio row while showing the APY the user is actually earning.

- Weight locked and unlocked APYs by each position value
- Show a hover and tap breakdown with rates, weights, and USD values
- Use the personalized blended APY for portfolio metrics and sorting
- Add a dotted underline to communicate the APY tooltip affordance

## Root cause

The portfolio model already calculated a value-weighted yvUSD APY, but the list row rendered the synthetic unlocked vault APY instead. This caused locked-only and mixed positions to display a rate that did not reflect the user position.

## User impact

Users now see one yvUSD position with an APY matching their locked and unlocked allocation. The breakdown remains available without adding separate portfolio rows.

## Validation

- `bun run lint:fix`
- `bun run tslint`
- Focused Vitest coverage for APY weighting, tooltip content, and row rendering
- `bun run build`