### PR TITLE
Improve vault strategy visibility

### DIFF
--- a/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/src/components/pages/vaults/[chainID]/[address].tsx
@@ -39,12 +39,15 @@ import {
 } from '@pages/vaults/domain/normalizeVault'
 import { isNonYearnErc4626Vault, NON_YEARN_ERC4626_WARNING_MESSAGE } from '@pages/vaults/domain/vaultWarnings'
 import { useEnsureVaultListFetch } from '@pages/vaults/hooks/useEnsureVaultListFetch'
+import { usePendingTimelockStrategies } from '@pages/vaults/hooks/usePendingTimelockStrategies'
 import { useVaultApyData } from '@pages/vaults/hooks/useVaultApyData'
 import { useVaultSnapshot } from '@pages/vaults/hooks/useVaultSnapshot'
 import { useVaultUserData } from '@pages/vaults/hooks/useVaultUserData'
 import { useYvBtcVaults } from '@pages/vaults/hooks/useYvBtcVaults'
 import { useYvUsdVaults } from '@pages/vaults/hooks/useYvUsdVaults'
 import { WidgetActionType } from '@pages/vaults/types'
+import type { TPendingTimelockStrategy } from '@pages/vaults/types/timelockStrategies'
+import { formatTimelockEta, getTimelockBadgeLabel } from '@pages/vaults/utils/timelockStrategyDisplay'
 import { getVaultUserHistoryVaults } from '@pages/vaults/utils/vaultUserHistoryVaults'
 import { YVBTC_CHAIN_ID, YVBTC_LOCKED_ADDRESS, YVBTC_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvBtc'
 import {
@@ -81,7 +84,7 @@ import {
   useRef,
   useState
 } from 'react'
-import { formatUnits, isAddressEqual } from 'viem'
+import { formatUnits, isAddressEqual, zeroAddress } from 'viem'
 import { VaultsListChip } from '@/components/pages/vaults/components/list/VaultsListChip'
 import { isRouteChainAddressMatch, resolveRouteVaultFromMap } from '@/components/pages/vaults/utils/routeVault'
 import { deriveListKind } from '@/components/pages/vaults/utils/vaultListFacets'
@@ -110,6 +113,32 @@ const resolveHeaderOffset = (): number => {
 }
 
 const desktopWidgetHeightClassNames = getDesktopWidgetHeightClassNames()
+
+function PendingStrategyChangesTooltip({ items }: { items: TPendingTimelockStrategy[] }): ReactElement {
+  const visibleItems = items.slice(0, 3)
+  const remainingCount = items.length - visibleItems.length
+
+  return (
+    <div
+      className={
+        'flex w-[320px] max-w-[calc(100vw-2rem)] flex-col gap-2 rounded-lg border border-border bg-surface p-3 text-left text-xs text-text-secondary shadow-lg'
+      }
+    >
+      <p className={'font-semibold text-text-primary'}>
+        {`${items.length} pending timelocked strategy ${items.length === 1 ? 'change' : 'changes'}`}
+      </p>
+      {visibleItems.map((item) => (
+        <div key={item.operationId} className={'flex flex-col gap-0.5'}>
+          <span className={'font-medium text-text-primary'}>
+            {item.strategyName ?? `Strategy ${item.strategyAddress.slice(0, 8)}…`}
+          </span>
+          <span>{`${getTimelockBadgeLabel(item.status)}, ${formatTimelockEta(item.eta)}`}</span>
+        </div>
+      ))}
+      {remainingCount > 0 ? <span>{`+${remainingCount} more in Strategies`}</span> : null}
+    </div>
+  )
+}
 
 const EMPTY_VAULT_FOR_APY_DATA: TKongVaultView = {
   address: '0x0000000000000000000000000000000000000000',
@@ -701,6 +730,15 @@ function Index(): ReactElement | null {
     vaultViewInput,
     mergedSnapshot
   ])
+  const pendingTimelockStrategies = usePendingTimelockStrategies({
+    chainId,
+    vaultAddress: toAddress(currentVault?.address ?? params.address ?? zeroAddress),
+    enabled: Boolean(currentVault)
+  })
+  const pendingTimelockItems = useMemo(
+    () => pendingTimelockStrategies.data?.items ?? [],
+    [pendingTimelockStrategies.data?.items]
+  )
 
   const shouldBootstrapYvUsdVaultList = isYvUsd && !hasVaultList && !hasTriggeredVaultListFetch
   const shouldBootstrapYvBtcVaultList = isYvBtc && !hasVaultList && !hasTriggeredVaultListFetch
@@ -1164,9 +1202,9 @@ function Index(): ReactElement | null {
       },
       {
         key: 'strategies' as const,
-        shouldRender: Number(currentVault.strategies?.length || 0) > 0,
+        shouldRender: Number(currentVault.strategies?.length || 0) > 0 || pendingTimelockItems.length > 0,
         ref: sectionRefs.strategies,
-        content: <VaultStrategiesSection currentVault={currentVault} />
+        content: <VaultStrategiesSection currentVault={currentVault} pendingTimelockStrategies={pendingTimelockItems} />
       },
       {
         key: 'risk' as const,
@@ -1187,6 +1225,7 @@ function Index(): ReactElement | null {
     chainId,
     currentVault,
     isYvUsd,
+    pendingTimelockItems,
     sectionRefs,
     shouldRenderDesktopCharts,
     snapshotVault?.inceptTime,
@@ -1197,7 +1236,18 @@ function Index(): ReactElement | null {
   const renderableSections = useMemo(() => sections.filter((section) => section.shouldRender), [sections])
   const sectionTabs = renderableSections.map((section) => ({
     key: section.key,
-    label: collapsibleTitles[section.key]
+    label: collapsibleTitles[section.key],
+    supportsNotification: section.key === 'strategies',
+    notificationTooltip:
+      section.key === 'strategies' && pendingTimelockItems.length > 0 ? (
+        <PendingStrategyChangesTooltip items={pendingTimelockItems} />
+      ) : undefined,
+    notificationAriaLabel:
+      section.key === 'strategies' && pendingTimelockItems.length > 0
+        ? `${pendingTimelockItems.length} pending timelocked strategy ${
+            pendingTimelockItems.length === 1 ? 'change' : 'changes'
+          }`
+        : undefined
   }))
   const sectionTourTargets: Partial<Record<SectionKey, string>> = {
     charts: 'vault-detail-section-charts',

--- a/src/components/pages/vaults/components/detail/VaultDetailsHeader.test.tsx
+++ b/src/components/pages/vaults/components/detail/VaultDetailsHeader.test.tsx
@@ -327,6 +327,28 @@ describe('VaultDetailsHeaderPresentation', () => {
     expect(html).toContain('/address/')
   })
 
+  it('shows a strategy notification indicator when a tab has pending changes', () => {
+    const html = renderToStaticMarkup(
+      <VaultDetailsHeaderPresentation
+        currentVault={YVUSD_VAULT as never}
+        depositedValue={0n}
+        isCompressed={true}
+        sectionTabs={[
+          {
+            key: 'strategies',
+            label: 'Strategies',
+            supportsNotification: true,
+            notificationTooltip: 'One pending strategy change',
+            notificationAriaLabel: '1 pending timelocked strategy change'
+          }
+        ]}
+      />
+    )
+
+    expect(html).toContain('Strategies')
+    expect(html).toContain('aria-label="1 pending timelocked strategy change"')
+  })
+
   it('hides cooldown information when there is no locked yvUSD deposit', () => {
     const html = renderToStaticMarkup(
       <VaultDetailsHeaderPresentation currentVault={YVUSD_VAULT as never} depositedValue={0n} isCompressed={false} />

--- a/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
+++ b/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
@@ -53,6 +53,7 @@ import { yvUsdLockedVaultAbi } from '@shared/contracts/abi/yvUsdLockedVault.abi'
 import { useReadContract } from '@shared/hooks/useAppWagmi'
 import { useChainTimestamp } from '@shared/hooks/useChainTimestamp'
 import { useYearnSpotPrices } from '@shared/hooks/useYearnSpotPrices'
+import { IconAlertWarning } from '@shared/icons/IconAlertWarning'
 import { IconInfinifiPoints } from '@shared/icons/IconInfinifiPoints'
 import { IconLinkOut } from '@shared/icons/IconLinkOut'
 import { IconLock } from '@shared/icons/IconLock'
@@ -415,7 +416,13 @@ function SectionSelectorBar({
   activeSectionKey?: string
   onSelectSection?: (key: string) => void
   sectionSelectorRef?: Ref<HTMLDivElement>
-  sectionTabs: { key: string; label: string }[]
+  sectionTabs: {
+    key: string
+    label: string
+    supportsNotification?: boolean
+    notificationTooltip?: string | ReactElement
+    notificationAriaLabel?: string
+  }[]
   isCompressed: boolean
   includeTourAttributes?: boolean
 }): ReactElement {
@@ -431,27 +438,59 @@ function SectionSelectorBar({
           isCompressed ? 'border-t' : 'border-x border-b'
         )}
       >
-        {sectionTabs.map((section) => (
-          <button
-            key={section.key}
-            type={'button'}
-            onClick={(): void => {
-              if (!isCompressed && section.key === 'charts') {
-                return
-              }
-              onSelectSection?.(section.key)
-            }}
-            className={cl(
-              'flex-1 rounded-md px-2 py-2 text-xs font-semibold transition-all md:px-4 md:py-2.5',
-              SELECTOR_BAR_STYLES.buttonBase,
-              'min-h-9 active:scale-[0.98] truncate',
-              activeSectionKey === section.key ? SELECTOR_BAR_STYLES.buttonActive : SELECTOR_BAR_STYLES.buttonInactive
-            )}
-            aria-disabled={!isCompressed && section.key === 'charts'}
-          >
-            {section.label}
-          </button>
-        ))}
+        {sectionTabs.map((section) => {
+          const button = (
+            <button
+              type={'button'}
+              onClick={(): void => {
+                if (!isCompressed && section.key === 'charts') {
+                  return
+                }
+                onSelectSection?.(section.key)
+              }}
+              className={cl(
+                'w-full rounded-md px-2 py-2 text-xs font-semibold transition-all md:px-4 md:py-2.5',
+                SELECTOR_BAR_STYLES.buttonBase,
+                'min-h-9 active:scale-[0.98]',
+                activeSectionKey === section.key ? SELECTOR_BAR_STYLES.buttonActive : SELECTOR_BAR_STYLES.buttonInactive
+              )}
+              aria-disabled={!isCompressed && section.key === 'charts'}
+            >
+              <span className={'flex min-w-0 items-center justify-center gap-1.5'}>
+                <span className={'truncate'}>{section.label}</span>
+                {section.supportsNotification ? (
+                  <IconAlertWarning
+                    aria-label={section.notificationAriaLabel}
+                    aria-hidden={section.notificationTooltip ? undefined : true}
+                    className={cl(
+                      'size-3.5 shrink-0 text-amber-600 dark:text-amber-400',
+                      section.notificationTooltip ? 'visible' : 'invisible'
+                    )}
+                  />
+                ) : null}
+              </span>
+            </button>
+          )
+
+          return (
+            <div key={section.key} className={'group relative min-w-0 flex-1'}>
+              {button}
+              {section.supportsNotification ? (
+                <div
+                  role={'tooltip'}
+                  className={cl(
+                    'pointer-events-none invisible absolute bottom-full left-[calc(50%+2rem)] z-50 mb-2 -translate-x-1/2 opacity-0 transition-opacity duration-150',
+                    section.notificationTooltip
+                      ? 'group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100'
+                      : ''
+                  )}
+                >
+                  {section.notificationTooltip ?? <span />}
+                </div>
+              ) : null}
+            </div>
+          )
+        })}
       </div>
     </div>
   )
@@ -1050,7 +1089,13 @@ type TVaultDetailsHeaderBaseProps = {
   currentVault: TKongVaultInput
   depositedValue: bigint
   yvUsdApyVariant?: TYvUsdVariant
-  sectionTabs?: { key: string; label: string }[]
+  sectionTabs?: {
+    key: string
+    label: string
+    supportsNotification?: boolean
+    notificationTooltip?: string | ReactElement
+    notificationAriaLabel?: string
+  }[]
   activeSectionKey?: string
   onSelectSection?: (key: string) => void
   sectionSelectorRef?: Ref<HTMLDivElement>

--- a/src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
+++ b/src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
@@ -4,7 +4,6 @@ import {
 } from '@pages/vaults/components/detail/strategyDisplayFees'
 import { ALL_VAULTSV3_KINDS_KEYS } from '@pages/vaults/constants'
 import {
-  getVaultAddress,
   getVaultAPR,
   getVaultChainID,
   getVaultName,
@@ -15,19 +14,20 @@ import {
   type TKongVaultInput,
   type TKongVaultStrategy
 } from '@pages/vaults/domain/kongVaultSelectors'
-import { usePendingTimelockStrategies } from '@pages/vaults/hooks/usePendingTimelockStrategies'
 import { useQueryArguments } from '@pages/vaults/hooks/useVaultsQueryArgs'
 import type { TPendingTimelockStrategy } from '@pages/vaults/types/timelockStrategies'
 import type { TAllocationChartData } from '@shared/components/AllocationChart'
 import { DARK_MODE_COLORS, LIGHT_MODE_COLORS, useDarkMode } from '@shared/components/AllocationChart'
 import { useYearn } from '@shared/contexts/useYearn'
 import { useYearnTokenPrice } from '@shared/hooks/useYearnTokenPrice'
+import { IconChevron } from '@shared/icons/IconChevron'
 import type { TSortDirection } from '@shared/types'
 import { cl, formatTvlDisplay, toAddress, toBigInt, toNormalizedBN } from '@shared/utils'
 import type { ReactElement } from 'react'
-import { lazy, Suspense, useCallback, useMemo } from 'react'
+import { lazy, Suspense, useCallback, useMemo, useState } from 'react'
 import { PendingTimelockStrategiesTable } from './PendingTimelockStrategiesTable'
 import { formatStrategiesPercent } from './strategiesPercentFormat'
+import { isActiveStrategy } from './strategyActivity'
 import { VaultsListHead } from './VaultsListHead'
 import { VaultsListStrategy } from './VaultsListStrategy'
 
@@ -41,21 +41,23 @@ type TStrategyRow = TKongVaultStrategy & {
   fees: TStrategyDisplayFees
 }
 
-export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVaultInput }): ReactElement {
+export function VaultStrategiesSection({
+  currentVault,
+  pendingTimelockStrategies = []
+}: {
+  currentVault: TKongVaultInput
+  pendingTimelockStrategies?: TPendingTimelockStrategy[]
+}): ReactElement {
   const { allVaults, vaults } = useYearn()
   const isDark = useDarkMode()
   const vaultVersion = getVaultVersion(currentVault)
   const vaultVariant = vaultVersion?.startsWith('3') || vaultVersion?.startsWith('~3') ? 'v3' : 'v2'
   const chainId = getVaultChainID(currentVault)
-  const vaultAddress = getVaultAddress(currentVault)
   const token = getVaultToken(currentVault)
   const fees = getVaultAPR(currentVault).fees
   const strategies = getVaultStrategies(currentVault)
   const totalAssets = getVaultTVL(currentVault).totalAssets
-  const pendingTimelockStrategies = usePendingTimelockStrategies({
-    chainId,
-    vaultAddress
-  })
+  const [areInactiveStrategiesOpen, setAreInactiveStrategiesOpen] = useState(false)
   const { sortDirection, sortBy, onChangeSortDirection, onChangeSortBy } = useQueryArguments({
     defaultSortBy: 'allocationPercentage',
     defaultTypes: ALL_VAULTSV3_KINDS_KEYS,
@@ -89,19 +91,15 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
   const pendingRows = useMemo((): TPendingTimelockStrategy[] => {
     const currentStrategyAddresses = new Set(mergedList.map((strategy) => toAddress(strategy.address)))
 
-    return (pendingTimelockStrategies.data?.items ?? []).filter(
-      (item) => !currentStrategyAddresses.has(toAddress(item.strategyAddress))
-    )
-  }, [mergedList, pendingTimelockStrategies.data?.items])
+    return pendingTimelockStrategies.filter((item) => !currentStrategyAddresses.has(toAddress(item.strategyAddress)))
+  }, [mergedList, pendingTimelockStrategies])
 
   const allocatedRatio = mergedList.reduce((acc, strategy) => acc + (strategy.details?.debtRatio || 0), 0)
   const unallocatedPercentage = Math.max(0, 10000 - allocatedRatio)
   const allocatedDebt = mergedList.reduce((acc, strategy) => acc + toBigInt(strategy.details?.totalDebt || 0), 0n)
   const unallocatedValue = totalAssets > allocatedDebt ? totalAssets - allocatedDebt : 0n
 
-  const filteredVaultList = useMemo(() => {
-    return mergedList
-  }, [mergedList])
+  const filteredVaultList = mergedList
 
   const sortedVaultsToDisplay = useMemo(() => {
     const direction = sortDirection === 'asc' ? 1 : -1
@@ -120,6 +118,9 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
     })
   }, [filteredVaultList, sortBy, sortDirection])
 
+  const activeStrategies = sortedVaultsToDisplay.filter(isActiveStrategy)
+  const inactiveStrategies = sortedVaultsToDisplay.filter((strategy) => !isActiveStrategy(strategy))
+
   const resolveStrategyUsdValue = useCallback(
     (totalDebt: string | undefined): number => {
       const normalized = toNormalizedBN(totalDebt || 0, token.decimals).normalized
@@ -134,18 +135,12 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
   )
 
   const activeStrategyData = useMemo(() => {
-    return filteredVaultList
-      .filter((strategy) => {
-        const hasAllocation =
-          strategy.details?.totalDebt && strategy.details.totalDebt !== '0' && strategy.details?.debtRatio
-        return hasAllocation
-      })
-      .map((strategy) => ({
-        id: strategy.address,
-        name: strategy.name,
-        value: (strategy.details?.debtRatio || 0) / 100,
-        amount: formatAllocationAmount(strategy.details?.totalDebt)
-      }))
+    return filteredVaultList.filter(isActiveStrategy).map((strategy) => ({
+      id: strategy.address,
+      name: strategy.name,
+      value: (strategy.details?.debtRatio || 0) / 100,
+      amount: formatAllocationAmount(strategy.details?.totalDebt)
+    }))
   }, [filteredVaultList, formatAllocationAmount])
 
   const allocationChartData = useMemo(() => {
@@ -252,34 +247,25 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
                     }
                   ]}
                 />
-                {sortedVaultsToDisplay
-                  .filter(
-                    (strategy) =>
-                      !(
-                        strategy.status === 'unallocated' ||
-                        strategy.details?.totalDebt === '0' ||
-                        !strategy.details?.debtRatio
-                      )
-                  )
-                  .map((strategy) => (
-                    <VaultsListStrategy
-                      key={strategy.address}
-                      details={strategy.details}
-                      status={strategy.status}
-                      chainId={chainId}
-                      allocation={formatAllocationAmount(strategy.details?.totalDebt)}
-                      totalValueUsd={resolveStrategyUsdValue(strategy.details?.totalDebt)}
-                      name={strategy.name}
-                      tokenAddress={token.address}
-                      address={strategy.address}
-                      isVault={strategy.isVault}
-                      variant={vaultVariant}
-                      apr={strategy.estimatedAPY}
-                      netApr={strategy.netAPR}
-                      katRewardsAPR={strategy.katRewardsAPR}
-                      fees={strategy.fees}
-                    />
-                  ))}
+                {activeStrategies.map((strategy) => (
+                  <VaultsListStrategy
+                    key={strategy.address}
+                    details={strategy.details}
+                    status={strategy.status}
+                    chainId={chainId}
+                    allocation={formatAllocationAmount(strategy.details?.totalDebt)}
+                    totalValueUsd={resolveStrategyUsdValue(strategy.details?.totalDebt)}
+                    name={strategy.name}
+                    tokenAddress={token.address}
+                    address={strategy.address}
+                    isVault={strategy.isVault}
+                    variant={vaultVariant}
+                    apr={strategy.estimatedAPY}
+                    netApr={strategy.netAPR}
+                    katRewardsAPR={strategy.katRewardsAPR}
+                    fees={strategy.fees}
+                  />
+                ))}
                 {unallocatedPercentage > 0 && unallocatedValue > 0n ? (
                   <div className={'w-full rounded-lg text-text-primary opacity-50'}>
                     <div className={'grid w-full grid-cols-1 items-center gap-4 px-4 py-3 md:grid-cols-24 md:px-8'}>
@@ -313,32 +299,50 @@ export function VaultStrategiesSection({ currentVault }: { currentVault: TKongVa
                     </div>
                   </div>
                 ) : null}
-                {sortedVaultsToDisplay
-                  .filter(
-                    (strategy) =>
-                      strategy.status === 'unallocated' ||
-                      strategy.details?.totalDebt === '0' ||
-                      !strategy.details?.debtRatio
-                  )
-                  .map((strategy) => (
-                    <VaultsListStrategy
-                      key={strategy.address}
-                      details={strategy.details}
-                      status={strategy.status}
-                      chainId={chainId}
-                      allocation={formatAllocationAmount(strategy.details?.totalDebt)}
-                      totalValueUsd={resolveStrategyUsdValue(strategy.details?.totalDebt)}
-                      name={strategy.name}
-                      tokenAddress={token.address}
-                      address={strategy.address}
-                      isVault={strategy.isVault}
-                      variant={vaultVariant}
-                      apr={strategy.estimatedAPY}
-                      netApr={strategy.netAPR}
-                      katRewardsAPR={strategy.katRewardsAPR}
-                      fees={strategy.fees}
-                    />
-                  ))}
+                {inactiveStrategies.length > 0 ? (
+                  <div className={'border-t border-border'}>
+                    <button
+                      type={'button'}
+                      className={
+                        'flex w-full items-center justify-between rounded-lg px-4 py-3 text-left text-base font-normal text-text-secondary transition-colors hover:bg-surface-secondary/50 hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary md:px-8'
+                      }
+                      aria-expanded={areInactiveStrategiesOpen}
+                      onClick={(): void => setAreInactiveStrategiesOpen((isOpen) => !isOpen)}
+                    >
+                      <span>
+                        {areInactiveStrategiesOpen ? 'Hide Inactive Strategies' : 'Show Inactive Strategies'}
+                        <span className={'ml-1 font-normal text-text-secondary'}>({inactiveStrategies.length})</span>
+                      </span>
+                      <IconChevron
+                        className={'size-4 transition-transform duration-200'}
+                        direction={areInactiveStrategiesOpen ? 'up' : 'down'}
+                      />
+                    </button>
+                    {areInactiveStrategiesOpen ? (
+                      <div className={'space-y-px'}>
+                        {inactiveStrategies.map((strategy) => (
+                          <VaultsListStrategy
+                            key={strategy.address}
+                            details={strategy.details}
+                            status={'not_active'}
+                            chainId={chainId}
+                            allocation={formatAllocationAmount(strategy.details?.totalDebt)}
+                            totalValueUsd={resolveStrategyUsdValue(strategy.details?.totalDebt)}
+                            name={strategy.name}
+                            tokenAddress={token.address}
+                            address={strategy.address}
+                            isVault={strategy.isVault}
+                            variant={vaultVariant}
+                            apr={strategy.estimatedAPY}
+                            netApr={strategy.netAPR}
+                            katRewardsAPR={strategy.katRewardsAPR}
+                            fees={strategy.fees}
+                          />
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
               </>
             ) : null}
             <PendingTimelockStrategiesTable

--- a/src/components/pages/vaults/components/detail/VaultsListStrategy.test.tsx
+++ b/src/components/pages/vaults/components/detail/VaultsListStrategy.test.tsx
@@ -54,4 +54,15 @@ describe('VaultsListStrategy desktop layout', () => {
     expect(html).toContain('opacity-50')
     expect(html).not.toContain('Timelock ready')
   })
+
+  it('shows APY for inactive strategies', () => {
+    const html = renderStrategyHtml({
+      status: 'not_active',
+      apr: 0.042
+    })
+
+    expect(html).toContain('4.20%')
+    expect(html).toContain('opacity-70')
+    expect(html).not.toContain('opacity-50')
+  })
 })

--- a/src/components/pages/vaults/components/detail/VaultsListStrategy.tsx
+++ b/src/components/pages/vaults/components/detail/VaultsListStrategy.tsx
@@ -51,14 +51,14 @@ export function VaultsListStrategy({
   const [isExpanded, setIsExpanded] = useState(false)
   const isInactive = status === 'not_active'
   const isUnallocated = status === 'unallocated'
-  const shouldShowPlaceholders = isInactive || isUnallocated
+  const rowOpacityClassName = isInactive ? 'opacity-70' : isUnallocated ? 'opacity-50' : ''
   const hasKatRewards = typeof katRewardsAPR === 'number' && katRewardsAPR > 0
   const baseApr = apr ?? netApr ?? 0
   const displayApr = hasKatRewards ? baseApr + (katRewardsAPR ?? 0) : baseApr
 
   const lastReportTime = details?.lastReport ? formatDuration(details.lastReport * 1000 - Date.now(), true) : 'N/A'
   let apyContent: ReactElement | string = '-'
-  if (shouldShowPlaceholders) {
+  if (isUnallocated) {
     apyContent = '-'
   } else if (hasKatRewards) {
     const tooltipContent = (
@@ -95,7 +95,7 @@ export function VaultsListStrategy({
   const blockExplorer = getNetwork(chainId)?.defaultBlockExplorer
 
   return (
-    <div className={cl('w-full rounded-lg text-text-primary', shouldShowPlaceholders ? 'opacity-50' : '')}>
+    <div className={cl('w-full rounded-lg text-text-primary', rowOpacityClassName)}>
       {/* Collapsible header - always visible */}
       <div
         className={cl(
@@ -174,7 +174,7 @@ export function VaultsListStrategy({
             className={`flex flex-col items-center md:items-end ${STRATEGY_PANEL_ROW_DESKTOP_LAYOUT.valueColumnSpanClass}`}
           >
             <p className={'text-xs text-text-primary/60 mb-1 md:hidden'}>{'APY'}</p>
-            <p className={'font-semibold'}>{apyContent}</p>
+            <div className={'font-semibold'}>{apyContent}</div>
           </div>
         </div>
 

--- a/src/components/pages/vaults/components/detail/strategyActivity.test.ts
+++ b/src/components/pages/vaults/components/detail/strategyActivity.test.ts
@@ -1,0 +1,33 @@
+import type { TKongVaultStrategy } from '@pages/vaults/domain/kongVaultSelectors'
+import { describe, expect, it } from 'vitest'
+import { isActiveStrategy } from './strategyActivity'
+
+const ACTIVE_STRATEGY: TKongVaultStrategy = {
+  address: '0x0000000000000000000000000000000000000001',
+  name: 'Active strategy',
+  description: '',
+  netAPR: 0.05,
+  status: 'active',
+  details: {
+    totalDebt: '1000',
+    totalLoss: '0',
+    totalGain: '0',
+    performanceFee: 0,
+    lastReport: 0,
+    debtRatio: 5000
+  }
+}
+
+describe('isActiveStrategy', () => {
+  it('requires active status and a positive allocation', () => {
+    expect(isActiveStrategy(ACTIVE_STRATEGY)).toBe(true)
+    expect(isActiveStrategy({ ...ACTIVE_STRATEGY, status: 'not_active' })).toBe(false)
+    expect(isActiveStrategy({ ...ACTIVE_STRATEGY, status: 'unallocated' })).toBe(false)
+    expect(
+      isActiveStrategy({
+        ...ACTIVE_STRATEGY,
+        details: { ...ACTIVE_STRATEGY.details!, totalDebt: '0', debtRatio: 0 }
+      })
+    ).toBe(false)
+  })
+})

--- a/src/components/pages/vaults/components/detail/strategyActivity.ts
+++ b/src/components/pages/vaults/components/detail/strategyActivity.ts
@@ -1,0 +1,10 @@
+import type { TKongVaultStrategy } from '@pages/vaults/domain/kongVaultSelectors'
+import { toBigInt } from '@shared/utils'
+
+export function isActiveStrategy(strategy: TKongVaultStrategy): boolean {
+  return (
+    strategy.status === 'active' &&
+    toBigInt(strategy.details?.totalDebt || 0) > 0n &&
+    (strategy.details?.debtRatio || 0) > 0
+  )
+}


### PR DESCRIPTION
## Summary

- show a warning indicator and tooltip for pending timelocked strategy changes
- collapse inactive and zero-allocation strategies behind a stateful rollout
- preserve inactive strategy APY and improve inactive row visibility

## Why

Visitors can see pending strategy changes from the vault header without scrolling, while inactive strategies no longer clutter the primary allocation list. The inactive classification now includes zero-allocation strategies that were previously left in the main list.

## Validation

- `bun run tslint`
- `bun run lint:fix`
- focused Vitest coverage for strategy classification, inactive APY, and the header indicator
- `bun run build`
- production browser smoke tests for yvUSD and pending timelock vaults

## Screenshots
alert when timelocked strategies are pending:
<img width="799" height="578" alt="image" src="https://github.com/user-attachments/assets/16fe7fb5-9445-4b0d-80d0-862fea351866" />

collapsed state of inactive strategies:
<img width="796" height="526" alt="image" src="https://github.com/user-attachments/assets/f6d2173e-b52d-42bb-a918-f63ea5840c68" />
