### PR TITLE
Rename inactive strategies rollout

### DIFF
--- a/src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
+++ b/src/components/pages/vaults/components/detail/VaultStrategiesSection.tsx
@@ -310,7 +310,7 @@ export function VaultStrategiesSection({
                       onClick={(): void => setAreInactiveStrategiesOpen((isOpen) => !isOpen)}
                     >
                       <span>
-                        {areInactiveStrategiesOpen ? 'Hide Inactive Strategies' : 'Show Inactive Strategies'}
+                        {areInactiveStrategiesOpen ? 'Hide Unallocated Strategies' : 'Show Unallocated Strategies'}
                         <span className={'ml-1 font-normal text-text-secondary'}>({inactiveStrategies.length})</span>
                       </span>
                       <IconChevron


### PR DESCRIPTION
## What changed

Per Schlag request:
- Rename the collapsed rollout label to `Show Unallocated Strategies`.
- Rename the expanded rollout label to `Hide Unallocated Strategies`.

## Why

The rollout groups strategies without allocations, so “unallocated” describes the visible behavior more accurately than “inactive.”

## Validation

- `bun run tslint`
- `bun run lint:fix`
- `bun run build`
- Production preview HTTP checks
