### PR TITLE
Fix activity loading render loop

### DIFF
--- a/src/components/pages/portfolio/hooks/usePortfolioActivity.test.tsx
+++ b/src/components/pages/portfolio/hooks/usePortfolioActivity.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import { render } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { usePortfolioActivity } from './usePortfolioActivity'
+
+vi.mock('@shared/contexts/useWeb3', () => ({
+  useWeb3: () => ({ address: '0x1111111111111111111111111111111111111111' })
+}))
+
+vi.mock('@shared/hooks/useFetch', () => ({
+  fetchWithSchema: vi.fn()
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useInfiniteQuery: vi.fn(),
+  useQuery: vi.fn()
+}))
+
+const useInfiniteQueryMock = vi.mocked(useInfiniteQuery)
+const useQueryMock = vi.mocked(useQuery)
+
+describe('usePortfolioActivity', () => {
+  beforeEach(() => {
+    useInfiniteQueryMock.mockReturnValue({
+      data: {
+        pages: [
+          {
+            entries: [{ chainId: 137 }, { chainId: 1 }, { chainId: 137 }]
+          }
+        ]
+      },
+      error: null,
+      fetchNextPage: vi.fn(),
+      hasNextPage: true,
+      isFetching: false,
+      isFetchingNextPage: false,
+      isLoading: false
+    } as unknown as ReturnType<typeof useInfiniteQuery>)
+    useQueryMock.mockReturnValue({ data: undefined } as unknown as ReturnType<typeof useQuery>)
+  })
+
+  it('keeps fallback activity chain IDs stable while facets are loading', () => {
+    const results: Array<ReturnType<typeof usePortfolioActivity>> = []
+
+    function Probe(): ReactElement | null {
+      results.push(usePortfolioActivity())
+      return null
+    }
+
+    const view = render(<Probe />)
+    view.rerender(<Probe />)
+
+    expect(results[0]?.availableChainIds).toEqual([1, 137])
+    expect(results[1]?.availableChainIds).toBe(results[0]?.availableChainIds)
+  })
+})

--- a/src/components/pages/portfolio/hooks/usePortfolioActivity.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioActivity.ts
@@ -1,6 +1,7 @@
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { fetchWithSchema } from '@shared/hooks/useFetch'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
 import {
   portfolioActivityFacetsResponseSchema,
   portfolioActivityResponseSchema,
@@ -106,15 +107,23 @@ export function usePortfolioActivity(limit = 10, enabled = true, filters: TPortf
     retryDelay: getActivityRetryDelay
   })
 
-  const entries: TPortfolioActivityEntry[] = query.data?.pages.flatMap((page) => page.entries) ?? []
-  const facetChainIds = facetsQuery.data?.facets.chainIds ?? null
-  const availableChainIds =
-    facetChainIds ??
-    (shouldFetchFacets && query.data
+  const entries: TPortfolioActivityEntry[] = useMemo(
+    () => query.data?.pages.flatMap((page) => page.entries) ?? [],
+    [query.data]
+  )
+  const availableChainIds = useMemo(() => {
+    const facetChainIds = facetsQuery.data?.facets.chainIds
+
+    if (facetChainIds) {
+      return facetChainIds
+    }
+
+    return shouldFetchFacets && query.data
       ? Array.from(new Set(entries.map((entry) => entry.chainId))).sort(
           (firstChainId, secondChainId) => firstChainId - secondChainId
         )
-      : null)
+      : null
+  }, [entries, facetsQuery.data, query.data, shouldFetchFacets])
   const isInitialLoading = query.isLoading || (query.isFetching && entries.length === 0)
   const isEmpty = !isInitialLoading && !query.error && Boolean(address) && entries.length === 0
   const error = query.error instanceof Error ? query.error : query.error ? new Error('Failed to fetch activity') : null


### PR DESCRIPTION
## Summary

Fixes an issue where, when new activity rows were being loaded, the page was preventing any further actions outside the activity component. Navigation was blocked and required waiting or reloading.

Fix:
- memoize derived activity entries and fallback chain IDs
- prevent the Activity tab from entering a render loop while facets load
- add a regression test for reference stability before facet data arrives

## Root cause

While the activity facets request was pending, the hook recreated its fallback chain ID array on every render. The Activity section watched that array by reference and wrote it into state, producing a maximum-update-depth loop that could block navigation and other interactions until the facets request completed.

## Impact

The Activity tab remains responsive while additional activity pages and facet data are loading.

## Validation

- `bunx vitest run src/components/pages/portfolio/hooks/usePortfolioActivity.test.tsx`
- `bun run tslint`
- `bun run lint:fix`
- `bun run build`
- browser verification while `Loading more...` was visible
