### PR TITLE
Use 7-day APY for yBOLD estimates

### DIFF
--- a/src/components/pages/vaults/components/detail/VaultDetailsHeader.test.tsx
+++ b/src/components/pages/vaults/components/detail/VaultDetailsHeader.test.tsx
@@ -1,3 +1,4 @@
+import { YBOLD_VAULT_ADDRESS } from '@pages/vaults/domain/normalizeVault'
 import { YVBTC_LOCKED_ADDRESS, YVBTC_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvBtc'
 import { YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import type { ReactNode } from 'react'
@@ -181,7 +182,12 @@ vi.mock('@pages/vaults/hooks/useYvBtcVaults', () => ({
 vi.mock('@shared/components/MetricsCard', () => ({
   METRIC_FOOTNOTE_CLASS: 'metric-footnote',
   METRIC_VALUE_CLASS: 'metric-value',
-  MetricHeader: ({ label }: { label: string }) => <span>{label}</span>,
+  MetricHeader: ({ label, tooltip }: { label: string; tooltip?: ReactNode }) => (
+    <span>
+      {label}
+      {tooltip}
+    </span>
+  ),
   MetricsCard: ({
     items,
     className
@@ -303,6 +309,19 @@ const YVBTC_VAULT = {
   }
 } as const
 
+const YBOLD_VAULT = {
+  ...YVUSD_VAULT,
+  address: YBOLD_VAULT_ADDRESS,
+  symbol: 'yBOLD',
+  name: 'yBOLD',
+  token: {
+    address: '0x6440F144b7e50D6a8439336510312d2F54beB01D',
+    symbol: 'BOLD',
+    name: 'BOLD',
+    decimals: 18
+  }
+} as const
+
 describe('VaultDetailsHeaderPresentation', () => {
   beforeEach(() => {
     useVaultUserDataMock.mockClear()
@@ -349,5 +368,22 @@ describe('VaultDetailsHeaderPresentation', () => {
         enabled: false
       })
     )
+  })
+
+  it('describes the 7 day historical basis for the yBOLD estimated APY', () => {
+    const html = renderToStaticMarkup(
+      <VaultDetailsHeaderPresentation currentVault={YBOLD_VAULT as never} depositedValue={0n} isCompressed={false} />
+    )
+
+    expect(html).toContain('Projected APY based on 7 day historical performance')
+    expect(html).not.toContain('Projected APY based on underlying markets')
+  })
+
+  it('keeps the underlying-markets tooltip for other vaults', () => {
+    const html = renderToStaticMarkup(
+      <VaultDetailsHeaderPresentation currentVault={YVBTC_VAULT as never} depositedValue={0n} isCompressed={false} />
+    )
+
+    expect(html).toContain('Projected APY based on underlying markets')
   })
 })

--- a/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
+++ b/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
@@ -12,6 +12,7 @@ import {
 import { YvUsdApyTooltipContent, YvUsdTvlTooltipContent } from '@pages/vaults/components/yvUSD/YvUsdBreakdown'
 import { YvUsdHeaderBanner } from '@pages/vaults/components/yvUSD/YvUsdHeaderBanner'
 import { getVaultView, type TKongVaultInput } from '@pages/vaults/domain/kongVaultSelectors'
+import { isYBoldProductAddress } from '@pages/vaults/domain/normalizeVault'
 import { useHeaderCompression } from '@pages/vaults/hooks/useHeaderCompression'
 import { useVaultUserData, type VaultUserData } from '@pages/vaults/hooks/useVaultUserData'
 import { useYvBtcVaults } from '@pages/vaults/hooks/useYvBtcVaults'
@@ -471,6 +472,9 @@ function VaultOverviewCard({
   onYvUsdApyVariantChange?: (variant: TYvUsdVariant) => void
 }): ReactElement {
   const currentVault = getVaultView(currentVaultInput)
+  const estimatedApyTooltip = isYBoldProductAddress(currentVault.address)
+    ? 'Projected APY based on 7 day historical performance'
+    : 'Projected APY based on underlying markets'
   const totalAssets = toNormalizedBN(currentVault.tvl.totalAssets, currentVault.decimals).normalized
   const listKind = deriveListKind(currentVault)
   const isFactoryVault = listKind === 'factory'
@@ -561,7 +565,7 @@ function VaultOverviewCard({
   const metrics: TMetricBlock[] = [
     {
       key: 'est-apy',
-      header: <MetricHeader label={'Est. APY'} tooltip={'Projected APY based on underlying markets'} />,
+      header: <MetricHeader label={'Est. APY'} tooltip={estimatedApyTooltip} />,
       value: isDualVariantVault ? (
         <Tooltip
           className={'h-auto w-full gap-0'}

--- a/src/components/pages/vaults/domain/normalizeVault.test.ts
+++ b/src/components/pages/vaults/domain/normalizeVault.test.ts
@@ -2,9 +2,18 @@ import { describe, expect, it } from 'vitest'
 import {
   getCanonicalHoldingsVaultAddress,
   getHoldingsAliasVaultAddress,
+  isYBoldProductAddress,
   YBOLD_STAKING_ADDRESS,
   YBOLD_VAULT_ADDRESS
 } from './normalizeVault'
+
+describe('yBOLD product helpers', () => {
+  it('identifies the base and staked yBOLD vault addresses', () => {
+    expect(isYBoldProductAddress(YBOLD_VAULT_ADDRESS)).toBe(true)
+    expect(isYBoldProductAddress(YBOLD_STAKING_ADDRESS.toLowerCase())).toBe(true)
+    expect(isYBoldProductAddress('0x0000000000000000000000000000000000000001')).toBe(false)
+  })
+})
 
 describe('holdings alias helpers', () => {
   it('maps the yBOLD staking wrapper to the base vault', () => {

--- a/src/components/pages/vaults/domain/normalizeVault.ts
+++ b/src/components/pages/vaults/domain/normalizeVault.ts
@@ -7,8 +7,14 @@ import { type Address, zeroAddress } from 'viem'
 export const YBOLD_VAULT_ADDRESS: Address = '0x9F4330700a36B29952869fac9b33f45EEdd8A3d8'
 export const YBOLD_STAKING_ADDRESS: Address = '0x23346B04a7f55b8760E5860AA5A77383D63491cD'
 
+const YBOLD_PRODUCT_ADDRESSES = new Set([toAddress(YBOLD_VAULT_ADDRESS), toAddress(YBOLD_STAKING_ADDRESS)])
+
 const HOLDINGS_ALIAS_BY_ADDRESS: Record<string, Address> = {
   [toAddress(YBOLD_STAKING_ADDRESS)]: YBOLD_VAULT_ADDRESS
+}
+
+export function isYBoldProductAddress(address: Address | string | undefined): boolean {
+  return Boolean(address && YBOLD_PRODUCT_ADDRESSES.has(toAddress(address)))
 }
 
 export function mergeYBoldVault(baseVault: TKongVaultListItem, stakedVault: TKongVaultListItem): TKongVaultListItem {

--- a/src/components/pages/vaults/hooks/useVaultApyData.ts
+++ b/src/components/pages/vaults/hooks/useVaultApyData.ts
@@ -13,7 +13,12 @@ import {
   projectVeYfiRange
 } from '@pages/vaults/utils/apy'
 import { isZero } from '@shared/utils'
-import { calculateKatanaTotalApr, getKatanaAprData, type TKatanaAprData } from '@shared/utils/vaultApy'
+import {
+  calculateKatanaTotalApr,
+  getKatanaAprData,
+  getVaultForwardAPY,
+  type TKatanaAprData
+} from '@shared/utils/vaultApy'
 import { useMemo } from 'react'
 
 export type TVaultApyMode = 'katana' | 'noForward' | 'boosted' | 'rewards' | 'spot' | 'historical'
@@ -57,7 +62,7 @@ export function useVaultApyData(vault: TKongVaultInput): TVaultApyData {
 
   const apr = getVaultAPR(vault)
   const staking = getVaultStaking(vault)
-  const baseForwardApr = apr.forwardAPR.netAPR
+  const baseForwardApr = getVaultForwardAPY(vault)
   const netApr = apr.netAPR
   const rewardsAprSum = apr.extra.stakingRewardsAPR + apr.extra.gammaRewardAPR
   const isBoosted =

--- a/src/components/shared/utils/vaultApy.test.ts
+++ b/src/components/shared/utils/vaultApy.test.ts
@@ -1,10 +1,12 @@
 import type { TKongVault, TKongVaultInput } from '@pages/vaults/domain/kongVaultSelectors'
+import { YBOLD_STAKING_ADDRESS, YBOLD_VAULT_ADDRESS } from '@pages/vaults/domain/normalizeVault'
 import { describe, expect, it } from 'vitest'
 import {
   calculateKatanaThirtyDayAPY,
   calculateVaultEstimatedAPY,
   calculateVaultHistoricalAPY,
-  getKatanaAprData
+  getKatanaAprData,
+  getVaultForwardAPY
 } from './vaultApy'
 
 const BASE_VAULT: TKongVault = {
@@ -148,5 +150,43 @@ describe('vaultApy Katana calculations', () => {
   it('falls back to monthly historical APY for Katana vaults when components are absent', () => {
     const apy = calculateVaultHistoricalAPY(BASE_VAULT)
     expect(apy).toBeCloseTo(0.02, 6)
+  })
+})
+
+describe('yBOLD estimated APY override', () => {
+  const createYBoldVault = (address: string): TKongVault =>
+    ({
+      ...BASE_VAULT,
+      chainId: 1,
+      address,
+      performance: {
+        ...BASE_VAULT.performance,
+        oracle: {
+          apr: 0.12,
+          apy: 0.13,
+          netAPR: 0.11,
+          netAPY: 0.115
+        },
+        historical: {
+          net: 0.08,
+          weeklyNet: 0.0725,
+          monthlyNet: 0.081,
+          inceptionNet: 0.09
+        }
+      }
+    }) as TKongVault
+
+  it.each([
+    YBOLD_VAULT_ADDRESS,
+    YBOLD_STAKING_ADDRESS
+  ])('uses 7 day historical net APY as the estimated APY for %s', (address) => {
+    const vault = createYBoldVault(address)
+
+    expect(getVaultForwardAPY(vault)).toBe(0.0725)
+    expect(calculateVaultEstimatedAPY(vault)).toBe(0.0725)
+  })
+
+  it('keeps the forward APY for other vaults', () => {
+    expect(getVaultForwardAPY(BASE_VAULT)).toBe(0.068)
   })
 })

--- a/src/components/shared/utils/vaultApy.ts
+++ b/src/components/shared/utils/vaultApy.ts
@@ -1,4 +1,10 @@
-import { getVaultAPR, getVaultChainID, type TKongVaultInput } from '@pages/vaults/domain/kongVaultSelectors'
+import {
+  getVaultAddress,
+  getVaultAPR,
+  getVaultChainID,
+  type TKongVaultInput
+} from '@pages/vaults/domain/kongVaultSelectors'
+import { isYBoldProductAddress } from '@pages/vaults/domain/normalizeVault'
 import { isZero } from '@shared/utils'
 
 const KATANA_CHAIN_ID = 747474
@@ -58,17 +64,32 @@ export function getKatanaAprData(vault: TKongVaultInput): TKatanaAprData | undef
   }
 }
 
+export function getVaultForwardAPY(vault: TKongVaultInput): number {
+  const apr = getVaultAPR(vault)
+
+  if (isYBoldProductAddress(getVaultAddress(vault))) {
+    return apr.points.weekAgo
+  }
+
+  return apr.forwardAPR?.netAPR || 0
+}
+
 export function calculateVaultEstimatedAPY(vault: TKongVaultInput): number {
   const apr = getVaultAPR(vault)
   const chainID = getVaultChainID(vault)
+  const forwardAPY = getVaultForwardAPY(vault)
+
+  if (isYBoldProductAddress(getVaultAddress(vault))) {
+    return forwardAPY
+  }
 
   if (chainID === KATANA_CHAIN_ID) {
     const katanaAprData = getKatanaAprData(vault)
     if (katanaAprData) {
-      const katanaEstimatedApr = calculateKatanaTotalApr(katanaAprData, apr.forwardAPR?.netAPR || 0)
-      return katanaEstimatedApr ?? (apr.forwardAPR?.netAPR || 0)
+      const katanaEstimatedApr = calculateKatanaTotalApr(katanaAprData, forwardAPY)
+      return katanaEstimatedApr ?? forwardAPY
     }
-    return apr.forwardAPR?.netAPR || 0
+    return forwardAPY
   }
 
   if (apr.forwardAPR?.type === '') {
@@ -76,17 +97,17 @@ export function calculateVaultEstimatedAPY(vault: TKongVaultInput): number {
   }
 
   if (chainID === 1 && apr.forwardAPR?.composite?.boost > 0 && !apr.extra?.stakingRewardsAPR) {
-    return apr.forwardAPR?.netAPR || 0
+    return forwardAPY
   }
 
   const sumOfRewardsAPY = (apr.extra?.stakingRewardsAPR || 0) + (apr.extra?.gammaRewardAPR || 0)
-  const hasCurrentAPY = !isZero(apr.forwardAPR?.netAPR || 0)
+  const hasCurrentAPY = !isZero(forwardAPY)
 
   if (sumOfRewardsAPY > 0) {
-    return sumOfRewardsAPY + (apr.forwardAPR?.netAPR || 0)
+    return sumOfRewardsAPY + forwardAPY
   }
   if (hasCurrentAPY) {
-    return apr.forwardAPR?.netAPR || 0
+    return forwardAPY
   }
   return apr?.netAPR || 0
 }


### PR DESCRIPTION
## Summary

- show the 7-day historical net APY as the estimated APY for yBOLD and ysyBOLD
- apply the override to vault lists, detail pages, sorting, and portfolio calculations
- add tests covering both yBOLD product addresses and unchanged behavior for other vaults

## Why

As requested by Schlag and Johnny.
The forward estimate currently shown for yBOLD products does not reflect the desired user-facing yield. Both products should use their realized 7-day net APY wherever the interface presents an estimated or current APY.

## Validation

- `bun run tslint`
- `bun run lint:fix`
- `bunx vitest run src/components/shared/utils/vaultApy.test.ts src/components/pages/vaults/domain/normalizeVault.test.ts`
- `bun run build`
