### PR TITLE
Feat/growth index upd

### DIFF
--- a/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -36,7 +36,11 @@ import type {
   TPortfolioProtocolReturnHistorySummary
 } from '../types/api'
 import { PortfolioHistoryBreakdownModal } from './PortfolioHistoryBreakdownModal'
-import type { TPortfolioVaultGrowthChartMode, TPortfolioVaultGrowthChartSeries } from './PortfolioVaultGrowthChart'
+import type {
+  TPortfolioVaultGrowthChartMode,
+  TPortfolioVaultGrowthChartSeries,
+  TPortfolioVaultGrowthChartSortDirection
+} from './PortfolioVaultGrowthChart'
 import { PortfolioVaultGrowthChart } from './PortfolioVaultGrowthChart'
 
 export type TPortfolioHistoryChartTimeframe = '30d' | '90d' | '1y' | 'all'
@@ -56,6 +60,8 @@ type TPortfolioHistoryChartProps = {
   onGrowthDisplayModeOverrideChange: (mode: TGrowthDisplayMode | null) => void
   vaultGrowthMode: TPortfolioVaultGrowthChartMode
   onVaultGrowthModeChange: (mode: TPortfolioVaultGrowthChartMode) => void
+  vaultGrowthSortDirection: TPortfolioVaultGrowthChartSortDirection
+  onVaultGrowthSortDirectionChange: (direction: TPortfolioVaultGrowthChartSortDirection) => void
   balanceIsLoading: boolean
   balanceIsEmpty?: boolean
   balanceError?: Error | null
@@ -514,6 +520,7 @@ function buildPortfolioVaultGrowthSeries(
   labelByVaultKey: Record<string, string>
 ): TPortfolioVaultGrowthChartSeries[] {
   return familySeries.map((series) => ({
+    chainId: series.chainId,
     vaultAddress: series.vaultAddress,
     vaultName:
       labelByVaultKey[`${series.chainId}:${series.vaultAddress.toLowerCase()}`] ??
@@ -613,6 +620,8 @@ export function PortfolioHistoryChart({
   onGrowthDisplayModeOverrideChange,
   vaultGrowthMode,
   onVaultGrowthModeChange,
+  vaultGrowthSortDirection,
+  onVaultGrowthSortDirectionChange,
   balanceIsLoading,
   balanceIsEmpty = false,
   balanceError,
@@ -1054,12 +1063,15 @@ export function PortfolioHistoryChart({
           series={vaultGrowthSeries}
           mode={vaultGrowthMode}
           onModeChange={onVaultGrowthModeChange}
+          sortDirection={vaultGrowthSortDirection}
+          onSortDirectionChange={onVaultGrowthSortDirectionChange}
           timeframe={timeframe}
           maxVaults={INDEX_SERIES_COLORS.length - 1}
           colors={[...INDEX_SERIES_COLORS.slice(1)]}
           title={''}
           height={'100%'}
           showModeToggle={false}
+          showSortToggle
           className={'h-full min-h-0 pt-1'}
           emptyMessage={getEmptyMessage(activeTab, resolvedGrowthDisplayMode)}
         />

--- a/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -157,7 +157,7 @@ const CHART_TABS: Array<{ id: TPortfolioHistoryChartTab; label: string }> = [
   { id: 'balance', label: 'Balance' },
   { id: 'growth', label: 'Growth' },
   { id: 'annualized', label: 'Annualized %' },
-  { id: 'index', label: 'Growth Index' }
+  { id: 'index', label: 'Vault Performance' }
 ]
 const TIMEFRAME_OPTIONS: Array<{ id: TPortfolioHistoryChartTimeframe; label: string }> = [
   { id: '30d', label: '30D' },
@@ -602,7 +602,7 @@ function getEmptyMessage(activeTab: TPortfolioHistoryChartTab, growthDisplayMode
   }
 
   if (activeTab === 'index') {
-    return 'No growth index history available'
+    return 'No vault performance history available'
   }
 
   return 'No holdings history available'
@@ -870,7 +870,7 @@ export function PortfolioHistoryChart({
                   ? 'Protocol Growth (ETH)'
                   : 'Protocol Growth (USD)'
               : activeTab === 'index'
-                ? 'Growth Index'
+                ? 'Vault Performance'
                 : 'Protocol Return (%)',
         color: 'var(--chart-1)'
       }

--- a/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
@@ -15,6 +15,7 @@ import {
   getChartWeeklyTicks,
   getTimeframeLimit
 } from '@pages/vaults/utils/charts'
+import { IconChevron } from '@shared/icons/IconChevron'
 import { cl, formatUSD, SELECTOR_BAR_STYLES } from '@shared/utils'
 import type { ReactElement } from 'react'
 import { useMemo, useState } from 'react'
@@ -23,6 +24,7 @@ import type { AxisDomain } from 'recharts/types/util/types'
 
 export type TPortfolioVaultGrowthChartMode = 'position' | 'index'
 export type TPortfolioVaultGrowthChartTimeframe = '30d' | '90d' | '1y' | 'all'
+export type TPortfolioVaultGrowthChartSortDirection = 'desc' | 'asc'
 
 const NON_NEGATIVE_AUTO_DOMAIN: AxisDomain = [
   (dataMin: number) => (Number.isFinite(dataMin) && dataMin < 0 ? dataMin : 0),
@@ -77,6 +79,7 @@ export type TPortfolioVaultGrowthChartSeriesPoint = {
 }
 
 export type TPortfolioVaultGrowthChartSeries = {
+  chainId?: number
   vaultAddress: string
   vaultName: string
   symbol?: string | null
@@ -89,6 +92,9 @@ export type TPortfolioVaultGrowthChartProps = {
   mode?: TPortfolioVaultGrowthChartMode
   initialMode?: TPortfolioVaultGrowthChartMode
   onModeChange?: (mode: TPortfolioVaultGrowthChartMode) => void
+  sortDirection?: TPortfolioVaultGrowthChartSortDirection
+  initialSortDirection?: TPortfolioVaultGrowthChartSortDirection
+  onSortDirectionChange?: (direction: TPortfolioVaultGrowthChartSortDirection) => void
   timeframe?: TPortfolioVaultGrowthChartTimeframe
   vaultOrder?: string[]
   maxVaults?: number
@@ -97,6 +103,7 @@ export type TPortfolioVaultGrowthChartProps = {
   title?: string
   height?: number | string
   showModeToggle?: boolean
+  showSortToggle?: boolean
   className?: string
   emptyMessage?: string
 }
@@ -147,8 +154,42 @@ const MODE_COPY: Record<TPortfolioVaultGrowthChartMode, string> = {
   index: 'Shows vault performance normalized to 100, ignoring position size.'
 }
 
+const SORT_LABELS: Record<TPortfolioVaultGrowthChartMode, Record<TPortfolioVaultGrowthChartSortDirection, string>> = {
+  position: {
+    desc: 'Top contributors',
+    asc: 'Bottom contributors'
+  },
+  index: {
+    desc: 'Best performance',
+    asc: 'Worst performance'
+  }
+}
+
+export function getPortfolioVaultGrowthSortLabel(
+  mode: TPortfolioVaultGrowthChartMode,
+  direction: TPortfolioVaultGrowthChartSortDirection
+): string {
+  return SORT_LABELS[mode][direction]
+}
+
+export function getPortfolioVaultGrowthSortOptions(
+  mode: TPortfolioVaultGrowthChartMode
+): Array<{ id: TPortfolioVaultGrowthChartSortDirection; label: string }> {
+  return (['desc', 'asc'] as const).map((direction) => ({
+    id: direction,
+    label: getPortfolioVaultGrowthSortLabel(mode, direction)
+  }))
+}
+
 function getVaultKey(address: string): string {
   return address.toLowerCase()
+}
+
+export function getPortfolioVaultGrowthSeriesKey(
+  vaultSeries: Pick<TPortfolioVaultGrowthChartSeries, 'chainId' | 'vaultAddress'>
+): string {
+  const address = getVaultKey(vaultSeries.vaultAddress)
+  return vaultSeries.chainId === undefined ? address : `${vaultSeries.chainId}:${address}`
 }
 
 function normalizeTimestamp(timestamp: number): number {
@@ -241,78 +282,64 @@ function buildIndexPoints(points: TPortfolioVaultGrowthChartPoint[], indexBase: 
   })
 }
 
-function getFiniteValues(points: TTransformedPoint[]): number[] {
+function getFiniteValues(points: Array<{ value: number | null }>): number[] {
   return points.flatMap((point) => (isFiniteNumber(point.value) ? [point.value] : []))
 }
 
-function getPositionRelevance(points: TTransformedPoint[]): number {
-  return Math.max(0, ...getFiniteValues(points).map((value) => Math.abs(value)))
+export type TPortfolioVaultGrowthRankableSeries = {
+  positionPoints: Array<{ value: number | null }>
+  indexPoints: Array<{ value: number | null }>
 }
 
-function getIndexRelevance(points: TTransformedPoint[], indexBase: number): number {
-  return Math.max(0, ...getFiniteValues(points).map((value) => Math.abs(value - indexBase)))
+function getSeriesSortScore(
+  series: TPortfolioVaultGrowthRankableSeries,
+  mode: TPortfolioVaultGrowthChartMode
+): number | null {
+  const points = mode === 'position' ? series.positionPoints : series.indexPoints
+  const finiteValues = getFiniteValues(points)
+
+  if (mode === 'index') {
+    if (finiteValues.length < 2) {
+      return null
+    }
+
+    return (finiteValues.at(-1) ?? 0) - finiteValues[0]
+  }
+
+  if (finiteValues.length < 2) {
+    return null
+  }
+
+  return (finiteValues.at(-1) ?? 0) - finiteValues[0]
 }
 
-function selectRelevantSeries(args: {
-  series: TTransformedSeries[]
+export function rankPortfolioVaultGrowthChartSeries<TSeries extends TPortfolioVaultGrowthRankableSeries>(args: {
+  series: TSeries[]
+  mode: TPortfolioVaultGrowthChartMode
+  sortDirection: TPortfolioVaultGrowthChartSortDirection
   maxVaults?: number
-  indexBase: number
-}): TTransformedSeries[] {
-  const scoredSeries = args.series.map((vaultSeries) => {
-    const positionScore = getPositionRelevance(vaultSeries.positionPoints)
-    const indexScore = getIndexRelevance(vaultSeries.indexPoints, args.indexBase)
-    return {
+}): TSeries[] {
+  const directionMultiplier = args.sortDirection === 'desc' ? -1 : 1
+  const rankedSeries = args.series
+    .map((vaultSeries, originalIndex) => ({
       vaultSeries,
-      positionScore,
-      indexScore,
-      combinedScore: positionScore + indexScore
-    }
-  })
-  const hasRelevantSeries = scoredSeries.some(
-    (series) => series.positionScore > MIN_RELEVANCE_SCORE || series.indexScore > MIN_RELEVANCE_SCORE
-  )
-  const candidates = hasRelevantSeries
-    ? scoredSeries.filter(
-        (series) => series.positionScore > MIN_RELEVANCE_SCORE || series.indexScore > MIN_RELEVANCE_SCORE
-      )
-    : scoredSeries
+      originalIndex,
+      score: getSeriesSortScore(vaultSeries, args.mode)
+    }))
+    .filter(
+      (candidate): candidate is { vaultSeries: TSeries; originalIndex: number; score: number } =>
+        candidate.score !== null && Math.abs(candidate.score) > MIN_RELEVANCE_SCORE
+    )
+    .toSorted(
+      (left, right) => (left.score - right.score) * directionMultiplier || left.originalIndex - right.originalIndex
+    )
 
-  if (typeof args.maxVaults !== 'number' || candidates.length <= args.maxVaults) {
-    return candidates.map((series) => series.vaultSeries)
-  }
+  const limit =
+    typeof args.maxVaults === 'number' && Number.isFinite(args.maxVaults)
+      ? Math.max(0, Math.floor(args.maxVaults))
+      : rankedSeries.length
 
-  const maxVaults = args.maxVaults
-  const selectedKeys = new Set<string>()
-  const selectedSeries: TTransformedSeries[] = []
-  const addSeries = (vaultSeries: TTransformedSeries): void => {
-    if (selectedSeries.length >= maxVaults || selectedKeys.has(vaultSeries.vaultAddress.toLowerCase())) {
-      return
-    }
-    selectedKeys.add(vaultSeries.vaultAddress.toLowerCase())
-    selectedSeries.push(vaultSeries)
-  }
-  const positionTarget = Math.ceil(maxVaults / 2)
-
-  candidates
-    .toSorted((left, right) => right.positionScore - left.positionScore || right.combinedScore - left.combinedScore)
-    .slice(0, positionTarget)
-    .forEach((series) => {
-      addSeries(series.vaultSeries)
-    })
-
-  candidates
-    .toSorted((left, right) => right.indexScore - left.indexScore || right.combinedScore - left.combinedScore)
-    .forEach((series) => {
-      addSeries(series.vaultSeries)
-    })
-
-  candidates
-    .toSorted((left, right) => right.combinedScore - left.combinedScore)
-    .forEach((series) => {
-      addSeries(series.vaultSeries)
-    })
-
-  return selectedSeries
+  return rankedSeries.slice(0, limit).map((candidate) => candidate.vaultSeries)
 }
 
 function applySeriesPresentation(series: TTransformedSeries[], colors: string[]): TTransformedSeries[] {
@@ -337,7 +364,6 @@ function buildSeries(args: {
   points: TPortfolioVaultGrowthChartPoint[]
   timeframe: TPortfolioVaultGrowthChartTimeframe
   vaultOrder?: string[]
-  maxVaults?: number
   indexBase: number
   colors: string[]
 }): TTransformedSeries[] {
@@ -373,10 +399,7 @@ function buildSeries(args: {
     ]
   })
 
-  return applySeriesPresentation(
-    selectRelevantSeries({ series: transformedSeries, maxVaults: args.maxVaults, indexBase: args.indexBase }),
-    args.colors
-  )
+  return transformedSeries
 }
 
 function buildPrecomputedIndexPoints(
@@ -428,16 +451,19 @@ function buildSeriesFromPrecomputed(args: {
   series: TPortfolioVaultGrowthChartSeries[]
   timeframe: TPortfolioVaultGrowthChartTimeframe
   vaultOrder?: string[]
-  maxVaults?: number
   indexBase: number
   colors: string[]
 }): TTransformedSeries[] {
   const seriesByVaultKey = new Map(
-    args.series.map((vaultSeries) => [getVaultKey(vaultSeries.vaultAddress), vaultSeries])
+    args.series.map((vaultSeries) => [getPortfolioVaultGrowthSeriesKey(vaultSeries), vaultSeries])
   )
+  const availableKeys = Array.from(seriesByVaultKey.keys())
   const orderedKeys = args.vaultOrder?.length
-    ? args.vaultOrder.map(getVaultKey).filter((key) => seriesByVaultKey.has(key))
-    : Array.from(seriesByVaultKey.keys())
+    ? args.vaultOrder.flatMap((orderedVault) => {
+        const orderedKey = getVaultKey(orderedVault)
+        return availableKeys.filter((key) => key === orderedKey || key.endsWith(`:${orderedKey}`))
+      })
+    : availableKeys
   const limit = getTimeframeLimit(args.timeframe)
 
   const transformedSeries = orderedKeys.flatMap((vaultKey) => {
@@ -466,10 +492,7 @@ function buildSeriesFromPrecomputed(args: {
     ]
   })
 
-  return applySeriesPresentation(
-    selectRelevantSeries({ series: transformedSeries, maxVaults: args.maxVaults, indexBase: args.indexBase }),
-    args.colors
-  )
+  return transformedSeries
 }
 
 function buildChartData(series: TTransformedSeries[], mode: TPortfolioVaultGrowthChartMode): TChartPoint[] {
@@ -537,9 +560,11 @@ function PortfolioVaultGrowthTooltip({
   active,
   payload,
   mode,
+  sortDirection,
   seriesLabels
 }: TTooltipProps & {
   mode: TPortfolioVaultGrowthChartMode
+  sortDirection: TPortfolioVaultGrowthChartSortDirection
   seriesLabels: Record<string, string>
 }): ReactElement | null {
   if (!active || !payload?.length) {
@@ -569,7 +594,7 @@ function PortfolioVaultGrowthTooltip({
         }
       ]
     })
-    .toSorted((left, right) => right.value - left.value)
+    .toSorted((left, right) => (sortDirection === 'desc' ? right.value - left.value : left.value - right.value))
 
   return (
     <div
@@ -603,6 +628,9 @@ export function PortfolioVaultGrowthChart({
   mode,
   initialMode = 'position',
   onModeChange,
+  sortDirection,
+  initialSortDirection = 'desc',
+  onSortDirectionChange,
   timeframe = 'all',
   vaultOrder,
   maxVaults,
@@ -611,46 +639,74 @@ export function PortfolioVaultGrowthChart({
   title = 'Vault Growth',
   height = 300,
   showModeToggle = true,
+  showSortToggle = showModeToggle,
   className,
   emptyMessage = 'No vault growth history available'
 }: TPortfolioVaultGrowthChartProps): ReactElement {
   const [uncontrolledMode, setUncontrolledMode] = useState<TPortfolioVaultGrowthChartMode>(initialMode)
+  const [uncontrolledSortDirection, setUncontrolledSortDirection] =
+    useState<TPortfolioVaultGrowthChartSortDirection>(initialSortDirection)
   const activeMode = mode ?? uncontrolledMode
-  const series = useMemo(() => {
+  const activeSortDirection = sortDirection ?? uncontrolledSortDirection
+  const unrankedSeries = useMemo(() => {
     if (precomputedSeries) {
       return buildSeriesFromPrecomputed({
         series: precomputedSeries,
         timeframe,
         vaultOrder,
-        maxVaults,
         indexBase,
         colors
       })
     }
 
-    return buildSeries({ points, timeframe, vaultOrder, maxVaults, indexBase, colors })
-  }, [colors, indexBase, maxVaults, points, precomputedSeries, timeframe, vaultOrder])
+    return buildSeries({ points, timeframe, vaultOrder, indexBase, colors })
+  }, [colors, indexBase, points, precomputedSeries, timeframe, vaultOrder])
+  const series = useMemo(
+    () =>
+      applySeriesPresentation(
+        rankPortfolioVaultGrowthChartSeries({
+          series: unrankedSeries,
+          mode: activeMode,
+          sortDirection: activeSortDirection,
+          maxVaults
+        }),
+        colors
+      ),
+    [activeMode, activeSortDirection, colors, maxVaults, unrankedSeries]
+  )
   const chartData = useMemo(() => buildChartData(series, activeMode), [activeMode, series])
-  const yAxisFloor = activeMode === 'index' ? 100 : 0
   const yAxisTicks = useMemo(
     () =>
-      buildNonNegativeEvenTicks(
-        chartData.flatMap((point) =>
-          Object.entries(point).flatMap(([key, value]) => {
-            if (key === 'timestamp' || key === 'date') {
-              return []
-            }
-            return typeof value === 'number' ? [value] : []
-          })
-        ),
-        yAxisFloor
-      ),
-    [chartData, yAxisFloor]
+      activeMode === 'position'
+        ? buildNonNegativeEvenTicks(
+            chartData.flatMap((point) =>
+              Object.entries(point).flatMap(([key, value]) => {
+                if (key === 'timestamp' || key === 'date') {
+                  return []
+                }
+                return typeof value === 'number' ? [value] : []
+              })
+            )
+          )
+        : undefined,
+    [activeMode, chartData]
   )
-  const yAxisDomain = useMemo<AxisDomain>(
-    () => (yAxisTicks ? [yAxisFloor, yAxisTicks.at(-1) ?? yAxisFloor] : NON_NEGATIVE_AUTO_DOMAIN),
-    [yAxisFloor, yAxisTicks]
-  )
+  const yAxisDomain = useMemo<AxisDomain>(() => {
+    if (activeMode === 'index') {
+      return [
+        (dataMin: number) => {
+          const minValue = Number.isFinite(dataMin) ? Math.min(indexBase, dataMin) : indexBase
+          return indexBase - (indexBase - minValue) * Y_AXIS_HEADROOM_MULTIPLIER
+        },
+        (dataMax: number) => {
+          const maxValue = Number.isFinite(dataMax) ? Math.max(indexBase, dataMax) : indexBase
+          return indexBase + (maxValue - indexBase) * Y_AXIS_HEADROOM_MULTIPLIER
+        }
+      ]
+    }
+
+    return yAxisTicks ? [0, yAxisTicks.at(-1) ?? 0] : NON_NEGATIVE_AUTO_DOMAIN
+  }, [activeMode, indexBase, yAxisTicks])
   const chartConfig = useMemo<ChartConfig>(() => {
     return Object.fromEntries(
       series.map((vaultSeries) => [vaultSeries.key, { label: vaultSeries.label, color: vaultSeries.color }])
@@ -673,29 +729,75 @@ export function PortfolioVaultGrowthChart({
     onModeChange?.(nextMode)
   }
 
+  const handleSortDirectionChange = (nextDirection: TPortfolioVaultGrowthChartSortDirection): void => {
+    if (!sortDirection) {
+      setUncontrolledSortDirection(nextDirection)
+    }
+    onSortDirectionChange?.(nextDirection)
+  }
+
   return (
     <section className={cl('flex flex-col gap-3', className)}>
-      {title || showModeToggle ? (
+      {title || showModeToggle || showSortToggle ? (
         <div className={'flex flex-col gap-2'}>
           <div className={'flex flex-col gap-2 md:flex-row md:items-center md:justify-between'}>
             {title ? <h3 className={'text-base font-semibold text-text-primary'}>{title}</h3> : null}
-            {showModeToggle ? (
-              <div className={cl('flex w-full items-center gap-0.5 md:w-auto md:gap-1', SELECTOR_BAR_STYLES.container)}>
-                {(['position', 'index'] as const).map((nextMode) => (
-                  <button
-                    key={nextMode}
-                    type={'button'}
-                    onClick={() => handleModeChange(nextMode)}
+            {showModeToggle || showSortToggle ? (
+              <div className={'flex w-full items-center gap-2 md:ml-auto md:w-auto'}>
+                {showModeToggle ? (
+                  <div
                     className={cl(
-                      'min-h-[36px] flex-1 rounded-sm px-3 py-2 text-xs font-semibold transition-all md:min-h-0 md:flex-initial md:py-1',
-                      'active:scale-[0.98]',
-                      SELECTOR_BAR_STYLES.buttonBase,
-                      activeMode === nextMode ? SELECTOR_BAR_STYLES.buttonActive : SELECTOR_BAR_STYLES.buttonInactive
+                      'flex flex-1 items-center gap-0.5 md:w-auto md:flex-initial md:gap-1',
+                      SELECTOR_BAR_STYLES.container
                     )}
                   >
-                    {nextMode === 'position' ? 'Position' : 'Index'}
-                  </button>
-                ))}
+                    {(['position', 'index'] as const).map((nextMode) => (
+                      <button
+                        key={nextMode}
+                        type={'button'}
+                        onClick={() => handleModeChange(nextMode)}
+                        className={cl(
+                          'min-h-[36px] flex-1 rounded-sm px-3 py-2 text-xs font-semibold transition-all md:min-h-0 md:flex-initial md:py-1',
+                          'active:scale-[0.98]',
+                          SELECTOR_BAR_STYLES.buttonBase,
+                          activeMode === nextMode
+                            ? SELECTOR_BAR_STYLES.buttonActive
+                            : SELECTOR_BAR_STYLES.buttonInactive
+                        )}
+                      >
+                        {nextMode === 'position' ? 'Position' : 'Index'}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+                {showSortToggle ? (
+                  <label className={'relative min-w-[150px] flex-1 md:flex-initial'}>
+                    <span className={'sr-only'}>{'Vault ranking'}</span>
+                    <select
+                      value={activeSortDirection}
+                      onChange={(event) =>
+                        handleSortDirectionChange(event.target.value as TPortfolioVaultGrowthChartSortDirection)
+                      }
+                      className={cl(
+                        'h-10 w-full appearance-none rounded-lg border border-border bg-surface-secondary py-2 pr-8 pl-3 md:h-8 md:py-1',
+                        'text-xs font-semibold text-text-primary shadow-inner transition-colors',
+                        'hover:border-text-tertiary focus:border-primary focus:outline-none'
+                      )}
+                      aria-label={'Vault ranking'}
+                    >
+                      {getPortfolioVaultGrowthSortOptions(activeMode).map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                    <IconChevron
+                      className={
+                        'pointer-events-none absolute top-1/2 right-2 size-4 -translate-y-1/2 text-text-secondary'
+                      }
+                    />
+                  </label>
+                ) : null}
               </div>
             ) : null}
           </div>
@@ -741,7 +843,12 @@ export function PortfolioVaultGrowthChart({
               <ChartTooltip
                 cursor={{ stroke: 'var(--chart-cursor-line)', strokeWidth: 1 }}
                 content={(props) => (
-                  <PortfolioVaultGrowthTooltip {...props} mode={activeMode} seriesLabels={seriesLabels} />
+                  <PortfolioVaultGrowthTooltip
+                    {...props}
+                    mode={activeMode}
+                    sortDirection={activeSortDirection}
+                    seriesLabels={seriesLabels}
+                  />
                 )}
               />
               {series.map((vaultSeries) => (

--- a/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
+++ b/src/components/pages/portfolio/components/PortfolioVaultGrowthChart.tsx
@@ -17,14 +17,23 @@ import {
 } from '@pages/vaults/utils/charts'
 import { IconChevron } from '@shared/icons/IconChevron'
 import { cl, formatUSD, SELECTOR_BAR_STYLES } from '@shared/utils'
+import {
+  rankPortfolioVaultGrowthChartSeries,
+  type TPortfolioVaultGrowthChartMode,
+  type TPortfolioVaultGrowthChartSortDirection,
+  type TPortfolioVaultGrowthRankableSeries
+} from '@shared/utils/portfolioVaultGrowth'
 import type { ReactElement } from 'react'
 import { useMemo, useState } from 'react'
 import { CartesianGrid, ComposedChart, Line, XAxis, YAxis } from 'recharts'
 import type { AxisDomain } from 'recharts/types/util/types'
 
-export type TPortfolioVaultGrowthChartMode = 'position' | 'index'
 export type TPortfolioVaultGrowthChartTimeframe = '30d' | '90d' | '1y' | 'all'
-export type TPortfolioVaultGrowthChartSortDirection = 'desc' | 'asc'
+export type {
+  TPortfolioVaultGrowthChartMode,
+  TPortfolioVaultGrowthChartSortDirection,
+  TPortfolioVaultGrowthRankableSeries
+}
 
 const NON_NEGATIVE_AUTO_DOMAIN: AxisDomain = [
   (dataMin: number) => (Number.isFinite(dataMin) && dataMin < 0 ? dataMin : 0),
@@ -147,7 +156,6 @@ const PORTFOLIO_VAULT_GROWTH_CHART_MARGIN = {
   ...CHART_WITH_AXES_MARGIN,
   bottom: 4
 }
-const MIN_RELEVANCE_SCORE = 0.000001
 
 const MODE_COPY: Record<TPortfolioVaultGrowthChartMode, string> = {
   position: 'Shows actual protocol gain from your deposited positions during the selected timeframe.',
@@ -282,65 +290,7 @@ function buildIndexPoints(points: TPortfolioVaultGrowthChartPoint[], indexBase: 
   })
 }
 
-function getFiniteValues(points: Array<{ value: number | null }>): number[] {
-  return points.flatMap((point) => (isFiniteNumber(point.value) ? [point.value] : []))
-}
-
-export type TPortfolioVaultGrowthRankableSeries = {
-  positionPoints: Array<{ value: number | null }>
-  indexPoints: Array<{ value: number | null }>
-}
-
-function getSeriesSortScore(
-  series: TPortfolioVaultGrowthRankableSeries,
-  mode: TPortfolioVaultGrowthChartMode
-): number | null {
-  const points = mode === 'position' ? series.positionPoints : series.indexPoints
-  const finiteValues = getFiniteValues(points)
-
-  if (mode === 'index') {
-    if (finiteValues.length < 2) {
-      return null
-    }
-
-    return (finiteValues.at(-1) ?? 0) - finiteValues[0]
-  }
-
-  if (finiteValues.length < 2) {
-    return null
-  }
-
-  return (finiteValues.at(-1) ?? 0) - finiteValues[0]
-}
-
-export function rankPortfolioVaultGrowthChartSeries<TSeries extends TPortfolioVaultGrowthRankableSeries>(args: {
-  series: TSeries[]
-  mode: TPortfolioVaultGrowthChartMode
-  sortDirection: TPortfolioVaultGrowthChartSortDirection
-  maxVaults?: number
-}): TSeries[] {
-  const directionMultiplier = args.sortDirection === 'desc' ? -1 : 1
-  const rankedSeries = args.series
-    .map((vaultSeries, originalIndex) => ({
-      vaultSeries,
-      originalIndex,
-      score: getSeriesSortScore(vaultSeries, args.mode)
-    }))
-    .filter(
-      (candidate): candidate is { vaultSeries: TSeries; originalIndex: number; score: number } =>
-        candidate.score !== null && Math.abs(candidate.score) > MIN_RELEVANCE_SCORE
-    )
-    .toSorted(
-      (left, right) => (left.score - right.score) * directionMultiplier || left.originalIndex - right.originalIndex
-    )
-
-  const limit =
-    typeof args.maxVaults === 'number' && Number.isFinite(args.maxVaults)
-      ? Math.max(0, Math.floor(args.maxVaults))
-      : rankedSeries.length
-
-  return rankedSeries.slice(0, limit).map((candidate) => candidate.vaultSeries)
-}
+export { rankPortfolioVaultGrowthChartSeries }
 
 function applySeriesPresentation(series: TTransformedSeries[], colors: string[]): TTransformedSeries[] {
   return series.map((vaultSeries, index) => ({
@@ -862,7 +812,6 @@ export function PortfolioVaultGrowthChart({
                   strokeOpacity={0.9}
                   dot={false}
                   activeDot={{ r: 4, strokeWidth: 0, fill: vaultSeries.color }}
-                  connectNulls
                   isAnimationActive={false}
                 />
               ))}

--- a/src/components/pages/portfolio/hooks/usePortfolioHistory.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioHistory.ts
@@ -54,6 +54,7 @@ export function usePortfolioHistory(
       cacheDuration: PORTFOLIO_HISTORY_CACHE_DURATION,
       gcTime: PORTFOLIO_HISTORY_CACHE_DURATION,
       keepPreviousData: false,
+      maxRetries: 0,
       timeout: 2 * 60 * 1000 // 2 minutes for large holdings requests
     }
   })

--- a/src/components/pages/portfolio/hooks/usePortfolioProtocolReturnHistory.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioProtocolReturnHistory.ts
@@ -42,7 +42,8 @@ export function usePortfolioProtocolReturnHistory(timeframe: TPortfolioHistoryTi
       cacheDuration: PORTFOLIO_HISTORY_CACHE_DURATION,
       gcTime: PORTFOLIO_HISTORY_CACHE_DURATION,
       keepPreviousData: false,
-      timeout: 2 * 60 * 1000
+      maxRetries: 0,
+      timeout: 5 * 60 * 1000 // Allow the first cold snapshot to finish and warm Redis.
     }
   })
 

--- a/src/components/pages/portfolio/index.tsx
+++ b/src/components/pages/portfolio/index.tsx
@@ -95,7 +95,10 @@ import {
   PortfolioHistoryChartControls,
   resolvePortfolioGrowthDisplayMode
 } from './components/PortfolioHistoryChart'
-import type { TPortfolioVaultGrowthChartMode } from './components/PortfolioVaultGrowthChart'
+import type {
+  TPortfolioVaultGrowthChartMode,
+  TPortfolioVaultGrowthChartSortDirection
+} from './components/PortfolioVaultGrowthChart'
 import { usePortfolioActivity } from './hooks/usePortfolioActivity'
 import { usePortfolioHistory } from './hooks/usePortfolioHistory'
 import { usePortfolioProtocolReturnHistory } from './hooks/usePortfolioProtocolReturnHistory'
@@ -3021,6 +3024,8 @@ function PortfolioPage(): ReactElement {
     null
   )
   const [historyVaultGrowthMode, setHistoryVaultGrowthMode] = useState<TPortfolioVaultGrowthChartMode>('position')
+  const [historyVaultGrowthSortDirection, setHistoryVaultGrowthSortDirection] =
+    useState<TPortfolioVaultGrowthChartSortDirection>('desc')
   const searchParams = useSearchParams()
   const pathname = usePathname() || '/portfolio'
   const router = useRouter()
@@ -3090,6 +3095,8 @@ function PortfolioPage(): ReactElement {
       onGrowthDisplayModeOverrideChange={setHistoryGrowthDisplayModeOverride}
       vaultGrowthMode={historyVaultGrowthMode}
       onVaultGrowthModeChange={setHistoryVaultGrowthMode}
+      vaultGrowthSortDirection={historyVaultGrowthSortDirection}
+      onVaultGrowthSortDirectionChange={setHistoryVaultGrowthSortDirection}
       balanceIsLoading={model.isHoldingsLoading || historyLoading}
       balanceIsEmpty={historyEmpty}
       balanceError={historyError}

--- a/src/components/pages/portfolio/types/api.ts
+++ b/src/components/pages/portfolio/types/api.ts
@@ -29,9 +29,7 @@ const portfolioProtocolReturnHistorySummarySchema = z.object({
 })
 
 const portfolioProtocolReturnHistoryFamilyPointSchema = z.object({
-  date: z.string(),
   timestamp: z.number(),
-  protocolReturnPct: z.number().nullable(),
   growthWeightUsd: z.number().nullable(),
   growthIndex: z.number().nullable()
 })
@@ -209,9 +207,7 @@ export type TPortfolioProtocolReturnHistoryFamilySeries = Array<{
   symbol: string | null
   status: 'ok' | 'missing_metadata' | 'missing_pps' | 'missing_receipt_price' | 'partial'
   dataPoints: Array<{
-    date: string
     timestamp: number
-    protocolReturnPct: number | null
     growthWeightUsd: number | null
     growthIndex: number | null
   }>

--- a/src/components/shared/utils/portfolioVaultGrowth.ts
+++ b/src/components/shared/utils/portfolioVaultGrowth.ts
@@ -1,0 +1,60 @@
+export type TPortfolioVaultGrowthChartMode = 'position' | 'index'
+export type TPortfolioVaultGrowthChartSortDirection = 'desc' | 'asc'
+
+const MIN_RELEVANCE_SCORE = 0.000001
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function getFiniteValues(points: Array<{ value: number | null }>): number[] {
+  return points.flatMap((point) => (isFiniteNumber(point.value) ? [point.value] : []))
+}
+
+export type TPortfolioVaultGrowthRankableSeries = {
+  positionPoints: Array<{ value: number | null }>
+  indexPoints: Array<{ value: number | null }>
+}
+
+function getSeriesSortScore(
+  series: TPortfolioVaultGrowthRankableSeries,
+  mode: TPortfolioVaultGrowthChartMode
+): number | null {
+  const points = mode === 'position' ? series.positionPoints : series.indexPoints
+  const finiteValues = getFiniteValues(points)
+
+  if (finiteValues.length < 2) {
+    return null
+  }
+
+  return (finiteValues.at(-1) ?? 0) - finiteValues[0]
+}
+
+export function rankPortfolioVaultGrowthChartSeries<TSeries extends TPortfolioVaultGrowthRankableSeries>(args: {
+  series: TSeries[]
+  mode: TPortfolioVaultGrowthChartMode
+  sortDirection: TPortfolioVaultGrowthChartSortDirection
+  maxVaults?: number
+}): TSeries[] {
+  const directionMultiplier = args.sortDirection === 'desc' ? -1 : 1
+  const rankedSeries = args.series
+    .map((vaultSeries, originalIndex) => ({
+      vaultSeries,
+      originalIndex,
+      score: getSeriesSortScore(vaultSeries, args.mode)
+    }))
+    .filter(
+      (candidate): candidate is { vaultSeries: TSeries; originalIndex: number; score: number } =>
+        candidate.score !== null && Math.abs(candidate.score) > MIN_RELEVANCE_SCORE
+    )
+    .toSorted(
+      (left, right) => (left.score - right.score) * directionMultiplier || left.originalIndex - right.originalIndex
+    )
+
+  const limit =
+    typeof args.maxVaults === 'number' && Number.isFinite(args.maxVaults)
+      ? Math.max(0, Math.floor(args.maxVaults))
+      : rankedSeries.length
+
+  return rankedSeries.slice(0, limit).map((candidate) => candidate.vaultSeries)
+}

--- a/src/server/holdings/history.test.ts
+++ b/src/server/holdings/history.test.ts
@@ -88,7 +88,7 @@ describe('holdings history route', () => {
     )
   })
 
-  it('keeps public timeframe while ignoring advanced event-fetch params', async () => {
+  it('uses the requested event fetch type while ignoring advanced pagination mode', async () => {
     getHistoricalHoldingsChartMock.mockResolvedValue({
       address: TEST_WALLET_ADDRESS,
       periodDays: 365,
@@ -113,7 +113,7 @@ describe('holdings history route', () => {
     expect(getHistoricalHoldingsChartMock).toHaveBeenCalledWith(
       TEST_WALLET_ADDRESS,
       'all',
-      'seq',
+      'parallel',
       'paged',
       'eth',
       'all',

--- a/src/server/holdings/history.ts
+++ b/src/server/holdings/history.ts
@@ -123,8 +123,8 @@ export async function GET(request: Request): Promise<Response> {
   const versionParam = queryValue(request, 'version')
   const denominationParam = queryValue(request, 'denomination')
   const timeframeParam = queryValue(request, 'timeframe')
-  // Keep the advanced event-fetch modes in the service layer for now, but do not expose them.
-  // const fetchTypeParam = queryValue(request, 'fetchType')
+  const fetchTypeParam = queryValue(request, 'fetchType')
+  // Keep the advanced pagination mode in the service layer for now, but do not expose it.
   // const paginationModeParam = queryValue(request, 'paginationMode')
   const debugParam = queryValue(request, 'debug')
   const progressIdParam = queryValue(request, 'progressId')
@@ -148,7 +148,7 @@ export async function GET(request: Request): Promise<Response> {
   }
 
   const version: VaultVersion = versionParam === 'v2' || versionParam === 'v3' ? versionParam : 'all'
-  const fetchType = parseHoldingsEventFetchType(undefined)
+  const fetchType = parseHoldingsEventFetchType(fetchTypeParam)
   const paginationMode = parseHoldingsEventPaginationMode(undefined)
   const denomination = parseHoldingsHistoryDenomination(denominationParam)
   const timeframe = parseHoldingsHistoryTimeframe(timeframeParam)

--- a/src/server/holdings/protocol-return/history.test.ts
+++ b/src/server/holdings/protocol-return/history.test.ts
@@ -53,4 +53,20 @@ describe('holdings protocol return history route', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get('Cache-Control')).toBe('private, no-store, max-age=0, must-revalidate')
   })
+
+  it('treats an empty vaults query as an unfiltered request', async () => {
+    const { default: handler } = await import('./history')
+
+    const response = await handler(createRequest({ address: TEST_ADDRESS, vaults: '' }))
+
+    expect(response.status).toBe(200)
+    expect(getHoldingsProtocolReturnHistoryMock).toHaveBeenCalledWith(
+      TEST_ADDRESS,
+      'all',
+      'seq',
+      'paged',
+      '1y',
+      undefined
+    )
+  })
 })

--- a/src/server/holdings/protocol-return/history.ts
+++ b/src/server/holdings/protocol-return/history.ts
@@ -37,6 +37,10 @@ function parseVaultFilters({
       .split(',')
       .map((entry) => entry.trim())
       .filter(Boolean)
+    if (entries.length === 0) {
+      return undefined
+    }
+
     const parsedEntries = entries.map((entry) => {
       const [entryChainId, entryVaultAddress] = entry.split(':')
       const parsedChainId = Number(entryChainId)

--- a/src/server/lib/holdings/README.md
+++ b/src/server/lib/holdings/README.md
@@ -435,6 +435,8 @@ Response:
 
 When a vault filter is present, each history point can also include `currentUnderlying`, `growthUnderlying`, `sharesFormatted`, and `pricePerShare`.
 
+Non-empty settled responses are cached in Redis for up to 24 hours and invalidated lazily when one of their vaults changes. Responses produced after a failed or empty historical-price request, failed Kong PPS request, or retryable metadata fallback failure are returned to the caller but are not cached, so a temporary upstream outage cannot preserve incomplete chart data for the rest of the day.
+
 ### `POST /api/admin/invalidate-cache`
 
 Marks vaults as invalidated so affected user daily totals are lazily cleared and recomputed on the next cached history request. Requires `x-admin-secret: $ADMIN_SECRET` and DB caching.
@@ -521,6 +523,7 @@ Server-side cache is optional. When `UPSTASH_REDIS_REST_URL_PORTFOLIO` or `UPSTA
 
 1. Upstash Redis:
    - `holdings:totals:<addressHash>:<version>`: daily USD totals per hashed user address, vault version, and date. Hash fields are `YYYY-MM-DD`; values include `usdValue` and `updatedAt`.
+   - `holdings:protocol-return-history:v3:<addressHash>:<version>:<timeframe>:<vaultScope>`: successful non-empty protocol-return history snapshots. The payload includes its settled date and relevant vault identifiers for invalidation checks.
    - `holdings:vault-invalidated:<chainId>:<vaultAddress>`: per-vault invalidation timestamps for lazy cache clearing.
    - `holdings:progress:<progressId>`: authoritative short-lived progress records keyed by caller-supplied progress ID for long history requests across Vercel function instances.
 2. HTTP cache:
@@ -543,6 +546,14 @@ Cache behavior:
 - If any relevant vault was invalidated after the oldest cached row was written, the user's cached totals for that version are cleared and recomputed.
 - Recalculated totals are not cached when any token price batch failed, because partial price data can undercount chart totals.
 
+### Protocol Return History Snapshots
+
+- Protocol-return history is path-dependent, so the cache stores an atomic response snapshot instead of independent daily points.
+- Cache keys use the normalized wallet hash plus version, timeframe, and a hashed vault scope. A calculation-version prefix prevents incompatible response logic from reusing older snapshots.
+- Snapshots expire after 24 hours, must match the current settled date, and are rejected when any stored vault invalidation marker is newer than the calculation start.
+- Successful non-empty responses are cached even when some vault histories are partial; empty responses are not cached.
+- Identical requests in the same server process share one in-flight calculation.
+
 ### Progress
 
 - Progress writes only when Redis persistence is enabled and the supplied `progressId` matches `[a-zA-Z0-9:_-]{1,160}`.
@@ -559,6 +570,7 @@ No schema migration is required. Redis keys are created lazily:
 | Key | Type | TTL | Purpose |
 |-----|------|-----|---------|
 | `holdings:totals:<addressHash>:<version>` | Hash | 30 days from write | Daily holdings chart totals. |
+| `holdings:protocol-return-history:v3:<addressHash>:<version>:<timeframe>:<vaultScope>` | String JSON | 24 hours | Atomic protocol-return history response snapshot. |
 | `holdings:vault-invalidated:<chainId>:<vaultAddress>` | String timestamp | None | Lazy invalidation marker for totals cache. |
 | `holdings:progress:<progressId>` | String JSON record | 10 minutes | Progress polling state for long requests. |
 

--- a/src/server/lib/holdings/services/aggregator.test.ts
+++ b/src/server/lib/holdings/services/aggregator.test.ts
@@ -43,7 +43,9 @@ vi.mock('./holdings', () => ({
 }))
 
 vi.mock('./vaults', () => ({
-  fetchMultipleVaultsMetadata: fetchMultipleVaultsMetadataMock
+  fetchMultipleVaultsMetadata: fetchMultipleVaultsMetadataMock,
+  getVaultMetadataFetchFailedVaults: vi.fn(() => 0),
+  markVaultMetadataFetchFailures: vi.fn((metadata: Map<unknown, unknown>) => metadata)
 }))
 
 vi.mock('./kong', () => ({

--- a/src/server/lib/holdings/services/cache.test.ts
+++ b/src/server/lib/holdings/services/cache.test.ts
@@ -64,3 +64,139 @@ describe('Redis cache writes', () => {
     expect(result.oldestUpdatedAt?.getTime()).toBe(2000)
   })
 })
+
+describe('protocol return history snapshot cache', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it('stores a versioned wallet snapshot without exposing the wallet address in the key', async () => {
+    const setMock = vi.fn().mockResolvedValue('OK')
+    isHoldingsStorageEnabledMock.mockReturnValue(true)
+    getHoldingsRedisClientMock.mockReturnValue({ set: setMock })
+
+    const { getProtocolReturnHistoryCacheKey, saveCachedProtocolReturnHistory } = await import('./cache')
+    const identity = {
+      userAddress: '0x0000000000000000000000000000000000000001',
+      version: 'all',
+      timeframe: '1y'
+    }
+    const response = { summary: { isComplete: true }, dataPoints: [{ date: '2026-07-15' }] }
+    const saved = await saveCachedProtocolReturnHistory(
+      identity,
+      '2026-07-15',
+      [{ address: '0x00000000000000000000000000000000000000A1', chainId: 1 }],
+      response,
+      1234
+    )
+    const key = getProtocolReturnHistoryCacheKey(identity)
+
+    expect(saved).toBe(true)
+    expect(key).toMatch(/^holdings:protocol-return-history:v3:[a-f0-9]{64}:all:1y:all$/)
+    expect(key).not.toContain(identity.userAddress)
+    expect(setMock).toHaveBeenCalledWith(
+      key,
+      JSON.stringify({
+        settledDate: '2026-07-15',
+        updatedAt: 1234,
+        vaults: [{ address: '0x00000000000000000000000000000000000000a1', chainId: 1 }],
+        response
+      }),
+      { ex: 24 * 60 * 60 }
+    )
+  })
+
+  it('builds a stable hashed key for filtered vault scopes', async () => {
+    const { getProtocolReturnHistoryCacheKey } = await import('./cache')
+    const identity = {
+      userAddress: '0x0000000000000000000000000000000000000001',
+      version: 'all',
+      timeframe: '1y',
+      vaultScope: [
+        { address: '0x00000000000000000000000000000000000000b2', chainId: 10 },
+        { address: '0x00000000000000000000000000000000000000A1', chainId: 1 }
+      ]
+    }
+    const reversedIdentity = { ...identity, vaultScope: [...identity.vaultScope].reverse() }
+    const key = getProtocolReturnHistoryCacheKey(identity)
+
+    expect(key).toBe(getProtocolReturnHistoryCacheKey(reversedIdentity))
+    expect(key).toMatch(/^holdings:protocol-return-history:v3:[a-f0-9]{64}:all:1y:[a-f0-9]{64}$/)
+    expect(key).not.toContain(identity.vaultScope[0].address)
+  })
+
+  it('returns a current snapshot after checking vault invalidation markers with the supported array signature', async () => {
+    const getMock = vi.fn().mockResolvedValue({
+      settledDate: '2026-07-15',
+      updatedAt: 2000,
+      vaults: [{ address: '0x00000000000000000000000000000000000000a1', chainId: 1 }],
+      response: { dataPoints: [{ date: '2026-07-15' }] }
+    })
+    const mgetMock = vi.fn().mockResolvedValue([null])
+    isHoldingsStorageEnabledMock.mockReturnValue(true)
+    getHoldingsRedisClientMock.mockReturnValue({ get: getMock, mget: mgetMock })
+
+    const { getCachedProtocolReturnHistory } = await import('./cache')
+    const response = await getCachedProtocolReturnHistory<{ dataPoints: Array<{ date: string }> }>(
+      {
+        userAddress: '0x0000000000000000000000000000000000000001',
+        version: 'all',
+        timeframe: '1y'
+      },
+      '2026-07-15'
+    )
+
+    expect(response).toEqual({ dataPoints: [{ date: '2026-07-15' }] })
+    expect(mgetMock).toHaveBeenCalledWith(['holdings:vault-invalidated:1:0x00000000000000000000000000000000000000a1'])
+  })
+
+  it('misses snapshots from a different settled day before checking invalidations', async () => {
+    const getMock = vi.fn().mockResolvedValue({
+      settledDate: '2026-07-14',
+      updatedAt: 2000,
+      vaults: [{ address: '0x00000000000000000000000000000000000000a1', chainId: 1 }],
+      response: { dataPoints: [] }
+    })
+    const mgetMock = vi.fn()
+    isHoldingsStorageEnabledMock.mockReturnValue(true)
+    getHoldingsRedisClientMock.mockReturnValue({ get: getMock, mget: mgetMock })
+
+    const { getCachedProtocolReturnHistory } = await import('./cache')
+    const response = await getCachedProtocolReturnHistory(
+      {
+        userAddress: '0x0000000000000000000000000000000000000001',
+        version: 'all',
+        timeframe: '1y'
+      },
+      '2026-07-15'
+    )
+
+    expect(response).toBeNull()
+    expect(mgetMock).not.toHaveBeenCalled()
+  })
+
+  it('misses snapshots invalidated after their calculation started', async () => {
+    const getMock = vi.fn().mockResolvedValue({
+      settledDate: '2026-07-15',
+      updatedAt: 2000,
+      vaults: [{ address: '0x00000000000000000000000000000000000000a1', chainId: 1 }],
+      response: { dataPoints: [] }
+    })
+    const mgetMock = vi.fn().mockResolvedValue([3000])
+    isHoldingsStorageEnabledMock.mockReturnValue(true)
+    getHoldingsRedisClientMock.mockReturnValue({ get: getMock, mget: mgetMock })
+
+    const { getCachedProtocolReturnHistory } = await import('./cache')
+    const response = await getCachedProtocolReturnHistory(
+      {
+        userAddress: '0x0000000000000000000000000000000000000001',
+        version: 'all',
+        timeframe: '1y'
+      },
+      '2026-07-15'
+    )
+
+    expect(response).toBeNull()
+  })
+})

--- a/src/server/lib/holdings/services/cache.ts
+++ b/src/server/lib/holdings/services/cache.ts
@@ -30,8 +30,25 @@ export interface VaultIdentifier {
 
 const HOLDINGS_TOTALS_TTL_SECONDS = 30 * 24 * 60 * 60
 const HOLDINGS_TOTALS_KEY_PREFIX = 'holdings:totals'
+// Settled snapshots remain valid through the day; the settled-date guard rolls them over on the next day.
+const PROTOCOL_RETURN_HISTORY_TTL_SECONDS = 24 * 60 * 60
+const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v3'
 const VAULT_INVALIDATION_KEY_PREFIX = 'holdings:vault-invalidated'
 const REDIS_SCAN_COUNT = 500
+
+export interface ProtocolReturnHistoryCacheIdentity {
+  userAddress: string
+  version: string
+  timeframe: string
+  vaultScope?: VaultIdentifier[]
+}
+
+interface CachedProtocolReturnHistoryPayload<TResponse> {
+  settledDate: string
+  updatedAt: number
+  vaults: VaultIdentifier[]
+  response: TResponse
+}
 
 function normalizeUserAddress(userAddress: string): string {
   return userAddress.toLowerCase()
@@ -47,6 +64,25 @@ function getTotalsKey(userAddressHash: string, version: string): string {
 
 function getTotalsKeyPattern(userAddressHash: string): string {
   return `${HOLDINGS_TOTALS_KEY_PREFIX}:${userAddressHash}:*`
+}
+
+function getVaultScopeCacheKey(vaultScope?: VaultIdentifier[]): string {
+  if (!vaultScope?.length) {
+    return 'all'
+  }
+
+  const normalizedScope = Array.from(
+    new Set(vaultScope.map((vault) => `${vault.chainId}:${vault.address.toLowerCase()}`))
+  )
+    .sort()
+    .join(',')
+  return createHash('sha256').update(normalizedScope).digest('hex')
+}
+
+export function getProtocolReturnHistoryCacheKey(identity: ProtocolReturnHistoryCacheIdentity): string {
+  const userAddressHash = getUserAddressCacheKey(identity.userAddress)
+  const vaultScopeKey = getVaultScopeCacheKey(identity.vaultScope)
+  return `${PROTOCOL_RETURN_HISTORY_KEY_PREFIX}:${userAddressHash}:${identity.version}:${identity.timeframe}:${vaultScopeKey}`
 }
 
 function getVaultInvalidationKey(vault: VaultIdentifier): string {
@@ -80,6 +116,47 @@ function parseCachedTotalPayload(value: unknown): CachedTotalPayload | null {
   }
 
   return { usdValue, updatedAt }
+}
+
+function parseVaultIdentifier(value: unknown): VaultIdentifier | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+
+  const candidate = value as Partial<VaultIdentifier>
+  return typeof candidate.address === 'string' && Number.isInteger(candidate.chainId)
+    ? { address: candidate.address, chainId: Number(candidate.chainId) }
+    : null
+}
+
+function parseCachedProtocolReturnHistoryPayload<TResponse>(
+  value: unknown
+): CachedProtocolReturnHistoryPayload<TResponse> | null {
+  const parsed = parseJsonValue(value)
+  if (!parsed || typeof parsed !== 'object') {
+    return null
+  }
+
+  const payload = parsed as Partial<CachedProtocolReturnHistoryPayload<TResponse>>
+  const updatedAt = Number(payload.updatedAt)
+  const vaults = Array.isArray(payload.vaults) ? payload.vaults.map(parseVaultIdentifier) : []
+
+  if (
+    typeof payload.settledDate !== 'string' ||
+    !Number.isFinite(updatedAt) ||
+    !Array.isArray(payload.vaults) ||
+    vaults.some((vault) => vault === null) ||
+    !('response' in payload)
+  ) {
+    return null
+  }
+
+  return {
+    settledDate: payload.settledDate,
+    updatedAt,
+    vaults: vaults.filter((vault): vault is VaultIdentifier => vault !== null),
+    response: payload.response as TResponse
+  }
 }
 
 function isDateInRange(date: string, startDate: string, endDate: string): boolean {
@@ -170,6 +247,94 @@ export async function saveCachedTotals(userAddress: string, version: string, tot
   } catch (error) {
     handleHoldingsRedisError('cached totals save failed', error)
     debugError('cache', 'cached totals save failed', error, { rows: totals.length })
+    return false
+  }
+}
+
+export async function getCachedProtocolReturnHistory<TResponse>(
+  identity: ProtocolReturnHistoryCacheIdentity,
+  settledDate: string
+): Promise<TResponse | null> {
+  if (!isHoldingsStorageEnabled()) {
+    debugLog('cache', 'skipping protocol return history cache lookup because Redis storage is disabled')
+    return null
+  }
+
+  const redis = getHoldingsRedisClient()
+  if (!redis) {
+    debugLog('cache', 'skipping protocol return history cache lookup because Redis client is unavailable')
+    return null
+  }
+
+  const key = getProtocolReturnHistoryCacheKey(identity)
+
+  try {
+    const payload = parseCachedProtocolReturnHistoryPayload<TResponse>(await redis.get(key))
+    if (!payload) {
+      debugLog('cache', 'protocol return history cache miss', { key })
+      return null
+    }
+
+    if (payload.settledDate !== settledDate) {
+      debugLog('cache', 'protocol return history cache settled date mismatch', {
+        key,
+        cachedSettledDate: payload.settledDate,
+        requestedSettledDate: settledDate
+      })
+      return null
+    }
+
+    const isStale = await checkCacheStaleness(payload.vaults, new Date(payload.updatedAt))
+    if (isStale) {
+      debugLog('cache', 'protocol return history cache is stale', { key, vaults: payload.vaults.length })
+      return null
+    }
+
+    debugLog('cache', 'protocol return history cache hit', { key, vaults: payload.vaults.length })
+    return payload.response
+  } catch (error) {
+    handleHoldingsRedisError('protocol return history cache lookup failed', error)
+    debugError('cache', 'protocol return history cache lookup failed', error, { key })
+    return null
+  }
+}
+
+export async function saveCachedProtocolReturnHistory<TResponse>(
+  identity: ProtocolReturnHistoryCacheIdentity,
+  settledDate: string,
+  vaults: VaultIdentifier[],
+  response: TResponse,
+  updatedAt = Date.now()
+): Promise<boolean> {
+  if (!isHoldingsStorageEnabled()) {
+    debugLog('cache', 'skipping protocol return history cache save because Redis storage is disabled')
+    return false
+  }
+
+  const redis = getHoldingsRedisClient()
+  if (!redis) {
+    debugLog('cache', 'skipping protocol return history cache save because Redis client is unavailable')
+    return false
+  }
+
+  const key = getProtocolReturnHistoryCacheKey(identity)
+
+  try {
+    const payload: CachedProtocolReturnHistoryPayload<TResponse> = {
+      settledDate,
+      updatedAt,
+      vaults: vaults.map((vault) => ({
+        address: vault.address.toLowerCase(),
+        chainId: vault.chainId
+      })),
+      response
+    }
+    await redis.set(key, JSON.stringify(payload), { ex: PROTOCOL_RETURN_HISTORY_TTL_SECONDS })
+    debugLog('cache', 'saved protocol return history snapshot to Redis', { key, vaults: vaults.length })
+    return true
+  } catch (error) {
+    handleHoldingsRedisError('protocol return history cache save failed', error)
+    debugError('cache', 'protocol return history cache save failed', error, { key, vaults: vaults.length })
     return false
   }
 }

--- a/src/server/lib/holdings/services/debug.test.ts
+++ b/src/server/lib/holdings/services/debug.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const appendHoldingsProgressLogMock = vi.fn()
+const updateHoldingsProgressMock = vi.fn()
+
+vi.mock('@/server/lib/holdings/services/progress', () => ({
+  appendHoldingsProgressLog: appendHoldingsProgressLogMock,
+  updateHoldingsProgress: updateHoldingsProgressMock
+}))
+
+describe('holdings debug context', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    appendHoldingsProgressLogMock.mockResolvedValue(undefined)
+    updateHoldingsProgressMock.mockResolvedValue(undefined)
+  })
+
+  it('skips verbose progress logs unless debug is enabled', async () => {
+    const { createHoldingsDebugContext, debugLog, withHoldingsDebugContext } = await import(
+      '@/server/lib/holdings/services/debug'
+    )
+    const context = createHoldingsDebugContext('history', '0x0000000000000000000000000000000000000001', false, {
+      progressId: 'portfolio:test'
+    })
+
+    await withHoldingsDebugContext(context, async () => {
+      debugLog('prices', 'fetched price batch')
+    })
+
+    expect(appendHoldingsProgressLogMock).not.toHaveBeenCalled()
+  })
+
+  it('flushes reported progress before leaving the request context', async () => {
+    const pendingUpdate: { resolve?: () => void } = {}
+    updateHoldingsProgressMock.mockReturnValue(
+      new Promise<void>((resolve) => {
+        pendingUpdate.resolve = resolve
+      })
+    )
+    const { createHoldingsDebugContext, reportHoldingsProgress, withHoldingsDebugContext } = await import(
+      '@/server/lib/holdings/services/debug'
+    )
+    const context = createHoldingsDebugContext(
+      'protocol-return-history',
+      '0x0000000000000000000000000000000000000001',
+      false,
+      { progressId: 'portfolio:test' }
+    )
+    const request = withHoldingsDebugContext(context, async () => {
+      reportHoldingsProgress(92, 'Built historical chart series')
+      return 'done'
+    })
+    const requestState = { settled: false }
+    void request.finally(() => {
+      requestState.settled = true
+    })
+
+    await vi.waitFor(() => expect(updateHoldingsProgressMock).toHaveBeenCalledTimes(1))
+    expect(requestState.settled).toBe(false)
+    pendingUpdate.resolve?.()
+
+    await expect(request).resolves.toBe('done')
+    expect(requestState.settled).toBe(true)
+  })
+})

--- a/src/server/lib/holdings/services/debug.ts
+++ b/src/server/lib/holdings/services/debug.ts
@@ -11,6 +11,7 @@ export interface HoldingsDebugContext {
   vaultFilter: string | null
   txFilter: string | null
   progressId: string | null
+  pendingProgressWrites: Promise<void>[]
 }
 
 const storage = new AsyncLocalStorage<HoldingsDebugContext>()
@@ -52,12 +53,19 @@ export function createHoldingsDebugContext(
     lotsEnabled: options?.lotsEnabled ?? false,
     vaultFilter: options?.vaultFilter?.toLowerCase() ?? null,
     txFilter: options?.txFilter?.toLowerCase() ?? null,
-    progressId: options?.progressId ?? null
+    progressId: options?.progressId ?? null,
+    pendingProgressWrites: []
   }
 }
 
 export async function withHoldingsDebugContext<T>(context: HoldingsDebugContext, fn: () => Promise<T>): Promise<T> {
-  return storage.run(context, fn)
+  return storage.run(context, async () => {
+    try {
+      return await fn()
+    } finally {
+      await Promise.allSettled(context.pendingProgressWrites)
+    }
+  })
 }
 
 export function getHoldingsDebugContext(): HoldingsDebugContext | undefined {
@@ -81,23 +89,25 @@ export function getHoldingsDebugFilters(): {
 export function debugLog(scope: string, message: string, payload?: Record<string, unknown>): void {
   const context = getHoldingsDebugContext()
 
-  if (!context) {
+  if (!context?.enabled) {
     return
   }
 
   const elapsedMs = Date.now() - context.startedAt
-  void appendHoldingsProgressLog(context.progressId, { elapsedMs, scope, message })
-
-  if (!context.enabled) {
-    return
-  }
+  context.pendingProgressWrites.push(appendHoldingsProgressLog(context.progressId, { elapsedMs, scope, message }))
 
   console.log(`[HoldingsDebug][${context.requestId}][+${elapsedMs}ms][${scope}] ${message}${formatPayload(payload)}`)
 }
 
 export function reportHoldingsProgress(progress: number, message: string, detail?: string | null): void {
   const context = getHoldingsDebugContext()
-  void updateHoldingsProgress(context?.progressId, { progress, message, detail: detail ?? null })
+  if (!context) {
+    return
+  }
+
+  context.pendingProgressWrites.push(
+    updateHoldingsProgress(context.progressId, { progress, message, detail: detail ?? null })
+  )
 }
 
 export function debugError(scope: string, message: string, error: unknown, payload?: Record<string, unknown>): void {

--- a/src/server/lib/holdings/services/graphql.test.ts
+++ b/src/server/lib/holdings/services/graphql.test.ts
@@ -13,6 +13,29 @@ function createGraphqlResponse(data: Record<string, unknown>): Response {
   })
 }
 
+function createInMemoryGraphqlResponse(data: Record<string, unknown>): Response {
+  return {
+    ok: true,
+    json: async () => ({ data })
+  } as unknown as Response
+}
+
+function createTransferEvent(id: string, blockNumber: number) {
+  return {
+    id,
+    vaultAddress: VAULT,
+    chainId: 1,
+    blockNumber,
+    blockTimestamp: 200 + blockNumber,
+    logIndex: blockNumber,
+    transactionHash: `${TX_HASH}-${id}`,
+    transactionFrom: ROUTER,
+    sender: ROUTER,
+    receiver: USER,
+    value: '900'
+  }
+}
+
 function getEmptyResultKey(query: string): string {
   return query.includes('V2Deposit')
     ? 'V2Deposit'
@@ -36,36 +59,10 @@ describe('fetchUserEvents', () => {
     vi.unstubAllGlobals()
   })
 
-  it('falls back to sequential pagination when aggregate counts are unavailable', async () => {
-    const transferBatches = [
-      Array.from({ length: 1000 }, (_, index) => ({
-        id: `aggregate-transfer-in-${index}`,
-        vaultAddress: VAULT,
-        chainId: 1,
-        blockNumber: index + 1,
-        blockTimestamp: 200 + index,
-        logIndex: index,
-        transactionHash: `${TX_HASH}-${index}`,
-        transactionFrom: ROUTER,
-        sender: ROUTER,
-        receiver: USER,
-        value: '900'
-      })),
-      [
-        {
-          id: 'aggregate-transfer-in-last',
-          vaultAddress: VAULT,
-          chainId: 1,
-          blockNumber: 1001,
-          blockTimestamp: 1201,
-          logIndex: 1000,
-          transactionHash: `${TX_HASH}-last`,
-          transactionFrom: ROUTER,
-          sender: ROUTER,
-          receiver: USER,
-          value: '900'
-        }
-      ]
+  it('falls back to one count-free bulk page when aggregate counts are unavailable', async () => {
+    const transferEvents = [
+      createTransferEvent('aggregate-transfer-in-first', 1),
+      createTransferEvent('aggregate-transfer-in-last', 2)
     ]
 
     const fetchStub = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
@@ -89,11 +86,11 @@ describe('fetchUserEvents', () => {
       }
 
       if (query.includes('GetTransfersIn')) {
-        const offset = Number(variables.offset ?? 0)
-        const batch = offset === 0 ? transferBatches[0] : offset === 1000 ? transferBatches[1] : []
+        expect(variables.limit).toBe(50000)
+        expect(variables.offset).toBe(0)
 
         return createGraphqlResponse({
-          Transfer: batch
+          Transfer: transferEvents
         })
       }
 
@@ -115,13 +112,13 @@ describe('fetchUserEvents', () => {
     const { fetchUserEvents } = await importGraphqlModule()
     const events = await fetchUserEvents(USER, 'all', undefined, 'parallel')
 
-    expect(events.transfersIn).toHaveLength(1001)
+    expect(events.transfersIn).toHaveLength(2)
     expect(events.transfersIn[0]).toEqual(
       expect.objectContaining({
-        id: 'aggregate-transfer-in-0'
+        id: 'aggregate-transfer-in-first'
       })
     )
-    expect(events.transfersIn[1000]).toEqual(
+    expect(events.transfersIn[1]).toEqual(
       expect.objectContaining({
         id: 'aggregate-transfer-in-last'
       })
@@ -136,7 +133,69 @@ describe('fetchUserEvents', () => {
       fetchStub.mock.calls.filter(([, init]) =>
         String((init as RequestInit | undefined)?.body ?? '').includes('GetTransfersIn')
       )
-    ).toHaveLength(2)
+    ).toHaveLength(1)
+  })
+
+  it('continues count-free bulk pagination when a page reaches the single-query limit', async () => {
+    const firstTransfer = createTransferEvent('bulk-transfer-in-first', 1)
+    const finalTransfer = createTransferEvent('bulk-transfer-in-final', 2)
+    const fullPage = Array.from({ length: 50000 }, () => firstTransfer)
+
+    const fetchStub = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}')) as {
+        query: string
+        variables: Record<string, unknown>
+      }
+      const query = body.query
+      const variables = body.variables
+
+      if (query.includes('GetUserEventCountsAggregate')) {
+        return new Response(
+          JSON.stringify({
+            errors: [{ message: "field 'Deposit_aggregate' not found in type: 'query_root'" }]
+          }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' }
+          }
+        )
+      }
+
+      if (query.includes('GetTransfersIn')) {
+        const offset = Number(variables.offset ?? 0)
+
+        return createInMemoryGraphqlResponse({
+          Transfer: offset === 0 ? fullPage : offset === 50000 ? [finalTransfer] : []
+        })
+      }
+
+      if (
+        query.includes('GetDeposits(') ||
+        query.includes('GetWithdrawals(') ||
+        query.includes('GetTransfersOut') ||
+        query.includes('GetV2Deposits(') ||
+        query.includes('GetV2Withdrawals(')
+      ) {
+        return createGraphqlResponse({ [getEmptyResultKey(query)]: [] })
+      }
+
+      throw new Error(`Unexpected query: ${query}`)
+    })
+
+    vi.stubGlobal('fetch', fetchStub)
+
+    const { fetchUserEvents } = await importGraphqlModule()
+    const events = await fetchUserEvents(USER, 'all', undefined, 'parallel')
+    const transferRequests = fetchStub.mock.calls
+      .map(([, init]) => JSON.parse(String((init as RequestInit | undefined)?.body ?? '{}')))
+      .filter(({ query }) => String(query).includes('GetTransfersIn'))
+
+    expect(events.transfersIn).toHaveLength(50001)
+    expect(events.transfersIn[50000]).toEqual(expect.objectContaining({ id: 'bulk-transfer-in-final' }))
+    expect(transferRequests).toEqual([
+      expect.objectContaining({ variables: expect.objectContaining({ limit: 50000, offset: 0 }) }),
+      expect.objectContaining({ variables: expect.objectContaining({ limit: 50000, offset: 50000 }) })
+    ])
   })
 
   it('supports fetching address events in a single query without aggregate preflight', async () => {

--- a/src/server/lib/holdings/services/graphql.ts
+++ b/src/server/lib/holdings/services/graphql.ts
@@ -480,7 +480,7 @@ async function fetchUserCounts(userAddress: string, maxTimestamp?: number): Prom
   } catch (error) {
     debugError(
       'graphql',
-      'aggregate user event counts fetch failed, falling back to sequential event pagination',
+      'aggregate user event counts fetch failed, falling back to count-free bulk event pagination',
       error,
       {
         address: addressLower,
@@ -915,6 +915,53 @@ function getSequentialAddressEventFetches(addressLower: string, maxTimestamp?: n
   ]
 }
 
+async function fetchSingleQueryPage<T>(
+  query: string,
+  variableKey: string,
+  address: string,
+  resultKey: string,
+  offset: number,
+  maxTimestamp?: number
+): Promise<T[]> {
+  const ts = maxTimestamp ?? DEFAULT_MAX_TIMESTAMP
+  const startedAt = Date.now()
+  const variables: Record<string, unknown> = {
+    [variableKey]: address,
+    limit: SINGLE_QUERY_LIMIT,
+    offset,
+    maxTimestamp: ts
+  }
+
+  try {
+    const data = await executeQuery<Record<string, T[]>>(query, variables)
+    const results = data[resultKey] || []
+
+    debugLog('graphql', 'fetched single-query event page', {
+      resultKey,
+      variableKey,
+      address,
+      count: results.length,
+      durationMs: Date.now() - startedAt,
+      maxTimestamp: ts,
+      limit: SINGLE_QUERY_LIMIT,
+      offset,
+      hasMore: results.length === SINGLE_QUERY_LIMIT
+    })
+
+    return results
+  } catch (error) {
+    debugError('graphql', 'single-query event page fetch failed', error, {
+      resultKey,
+      variableKey,
+      address,
+      maxTimestamp: ts,
+      limit: SINGLE_QUERY_LIMIT,
+      offset
+    })
+    throw error
+  }
+}
+
 async function fetchAllSingleQuery<T>(
   query: string,
   variableKey: string,
@@ -924,16 +971,19 @@ async function fetchAllSingleQuery<T>(
 ): Promise<T[]> {
   const ts = maxTimestamp ?? DEFAULT_MAX_TIMESTAMP
   const startedAt = Date.now()
-  const variables: Record<string, unknown> = {
-    [variableKey]: address,
-    limit: SINGLE_QUERY_LIMIT,
-    offset: 0,
-    maxTimestamp: ts
+  const fetchFromOffset = async (offset: number): Promise<T[]> => {
+    const page = await fetchSingleQueryPage<T>(query, variableKey, address, resultKey, offset, maxTimestamp)
+
+    if (page.length < SINGLE_QUERY_LIMIT) {
+      return page
+    }
+
+    const remaining = await fetchFromOffset(offset + SINGLE_QUERY_LIMIT)
+    return [...page, ...remaining]
   }
 
   try {
-    const data = await executeQuery<Record<string, T[]>>(query, variables)
-    const results = data[resultKey] || []
+    const results = await fetchFromOffset(0)
 
     debugLog('graphql', 'fetched single-query event set', {
       resultKey,
@@ -943,7 +993,7 @@ async function fetchAllSingleQuery<T>(
       durationMs: Date.now() - startedAt,
       maxTimestamp: ts,
       limit: SINGLE_QUERY_LIMIT,
-      possibleTruncation: results.length === SINGLE_QUERY_LIMIT
+      pages: Math.ceil((results.length + 1) / SINGLE_QUERY_LIMIT)
     })
 
     return results
@@ -957,6 +1007,17 @@ async function fetchAllSingleQuery<T>(
     })
     throw error
   }
+}
+
+function getSingleQueryAddressEventFetches(addressLower: string, maxTimestamp?: number): AddressEventFetches {
+  return [
+    fetchAllSingleQuery<DepositEvent>(DEPOSITS_QUERY, 'owner', addressLower, 'Deposit', maxTimestamp),
+    fetchAllSingleQuery<WithdrawEvent>(WITHDRAWALS_QUERY, 'owner', addressLower, 'Withdraw', maxTimestamp),
+    fetchAllSingleQuery<V2DepositEvent>(V2_DEPOSITS_QUERY, 'recipient', addressLower, 'V2Deposit', maxTimestamp),
+    fetchAllSingleQuery<V2WithdrawEvent>(V2_WITHDRAWALS_QUERY, 'recipient', addressLower, 'V2Withdraw', maxTimestamp),
+    fetchAllSingleQuery<TransferEvent>(TRANSFERS_IN_QUERY, 'receiver', addressLower, 'Transfer', maxTimestamp),
+    fetchAllSingleQuery<TransferEvent>(TRANSFERS_OUT_QUERY, 'sender', addressLower, 'Transfer', maxTimestamp)
+  ]
 }
 
 async function fetchRecentLimited<T>(
@@ -1072,14 +1133,7 @@ async function fetchAddressScopedEventsUncached(
   paginationMode: HoldingsEventPaginationMode
 ): Promise<AddressEventResults> {
   if (paginationMode === 'all') {
-    return Promise.all([
-      fetchAllSingleQuery<DepositEvent>(DEPOSITS_QUERY, 'owner', addressLower, 'Deposit', maxTimestamp),
-      fetchAllSingleQuery<WithdrawEvent>(WITHDRAWALS_QUERY, 'owner', addressLower, 'Withdraw', maxTimestamp),
-      fetchAllSingleQuery<V2DepositEvent>(V2_DEPOSITS_QUERY, 'recipient', addressLower, 'V2Deposit', maxTimestamp),
-      fetchAllSingleQuery<V2WithdrawEvent>(V2_WITHDRAWALS_QUERY, 'recipient', addressLower, 'V2Withdraw', maxTimestamp),
-      fetchAllSingleQuery<TransferEvent>(TRANSFERS_IN_QUERY, 'receiver', addressLower, 'Transfer', maxTimestamp),
-      fetchAllSingleQuery<TransferEvent>(TRANSFERS_OUT_QUERY, 'sender', addressLower, 'Transfer', maxTimestamp)
-    ]) as Promise<AddressEventResults>
+    return Promise.all(getSingleQueryAddressEventFetches(addressLower, maxTimestamp)) as Promise<AddressEventResults>
   }
 
   if (fetchType === 'seq') {
@@ -1089,7 +1143,7 @@ async function fetchAddressScopedEventsUncached(
   const counts = await fetchUserCounts(addressLower, maxTimestamp)
   const fetches =
     counts === null
-      ? getSequentialAddressEventFetches(addressLower, maxTimestamp)
+      ? getSingleQueryAddressEventFetches(addressLower, maxTimestamp)
       : getParallelAddressEventFetches(addressLower, counts, maxTimestamp)
 
   return Promise.all(fetches) as Promise<AddressEventResults>

--- a/src/server/lib/holdings/services/kong.test.ts
+++ b/src/server/lib/holdings/services/kong.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { fetchMultipleVaultsPPS, getPPS } from './kong'
+import { fetchMultipleVaultsPPS, getPPS, getPpsFetchFailedVaults } from './kong'
 
 function createResponse(points: Array<{ time: number; value: string }>): Response {
   return new Response(JSON.stringify(points.map((point) => ({ ...point, component: 'pps' }))), {
@@ -112,5 +112,18 @@ describe('fetchMultipleVaultsPPS', () => {
     expect(fetchFn).toHaveBeenCalledTimes(1)
     expect(first.get('1:0xabc')?.get(100)).toBe(1.2)
     expect(second.get('1:0xabc')?.get(100)).toBe(1.2)
+  })
+
+  it('reports PPS requests that still fail after retries', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const fetchFn = vi.fn().mockRejectedValue(new Error('permanent failure')) as typeof fetch
+
+    const timelines = await fetchMultipleVaultsPPS([{ chainId: 1, vaultAddress: '0xABC' }], {
+      fetchFn,
+      maxRetries: 0
+    })
+
+    expect(timelines.get('1:0xabc')).toEqual(new Map())
+    expect(getPpsFetchFailedVaults(timelines)).toBe(1)
   })
 })

--- a/src/server/lib/holdings/services/kong.ts
+++ b/src/server/lib/holdings/services/kong.ts
@@ -4,6 +4,16 @@ import { debugError, debugLog } from './debug'
 
 export type PPSTimeline = Map<number, number>
 
+const PPS_FETCH_FAILED_VAULTS = Symbol('ppsFetchFailedVaults')
+
+type TPpsFetchResult = Map<string, PPSTimeline> & {
+  [PPS_FETCH_FAILED_VAULTS]?: number
+}
+
+export function getPpsFetchFailedVaults(ppsData: Map<string, PPSTimeline>): number {
+  return (ppsData as TPpsFetchResult)[PPS_FETCH_FAILED_VAULTS] ?? 0
+}
+
 type TFetchLike = typeof fetch
 
 type TKongFetchOptions = {
@@ -190,7 +200,7 @@ export async function fetchMultipleVaultsPPS(
     maxRetries: getMaxRetries(options)
   })
   const results = await chunkVaults(uniqueVaults, getConcurrency(options)).reduce<
-    Promise<Array<{ key: string; timeline: PPSTimeline }>>
+    Promise<Array<{ key: string; timeline: PPSTimeline; failed: boolean }>>
   >(async (allResultsPromise, batch) => {
     const allResults = await allResultsPromise
     const batchResults = await Promise.all(
@@ -198,11 +208,11 @@ export async function fetchMultipleVaultsPPS(
         const key = `${chainId}:${vaultAddress.toLowerCase()}`
         try {
           const timeline = await fetchVaultPPSDeduped(chainId, vaultAddress, options)
-          return { key, timeline }
+          return { key, timeline, failed: false }
         } catch (error) {
           console.error(`[Kong] Failed to fetch PPS for ${key}:`, error)
           debugError('kong-pps', 'vault PPS fetch failed', error, { key })
-          return { key, timeline: new Map() as PPSTimeline }
+          return { key, timeline: new Map() as PPSTimeline, failed: true }
         }
       })
     )
@@ -211,7 +221,13 @@ export async function fetchMultipleVaultsPPS(
   }, Promise.resolve([]))
 
   const map = new Map<string, PPSTimeline>()
-  results.map(({ key, timeline }) => map.set(key, timeline))
+  results.forEach(({ key, timeline }) => {
+    map.set(key, timeline)
+  })
+  Object.defineProperty(map, PPS_FETCH_FAILED_VAULTS, {
+    value: results.filter((result) => result.failed).length,
+    enumerable: false
+  })
   debugLog('kong-pps', 'resolved PPS timelines', {
     resolved: map.size,
     emptyTimelines: Array.from(map.values()).filter((timeline) => timeline.size === 0).length

--- a/src/server/lib/holdings/services/nestedVaultPrices.test.ts
+++ b/src/server/lib/holdings/services/nestedVaultPrices.test.ts
@@ -4,9 +4,11 @@ import {
   deriveNestedVaultAssetPriceData,
   expandNestedVaultAssetPriceRequests,
   getNestedVaultPpsIdentifiersFromPriceRequests,
-  mergeVaultIdentifiers
+  mergeVaultIdentifiers,
+  resolveNestedVaultAssetMetadata
 } from './nestedVaultPrices'
 import { toVaultKey } from './pnlShared'
+import { getVaultMetadataFetchFailedVaults, markVaultMetadataFetchFailures } from './vaults'
 
 const INNER_VAULT = '0x696d02db93291651ed510704c9b286841d506987'
 const OUTER_VAULT = '0xaaafea48472f77563961cdb53291dedfb46f9040'
@@ -101,6 +103,15 @@ describe('nested vault asset prices', () => {
         metadata
       )
     ).toEqual([{ chainId: 1, vaultAddress: INNER_VAULT }])
+  })
+
+  it('preserves nested metadata fetch failures for cache eligibility', async () => {
+    const outerMetadata = new Map([[toVaultKey(1, OUTER_VAULT), metadata.get(toVaultKey(1, OUTER_VAULT))!]])
+    const fetchVaultMetadata = async () => markVaultMetadataFetchFailures(new Map<string, VaultMetadata>(), 1)
+
+    const resolvedMetadata = await resolveNestedVaultAssetMetadata(outerMetadata, 4, fetchVaultMetadata)
+
+    expect(getVaultMetadataFetchFailedVaults(resolvedMetadata)).toBe(1)
   })
 
   it('recursively expands multi-level vault-share asset price requests', () => {

--- a/src/server/lib/holdings/services/nestedVaultPrices.ts
+++ b/src/server/lib/holdings/services/nestedVaultPrices.ts
@@ -14,6 +14,11 @@ type TVaultIdentifier = {
   vaultAddress: string
 }
 
+type TFetchVaultMetadata = (
+  vaults: TVaultIdentifier[],
+  options: { skipSnapshotFallback: boolean }
+) => Promise<Map<string, VaultMetadata>>
+
 const DEFAULT_MAX_NESTED_VAULT_DEPTH = 4
 
 function priceMapKey(chainId: number, tokenAddress: string): string {
@@ -84,7 +89,8 @@ export function getAssetVaultMetadataLookupIdentifiers(vaultMetadata: Map<string
 
 export async function resolveNestedVaultAssetMetadata(
   vaultMetadata: Map<string, VaultMetadata>,
-  maxDepth = DEFAULT_MAX_NESTED_VAULT_DEPTH
+  maxDepth = DEFAULT_MAX_NESTED_VAULT_DEPTH,
+  fetchVaultMetadata?: TFetchVaultMetadata
 ): Promise<Map<string, VaultMetadata>> {
   if (maxDepth <= 0) {
     return vaultMetadata
@@ -98,17 +104,27 @@ export async function resolveNestedVaultAssetMetadata(
     return vaultMetadata
   }
 
-  const { fetchMultipleVaultsMetadata } = await import('./vaults')
-  const assetVaultMetadata = await fetchMultipleVaultsMetadata(missingAssetVaultIdentifiers, {
+  const {
+    fetchMultipleVaultsMetadata: defaultFetchVaultMetadata,
+    getVaultMetadataFetchFailedVaults,
+    markVaultMetadataFetchFailures
+  } = await import('./vaults')
+  const assetVaultMetadata = await (fetchVaultMetadata ?? defaultFetchVaultMetadata)(missingAssetVaultIdentifiers, {
     skipSnapshotFallback: true
   })
+  const failedVaults =
+    getVaultMetadataFetchFailedVaults(vaultMetadata) + getVaultMetadataFetchFailedVaults(assetVaultMetadata)
   const newEntries = Array.from(assetVaultMetadata.entries()).filter(([key]) => !vaultMetadata.has(key))
 
   if (newEntries.length === 0) {
-    return vaultMetadata
+    return markVaultMetadataFetchFailures(vaultMetadata, failedVaults)
   }
 
-  return resolveNestedVaultAssetMetadata(new Map([...vaultMetadata, ...newEntries]), maxDepth - 1)
+  return resolveNestedVaultAssetMetadata(
+    markVaultMetadataFetchFailures(new Map([...vaultMetadata, ...newEntries]), failedVaults),
+    maxDepth - 1,
+    fetchVaultMetadata ?? defaultFetchVaultMetadata
+  )
 }
 
 function getNestedVaultPpsIdentifiersForRequest(

--- a/src/server/lib/holdings/services/pnlSimple.test.ts
+++ b/src/server/lib/holdings/services/pnlSimple.test.ts
@@ -1504,10 +1504,167 @@ describe('pnl simple protocol return', () => {
 
     expect(familyHistory).toHaveLength(1)
     expect(familyHistory[0]?.vaultAddress).toBe(VAULT)
-    expect(familyHistory[0]?.dataPoints[0]?.protocolReturnPct).toBeCloseTo(0)
-    expect(familyHistory[0]?.dataPoints[1]?.protocolReturnPct).toBeCloseTo(10)
     expect(familyHistory[0]?.dataPoints[0]?.growthIndex).toBeCloseTo(100)
     expect(familyHistory[0]?.dataPoints[1]?.growthIndex).toBeCloseTo(110)
+  })
+
+  it('chains family PPS returns without treating added deposits or partial withdrawals as performance', () => {
+    const events = [
+      baseEvent({
+        kind: 'deposit',
+        id: 'initial-deposit',
+        blockTimestamp: 100,
+        shares: 100n * ONE,
+        assets: 100n * ONE,
+        owner: USER,
+        sender: USER
+      }),
+      baseEvent({
+        kind: 'deposit',
+        id: 'large-added-deposit',
+        blockTimestamp: 200,
+        blockNumber: 2,
+        shares: 1000n * ONE,
+        assets: 1090n * ONE,
+        owner: USER,
+        sender: USER
+      }),
+      baseEvent({
+        kind: 'withdrawal',
+        id: 'partial-withdrawal',
+        blockTimestamp: 250,
+        blockNumber: 3,
+        shares: 500n * ONE,
+        assets: 550n * ONE,
+        owner: USER
+      })
+    ]
+    const ppsData = new Map([
+      [
+        VAULT_KEY,
+        new Map([
+          [100, 1],
+          [200, 1.1],
+          [300, 1.2]
+        ])
+      ]
+    ])
+    const ledgers = buildProtocolReturnLedgers({
+      events,
+      userAddress: USER,
+      metadata,
+      ppsData,
+      priceData: new Map([[ASSET_PRICE_KEY, new Map([[100, 1]])]]),
+      currentTimestamp: 300
+    })
+    const selectedVault = materializeProtocolReturnVaults({
+      ledgers,
+      metadata,
+      ppsData,
+      currentTimestamp: 300
+    })[0]!
+
+    const familyHistory = buildProtocolReturnFamilyHistorySeries({
+      events,
+      userAddress: USER,
+      metadata,
+      ppsData,
+      priceData: new Map([[ASSET_PRICE_KEY, new Map([[100, 1]])]]),
+      timestamps: [100, 200, 300],
+      selectedVaults: [selectedVault]
+    })
+
+    expect(familyHistory[0]?.dataPoints.map((point) => point.growthIndex)).toEqual([
+      expect.closeTo(100),
+      expect.closeTo(110),
+      expect.closeTo(120)
+    ])
+  })
+
+  it('excludes fully exited periods and resumes the family index from a new PPS anchor on re-entry', () => {
+    const events = [
+      baseEvent({
+        kind: 'deposit',
+        id: 'first-entry',
+        blockTimestamp: 100,
+        shares: 100n * ONE,
+        assets: 100n * ONE,
+        owner: USER,
+        sender: USER
+      }),
+      baseEvent({
+        kind: 'withdrawal',
+        id: 'full-exit',
+        blockTimestamp: 200,
+        blockNumber: 2,
+        shares: 100n * ONE,
+        assets: 110n * ONE,
+        owner: USER
+      }),
+      baseEvent({
+        kind: 'deposit',
+        id: 're-entry',
+        blockTimestamp: 300,
+        blockNumber: 3,
+        shares: 100n * ONE,
+        assets: 200n * ONE,
+        owner: USER,
+        sender: USER
+      })
+    ]
+    const ppsData = new Map([
+      [
+        VAULT_KEY,
+        new Map([
+          [100, 1],
+          [200, 1.1],
+          [250, 1.5],
+          [300, 2],
+          [400, 2.2]
+        ])
+      ]
+    ])
+    const priceData = new Map([
+      [
+        ASSET_PRICE_KEY,
+        new Map([
+          [100, 1],
+          [300, 1]
+        ])
+      ]
+    ])
+    const ledgers = buildProtocolReturnLedgers({
+      events,
+      userAddress: USER,
+      metadata,
+      ppsData,
+      priceData,
+      currentTimestamp: 400
+    })
+    const selectedVault = materializeProtocolReturnVaults({
+      ledgers,
+      metadata,
+      ppsData,
+      currentTimestamp: 400
+    })[0]!
+
+    const familyHistory = buildProtocolReturnFamilyHistorySeries({
+      events,
+      userAddress: USER,
+      metadata,
+      ppsData,
+      priceData,
+      timestamps: [100, 200, 250, 300, 400],
+      selectedVaults: [selectedVault]
+    })
+
+    expect(familyHistory[0]?.dataPoints.map((point) => point.growthIndex)).toEqual([
+      expect.closeTo(100),
+      expect.closeTo(110),
+      null,
+      expect.closeTo(110),
+      expect.closeTo(121)
+    ])
   })
 
   it('keeps locked and unlocked yvUSD as separate protocol-return families', () => {
@@ -1803,11 +1960,8 @@ describe('pnl simple protocol return', () => {
     })
 
     expect(familyHistory[0]?.dataPoints[0]?.growthIndex).toBeCloseTo(100)
-    expect(familyHistory[0]?.dataPoints[0]?.protocolReturnPct).toBeCloseTo(0)
-    expect(familyHistory[0]?.dataPoints[1]?.growthIndex).toBeNull()
-    expect(familyHistory[0]?.dataPoints[1]?.protocolReturnPct).toBeNull()
+    expect(familyHistory[0]?.dataPoints[1]?.growthIndex).toBeCloseTo(110)
     expect(familyHistory[0]?.dataPoints[2]?.growthIndex).toBeNull()
-    expect(familyHistory[0]?.dataPoints[2]?.protocolReturnPct).toBeNull()
   })
 
   it('builds an aggregate growth index that does not step down when a new position opens', () => {

--- a/src/server/lib/holdings/services/pnlSimple.ts
+++ b/src/server/lib/holdings/services/pnlSimple.ts
@@ -1,10 +1,18 @@
 import { formatUnits } from 'viem'
+import { selectProtocolReturnFamilySeriesCandidates } from '@/server/lib/holdings/services/protocolReturnFamilySeries'
 import { holdingsConfig } from '../config'
 import type { VaultMetadata } from '../types'
+import {
+  getCachedProtocolReturnHistory,
+  getProtocolReturnHistoryCacheKey,
+  type ProtocolReturnHistoryCacheIdentity,
+  saveCachedProtocolReturnHistory
+} from './cache'
 import { debugError, debugLog, reportHoldingsProgress } from './debug'
 import {
   fetchHistoricalPricesForTokenTimestamps,
   getChainPrefix,
+  getHistoricalPriceFetchFailedBatches,
   getPriceAtTimestamp,
   type THistoricalPriceRequest
 } from './defillama'
@@ -20,7 +28,7 @@ import {
   timestampToDateString,
   toSettledDayTimestamp
 } from './holdings'
-import { getPPS } from './kong'
+import { getPPS, getPpsFetchFailedVaults } from './kong'
 import {
   deriveNestedVaultAssetPriceData,
   expandNestedVaultAssetPriceRequests,
@@ -185,9 +193,7 @@ export interface HoldingsPnLSimpleHistoryPoint {
 }
 
 export interface HoldingsPnLSimpleHistoryFamilyPoint {
-  date: string
   timestamp: number
-  protocolReturnPct: number | null
   growthWeightUsd: number | null
   growthIndex: number | null
 }
@@ -222,9 +228,24 @@ export interface HoldingsPnLSimpleHistoryResponse {
   familySeries: HoldingsPnLSimpleHistoryFamilySeries[]
 }
 
+type TProtocolReturnHistoryCalculation = {
+  response: HoldingsPnLSimpleHistoryResponse
+  vaults: TProtocolReturnVaultFilter[]
+  failedPriceBatches: number
+  failedPpsVaults: number
+  failedMetadataVaults: number
+}
+
+type TProtocolReturnPriceFetchResult<TPriceData> = {
+  priceData: TPriceData
+  failedBatches: number
+}
+
 const SECONDS_PER_YEAR = 365 * 24 * 60 * 60
 
 type TProtocolReturnVaultFilter = { chainId: number; vaultAddress: string }
+
+const inFlightProtocolReturnHistoryRequests = new Map<string, Promise<HoldingsPnLSimpleHistoryResponse>>()
 
 function emptyLedger(chainId: number, vaultAddress: string): TProtocolReturnLedger {
   return {
@@ -292,6 +313,31 @@ function advanceGrowthIndex(args: {
 
   const intervalReturn = (args.deltaGrowthWeightUsd * intervalYears) / args.deltaExposureWeightUsdYears
   const nextIndex = args.previousIndex * (1 + intervalReturn)
+  return Number.isFinite(nextIndex) ? nextIndex : args.previousIndex
+}
+
+function advanceVaultPerformanceIndex(args: {
+  previousIndex: number | null
+  previousPps: number | null
+  currentPps: number | null
+  wasOpen: boolean
+  isOpen: boolean
+}): number | null {
+  if (args.previousIndex === null) {
+    return args.isOpen ? 100 : null
+  }
+
+  if (
+    !args.wasOpen ||
+    args.previousPps === null ||
+    args.previousPps <= 0 ||
+    args.currentPps === null ||
+    args.currentPps <= 0
+  ) {
+    return args.previousIndex
+  }
+
+  const nextIndex = args.previousIndex * (args.currentPps / args.previousPps)
   return Number.isFinite(nextIndex) ? nextIndex : args.previousIndex
 }
 
@@ -365,7 +411,11 @@ function normalizeProtocolReturnVaultFilters(
       : undefined
   }
 
-  return requestedVaultFilters?.map((vault) => ({
+  if (!requestedVaultFilters?.length) {
+    return undefined
+  }
+
+  return requestedVaultFilters.map((vault) => ({
     chainId: Number(vault.chainId),
     vaultAddress: lowerCaseAddress(vault.vaultAddress)
   }))
@@ -456,25 +506,41 @@ function countReceiptPricePoints(requests: TSimpleReceiptPriceRequest[]): number
   return requests.reduce((total, request) => total + request.timestamps.length, 0)
 }
 
-async function fetchReceiptPrices(requests: TSimpleReceiptPriceRequest[]): Promise<Map<string, Map<number, number>>> {
+function countFetchedReceiptPricePoints(priceData: Map<string, Map<number, number>>): number {
+  return Array.from(priceData.values()).reduce((total, prices) => total + prices.size, 0)
+}
+
+async function fetchReceiptPrices(
+  requests: TSimpleReceiptPriceRequest[]
+): Promise<TProtocolReturnPriceFetchResult<Map<string, Map<number, number>>>> {
   if (requests.length === 0) {
-    return new Map()
+    return { priceData: new Map(), failedBatches: 0 }
   }
 
   try {
-    return await fetchHistoricalPricesForTokenTimestamps(requests, { resolution: 'utc_day' })
+    const priceData = await fetchHistoricalPricesForTokenTimestamps(requests, { resolution: 'utc_day' })
+    const reportedFailedBatches = getHistoricalPriceFetchFailedBatches(priceData)
+    return {
+      priceData,
+      failedBatches: Math.max(
+        reportedFailedBatches,
+        Number(countReceiptPricePoints(requests) > 0 && countFetchedReceiptPricePoints(priceData) === 0)
+      )
+    }
   } catch (error) {
     debugError('pnl-simple', 'receipt price fetch failed, continuing with missing receipt prices', error, {
       tokens: requests.length,
       pricePoints: countReceiptPricePoints(requests)
     })
-    return new Map()
+    return { priceData: new Map(), failedBatches: 1 }
   }
 }
 
-async function fetchEthReceiptPrices(timestamps: number[]): Promise<Map<number, number>> {
+async function fetchEthReceiptPrices(
+  timestamps: number[]
+): Promise<TProtocolReturnPriceFetchResult<Map<number, number>>> {
   if (timestamps.length === 0) {
-    return new Map()
+    return { priceData: new Map(), failedBatches: 0 }
   }
 
   try {
@@ -482,12 +548,16 @@ async function fetchEthReceiptPrices(timestamps: number[]): Promise<Map<number, 
       [{ chainId: 1, address: ETHEREUM_WETH_ADDRESS, timestamps }],
       { resolution: 'utc_day' }
     )
-    return priceData.get(ETHEREUM_WETH_PRICE_KEY) ?? new Map()
+    const ethPriceData = priceData.get(ETHEREUM_WETH_PRICE_KEY) ?? new Map()
+    return {
+      priceData: ethPriceData,
+      failedBatches: Math.max(getHistoricalPriceFetchFailedBatches(priceData), Number(ethPriceData.size === 0))
+    }
   } catch (error) {
     debugError('pnl-simple', 'eth receipt price fetch failed, continuing with missing eth receipt price', error, {
       timestamps: timestamps.length
     })
-    return new Map()
+    return { priceData: new Map(), failedBatches: 1 }
   }
 }
 
@@ -1546,18 +1616,39 @@ function getProtocolReturnTimestamps(events: TRawPnlEvent[], timeframe: '1y' | '
   )
 }
 
+function getLatestProtocolReturnSettledDate(): string {
+  const timestamps = generateDailyTimestamps(holdingsConfig.historyDays, 1)
+  const latestTimestamp = timestamps[timestamps.length - 1] ?? 0
+  return timestampToDateString(toSettledDayTimestamp(latestTimestamp))
+}
+
+function getProtocolReturnHistoryCacheIdentity(args: {
+  userAddress: string
+  version: VaultVersion
+  timeframe: '1y' | 'all'
+  requestedVaults?: TProtocolReturnVaultFilter[]
+}): ProtocolReturnHistoryCacheIdentity {
+  return {
+    userAddress: args.userAddress,
+    version: args.version,
+    timeframe: args.timeframe,
+    vaultScope: args.requestedVaults?.map((vault) => ({
+      address: vault.vaultAddress,
+      chainId: vault.chainId
+    }))
+  }
+}
+
 function buildTransactionHashesByChain(events: TRawPnlEvent[]): Map<number, string[]> {
-  return events.reduce<Map<number, string[]>>((grouped, event) => {
+  const groupedHashes = events.reduce<Map<number, Set<string>>>((grouped, event) => {
     const transactionHash = lowerCaseAddress(event.transactionHash)
-    const existing = grouped.get(event.chainId) ?? []
-
-    if (existing.includes(transactionHash)) {
-      return grouped
-    }
-
-    grouped.set(event.chainId, [...existing, transactionHash])
+    const hashes = grouped.get(event.chainId) ?? new Set<string>()
+    hashes.add(transactionHash)
+    grouped.set(event.chainId, hashes)
     return grouped
   }, new Map())
+
+  return new Map(Array.from(groupedHashes, ([chainId, hashes]) => [chainId, Array.from(hashes)]))
 }
 
 async function enrichSimpleHistoryRawEvents(args: {
@@ -1980,10 +2071,9 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
   const familyIndexState = new Map<
     string,
     {
-      previousTimestamp: number | null
-      previousGrowthWeightUsd: number
-      previousExposureWeightUsdYears: number
       growthIndex: number | null
+      previousPps: number | null
+      wasOpen: boolean
     }
   >(
     Array.from(
@@ -1992,10 +2082,9 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
         [
           key,
           {
-            previousTimestamp: null,
-            previousGrowthWeightUsd: 0,
-            previousExposureWeightUsdYears: 0,
-            growthIndex: null
+            growthIndex: null,
+            previousPps: null,
+            wasOpen: false
           }
         ] as const
     )
@@ -2043,30 +2132,23 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
       }
 
       const hasOpenPosition = (familyVault?.sharesFormatted ?? 0) > 0
-      const currentGrowthWeightUsd = familyVault?.growthWeightUsd ?? 0
-      const currentExposureWeightUsdYears = familyVault?.baselineExposureWeightUsdYears ?? 0
-      const deltaGrowthWeightUsd = currentGrowthWeightUsd - state.previousGrowthWeightUsd
-      const deltaExposureWeightUsdYears = currentExposureWeightUsdYears - state.previousExposureWeightUsdYears
-      const hasIntervalActivity =
-        state.previousTimestamp !== null && (deltaGrowthWeightUsd !== 0 || deltaExposureWeightUsdYears !== 0)
+      const currentPps = familyVault?.pricePerShare ?? null
+      const closesPosition = state.wasOpen && !hasOpenPosition
 
-      state.growthIndex = advanceGrowthIndex({
+      state.growthIndex = advanceVaultPerformanceIndex({
         previousIndex: state.growthIndex,
-        deltaGrowthWeightUsd,
-        deltaExposureWeightUsdYears,
-        deltaSeconds: state.previousTimestamp === null ? 0 : Math.max(0, timestamp - state.previousTimestamp),
-        hasCapital: (familyVault?.baselineWeightUsd ?? 0) > 0 || currentGrowthWeightUsd !== 0
+        previousPps: state.previousPps,
+        currentPps,
+        wasOpen: state.wasOpen,
+        isOpen: hasOpenPosition
       })
-      state.previousTimestamp = timestamp
-      state.previousGrowthWeightUsd = currentGrowthWeightUsd
-      state.previousExposureWeightUsdYears = currentExposureWeightUsdYears
+      state.previousPps = hasOpenPosition && currentPps !== null && currentPps > 0 ? currentPps : null
+      state.wasOpen = hasOpenPosition
 
       familyPointMap.get(vaultKey)?.push({
-        date: timestampToDateString(timestamp),
         timestamp,
-        protocolReturnPct: hasOpenPosition ? (familyVault?.protocolReturnPct ?? null) : null,
         growthWeightUsd: familyVault?.growthWeightUsd ?? null,
-        growthIndex: hasOpenPosition || hasIntervalActivity ? state.growthIndex : null
+        growthIndex: hasOpenPosition || closesPosition ? state.growthIndex : null
       })
     })
   })
@@ -2091,7 +2173,7 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
   })
 }
 
-export async function getHoldingsProtocolReturnHistory(
+async function calculateHoldingsProtocolReturnHistory(
   userAddress: string,
   version: VaultVersion = 'all',
   fetchType: HoldingsEventFetchType = 'seq',
@@ -2099,7 +2181,7 @@ export async function getHoldingsProtocolReturnHistory(
   timeframe: '1y' | 'all' = '1y',
   requestedVaultFilters?: Array<{ chainId: number; vaultAddress: string }> | string,
   legacyVaultChainId?: number
-): Promise<HoldingsPnLSimpleHistoryResponse> {
+): Promise<TProtocolReturnHistoryCalculation> {
   debugLog('protocol-return-history', 'starting holdings protocol return history calculation', {
     version,
     fetchType,
@@ -2140,25 +2222,31 @@ export async function getHoldingsProtocolReturnHistory(
   if (effectiveEvents.length === 0 || filteredVaultIdentifiers.length === 0) {
     reportHoldingsProgress(94, 'No historical protocol return events found', null)
     return {
-      address: lowerCaseAddress(userAddress),
-      version,
-      timeframe,
-      generatedAt: new Date().toISOString(),
-      summary: {
-        totalVaults: 0,
-        completeVaults: 0,
-        partialVaults: 0,
-        recommendedGrowthDisplay: 'index',
-        recommendedGrowthDisplayReason: 'mixed',
-        openBaselineCompositionUsd: {
-          stable: 0,
-          ethFamily: 0,
-          other: 0
+      response: {
+        address: lowerCaseAddress(userAddress),
+        version,
+        timeframe,
+        generatedAt: new Date().toISOString(),
+        summary: {
+          totalVaults: 0,
+          completeVaults: 0,
+          partialVaults: 0,
+          recommendedGrowthDisplay: 'index',
+          recommendedGrowthDisplayReason: 'mixed',
+          openBaselineCompositionUsd: {
+            stable: 0,
+            ethFamily: 0,
+            other: 0
+          },
+          isComplete: true
         },
-        isComplete: true
+        dataPoints: [],
+        familySeries: []
       },
-      dataPoints: [],
-      familySeries: []
+      vaults: [],
+      failedPriceBatches: 0,
+      failedPpsVaults: 0,
+      failedMetadataVaults: 0
     }
   }
 
@@ -2184,10 +2272,12 @@ export async function getHoldingsProtocolReturnHistory(
     'Prepared historical price requests',
     `${receiptPriceRequests.length} receipt price series, ${ethReceiptPriceTimestamps.length} ETH price points, ${ppsIdentifiers.length} PPS series`
   )
-  const [fetchedPriceData, ethPriceData] = await Promise.all([
+  const [receiptPriceResult, ethPriceResult] = await Promise.all([
     fetchReceiptPrices(receiptPriceRequests),
     fetchEthReceiptPrices(ethReceiptPriceTimestamps)
   ])
+  const fetchedPriceData = receiptPriceResult.priceData
+  const ethPriceData = ethPriceResult.priceData
   reportHoldingsProgress(72, 'Fetched historical receipt prices', `${receiptPriceRequests.length} price series`)
   const priceData = deriveNestedVaultAssetPriceData({
     priceData: fetchedPriceData,
@@ -2259,20 +2349,123 @@ export async function getHoldingsProtocolReturnHistory(
   })
 
   return {
-    address: lowerCaseAddress(userAddress),
+    response: {
+      address: lowerCaseAddress(userAddress),
+      version,
+      timeframe,
+      generatedAt: new Date().toISOString(),
+      summary: {
+        totalVaults: finalVaults.length,
+        completeVaults: finalVaults.filter((vault) => vault.status === 'ok').length,
+        partialVaults: finalVaults.filter((vault) => vault.status !== 'ok').length,
+        recommendedGrowthDisplay,
+        recommendedGrowthDisplayReason,
+        openBaselineCompositionUsd,
+        isComplete: finalVaults.every((vault) => vault.status === 'ok')
+      },
+      dataPoints: history,
+      familySeries
+    },
+    vaults: ppsIdentifiers,
+    failedPriceBatches: receiptPriceResult.failedBatches + ethPriceResult.failedBatches,
+    failedPpsVaults: getPpsFetchFailedVaults(settledContext.ppsData),
+    failedMetadataVaults: settledContext.metadataFetchFailedVaults ?? 0
+  }
+}
+
+export async function getHoldingsProtocolReturnHistory(
+  userAddress: string,
+  version: VaultVersion = 'all',
+  fetchType: HoldingsEventFetchType = 'seq',
+  paginationMode: HoldingsEventPaginationMode = 'paged',
+  timeframe: '1y' | 'all' = '1y',
+  requestedVaultFilters?: Array<{ chainId: number; vaultAddress: string }> | string,
+  legacyVaultChainId?: number
+): Promise<HoldingsPnLSimpleHistoryResponse> {
+  const requestedVaults = normalizeProtocolReturnVaultFilters(requestedVaultFilters, legacyVaultChainId)
+  const cacheIdentity = getProtocolReturnHistoryCacheIdentity({
+    userAddress,
     version,
     timeframe,
-    generatedAt: new Date().toISOString(),
-    summary: {
-      totalVaults: finalVaults.length,
-      completeVaults: finalVaults.filter((vault) => vault.status === 'ok').length,
-      partialVaults: finalVaults.filter((vault) => vault.status !== 'ok').length,
-      recommendedGrowthDisplay,
-      recommendedGrowthDisplayReason,
-      openBaselineCompositionUsd,
-      isComplete: finalVaults.every((vault) => vault.status === 'ok')
-    },
-    dataPoints: history,
-    familySeries
+    requestedVaults
+  })
+  const cacheKey = getProtocolReturnHistoryCacheKey(cacheIdentity)
+  const settledDate = getLatestProtocolReturnSettledDate()
+  const inFlightKey = `${cacheKey}:${settledDate}`
+  const inFlightRequest = inFlightProtocolReturnHistoryRequests.get(inFlightKey)
+
+  if (inFlightRequest) {
+    debugLog('protocol-return-history', 'reusing in-flight protocol return history request', { cacheKey })
+    reportHoldingsProgress(20, 'Reusing historical user data request', null)
+    return inFlightRequest
   }
+
+  const request = (async () => {
+    const cachedResponse = await getCachedProtocolReturnHistory<HoldingsPnLSimpleHistoryResponse>(
+      cacheIdentity,
+      settledDate
+    )
+
+    if (cachedResponse) {
+      reportHoldingsProgress(
+        94,
+        'Loaded cached protocol return history',
+        `${cachedResponse.dataPoints.length} chart points`
+      )
+      if (cachedResponse.familySeries.length === 0) {
+        return cachedResponse
+      }
+
+      return {
+        ...cachedResponse,
+        familySeries: selectProtocolReturnFamilySeriesCandidates(cachedResponse.familySeries, cachedResponse.timeframe)
+      }
+    }
+
+    const calculationStartedAt = Date.now()
+    const calculation = await calculateHoldingsProtocolReturnHistory(
+      userAddress,
+      version,
+      fetchType,
+      paginationMode,
+      timeframe,
+      requestedVaultFilters,
+      legacyVaultChainId
+    )
+
+    const compactResponse = {
+      ...calculation.response,
+      familySeries: selectProtocolReturnFamilySeriesCandidates(
+        calculation.response.familySeries,
+        calculation.response.timeframe
+      )
+    }
+    const failedUpstreamFetches =
+      calculation.failedPriceBatches + calculation.failedPpsVaults + calculation.failedMetadataVaults
+
+    if (compactResponse.summary.totalVaults > 0 && failedUpstreamFetches === 0) {
+      await saveCachedProtocolReturnHistory(
+        cacheIdentity,
+        settledDate,
+        calculation.vaults.map((vault) => ({ address: vault.vaultAddress, chainId: vault.chainId })),
+        compactResponse,
+        calculationStartedAt
+      )
+    } else if (compactResponse.summary.totalVaults === 0) {
+      debugLog('protocol-return-history', 'skipping empty protocol return history cache save')
+    } else {
+      debugLog('protocol-return-history', 'skipping protocol return history cache save after upstream fetch failures', {
+        failedPriceBatches: calculation.failedPriceBatches,
+        failedPpsVaults: calculation.failedPpsVaults,
+        failedMetadataVaults: calculation.failedMetadataVaults
+      })
+    }
+
+    return compactResponse
+  })().finally(() => {
+    inFlightProtocolReturnHistoryRequests.delete(inFlightKey)
+  })
+
+  inFlightProtocolReturnHistoryRequests.set(inFlightKey, request)
+  return request
 }

--- a/src/server/lib/holdings/services/pnlSimple.ts
+++ b/src/server/lib/holdings/services/pnlSimple.ts
@@ -1850,11 +1850,10 @@ function buildSummary(vaults: HoldingsPnLSimpleVault[]): HoldingsPnLSimpleRespon
   }
 }
 
-function selectHistoryFamilies(vaults: HoldingsPnLSimpleVault[], limit = 5): HoldingsPnLSimpleVault[] {
+function selectEligibleHistoryFamilies(vaults: HoldingsPnLSimpleVault[]): HoldingsPnLSimpleVault[] {
   return vaults
-    .filter((vault) => vault.baselineWeightUsd > 0 && vault.protocolReturnPct !== null)
+    .filter((vault) => vault.status === 'ok' && vault.baselineWeightUsd > 0 && vault.protocolReturnPct !== null)
     .sort((left, right) => right.baselineWeightUsd - left.baselineWeightUsd)
-    .slice(0, limit)
 }
 
 export function buildProtocolReturnHistorySeries(args: {
@@ -2044,25 +2043,30 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
       }
 
       const hasOpenPosition = (familyVault?.sharesFormatted ?? 0) > 0
+      const currentGrowthWeightUsd = familyVault?.growthWeightUsd ?? 0
+      const currentExposureWeightUsdYears = familyVault?.baselineExposureWeightUsdYears ?? 0
+      const deltaGrowthWeightUsd = currentGrowthWeightUsd - state.previousGrowthWeightUsd
+      const deltaExposureWeightUsdYears = currentExposureWeightUsdYears - state.previousExposureWeightUsdYears
+      const hasIntervalActivity =
+        state.previousTimestamp !== null && (deltaGrowthWeightUsd !== 0 || deltaExposureWeightUsdYears !== 0)
 
       state.growthIndex = advanceGrowthIndex({
         previousIndex: state.growthIndex,
-        deltaGrowthWeightUsd: (familyVault?.growthWeightUsd ?? 0) - state.previousGrowthWeightUsd,
-        deltaExposureWeightUsdYears:
-          (familyVault?.baselineExposureWeightUsdYears ?? 0) - state.previousExposureWeightUsdYears,
+        deltaGrowthWeightUsd,
+        deltaExposureWeightUsdYears,
         deltaSeconds: state.previousTimestamp === null ? 0 : Math.max(0, timestamp - state.previousTimestamp),
-        hasCapital: (familyVault?.baselineWeightUsd ?? 0) > 0 || (familyVault?.growthWeightUsd ?? 0) !== 0
+        hasCapital: (familyVault?.baselineWeightUsd ?? 0) > 0 || currentGrowthWeightUsd !== 0
       })
       state.previousTimestamp = timestamp
-      state.previousGrowthWeightUsd = familyVault?.growthWeightUsd ?? 0
-      state.previousExposureWeightUsdYears = familyVault?.baselineExposureWeightUsdYears ?? 0
+      state.previousGrowthWeightUsd = currentGrowthWeightUsd
+      state.previousExposureWeightUsdYears = currentExposureWeightUsdYears
 
       familyPointMap.get(vaultKey)?.push({
         date: timestampToDateString(timestamp),
         timestamp,
         protocolReturnPct: hasOpenPosition ? (familyVault?.protocolReturnPct ?? null) : null,
-        growthWeightUsd: hasOpenPosition ? (familyVault?.growthWeightUsd ?? null) : null,
-        growthIndex: hasOpenPosition ? state.growthIndex : null
+        growthWeightUsd: familyVault?.growthWeightUsd ?? null,
+        growthIndex: hasOpenPosition || hasIntervalActivity ? state.growthIndex : null
       })
     })
   })
@@ -2208,7 +2212,7 @@ export async function getHoldingsProtocolReturnHistory(
     currentTimestamp: latestTimestamp
   })
   reportHoldingsProgress(82, 'Calculated protocol return ledgers', `${finalVaults.length} vaults`)
-  const selectedHistoryFamilies = selectHistoryFamilies(finalVaults)
+  const eligibleHistoryFamilies = selectEligibleHistoryFamilies(finalVaults)
   const history = buildProtocolReturnHistorySeries({
     events: effectiveEvents,
     userAddress,
@@ -2229,7 +2233,7 @@ export async function getHoldingsProtocolReturnHistory(
     priceData,
     ethPriceData,
     timestamps,
-    selectedVaults: requestedVaults ? [] : selectedHistoryFamilies
+    selectedVaults: requestedVaults ? [] : eligibleHistoryFamilies
   })
   reportHoldingsProgress(92, 'Built historical chart series', `${history.length} chart points`)
   const openBaselineCompositionUsd = buildOpenBaselineCompositionUsd({

--- a/src/server/lib/holdings/services/pnlSimpleHistory.test.ts
+++ b/src/server/lib/holdings/services/pnlSimpleHistory.test.ts
@@ -4,6 +4,7 @@ import { toVaultKey } from './pnlShared'
 import type { TRawPnlEvent } from './pnlTypes'
 
 const fetchHistoricalPricesForTokenTimestampsMock = vi.fn()
+const getHistoricalPriceFetchFailedBatchesMock = vi.fn()
 const getPriceAtTimestampMock = vi.fn()
 const getSettledVersionedPpsContextMock = vi.fn()
 const getVaultIdentifiersMock = vi.fn()
@@ -13,10 +14,22 @@ const generateDailyTimestampsFromRangeMock = vi.fn()
 const toSettledDayTimestampMock = vi.fn()
 const timestampToDateStringMock = vi.fn()
 const getPPSMock = vi.fn()
+const getPpsFetchFailedVaultsMock = vi.fn()
+const getNestedVaultPpsIdentifiersFromPriceRequestsMock = vi.fn()
+const getCachedProtocolReturnHistoryMock = vi.fn()
+const getProtocolReturnHistoryCacheKeyMock = vi.fn()
+const saveCachedProtocolReturnHistoryMock = vi.fn()
+
+vi.mock('./cache', () => ({
+  getCachedProtocolReturnHistory: getCachedProtocolReturnHistoryMock,
+  getProtocolReturnHistoryCacheKey: getProtocolReturnHistoryCacheKeyMock,
+  saveCachedProtocolReturnHistory: saveCachedProtocolReturnHistoryMock
+}))
 
 vi.mock('./defillama', () => ({
   fetchHistoricalPricesForTokenTimestamps: fetchHistoricalPricesForTokenTimestampsMock,
   getChainPrefix: vi.fn(() => 'ethereum'),
+  getHistoricalPriceFetchFailedBatches: getHistoricalPriceFetchFailedBatchesMock,
   getPriceAtTimestamp: getPriceAtTimestampMock
 }))
 
@@ -37,13 +50,14 @@ vi.mock('./holdings', () => ({
 }))
 
 vi.mock('./kong', () => ({
-  getPPS: getPPSMock
+  getPPS: getPPSMock,
+  getPpsFetchFailedVaults: getPpsFetchFailedVaultsMock
 }))
 
 vi.mock('./nestedVaultPrices', () => ({
   expandNestedVaultAssetPriceRequests: vi.fn((requests: unknown[]) => requests),
   deriveNestedVaultAssetPriceData: vi.fn(({ priceData }: { priceData: Map<string, Map<number, number>> }) => priceData),
-  getNestedVaultPpsIdentifiersFromPriceRequests: vi.fn(() => []),
+  getNestedVaultPpsIdentifiersFromPriceRequests: getNestedVaultPpsIdentifiersFromPriceRequestsMock,
   mergeVaultIdentifiers: vi.fn((identifiers: unknown[]) => identifiers)
 }))
 
@@ -53,11 +67,13 @@ vi.mock('./pnlEvents', () => ({
 
 const USER = '0x1111111111111111111111111111111111111111'
 const VAULT = '0x3333333333333333333333333333333333333333'
+const NESTED_VAULT = '0x5555555555555555555555555555555555555555'
 const ASSET = '0x4444444444444444444444444444444444444444'
 const ONE = 10n ** 18n
 const HISTORY_START_TIMESTAMP = 1_704_067_200
 const VAULT_KEY = toVaultKey(1, VAULT)
 const ASSET_PRICE_KEY = `ethereum:${ASSET}`
+const WETH_PRICE_KEY = 'ethereum:0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 
 const metadata = new Map<string, VaultMetadata>([
   [
@@ -99,6 +115,28 @@ const event = {
   }
 } as TRawPnlEvent
 
+const settledContext = {
+  address: USER,
+  latestSettledDayTimestamp: 200,
+  maxTimestamp: 201,
+  events: {
+    deposits: [],
+    withdrawals: [],
+    transfersIn: [],
+    transfersOut: []
+  },
+  timeline: [],
+  hasActivity: true,
+  rawEvents: [event],
+  rawVaultIdentifiers: [{ chainId: 1, vaultAddress: VAULT }],
+  vaultMetadata: metadata,
+  metadataFetchFailedVaults: 0,
+  selectedEvents: [event],
+  selectedVaultIdentifiers: [{ chainId: 1, vaultAddress: VAULT }],
+  ppsIdentifiers: [{ chainId: 1, vaultAddress: VAULT }],
+  ppsData: new Map([[VAULT_KEY, new Map([[HISTORY_START_TIMESTAMP + 1, 1]])]])
+}
+
 describe('getHoldingsProtocolReturnHistory', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -108,9 +146,18 @@ describe('getHoldingsProtocolReturnHistory', () => {
     toSettledDayTimestampMock.mockImplementation((timestamp: number) => timestamp + 1)
     timestampToDateStringMock.mockImplementation((timestamp: number) => `date-${timestamp}`)
     getPPSMock.mockReturnValue(1)
+    getPpsFetchFailedVaultsMock.mockReturnValue(0)
+    getNestedVaultPpsIdentifiersFromPriceRequestsMock.mockReturnValue([])
+    getHistoricalPriceFetchFailedBatchesMock.mockReturnValue(0)
     getPriceAtTimestampMock.mockReturnValue(1)
+    getCachedProtocolReturnHistoryMock.mockResolvedValue(null)
+    getProtocolReturnHistoryCacheKeyMock.mockReturnValue('protocol-return-history-cache-key')
+    saveCachedProtocolReturnHistoryMock.mockResolvedValue(true)
     fetchHistoricalPricesForTokenTimestampsMock.mockResolvedValue(
-      new Map([[ASSET_PRICE_KEY, new Map([[HISTORY_START_TIMESTAMP + 1, 1]])]])
+      new Map([
+        [ASSET_PRICE_KEY, new Map([[HISTORY_START_TIMESTAMP + 1, 1]])],
+        [WETH_PRICE_KEY, new Map([[HISTORY_START_TIMESTAMP + 1, 1]])]
+      ])
     )
     fetchActivityEventsByTransactionHashesMock.mockResolvedValue({
       deposits: [],
@@ -118,26 +165,7 @@ describe('getHoldingsProtocolReturnHistory', () => {
       transfers: []
     })
     getVaultIdentifiersMock.mockReturnValue([{ chainId: 1, vaultAddress: VAULT }])
-    getSettledVersionedPpsContextMock.mockResolvedValue({
-      address: USER,
-      latestSettledDayTimestamp: 200,
-      maxTimestamp: 201,
-      events: {
-        deposits: [],
-        withdrawals: [],
-        transfersIn: [],
-        transfersOut: []
-      },
-      timeline: [],
-      hasActivity: true,
-      rawEvents: [event],
-      rawVaultIdentifiers: [{ chainId: 1, vaultAddress: VAULT }],
-      vaultMetadata: metadata,
-      selectedEvents: [event],
-      selectedVaultIdentifiers: [{ chainId: 1, vaultAddress: VAULT }],
-      ppsIdentifiers: [{ chainId: 1, vaultAddress: VAULT }],
-      ppsData: new Map([[VAULT_KEY, new Map([[HISTORY_START_TIMESTAMP + 1, 1]])]])
-    })
+    getSettledVersionedPpsContextMock.mockResolvedValue(settledContext)
   })
 
   it('starts all timeframe at the supported history floor', async () => {
@@ -150,5 +178,155 @@ describe('getHoldingsProtocolReturnHistory', () => {
       HISTORY_START_TIMESTAMP + 1,
       HISTORY_START_TIMESTAMP + 86_401
     ])
+    expect(saveCachedProtocolReturnHistoryMock).toHaveBeenCalledWith(
+      {
+        userAddress: USER,
+        version: 'all',
+        timeframe: 'all',
+        vaultScope: undefined
+      },
+      'date-201',
+      [{ address: VAULT, chainId: 1 }],
+      response,
+      expect.any(Number)
+    )
+  })
+
+  it('serves the settled protocol return history snapshot before loading wallet events', async () => {
+    const cachedResponse = {
+      address: USER,
+      version: 'all' as const,
+      timeframe: '1y' as const,
+      generatedAt: '2026-07-15T00:00:00.000Z',
+      summary: {
+        totalVaults: 1,
+        completeVaults: 1,
+        partialVaults: 0,
+        recommendedGrowthDisplay: 'index' as const,
+        recommendedGrowthDisplayReason: 'mixed' as const,
+        openBaselineCompositionUsd: { stable: 1, ethFamily: 0, other: 0 },
+        isComplete: true
+      },
+      dataPoints: [],
+      familySeries: []
+    }
+    getCachedProtocolReturnHistoryMock.mockResolvedValue(cachedResponse)
+
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    const response = await getHoldingsProtocolReturnHistory(USER, 'all', 'parallel', 'paged', '1y')
+
+    expect(response).toBe(cachedResponse)
+    expect(getSettledVersionedPpsContextMock).not.toHaveBeenCalled()
+    expect(saveCachedProtocolReturnHistoryMock).not.toHaveBeenCalled()
+  })
+
+  it('caches a successful partial protocol return history calculation', async () => {
+    getPPSMock.mockReturnValue(null)
+
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    const response = await getHoldingsProtocolReturnHistory(USER, 'all', 'parallel', 'paged', '1y')
+
+    expect(response.summary.isComplete).toBe(false)
+    expect(response.summary.totalVaults).toBe(1)
+    expect(saveCachedProtocolReturnHistoryMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      'date-201',
+      [{ address: VAULT, chainId: 1 }],
+      response,
+      expect.any(Number)
+    )
+  })
+
+  it('does not cache protocol return history when a price request succeeds without prices', async () => {
+    fetchHistoricalPricesForTokenTimestampsMock.mockResolvedValue(new Map())
+
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    const response = await getHoldingsProtocolReturnHistory(USER, 'all', 'parallel', 'paged', '1y')
+
+    expect(response.summary.totalVaults).toBe(1)
+    expect(saveCachedProtocolReturnHistoryMock).not.toHaveBeenCalled()
+  })
+
+  it('does not cache protocol return history when a historical price batch fails', async () => {
+    getHistoricalPriceFetchFailedBatchesMock.mockReturnValue(1)
+
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    const response = await getHoldingsProtocolReturnHistory(USER, 'all', 'parallel', 'paged', '1y')
+
+    expect(response.summary.totalVaults).toBe(1)
+    expect(saveCachedProtocolReturnHistoryMock).not.toHaveBeenCalled()
+  })
+
+  it('does not cache protocol return history when a PPS request fails', async () => {
+    getPpsFetchFailedVaultsMock.mockReturnValue(1)
+
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    await getHoldingsProtocolReturnHistory(USER, 'all', 'parallel', 'paged', '1y')
+
+    expect(saveCachedProtocolReturnHistoryMock).not.toHaveBeenCalled()
+  })
+
+  it('does not cache protocol return history when a metadata fallback fails', async () => {
+    getSettledVersionedPpsContextMock.mockResolvedValue({
+      ...settledContext,
+      metadataFetchFailedVaults: 1
+    })
+
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    await getHoldingsProtocolReturnHistory(USER, 'all', 'parallel', 'paged', '1y')
+
+    expect(saveCachedProtocolReturnHistoryMock).not.toHaveBeenCalled()
+  })
+
+  it('tracks nested PPS vaults as cache invalidation dependencies', async () => {
+    getNestedVaultPpsIdentifiersFromPriceRequestsMock.mockReturnValue([{ chainId: 1, vaultAddress: NESTED_VAULT }])
+
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    const response = await getHoldingsProtocolReturnHistory(USER, 'all', 'parallel', 'paged', '1y')
+
+    expect(saveCachedProtocolReturnHistoryMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      'date-201',
+      [
+        { address: VAULT, chainId: 1 },
+        { address: NESTED_VAULT, chainId: 1 }
+      ],
+      response,
+      expect.any(Number)
+    )
+  })
+
+  it('coalesces identical protocol return history requests while the cache lookup is in flight', async () => {
+    const cachedResponse = {
+      address: USER,
+      version: 'all' as const,
+      timeframe: '1y' as const,
+      generatedAt: '2026-07-15T00:00:00.000Z',
+      summary: {
+        totalVaults: 0,
+        completeVaults: 0,
+        partialVaults: 0,
+        recommendedGrowthDisplay: 'index' as const,
+        recommendedGrowthDisplayReason: 'mixed' as const,
+        openBaselineCompositionUsd: { stable: 0, ethFamily: 0, other: 0 },
+        isComplete: true
+      },
+      dataPoints: [],
+      familySeries: []
+    }
+    const cacheLookup: { resolve?: (value: typeof cachedResponse | null) => void } = {}
+    const cacheLookupPromise = new Promise<typeof cachedResponse | null>((resolve) => {
+      cacheLookup.resolve = resolve
+    })
+    getCachedProtocolReturnHistoryMock.mockReturnValue(cacheLookupPromise)
+
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    const firstRequest = getHoldingsProtocolReturnHistory(USER, 'all', 'parallel', 'paged', '1y')
+    const secondRequest = getHoldingsProtocolReturnHistory(USER, 'all', 'parallel', 'paged', '1y')
+
+    expect(getCachedProtocolReturnHistoryMock).toHaveBeenCalledTimes(1)
+    cacheLookup.resolve?.(cachedResponse)
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual([cachedResponse, cachedResponse])
+    expect(getSettledVersionedPpsContextMock).not.toHaveBeenCalled()
   })
 })

--- a/src/server/lib/holdings/services/protocolReturnFamilySeries.test.ts
+++ b/src/server/lib/holdings/services/protocolReturnFamilySeries.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { selectProtocolReturnFamilySeriesCandidates } from '@/server/lib/holdings/services/protocolReturnFamilySeries'
+
+type TWindow = '30d' | '90d' | '1y' | 'all'
+type TMode = 'position' | 'index'
+
+const WINDOW_LIMITS: Record<TWindow, number> = {
+  '30d': 30,
+  '90d': 90,
+  '1y': 365,
+  all: Number.MAX_SAFE_INTEGER
+}
+const SCORES = [-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6]
+
+function buildIsolatedSeries(args: { id: string; mode: TMode; window: TWindow; score: number; pointCount: number }) {
+  const windowLimit = WINDOW_LIMITS[args.window]
+  const windowStartIndex =
+    Number.isFinite(windowLimit) && windowLimit < args.pointCount ? args.pointCount - windowLimit : 0
+
+  return {
+    chainId: 1,
+    vaultAddress: args.id,
+    symbol: args.id,
+    status: 'ok' as const,
+    dataPoints: Array.from({ length: args.pointCount }, (_, index) => ({
+      date: `unused-${index}`,
+      timestamp: index,
+      protocolReturnPct: 123,
+      growthWeightUsd: args.mode === 'position' ? (index === windowStartIndex ? 0 : args.score) : null,
+      growthIndex: args.mode === 'index' ? (index === windowStartIndex ? 100 : 100 + args.score) : null
+    }))
+  }
+}
+
+function buildRankingGroups(windows: TWindow[], pointCount: number) {
+  return (['position', 'index'] as const).flatMap((mode) =>
+    windows.flatMap((window) =>
+      SCORES.map((score) =>
+        buildIsolatedSeries({
+          id: `${mode}-${window}-${score}`,
+          mode,
+          window,
+          score,
+          pointCount
+        })
+      )
+    )
+  )
+}
+
+describe('selectProtocolReturnFamilySeriesCandidates', () => {
+  it('keeps the best and worst five candidates for every 1y-response window and mode', () => {
+    const familySeries = buildRankingGroups(['30d', '90d', '1y'], 365)
+    const selected = selectProtocolReturnFamilySeriesCandidates(familySeries, '1y')
+    const expectedIds = familySeries
+      .filter((series) => Math.abs(Number(series.vaultAddress.split('-').at(-1))) >= 2)
+      .map((series) => series.vaultAddress)
+
+    expect(selected).toHaveLength(60)
+    expect(selected.map((series) => series.vaultAddress)).toEqual(expectedIds)
+  })
+
+  it('also keeps candidates that are only relevant to the all-time window', () => {
+    const familySeries = buildRankingGroups(['30d', '90d', '1y', 'all'], 400)
+    const selected = selectProtocolReturnFamilySeriesCandidates(familySeries, 'all')
+    const expectedIds = familySeries
+      .filter((series) => Math.abs(Number(series.vaultAddress.split('-').at(-1))) >= 2)
+      .map((series) => series.vaultAddress)
+
+    expect(selected).toHaveLength(80)
+    expect(selected.map((series) => series.vaultAddress)).toEqual(expectedIds)
+  })
+
+  it('preserves original-order tie breaks and removes unused point fields', () => {
+    const familySeries = Array.from({ length: 6 }, (_, index) =>
+      buildIsolatedSeries({
+        id: `tie-${index}`,
+        mode: 'position',
+        window: '30d',
+        score: 5,
+        pointCount: 365
+      })
+    )
+    const selected = selectProtocolReturnFamilySeriesCandidates(familySeries, '1y')
+
+    expect(selected.map((series) => series.vaultAddress)).toEqual(['tie-0', 'tie-1', 'tie-2', 'tie-3', 'tie-4'])
+    expect(selected[0]?.dataPoints[0]).toEqual({
+      timestamp: 0,
+      growthWeightUsd: 5,
+      growthIndex: null
+    })
+  })
+})

--- a/src/server/lib/holdings/services/protocolReturnFamilySeries.ts
+++ b/src/server/lib/holdings/services/protocolReturnFamilySeries.ts
@@ -1,0 +1,125 @@
+import {
+  rankPortfolioVaultGrowthChartSeries,
+  type TPortfolioVaultGrowthChartMode,
+  type TPortfolioVaultGrowthChartSortDirection
+} from '@shared/utils/portfolioVaultGrowth'
+
+type TProtocolReturnFamilyPoint = {
+  timestamp: number
+  growthWeightUsd: number | null
+  growthIndex: number | null
+}
+
+type TProtocolReturnFamilySeries = {
+  dataPoints: TProtocolReturnFamilyPoint[]
+}
+
+type TCompactProtocolReturnFamilySeries<TSeries extends TProtocolReturnFamilySeries> = Omit<TSeries, 'dataPoints'> & {
+  dataPoints: TProtocolReturnFamilyPoint[]
+}
+
+type TProtocolReturnFamilyWindow = '30d' | '90d' | '1y' | 'all'
+
+const MAX_FAMILY_SERIES_PER_RANKING = 5
+const FAMILY_SERIES_WINDOW_LIMITS: Record<TProtocolReturnFamilyWindow, number> = {
+  '30d': 30,
+  '90d': 90,
+  '1y': 365,
+  all: Number.MAX_SAFE_INTEGER
+}
+const FAMILY_SERIES_WINDOWS: Record<'1y' | 'all', TProtocolReturnFamilyWindow[]> = {
+  '1y': ['30d', '90d', '1y'],
+  all: ['30d', '90d', '1y', 'all']
+}
+const FAMILY_SERIES_MODES: TPortfolioVaultGrowthChartMode[] = ['position', 'index']
+const FAMILY_SERIES_SORT_DIRECTIONS: TPortfolioVaultGrowthChartSortDirection[] = ['desc', 'asc']
+
+function normalizeTimestamp(timestamp: number): number {
+  return timestamp > 1_000_000_000_000 ? Math.floor(timestamp / 1000) : Math.floor(timestamp)
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function buildPositionRankPoints(points: TProtocolReturnFamilyPoint[]): Array<{ value: number | null }> {
+  const firstFiniteIndex = points.findIndex((point) => isFiniteNumber(point.growthWeightUsd))
+  if (firstFiniteIndex < 0 || points.length - firstFiniteIndex < 2) {
+    return []
+  }
+
+  const firstValue = points[firstFiniteIndex]?.growthWeightUsd
+  const lastValue = points.findLast((point) => isFiniteNumber(point.growthWeightUsd))?.growthWeightUsd
+  if (!isFiniteNumber(firstValue) || !isFiniteNumber(lastValue)) {
+    return []
+  }
+
+  return [{ value: 0 }, { value: lastValue - firstValue }]
+}
+
+function buildIndexRankPoints(points: TProtocolReturnFamilyPoint[]): Array<{ value: number | null }> {
+  const baseValue = points.find((point) => isFiniteNumber(point.growthIndex))?.growthIndex
+
+  return points.map((point) => ({
+    value: baseValue && isFiniteNumber(point.growthIndex) ? (point.growthIndex / baseValue) * 100 : null
+  }))
+}
+
+/**
+ * Keeps every family the client could show after switching timeframe, mode, or
+ * sort direction. Returning the survivors in their original order preserves
+ * the client's stable tie-break while avoiding the full family-series payload.
+ */
+export function selectProtocolReturnFamilySeriesCandidates<TSeries extends TProtocolReturnFamilySeries>(
+  familySeries: TSeries[],
+  timeframe: '1y' | 'all'
+): Array<TCompactProtocolReturnFamilySeries<TSeries>> {
+  const preparedSeries = familySeries.map((series, originalIndex) => ({
+    originalIndex,
+    sortedPoints: series.dataPoints
+      .map((point) => ({ ...point, timestamp: normalizeTimestamp(point.timestamp) }))
+      .toSorted((left, right) => left.timestamp - right.timestamp)
+  }))
+
+  const selectedIndexes = new Set(
+    FAMILY_SERIES_WINDOWS[timeframe].flatMap((window) => {
+      const limit = FAMILY_SERIES_WINDOW_LIMITS[window]
+      const rankableSeries = preparedSeries.map((series) => {
+        const points = limit >= series.sortedPoints.length ? series.sortedPoints : series.sortedPoints.slice(-limit)
+        return {
+          originalIndex: series.originalIndex,
+          positionPoints: buildPositionRankPoints(points),
+          indexPoints: buildIndexRankPoints(points)
+        }
+      })
+
+      return FAMILY_SERIES_MODES.flatMap((mode) =>
+        FAMILY_SERIES_SORT_DIRECTIONS.flatMap((sortDirection) =>
+          rankPortfolioVaultGrowthChartSeries({
+            series: rankableSeries,
+            mode,
+            sortDirection,
+            maxVaults: MAX_FAMILY_SERIES_PER_RANKING
+          }).map((series) => series.originalIndex)
+        )
+      )
+    })
+  )
+
+  return familySeries.flatMap((series, originalIndex) => {
+    if (!selectedIndexes.has(originalIndex)) {
+      return []
+    }
+
+    return [
+      {
+        ...series,
+        dataPoints: series.dataPoints.map((point) => ({
+          timestamp: point.timestamp,
+          growthWeightUsd: point.growthWeightUsd,
+          growthIndex: point.growthIndex
+        }))
+      }
+    ]
+  })
+}

--- a/src/server/lib/holdings/services/settledHoldingsContext.ts
+++ b/src/server/lib/holdings/services/settledHoldingsContext.ts
@@ -18,7 +18,7 @@ import {
 import { buildAddressScopedRawPnlEvents } from './pnlEvents'
 import { lowerCaseAddress, toVaultKey } from './pnlShared'
 import type { TRawPnlEvent } from './pnlTypes'
-import { fetchMultipleVaultsMetadata } from './vaults'
+import { fetchMultipleVaultsMetadata, getVaultMetadataFetchFailedVaults } from './vaults'
 
 type TVaultIdentifier = {
   chainId: number
@@ -42,6 +42,7 @@ export interface TSettledAddressScopedContext {
   rawEvents: TRawPnlEvent[]
   rawVaultIdentifiers: TVaultIdentifier[]
   vaultMetadata: Map<string, VaultMetadata>
+  metadataFetchFailedVaults: number
 }
 
 export interface TSettledVersionedSelection {
@@ -211,6 +212,7 @@ export async function getSettledAddressScopedContext(args: {
     const baseVaultMetadata =
       rawVaultIdentifiers.length > 0 ? await fetchMultipleVaultsMetadata(rawVaultIdentifiers) : new Map()
     const vaultMetadata = await resolveNestedVaultAssetMetadata(baseVaultMetadata)
+    const metadataFetchFailedVaults = getVaultMetadataFetchFailedVaults(vaultMetadata)
 
     return {
       address: lowerCaseAddress(args.userAddress),
@@ -221,7 +223,8 @@ export async function getSettledAddressScopedContext(args: {
       hasActivity: timeline.length > 0,
       rawEvents,
       rawVaultIdentifiers,
-      vaultMetadata
+      vaultMetadata,
+      metadataFetchFailedVaults
     }
   })().finally(() => {
     inFlightSettledAddressScopedContexts.delete(key)

--- a/src/server/lib/holdings/services/vaults.test.ts
+++ b/src/server/lib/holdings/services/vaults.test.ts
@@ -178,4 +178,41 @@ describe('fetchMultipleVaultsMetadata', () => {
     expect(second.get(`1:${UNDERLYING_VAULT}`)?.token.symbol).toBe('USDC')
     expect(listAttempts).toBe(2)
   })
+
+  it('reports fallback metadata requests that still fail after retries', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const fetchStub = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+
+      if (url.includes('/list/vaults?origin=yearn')) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+      }
+
+      throw Object.assign(new Error('Unable to connect'), { code: 'ConnectionRefused' })
+    })
+
+    vi.stubGlobal('fetch', fetchStub)
+
+    const { fetchMultipleVaultsMetadata, getVaultMetadataFetchFailedVaults } = await importVaultsModule()
+    const metadata = await fetchMultipleVaultsMetadata([{ chainId: 1, vaultAddress: UNDERLYING_VAULT }])
+
+    expect(metadata.size).toBe(0)
+    expect(getVaultMetadataFetchFailedVaults(metadata)).toBe(1)
+  })
+
+  it('reports a failed vault list when snapshot fallback is intentionally skipped', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(Object.assign(new Error('socket closed'), { code: 'ECONNRESET' })))
+
+    const { fetchMultipleVaultsMetadata, getVaultMetadataFetchFailedVaults } = await importVaultsModule()
+    const metadata = await fetchMultipleVaultsMetadata([{ chainId: 1, vaultAddress: UNDERLYING_VAULT }], {
+      skipSnapshotFallback: true
+    })
+
+    expect(metadata.size).toBe(0)
+    expect(getVaultMetadataFetchFailedVaults(metadata)).toBe(1)
+  })
 })

--- a/src/server/lib/holdings/services/vaults.ts
+++ b/src/server/lib/holdings/services/vaults.ts
@@ -73,6 +73,7 @@ const DEFAULT_TIMEOUT_MS = 4_000
 const DEFAULT_MAX_RETRIES = 2
 const DEFAULT_RETRY_DELAY_MS = 200
 const SNAPSHOT_CONCURRENCY = 3
+const VAULT_METADATA_FETCH_FAILED_VAULTS = Symbol('vaultMetadataFetchFailedVaults')
 const KNOWN_STABLECOIN_SYMBOLS = new Set([
   'USDC',
   'USDT',
@@ -96,6 +97,26 @@ const vaultListState: TVaultListState = {
   stakingToVaultMap: null,
   hasLoadedGlobalVaultList: false,
   loadPromise: null
+}
+
+type TVaultMetadataFetchResult = Map<string, VaultMetadata> & {
+  [VAULT_METADATA_FETCH_FAILED_VAULTS]?: number
+}
+
+export function markVaultMetadataFetchFailures(
+  metadata: Map<string, VaultMetadata>,
+  failedVaults: number
+): Map<string, VaultMetadata> {
+  Object.defineProperty(metadata, VAULT_METADATA_FETCH_FAILED_VAULTS, {
+    value: failedVaults,
+    enumerable: false,
+    configurable: true
+  })
+  return metadata
+}
+
+export function getVaultMetadataFetchFailedVaults(metadata: Map<string, VaultMetadata>): number {
+  return (metadata as TVaultMetadataFetchResult)[VAULT_METADATA_FETCH_FAILED_VAULTS] ?? 0
 }
 
 function normalizeVaultCategory(category?: string | null): 'stable' | 'volatile' | null {
@@ -439,35 +460,49 @@ async function fetchFallbackMetadata(
   )
 
   const results = await chunkItems(uniqueVaults, SNAPSHOT_CONCURRENCY).reduce<
-    Promise<Array<{ key: string; metadata: VaultMetadata }>>
-  >(async (allResultsPromise, batch) => {
-    const allResults = await allResultsPromise
-    const batchResults = await Promise.allSettled(
-      batch.map(({ chainId, vaultAddress }) => fetchFallbackMetadataForVault(chainId, vaultAddress))
-    )
+    Promise<{ entries: Array<{ key: string; metadata: VaultMetadata }>; failedVaults: number }>
+  >(
+    async (allResultsPromise, batch) => {
+      const allResults = await allResultsPromise
+      const batchResults = await Promise.allSettled(
+        batch.map(({ chainId, vaultAddress }) => fetchFallbackMetadataForVault(chainId, vaultAddress))
+      )
 
-    const resolvedResults = batchResults.reduce<Array<{ key: string; metadata: VaultMetadata }>>((entries, result) => {
-      if (result.status === 'rejected') {
-        console.error('[Kong] Failed to fetch fallback vault metadata:', result.reason)
-        debugError('vaults', 'fallback metadata fetch failed', result.reason)
-        return entries
+      const resolvedResults = batchResults.reduce<{
+        entries: Array<{ key: string; metadata: VaultMetadata }>
+        failedVaults: number
+      }>(
+        (resultAccumulator, result) => {
+          if (result.status === 'rejected') {
+            console.error('[Kong] Failed to fetch fallback vault metadata:', result.reason)
+            debugError('vaults', 'fallback metadata fetch failed', result.reason)
+            resultAccumulator.failedVaults += Number(isRetryableError(result.reason))
+            return resultAccumulator
+          }
+
+          if (result.value === null) {
+            return resultAccumulator
+          }
+
+          resultAccumulator.entries.push(result.value)
+          return resultAccumulator
+        },
+        { entries: [], failedVaults: 0 }
+      )
+
+      return {
+        entries: [...allResults.entries, ...resolvedResults.entries],
+        failedVaults: allResults.failedVaults + resolvedResults.failedVaults
       }
+    },
+    Promise.resolve({ entries: [], failedVaults: 0 })
+  )
 
-      if (result.value === null) {
-        return entries
-      }
-
-      entries.push(result.value)
-      return entries
-    }, [])
-
-    return [...allResults, ...resolvedResults]
-  }, Promise.resolve([]))
-
-  return results.reduce<Map<string, VaultMetadata>>((map, { key, metadata }) => {
+  const metadata = results.entries.reduce<Map<string, VaultMetadata>>((map, { key, metadata }) => {
     map.set(key, metadata)
     return map
   }, new Map<string, VaultMetadata>())
+  return markVaultMetadataFetchFailures(metadata, results.failedVaults)
 }
 
 async function loadVaultList(): Promise<void> {
@@ -540,12 +575,19 @@ export async function fetchMultipleVaultsMetadata(
   const missingVaults = vaults.filter(
     ({ chainId, vaultAddress }) => !results.has(`${chainId}:${vaultAddress.toLowerCase()}`)
   )
+  const shouldFetchFallback = missingVaults.length > 0 && !options?.skipSnapshotFallback
 
-  if (missingVaults.length > 0 && !options?.skipSnapshotFallback) {
+  if (shouldFetchFallback) {
     debugLog('vaults', 'metadata missing from global cache, falling back to snapshots', {
       missing: missingVaults.length
     })
-    const fallbackResults = await fetchFallbackMetadata(missingVaults)
+  }
+
+  const fallbackResults = shouldFetchFallback
+    ? await fetchFallbackMetadata(missingVaults)
+    : new Map<string, VaultMetadata>()
+
+  if (shouldFetchFallback) {
     fallbackResults.forEach((metadata, key) => {
       results.set(key, metadata)
     })
@@ -560,5 +602,9 @@ export async function fetchMultipleVaultsMetadata(
     resolved: results.size,
     loadError: loadError?.message ?? null
   })
-  return results
+  const skippedFallbackFailures = options?.skipSnapshotFallback && loadError ? missingVaults.length : 0
+  return markVaultMetadataFetchFailures(
+    results,
+    getVaultMetadataFetchFailedVaults(fallbackResults) + skippedFallbackFailures
+  )
 }


### PR DESCRIPTION
### Summary

Improve the Portfolio Vault Performance charts and the protocol-return history pipeline.

- Rename **Growth Index** to **Vault Performance**.
- Clarify the two chart modes:
  - **Index** shows normalized PPS performance while the wallet held each vault, starting at `100`.
  - **Position** shows each vault’s contribution to the wallet’s protocol gain in USD.
- Prevent deposits and partial withdrawals from creating artificial Index jumps.
- Show gaps after a full exit and resume from a new PPS anchor after re-entry.
- Add best/worst performance sorting for Index and top/bottom contributor sorting for Position.
- Rank vaults using the selected timeframe and return the union of candidates required for switching chart modes without another request.
- Add a daily, wallet- and vault-scope-specific Redis snapshot for protocol-return history.
- Coalesce identical in-flight requests and only cache results when all required upstream data was fetched successfully.
- Respect vault invalidation markers so stale histories are recalculated.
- Improve GraphQL pagination and concurrent fallback fetching to avoid silently truncated histories.
- Make balance history respect `fetchType=parallel` and increase the protocol-history client timeout for larger wallets.

### How to review

1. Open Portfolio for a wallet with several historical vault positions.
2. Select **Vault Performance** and switch between:
   - Index and Position
   - Best and worst performance
   - Top and bottom contributors
   - Different timeframes
3. Confirm that:
   - Index lines begin at `100`.
   - Deposits and partial withdrawals do not create artificial jumps.
   - Full exits create visible gaps.
   - Position ranking reflects USD gain contribution.
   - Tooltip ordering matches the selected sorting direction.
4. With Redis enabled, request the same protocol-return history twice and confirm the second request uses the cached snapshot.
5. Confirm vault invalidation causes the affected snapshot to be recalculated.

### Test plan

- [x] Run the targeted holdings and protocol-return Vitest suites.
- [x] Compare the one-year aggregate history for `0x96A489A533bA0913dD8E507e6D985a45BC783566` against production: all 365 aggregate points and the summary match.
- [x] Run the one-year history three times for `0x93A62dA5a14C80f265DAbC077fCEE437B1a0Efde`: local calculation completed consistently, while the current production request timed out at approximately 60 seconds.
- [x] Verify the wallet’s yvUSD Index progresses from `100` to approximately `101.90%` without a deposit-related jump.
- [ ] Benchmark the Redis cold-to-warm path in an environment with Redis enabled.

### Risk / impact

- This affects read-only Portfolio charts and holdings history; it does not change deposits, withdrawals, or transaction execution.
- Cold calculations for wallets with very large histories may still exceed the current production function timeout. The new cache improves subsequent requests after one calculation completes.
- Returning the candidates needed for both sorting directions can produce a larger response than the previous fixed five-vault payload.
- Protocol-return cache entries are versioned and expire after 24 hours, allowing the cache format or calculation semantics to be invalidated safely.
- A vault-scoped yvUSD request can still return a partial result when the first required USDC price is earlier than the available scoped price history. The full-wallet calculation is unaffected; this should be handled separately.