### PR TITLE
Reduce Tenderly request fan-out

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -39,27 +39,22 @@ Use the smallest reviewed budget based on a previous measured run plus a small
 margin. Do not choose a large budget simply to prevent a test from failing.
 Running a multi-flow suite or adding a second chain requires deliberate review.
 
-The safe discovery command is:
+The safe discovery commands are:
 
 ```bash
-bun run qa:vault-widget:tenderly --list
+bun run tenderly --help
+bun scripts/tenderly-vnet-status.ts --help
 ```
 
-A deliberately scoped live invocation looks like:
-
-```bash
-bun run qa:vault-widget:tenderly \
-  --flow yvusd-direct \
-  --max-rpc-methods 30
-```
-
-Do not run `--suite full` unless the user explicitly asks for the full live
-suite and approves an appropriately reviewed budget.
+This branch does not provide a general-purpose live QA suite. Do not treat the
+generic Tenderly CLI or VNet status command as an implicit end-to-end runner.
+Do not add or run a broad live suite unless the user explicitly asks for it and
+approves an appropriately reviewed budget.
 
 ### Count requests accurately
 
-All Tenderly JSON-RPC transports in a QA script must use the shared budgeting
-logic in `tenderly-qa-control.ts`. Do not add a direct `fetch`, Viem transport,
+All Tenderly JSON-RPC transports in a live QA script must pass through shared,
+mock-tested budgeting logic. Do not add a direct `fetch`, Viem transport,
 poller, or retry path that bypasses accounting.
 
 Accounting must:

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,147 @@
+# Script Guidelines
+
+The repository-level guidance in `../AGENTS.md` and `../CLAUDE.md` also applies
+to this directory.
+
+## Tenderly VNet safety
+
+Tenderly Virtual TestNet (VNet) usage is expensive and consumes a limited
+Tenderly Unit (TU) quota. Treat every VNet request as costly. Do not run a live
+Tenderly script merely to inspect behavior, reproduce an old count, or perform
+routine verification when mocks or static analysis can answer the question.
+
+### Default to no live traffic
+
+- Unit, integration, and browser-routing tests must mock RPC responses.
+- Browser tests must intercept Tenderly hostnames and fail if any request would
+  reach one.
+- `--list`, help, parsing, reporting, and budget tests must work without
+  credentials and without making network requests.
+- Do not create, rotate, or replace a VNet as an incidental setup step. Only do
+  so when the user explicitly requests it.
+- Never run Tenderly smoke or full suites during routine implementation.
+- Build and serve review previews with `NEXT_PUBLIC_TENDERLY_MODE=false`.
+- Never print API keys, Admin RPC URLs, or other Tenderly credentials.
+
+### Require narrow, explicit live scope
+
+Every live QA runner must:
+
+1. Require an explicit flow or suite selection. It must have no implicit live
+   default.
+2. Require a hard JSON-RPC method budget before reading credentials or making
+   network requests.
+3. Select one flow and one canonical chain by default.
+4. Initialize additional chains only when the selected flow requires them.
+5. Abort before sending a request that would exceed the remaining budget.
+
+Use the smallest reviewed budget based on a previous measured run plus a small
+margin. Do not choose a large budget simply to prevent a test from failing.
+Running a multi-flow suite or adding a second chain requires deliberate review.
+
+The safe discovery command is:
+
+```bash
+bun run qa:vault-widget:tenderly --list
+```
+
+A deliberately scoped live invocation looks like:
+
+```bash
+bun run qa:vault-widget:tenderly \
+  --flow yvusd-direct \
+  --max-rpc-methods 30
+```
+
+Do not run `--suite full` unless the user explicitly asks for the full live
+suite and approves an appropriately reviewed budget.
+
+### Count requests accurately
+
+All Tenderly JSON-RPC transports in a QA script must use the shared budgeting
+logic in `tenderly-qa-control.ts`. Do not add a direct `fetch`, Viem transport,
+poller, or retry path that bypasses accounting.
+
+Accounting must:
+
+- Count both HTTP requests and individual JSON-RPC methods.
+- Count every entry in a JSON-RPC batch, not just the enclosing HTTP request.
+- Report counts per canonical chain and per method.
+- Include polling, retries, setup, funding, snapshots, and cleanup.
+- Reject unknown RPC methods before network I/O.
+- Disable transport retries for live verification.
+- Bound receipt polling and any other repeated request loop.
+- Fail if an unexpected second chain is contacted.
+
+When adding a new method, update the explicit allowlist and its mocked tests.
+Do not weaken the allowlist to accept arbitrary methods.
+
+### Snapshots and cleanup
+
+Every stateful flow must isolate its mutations with a snapshot and guaranteed
+revert:
+
+- Reserve budget for both `evm_snapshot` and its matching `evm_revert` before
+  creating the snapshot.
+- Run the revert in `finally`.
+- Keep the reserved cleanup available even when ordinary budget is exhausted.
+- Count the cleanup within the same total method budget.
+- Verify that `evm_revert` returned success.
+- Fail the run if any cleanup reservation remains outstanding.
+
+Never leave a shared VNet modified after a failed or interrupted flow. If code
+cannot guarantee cleanup, do not run it against a live VNet.
+
+### Choose VNet calls deliberately
+
+Use the VNet for state that must reflect the simulation:
+
+- Funding, snapshots, time travel, mining, and reverts.
+- Transactions, receipts, traces, nonces, and transaction lookups.
+- Balances, allowances, logs, previews, quotes, rewards, cooldowns, and block
+  data that can change after simulated mutations.
+
+Canonical APIs such as Enso or Kong may provide portfolio, routing, or metadata
+data when simulation-specific state is not required. Do not redirect
+transaction-critical reads to a default live-chain RPC: the live head can
+differ from the VNet fork and produce invalid QA results.
+
+Prefer eliminating redundant reads, caching immutable results within one flow,
+and selecting fewer flows over mixing live and simulated chain state. Avoid
+full-token-catalog balance multicalls; request only the contracts needed by the
+active flow.
+
+## VNet status checks
+
+Transaction history is diagnostic and is not required to inspect live chain
+state. Use the narrowest status query that answers the question:
+
+```bash
+bun scripts/tenderly-vnet-status.ts \
+  --chain 1 \
+  --transaction-mode none
+```
+
+Transaction modes have these costs:
+
+- `none`: no transaction-history requests.
+- `recent`: at most one transaction-history request per selected chain.
+- `full`: up to 100 history pages per selected chain.
+
+Use `none` for routine status checks. Use `recent` only when recent activity is
+needed. Never use `full` unless the user explicitly requests a complete history
+scan.
+
+## Verification order
+
+For Tenderly-related script changes:
+
+1. Run focused mocked tests.
+2. Run the broader mocked test suite with Tenderly mode disabled.
+3. Run type checking and linting.
+4. Perform a live flow only when it is explicitly required and authorized.
+5. Print the final per-chain, method-by-method accounting and cleanup result.
+
+A live verification fails if it exhausts its budget, uses an unexpected
+method, contacts an unexpected chain, retries transport requests, or fails to
+revert every snapshot.

--- a/scripts/tenderly-vnet-status.test.ts
+++ b/scripts/tenderly-vnet-status.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   buildTenderlyStatusJson,
   buildTenderlyStatusMarkdown,
   classifyPublicRpcMode,
+  fetchTenderlyRecentTransactions,
   normalizeTenderlyTransactionListResponse,
   normalizeTenderlyVnetListResponse,
+  parseTenderlyTransactionMode,
   resolveStableNamedPublicRpcName,
   resolveTenderlyStatusIdentity,
   selectMatchingTenderlyVnet
@@ -53,6 +55,85 @@ describe('tenderly-vnet-status', () => {
     expect(normalizeTenderlyTransactionListResponse([{ tx_hash: '0xabc' }])).toHaveLength(1)
     expect(normalizeTenderlyTransactionListResponse({ transactions: [{ tx_hash: '0xdef' }] })).toHaveLength(1)
     expect(normalizeTenderlyTransactionListResponse({ data: [{ tx_hash: '0xghi' }] })).toHaveLength(1)
+  })
+
+  it('defaults to a bounded recent transaction lookup', () => {
+    expect(parseTenderlyTransactionMode({})).toBe('recent')
+    expect(parseTenderlyTransactionMode({ 'transaction-mode': 'none' })).toBe('none')
+    expect(parseTenderlyTransactionMode({ 'transaction-mode': 'full' })).toBe('full')
+    expect(() => parseTenderlyTransactionMode({ 'transaction-mode': 'everything' })).toThrow('Invalid transaction mode')
+  })
+
+  it('makes one transaction request in recent mode and skips all requests in none mode', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify([{ tx_hash: '0xabc', status: 'success' }]), {
+        headers: { 'content-type': 'application/json' }
+      })
+    )
+    const identity = {
+      profile: 'webops' as const,
+      accountSlug: 'yearn',
+      projectSlug: 'frontend',
+      apiKey: 'test-key'
+    }
+
+    const recent = await fetchTenderlyRecentTransactions({
+      identity,
+      mode: 'recent',
+      recentCount: 5,
+      vnetId: 'vnet-1',
+      fetchFn
+    })
+    const none = await fetchTenderlyRecentTransactions({
+      identity,
+      mode: 'none',
+      recentCount: 5,
+      vnetId: 'vnet-1',
+      fetchFn
+    })
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(recent).toMatchObject({
+      recentTransactionsAvailable: true,
+      totalTransactionsAvailable: false,
+      totalTransactionsNote: 'not scanned (use --transaction-mode full)'
+    })
+    expect(none).toMatchObject({
+      recentTransactionsAvailable: false,
+      totalTransactionsAvailable: false
+    })
+  })
+
+  it('paginates only when full mode is explicit', async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      id: `tx-${index}`,
+      status: 'success'
+    }))
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(JSON.stringify(firstPage)))
+      .mockResolvedValueOnce(new Response(JSON.stringify([])))
+
+    const result = await fetchTenderlyRecentTransactions({
+      identity: {
+        profile: 'webops',
+        accountSlug: 'yearn',
+        projectSlug: 'frontend',
+        apiKey: 'test-key'
+      },
+      mode: 'full',
+      recentCount: 5,
+      vnetId: 'vnet-1',
+      fetchFn
+    })
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(result).toMatchObject({
+      recentTransactionsAvailable: true,
+      totalTransactionsAvailable: true,
+      totalTransactionsCount: 100
+    })
+    expect(result.recentTransactions).toHaveLength(5)
   })
 
   it('matches the active vnet by admin rpc before any weaker fallback', () => {
@@ -112,6 +193,7 @@ describe('tenderly-vnet-status', () => {
       projectSlug: 'frontend',
       restMetadataAvailable: true,
       recentTransactionCount: 5,
+      transactionMode: 'recent' as const,
       chainReports: [
         {
           canonicalChainId: 1,

--- a/scripts/tenderly-vnet-status.ts
+++ b/scripts/tenderly-vnet-status.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 
 import { resolve as resolvePath } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { parseTenderlyServerChains, type TTenderlyServerChainConfig } from '../src/config/tenderlyServer'
 import { buildPredictablePublicRpcUrl, readEnvFile, sanitizeConsoleText } from './tenderly-vnet'
 
@@ -45,6 +46,7 @@ type TTenderlyVnetRecord = {
 }
 
 type TTenderlyStatusMatchReason = 'admin-rpc' | 'public-rpc' | 'execution-chain-id' | 'single-vnet-fallback'
+export type TTenderlyTransactionMode = 'full' | 'none' | 'recent'
 
 type TTenderlyMatchedVnet = {
   record: TTenderlyVnetRecord
@@ -130,7 +132,17 @@ type TTenderlyStatusReport = {
   restMetadataAvailable: boolean
   restMetadataNote?: string
   recentTransactionCount: number
+  transactionMode: TTenderlyTransactionMode
   chainReports: TTenderlyStatusChainReport[]
+}
+
+type TTenderlyTransactionResult = {
+  recentTransactionsAvailable: boolean
+  totalTransactionsAvailable: boolean
+  totalTransactionsCount?: number
+  totalTransactionsNote?: string
+  recentTransactions: TTenderlyRecentTransaction[]
+  recentTransactionsNote?: string
 }
 
 const DEFAULT_ACCOUNT_SLUG = 'me'
@@ -169,6 +181,8 @@ Options:
   --project-env <name>  Env var name to read the project slug from
   --rpc-name <name>     Stable public RPC name override
   --recent-tx-count <n> Number of recent transactions to include per chain (default: 5)
+  --transaction-mode <mode>
+                        Transaction lookup: none, recent, or full (default: recent)
   --json                Print a sanitized JSON report instead of Markdown
   --help                Show this help text
 
@@ -176,6 +190,8 @@ Notes:
   - Reads the active Tenderly mapping from repo .env and process.env.
   - Uses Admin RPC for live chain state.
   - Uses the Tenderly REST API for VNet metadata when credentials are available.
+  - Recent mode makes at most one transaction-history request per configured chain.
+  - Full mode scans up to 100 transaction-history pages and must be selected explicitly.
   - Never prints API keys or admin RPC URLs.
 `
 
@@ -258,6 +274,14 @@ function parseRecentTransactionCount(flags: Record<string, string>): number {
     DEFAULT_RECENT_TRANSACTION_COUNT
 
   return Math.min(Math.max(parsedValue, 1), 20)
+}
+
+export function parseTenderlyTransactionMode(flags: Record<string, string>): TTenderlyTransactionMode {
+  const mode = getArg(flags, 'transaction-mode')?.toLowerCase() || 'recent'
+  if (mode === 'none' || mode === 'recent' || mode === 'full') {
+    return mode
+  }
+  throw new Error(`Invalid transaction mode: ${mode}. Expected none, recent, or full.`)
 }
 
 export function resolveTenderlyStatusIdentity(
@@ -545,30 +569,44 @@ async function fetchTenderlyVnets(identity: TTenderlyStatusIdentity): Promise<TT
   return normalizeTenderlyVnetListResponse(await response.json())
 }
 
-async function fetchTenderlyRecentTransactions(params: {
+export async function fetchTenderlyRecentTransactions(params: {
   identity: TTenderlyStatusIdentity
+  mode: TTenderlyTransactionMode
   vnetId?: string
   recentCount: number
-}): Promise<{
-  recentTransactions: TTenderlyRecentTransaction[]
-  totalTransactionsCount: number
-  totalTransactionsNote?: string
-}> {
-  if (!params.identity.apiKey || !params.identity.projectSlug || !params.vnetId) {
+  fetchFn?: typeof fetch
+}): Promise<TTenderlyTransactionResult> {
+  if (params.mode === 'none') {
     return {
+      recentTransactionsAvailable: false,
+      totalTransactionsAvailable: false,
+      totalTransactionsNote: 'skipped (--transaction-mode none)',
       recentTransactions: [],
-      totalTransactionsCount: 0
+      recentTransactionsNote: 'skipped (--transaction-mode none)'
     }
   }
 
+  if (!params.identity.apiKey || !params.identity.projectSlug || !params.vnetId) {
+    return {
+      recentTransactionsAvailable: false,
+      totalTransactionsAvailable: false,
+      totalTransactionsNote: 'credentials or VNet metadata unavailable',
+      recentTransactions: [],
+      recentTransactionsNote: 'credentials or VNet metadata unavailable'
+    }
+  }
+
+  const fetchFn = params.fetchFn || fetch
+  const maxPages = params.mode === 'full' ? TENDERLY_TRANSACTION_MAX_PAGES : 1
+  const pageSize = params.mode === 'full' ? TENDERLY_TRANSACTION_PAGE_SIZE : params.recentCount
   const recentTransactions: TTenderlyRecentTransaction[] = []
   let totalTransactionsCount = 0
 
-  for (let page = 1; page <= TENDERLY_TRANSACTION_MAX_PAGES; page += 1) {
-    const response = await fetch(
+  for (let page = 1; page <= maxPages; page += 1) {
+    const response = await fetchFn(
       `${TENDERLY_API_URL}/${encodeURIComponent(params.identity.accountSlug)}/project/${encodeURIComponent(
         params.identity.projectSlug
-      )}/vnets/${encodeURIComponent(params.vnetId)}/transactions?page=${page}&per_page=${TENDERLY_TRANSACTION_PAGE_SIZE}`,
+      )}/vnets/${encodeURIComponent(params.vnetId)}/transactions?page=${page}&per_page=${pageSize}`,
       {
         headers: {
           Accept: 'application/json',
@@ -602,10 +640,23 @@ async function fetchTenderlyRecentTransactions(params: {
       recentTransactions.push(...pageTransactions.slice(0, params.recentCount))
     }
 
-    if (pageTransactions.length < TENDERLY_TRANSACTION_PAGE_SIZE) {
+    if (params.mode === 'recent') {
       return {
+        recentTransactionsAvailable: true,
+        totalTransactionsAvailable: false,
+        totalTransactionsNote: 'not scanned (use --transaction-mode full)',
         recentTransactions,
-        totalTransactionsCount
+        recentTransactionsNote: recentTransactions.length > 0 ? undefined : 'none'
+      }
+    }
+
+    if (pageTransactions.length < pageSize) {
+      return {
+        recentTransactionsAvailable: true,
+        totalTransactionsAvailable: true,
+        recentTransactions,
+        totalTransactionsCount,
+        recentTransactionsNote: recentTransactions.length > 0 ? undefined : 'none'
       }
     }
   }
@@ -615,9 +666,12 @@ async function fetchTenderlyRecentTransactions(params: {
   ).toLocaleString('en-US')} transactions`
 
   return {
+    recentTransactionsAvailable: true,
+    totalTransactionsAvailable: true,
     recentTransactions,
     totalTransactionsCount,
-    totalTransactionsNote
+    totalTransactionsNote,
+    recentTransactionsNote: recentTransactions.length > 0 ? undefined : 'none'
   }
 }
 
@@ -644,21 +698,7 @@ function buildChainReport(params: {
   chain: TTenderlyServerChainConfig
   liveState: TTenderlyChainLiveState
   matchedVnet?: TTenderlyMatchedVnet
-  recentTransactionsResult:
-    | {
-        recentTransactionsAvailable: true
-        totalTransactionsCount: number
-        totalTransactionsNote?: string
-        recentTransactions: TTenderlyRecentTransaction[]
-        recentTransactionsNote?: string
-      }
-    | {
-        recentTransactionsAvailable: false
-        totalTransactionsCount?: number
-        totalTransactionsNote?: string
-        recentTransactions: TTenderlyRecentTransaction[]
-        recentTransactionsNote?: string
-      }
+  recentTransactionsResult: TTenderlyTransactionResult
   env: Record<string, string | undefined>
 }): TTenderlyStatusChainReport {
   const explorerUri =
@@ -691,7 +731,7 @@ function buildChainReport(params: {
     hasAdminRpc: Boolean(params.chain.adminRpcUri),
     explorerEnabled: Boolean(params.matchedVnet?.record.explorer_page_config?.enabled || explorerUri),
     explorerUri,
-    totalTransactionsAvailable: params.recentTransactionsResult.recentTransactionsAvailable,
+    totalTransactionsAvailable: params.recentTransactionsResult.totalTransactionsAvailable,
     totalTransactionsCount: params.recentTransactionsResult.totalTransactionsCount,
     totalTransactionsNote: params.recentTransactionsResult.totalTransactionsNote,
     recentTransactionsAvailable: params.recentTransactionsResult.recentTransactionsAvailable,
@@ -717,7 +757,8 @@ export function buildTenderlyStatusMarkdown(report: TTenderlyStatusReport): stri
     '',
     `Profile: ${report.profile}`,
     `Account / Project: ${report.accountSlug} / ${report.projectSlug || '[unset]'}`,
-    `Metadata: ${report.restMetadataAvailable ? 'available' : report.restMetadataNote || 'unavailable'}`
+    `Metadata: ${report.restMetadataAvailable ? 'available' : report.restMetadataNote || 'unavailable'}`,
+    `Transaction Mode: ${report.transactionMode}`
   ]
 
   const chainSections = report.chainReports.flatMap((chainReport) => {
@@ -787,6 +828,7 @@ export function buildTenderlyStatusJson(report: TTenderlyStatusReport): Record<s
     restMetadataAvailable: report.restMetadataAvailable,
     restMetadataNote: report.restMetadataNote || null,
     recentTransactionCount: report.recentTransactionCount,
+    transactionMode: report.transactionMode,
     chains: report.chainReports.map((chainReport) => ({
       canonicalChainId: chainReport.canonicalChainId,
       canonicalChainName: chainReport.canonicalChainName,
@@ -820,6 +862,7 @@ async function buildTenderlyStatusReport(
 ): Promise<TTenderlyStatusReport> {
   const identity = resolveTenderlyStatusIdentity(flags, env)
   const recentTransactionCount = parseRecentTransactionCount(flags)
+  const transactionMode = parseTenderlyTransactionMode(flags)
   if (!identity.projectSlug) {
     throw new Error(`Missing required value: ${identity.profile} project slug`)
   }
@@ -861,23 +904,17 @@ async function buildTenderlyStatusReport(
         fetchTenderlyChainLiveState(chain),
         fetchTenderlyRecentTransactions({
           identity,
+          mode: transactionMode,
           vnetId: matchedVnet?.record.id,
           recentCount: recentTransactionCount
-        })
-          .then(({ recentTransactions, totalTransactionsCount, totalTransactionsNote }) => ({
-            recentTransactionsAvailable: true as const,
-            totalTransactionsCount,
-            totalTransactionsNote,
-            recentTransactions,
-            recentTransactionsNote: recentTransactions.length > 0 ? undefined : 'none'
-          }))
-          .catch((error) => ({
-            recentTransactionsAvailable: false as const,
-            totalTransactionsCount: undefined,
-            totalTransactionsNote: sanitizeConsoleText(error instanceof Error ? error.message : String(error)),
-            recentTransactions: [] as TTenderlyRecentTransaction[],
-            recentTransactionsNote: sanitizeConsoleText(error instanceof Error ? error.message : String(error))
-          }))
+        }).catch((error) => ({
+          recentTransactionsAvailable: false,
+          totalTransactionsAvailable: false,
+          totalTransactionsCount: undefined,
+          totalTransactionsNote: sanitizeConsoleText(error instanceof Error ? error.message : String(error)),
+          recentTransactions: [] as TTenderlyRecentTransaction[],
+          recentTransactionsNote: sanitizeConsoleText(error instanceof Error ? error.message : String(error))
+        }))
       ])
 
       return buildChainReport({
@@ -898,6 +935,7 @@ async function buildTenderlyStatusReport(
     restMetadataAvailable: vnetResult.restMetadataAvailable,
     restMetadataNote: vnetResult.restMetadataNote,
     recentTransactionCount,
+    transactionMode,
     chainReports
   }
 }
@@ -923,7 +961,9 @@ async function main(): Promise<void> {
   console.log(buildTenderlyStatusMarkdown(report))
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? sanitizeConsoleText(error.message) : sanitizeConsoleText(String(error)))
-  process.exitCode = 1
-})
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  void main().catch((error) => {
+    console.error(error instanceof Error ? sanitizeConsoleText(error.message) : sanitizeConsoleText(String(error)))
+    process.exitCode = 1
+  })
+}

--- a/scripts/tenderly.test.ts
+++ b/scripts/tenderly.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseCliArgs, parseDecimalAmount, toHexQuantity } from './tenderly'
+import { assertTenderlyRevertSucceeded, parseCliArgs, parseDecimalAmount, toHexQuantity } from './tenderly'
 
 describe('tenderly script helpers', () => {
   it('parses command-line flags and positionals', () => {
@@ -44,5 +44,10 @@ describe('tenderly script helpers', () => {
   it('converts bigint values to JSON-RPC hex quantities', () => {
     expect(toHexQuantity(0n)).toBe('0x0')
     expect(toHexQuantity(255n)).toBe('0xff')
+  })
+
+  it('fails when Tenderly rejects a snapshot revert', () => {
+    expect(() => assertTenderlyRevertSucceeded(false, '0xdead')).toThrow('Tenderly rejected revert for snapshot 0xdead')
+    expect(() => assertTenderlyRevertSucceeded(true, '0x1')).not.toThrow()
   })
 })

--- a/scripts/tenderly.ts
+++ b/scripts/tenderly.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 
 import { getAddress } from 'viem'
+import { buildTenderlyRevertResponse } from '@/config/tenderlyServer'
 
 type TParsedCliArgs = {
   command?: string
@@ -231,6 +232,10 @@ function formatResult(result: unknown): string {
   return JSON.stringify(result, null, 2)
 }
 
+export function assertTenderlyRevertSucceeded(result: unknown, snapshotId: string): void {
+  buildTenderlyRevertResponse(result, snapshotId)
+}
+
 async function runCommand(parsedArgs: TParsedCliArgs): Promise<void> {
   const { command, flags } = parsedArgs
   const canonicalChainId = getCanonicalChainId(flags)
@@ -287,6 +292,7 @@ async function runCommand(parsedArgs: TParsedCliArgs): Promise<void> {
     case 'revert': {
       const snapshotId = requireFlag(flags, 'id')
       const result = await callAdminRpc(canonicalChainId, 'evm_revert', [snapshotId])
+      assertTenderlyRevertSucceeded(result, snapshotId)
       console.log(`Revert result on canonical chain ${canonicalChainId}: ${formatResult(result)}`)
       return
     }

--- a/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/src/components/pages/vaults/[chainID]/[address].tsx
@@ -40,6 +40,7 @@ import {
 import { isNonYearnErc4626Vault, NON_YEARN_ERC4626_WARNING_MESSAGE } from '@pages/vaults/domain/vaultWarnings'
 import { useEnsureVaultListFetch } from '@pages/vaults/hooks/useEnsureVaultListFetch'
 import { usePendingTimelockStrategies } from '@pages/vaults/hooks/usePendingTimelockStrategies'
+import { useTenderlyVaultBalanceOverrides } from '@pages/vaults/hooks/useTenderlyVaultBalanceOverrides'
 import { useVaultApyData } from '@pages/vaults/hooks/useVaultApyData'
 import { useVaultSnapshot } from '@pages/vaults/hooks/useVaultSnapshot'
 import { useVaultUserData } from '@pages/vaults/hooks/useVaultUserData'
@@ -63,6 +64,7 @@ import { useMediaQuery } from '@react-hookz/web'
 import { Breadcrumbs } from '@shared/components/Breadcrumbs'
 import { TokenLogo } from '@shared/components/TokenLogo'
 import { Tooltip } from '@shared/components/Tooltip'
+import { useTenderlyPanel } from '@shared/contexts/useTenderlyPanel'
 import { useWalletActions, useWalletStatus, useWalletTokens } from '@shared/contexts/useWallet'
 import { useYearn } from '@shared/contexts/useYearn'
 import { useYearnSpotPrices } from '@shared/hooks/useYearnSpotPrices'
@@ -503,6 +505,7 @@ function Index(): ReactElement | null {
   const chainId = Number(params.chainID)
   const { getBalance } = useWalletTokens()
   const { onRefresh } = useWalletActions()
+  const { stateRevision: tenderlyStateRevision } = useTenderlyPanel()
   const { isLoading: isWalletLoading } = useWalletStatus()
   const { address } = useWeb3()
   const { vaults, allVaults, isLoadingVaultList, enableVaultListFetch } = useYearn()
@@ -761,6 +764,12 @@ function Index(): ReactElement | null {
     ? toAddress(currentVault?.staking?.address)
     : undefined
   const disableDepositStaking = shouldDisableStakingForDeposit || !currentVault?.staking?.available
+  useTenderlyVaultBalanceOverrides({
+    account: address,
+    currentVault,
+    refreshRevision: tenderlyStateRevision,
+    stakingAddress
+  })
 
   const vaultUserData = useVaultUserData({
     vaultAddress: toAddress(currentVault?.address ?? '0x'),

--- a/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.test.ts
+++ b/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.test.ts
@@ -1,0 +1,263 @@
+// @vitest-environment jsdom
+
+import { YVBTC_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvBtc'
+import { YVUSD_CHAIN_ID, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
+import { useWalletActions } from '@shared/contexts/useWallet'
+import { fetchTokenBalances } from '@shared/hooks/useBalancesQueries'
+import type { TAddress } from '@shared/types'
+import { toAddress } from '@shared/utils'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  fetchTenderlyVaultBalanceOverrides,
+  getTenderlyVaultBalanceOverrideScopeId,
+  getTenderlyVaultOverrideRefreshKey,
+  getVaultTenderlyOverrideTokens,
+  useTenderlyVaultBalanceOverrides
+} from './useTenderlyVaultBalanceOverrides'
+
+vi.mock('@shared/contexts/useWallet', () => ({
+  useWalletActions: vi.fn()
+}))
+
+vi.mock('@shared/hooks/useBalancesQueries', () => ({
+  fetchTokenBalances: vi.fn()
+}))
+
+vi.mock('@/config/tenderly', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/config/tenderly')>()),
+  isTenderlyModeEnabled: () => true
+}))
+
+const ACCOUNT = toAddress('0x9999999999999999999999999999999999999999')
+const ASSET_ADDRESS = toAddress('0x1111111111111111111111111111111111111111')
+const STAKING_ADDRESS = toAddress('0x2222222222222222222222222222222222222222')
+const CURRENT_VAULT = {
+  address: YVUSD_UNLOCKED_ADDRESS,
+  chainID: YVUSD_CHAIN_ID,
+  decimals: 6,
+  name: 'yvUSD',
+  symbol: 'yvUSD',
+  token: {
+    address: ASSET_ADDRESS,
+    decimals: 6,
+    name: 'USDC',
+    symbol: 'USDC'
+  }
+}
+
+const useWalletActionsMock = vi.mocked(useWalletActions)
+const fetchTokenBalancesMock = vi.mocked(fetchTokenBalances)
+
+function tokenKeys(tokens: ReturnType<typeof getVaultTenderlyOverrideTokens>): string[] {
+  return tokens.map((token) => `${token.chainID}:${token.address}`)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getVaultTenderlyOverrideTokens', () => {
+  it('includes only the current vault, underlying asset, and staking token for a regular vault', () => {
+    const tokens = getVaultTenderlyOverrideTokens({
+      currentVault: {
+        address: toAddress('0x3333333333333333333333333333333333333333'),
+        chainID: 1,
+        decimals: 18,
+        name: 'Example Vault',
+        symbol: 'yvEX',
+        token: {
+          address: ASSET_ADDRESS,
+          decimals: 6,
+          name: 'Example Asset',
+          symbol: 'EX'
+        }
+      },
+      stakingAddress: STAKING_ADDRESS
+    })
+
+    expect(tokenKeys(tokens)).toEqual([
+      `1:${toAddress('0x3333333333333333333333333333333333333333')}`,
+      `1:${ASSET_ADDRESS}`,
+      `1:${STAKING_ADDRESS}`
+    ])
+  })
+
+  it('adds both yvUSD variants without duplicating the current variant', () => {
+    const tokens = getVaultTenderlyOverrideTokens({
+      currentVault: {
+        address: YVUSD_UNLOCKED_ADDRESS,
+        chainID: YVUSD_CHAIN_ID,
+        decimals: 6,
+        name: 'yvUSD',
+        symbol: 'yvUSD',
+        token: {
+          address: ASSET_ADDRESS,
+          decimals: 6,
+          name: 'USDC',
+          symbol: 'USDC'
+        }
+      }
+    })
+
+    expect(tokenKeys(tokens)).toEqual([
+      `${YVUSD_CHAIN_ID}:${YVUSD_UNLOCKED_ADDRESS}`,
+      `${YVUSD_CHAIN_ID}:${ASSET_ADDRESS}`,
+      `${YVUSD_CHAIN_ID}:${YVUSD_LOCKED_ADDRESS}`
+    ])
+  })
+
+  it('does not add the zero-address yvBTC locked placeholder', () => {
+    const tokens = getVaultTenderlyOverrideTokens({
+      currentVault: {
+        address: YVBTC_UNLOCKED_ADDRESS,
+        chainID: 1,
+        decimals: 8,
+        name: 'yvBTC',
+        symbol: 'yvBTC',
+        token: {
+          address: ASSET_ADDRESS,
+          decimals: 8,
+          name: 'Bitcoin',
+          symbol: 'BTC'
+        }
+      }
+    })
+
+    expect(tokenKeys(tokens)).toEqual([`1:${YVBTC_UNLOCKED_ADDRESS}`, `1:${ASSET_ADDRESS}`])
+  })
+
+  it('changes the refresh key when Tenderly state mutates', () => {
+    const currentVault = {
+      address: YVUSD_UNLOCKED_ADDRESS,
+      chainID: YVUSD_CHAIN_ID,
+      decimals: 6,
+      name: 'yvUSD',
+      symbol: 'yvUSD',
+      token: {
+        address: ASSET_ADDRESS,
+        decimals: 6,
+        name: 'USDC',
+        symbol: 'USDC'
+      }
+    }
+    const firstKey = getTenderlyVaultOverrideRefreshKey({
+      account: ACCOUNT,
+      currentVault,
+      refreshRevision: 1
+    })
+    const nextKey = getTenderlyVaultOverrideRefreshKey({
+      account: ACCOUNT,
+      currentVault,
+      refreshRevision: 2
+    })
+
+    expect(nextKey).not.toBe(firstKey)
+  })
+
+  it('uses a stable route scope that does not include the refresh revision', () => {
+    const currentVault = {
+      address: YVUSD_UNLOCKED_ADDRESS,
+      chainID: YVUSD_CHAIN_ID,
+      decimals: 6,
+      name: 'yvUSD',
+      symbol: 'yvUSD',
+      token: {
+        address: ASSET_ADDRESS,
+        decimals: 6,
+        name: 'USDC',
+        symbol: 'USDC'
+      }
+    }
+
+    expect(
+      getTenderlyVaultBalanceOverrideScopeId({
+        account: ACCOUNT,
+        currentVault
+      })
+    ).toBe(`tenderly-vault:${ACCOUNT}:${YVUSD_CHAIN_ID}:${YVUSD_UNLOCKED_ADDRESS}:`)
+  })
+
+  it('fetches only the explicitly selected override tokens', async () => {
+    const selectedTokens = getVaultTenderlyOverrideTokens({
+      currentVault: {
+        address: YVUSD_UNLOCKED_ADDRESS,
+        chainID: YVUSD_CHAIN_ID,
+        decimals: 6,
+        name: 'yvUSD',
+        symbol: 'yvUSD',
+        token: {
+          address: ASSET_ADDRESS,
+          decimals: 6,
+          name: 'USDC',
+          symbol: 'USDC'
+        }
+      }
+    })
+    const fetchBalances = vi.fn<typeof fetchTokenBalances>(async (chainId, _account, tokens) =>
+      Object.fromEntries(
+        tokens.map((token) => [
+          token.address,
+          {
+            address: token.address,
+            balance: {
+              raw: 1n,
+              normalized: 1,
+              display: '1',
+              decimals: token.decimals ?? 18
+            },
+            chainID: chainId,
+            decimals: token.decimals ?? 18,
+            name: token.name ?? '',
+            symbol: token.symbol ?? '',
+            value: 0
+          }
+        ])
+      )
+    )
+
+    const balances = await fetchTenderlyVaultBalanceOverrides({
+      account: ACCOUNT,
+      fetchBalances,
+      tokens: selectedTokens
+    })
+
+    expect(fetchBalances).toHaveBeenCalledOnce()
+    expect(fetchBalances).toHaveBeenCalledWith(YVUSD_CHAIN_ID, ACCOUNT, selectedTokens, true)
+    expect(Object.keys(balances[YVUSD_CHAIN_ID])).toEqual(selectedTokens.map((token) => token.address))
+  })
+})
+
+describe('useTenderlyVaultBalanceOverrides', () => {
+  it('refreshes again after reconnecting the same account to the same vault', async () => {
+    const clearBalanceOverride = vi.fn()
+    const registerBalanceOverrideRefresher = vi.fn()
+    const setBalanceOverride = vi.fn()
+    useWalletActionsMock.mockReturnValue({
+      clearBalanceOverride,
+      onRefresh: vi.fn(),
+      registerBalanceOverrideRefresher,
+      setBalanceOverride
+    })
+    fetchTokenBalancesMock.mockResolvedValue({})
+
+    const { rerender } = renderHook(
+      ({ account }: { account?: TAddress }) =>
+        useTenderlyVaultBalanceOverrides({
+          account,
+          currentVault: CURRENT_VAULT
+        }),
+      {
+        initialProps: { account: ACCOUNT as TAddress | undefined }
+      }
+    )
+
+    await waitFor(() => expect(fetchTokenBalancesMock).toHaveBeenCalledTimes(1))
+
+    rerender({ account: undefined })
+    await waitFor(() => expect(clearBalanceOverride).toHaveBeenCalledOnce())
+
+    rerender({ account: ACCOUNT })
+    await waitFor(() => expect(fetchTokenBalancesMock).toHaveBeenCalledTimes(2))
+  })
+})

--- a/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.test.ts
+++ b/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment jsdom
 
 import { YVBTC_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvBtc'
-import { YVUSD_CHAIN_ID, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
+import { YVUSD_CHAIN_ID, YVUSD_DECIMALS, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { useWalletActions } from '@shared/contexts/useWallet'
 import { fetchTokenBalances } from '@shared/hooks/useBalancesQueries'
 import type { TAddress } from '@shared/types'
 import { toAddress } from '@shared/utils'
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   fetchTenderlyVaultBalanceOverrides,
@@ -48,9 +48,50 @@ const CURRENT_VAULT = {
 
 const useWalletActionsMock = vi.mocked(useWalletActions)
 const fetchTokenBalancesMock = vi.mocked(fetchTokenBalances)
+type TFetchTokenBalancesResult = Awaited<ReturnType<typeof fetchTokenBalances>>
 
 function tokenKeys(tokens: ReturnType<typeof getVaultTenderlyOverrideTokens>): string[] {
   return tokens.map((token) => `${token.chainID}:${token.address}`)
+}
+
+function createTokenBalances(raw: bigint): TFetchTokenBalancesResult {
+  return {
+    [YVUSD_UNLOCKED_ADDRESS]: {
+      address: YVUSD_UNLOCKED_ADDRESS,
+      balance: {
+        raw,
+        normalized: Number(raw),
+        display: raw.toString(),
+        decimals: YVUSD_DECIMALS
+      },
+      chainID: YVUSD_CHAIN_ID,
+      decimals: YVUSD_DECIMALS,
+      name: 'yvUSD',
+      symbol: 'yvUSD',
+      value: 0
+    }
+  }
+}
+
+function setupWalletActionsMocks(): {
+  clearBalanceOverride: ReturnType<typeof vi.fn>
+  registerBalanceOverrideRefresher: ReturnType<typeof vi.fn>
+  setBalanceOverride: ReturnType<typeof vi.fn>
+} {
+  const clearBalanceOverride = vi.fn()
+  const registerBalanceOverrideRefresher = vi.fn()
+  const setBalanceOverride = vi.fn()
+  useWalletActionsMock.mockReturnValue({
+    clearBalanceOverride,
+    onRefresh: vi.fn(),
+    registerBalanceOverrideRefresher,
+    setBalanceOverride
+  })
+  return {
+    clearBalanceOverride,
+    registerBalanceOverrideRefresher,
+    setBalanceOverride
+  }
 }
 
 beforeEach(() => {
@@ -230,15 +271,7 @@ describe('getVaultTenderlyOverrideTokens', () => {
 
 describe('useTenderlyVaultBalanceOverrides', () => {
   it('refreshes again after reconnecting the same account to the same vault', async () => {
-    const clearBalanceOverride = vi.fn()
-    const registerBalanceOverrideRefresher = vi.fn()
-    const setBalanceOverride = vi.fn()
-    useWalletActionsMock.mockReturnValue({
-      clearBalanceOverride,
-      onRefresh: vi.fn(),
-      registerBalanceOverrideRefresher,
-      setBalanceOverride
-    })
+    const { clearBalanceOverride } = setupWalletActionsMocks()
     fetchTokenBalancesMock.mockResolvedValue({})
 
     const { rerender } = renderHook(
@@ -259,5 +292,100 @@ describe('useTenderlyVaultBalanceOverrides', () => {
 
     rerender({ account: ACCOUNT })
     await waitFor(() => expect(fetchTokenBalancesMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('ignores an older refresh that resolves after a newer state revision', async () => {
+    const { setBalanceOverride } = setupWalletActionsMocks()
+    const firstRefresh = Promise.withResolvers<TFetchTokenBalancesResult>()
+    const secondRefresh = Promise.withResolvers<TFetchTokenBalancesResult>()
+    const firstBalances = createTokenBalances(1n)
+    const secondBalances = createTokenBalances(2n)
+    const scopeId = getTenderlyVaultBalanceOverrideScopeId({
+      account: ACCOUNT,
+      currentVault: CURRENT_VAULT
+    })
+    fetchTokenBalancesMock
+      .mockImplementationOnce(async () => await firstRefresh.promise)
+      .mockImplementationOnce(async () => await secondRefresh.promise)
+
+    const { rerender } = renderHook(
+      ({ refreshRevision }: { refreshRevision: number }) =>
+        useTenderlyVaultBalanceOverrides({
+          account: ACCOUNT,
+          currentVault: CURRENT_VAULT,
+          refreshRevision
+        }),
+      {
+        initialProps: { refreshRevision: 0 }
+      }
+    )
+
+    await waitFor(() => expect(fetchTokenBalancesMock).toHaveBeenCalledTimes(1))
+    rerender({ refreshRevision: 1 })
+    await waitFor(() => expect(fetchTokenBalancesMock).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      secondRefresh.resolve(secondBalances)
+      await secondRefresh.promise
+    })
+    await waitFor(() =>
+      expect(setBalanceOverride).toHaveBeenCalledWith(scopeId, {
+        [YVUSD_CHAIN_ID]: secondBalances
+      })
+    )
+
+    await act(async () => {
+      firstRefresh.resolve(firstBalances)
+      await firstRefresh.promise
+    })
+    expect(setBalanceOverride).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores an older refresh after remounting the same account and vault scope', async () => {
+    const { clearBalanceOverride, setBalanceOverride } = setupWalletActionsMocks()
+    const firstMountRefresh = Promise.withResolvers<TFetchTokenBalancesResult>()
+    const secondMountRefresh = Promise.withResolvers<TFetchTokenBalancesResult>()
+    const firstBalances = createTokenBalances(1n)
+    const secondBalances = createTokenBalances(2n)
+    const scopeId = getTenderlyVaultBalanceOverrideScopeId({
+      account: ACCOUNT,
+      currentVault: CURRENT_VAULT
+    })
+    fetchTokenBalancesMock
+      .mockImplementationOnce(async () => await firstMountRefresh.promise)
+      .mockImplementationOnce(async () => await secondMountRefresh.promise)
+
+    const { rerender } = renderHook(
+      ({ account }: { account?: TAddress }) =>
+        useTenderlyVaultBalanceOverrides({
+          account,
+          currentVault: CURRENT_VAULT
+        }),
+      {
+        initialProps: { account: ACCOUNT as TAddress | undefined }
+      }
+    )
+
+    await waitFor(() => expect(fetchTokenBalancesMock).toHaveBeenCalledTimes(1))
+    rerender({ account: undefined })
+    await waitFor(() => expect(clearBalanceOverride).toHaveBeenCalledOnce())
+    rerender({ account: ACCOUNT })
+    await waitFor(() => expect(fetchTokenBalancesMock).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      secondMountRefresh.resolve(secondBalances)
+      await secondMountRefresh.promise
+    })
+    await waitFor(() =>
+      expect(setBalanceOverride).toHaveBeenCalledWith(scopeId, {
+        [YVUSD_CHAIN_ID]: secondBalances
+      })
+    )
+
+    await act(async () => {
+      firstMountRefresh.resolve(firstBalances)
+      await firstMountRefresh.promise
+    })
+    expect(setBalanceOverride).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.test.ts
+++ b/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.test.ts
@@ -388,4 +388,54 @@ describe('useTenderlyVaultBalanceOverrides', () => {
     })
     expect(setBalanceOverride).toHaveBeenCalledTimes(1)
   })
+
+  it('does not clear the active refresh key when an older lifecycle request rejects', async () => {
+    setupWalletActionsMocks()
+    const firstMountRefresh = Promise.withResolvers<TFetchTokenBalancesResult>()
+    const secondMountRefresh = Promise.withResolvers<TFetchTokenBalancesResult>()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    fetchTokenBalancesMock
+      .mockImplementationOnce(async () => await firstMountRefresh.promise)
+      .mockImplementationOnce(async () => await secondMountRefresh.promise)
+
+    const { rerender } = renderHook(
+      ({ account, currentVault }: { account?: TAddress; currentVault: typeof CURRENT_VAULT }) =>
+        useTenderlyVaultBalanceOverrides({
+          account,
+          currentVault
+        }),
+      {
+        initialProps: {
+          account: ACCOUNT as TAddress | undefined,
+          currentVault: CURRENT_VAULT
+        }
+      }
+    )
+
+    await waitFor(() => expect(fetchTokenBalancesMock).toHaveBeenCalledTimes(1))
+    rerender({ account: undefined, currentVault: CURRENT_VAULT })
+    rerender({ account: ACCOUNT, currentVault: CURRENT_VAULT })
+    await waitFor(() => expect(fetchTokenBalancesMock).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      secondMountRefresh.resolve(createTokenBalances(2n))
+      await secondMountRefresh.promise
+    })
+    await act(async () => {
+      firstMountRefresh.reject(new Error('stale refresh failed'))
+      await firstMountRefresh.promise.catch(() => undefined)
+    })
+
+    rerender({
+      account: ACCOUNT,
+      currentVault: {
+        ...CURRENT_VAULT,
+        token: { ...CURRENT_VAULT.token }
+      }
+    })
+    await act(async () => await Promise.resolve())
+
+    expect(fetchTokenBalancesMock).toHaveBeenCalledTimes(2)
+    consoleError.mockRestore()
+  })
 })

--- a/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.ts
+++ b/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.ts
@@ -177,6 +177,7 @@ export function useTenderlyVaultBalanceOverrides({
 }: TUseTenderlyVaultBalanceOverridesProps): TUseTenderlyVaultBalanceOverridesResult {
   const { clearBalanceOverride, registerBalanceOverrideRefresher, setBalanceOverride } = useWalletActions()
   const activeScopeIdRef = useRef<string | null>(null)
+  const refreshGenerationRef = useRef(0)
   const refreshKeyRef = useRef<string | null>(null)
   const registeredRefreshRef = useRef<() => Promise<TChainTokens>>(async () => ({}))
   const isTenderlyMode = isTenderlyModeEnabled()
@@ -206,11 +207,13 @@ export function useTenderlyVaultBalanceOverrides({
       return {}
     }
 
+    refreshGenerationRef.current += 1
+    const refreshGeneration = refreshGenerationRef.current
     const nextBalances = await fetchTenderlyVaultBalanceOverrides({
       account,
       tokens: tokensToRefresh
     })
-    if (activeScopeIdRef.current === scopeId) {
+    if (activeScopeIdRef.current === scopeId && refreshGenerationRef.current === refreshGeneration) {
       setBalanceOverride(scopeId, nextBalances)
     }
     return nextBalances
@@ -228,6 +231,7 @@ export function useTenderlyVaultBalanceOverrides({
     registerBalanceOverrideRefresher(scopeId, registeredRefresh)
 
     return () => {
+      refreshGenerationRef.current += 1
       if (activeScopeIdRef.current === scopeId) {
         activeScopeIdRef.current = null
       }

--- a/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.ts
+++ b/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.ts
@@ -1,0 +1,263 @@
+import { isYvBtcAddress, YVBTC_LOCKED_ADDRESS, YVBTC_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvBtc'
+import {
+  isYvUsdAddress,
+  YVUSD_CHAIN_ID,
+  YVUSD_DECIMALS,
+  YVUSD_LOCKED_ADDRESS,
+  YVUSD_UNLOCKED_ADDRESS
+} from '@pages/vaults/utils/yvUsd'
+import { useWalletActions } from '@shared/contexts/useWallet'
+import type { TUseBalancesTokens } from '@shared/hooks/useBalances.multichains'
+import { fetchTokenBalances } from '@shared/hooks/useBalancesQueries'
+import type { TAddress, TChainTokens } from '@shared/types'
+import { isZeroAddress, toAddress } from '@shared/utils'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { isTenderlyModeEnabled } from '@/config/tenderly'
+import type { TKongVaultView } from '../domain/kongVaultSelectors'
+
+type TTenderlyVaultBalanceOverrideVault = Pick<
+  TKongVaultView,
+  'address' | 'chainID' | 'decimals' | 'name' | 'symbol'
+> & {
+  token: Pick<TKongVaultView['token'], 'address' | 'decimals' | 'name' | 'symbol'>
+}
+
+type TUseTenderlyVaultBalanceOverridesProps = {
+  account?: TAddress
+  currentVault?: TTenderlyVaultBalanceOverrideVault
+  refreshRevision?: number
+  stakingAddress?: TAddress
+}
+
+type TUseTenderlyVaultBalanceOverridesResult = {
+  refresh: () => Promise<TChainTokens>
+}
+
+type TFetchTokenBalances = typeof fetchTokenBalances
+
+function addTenderlyOverrideToken(
+  tokens: Map<string, TUseBalancesTokens>,
+  address: string | undefined,
+  chainID: number | undefined,
+  metadata?: Partial<TUseBalancesTokens>
+): void {
+  if (!address || !Number.isInteger(chainID) || isZeroAddress(toAddress(address))) {
+    return
+  }
+
+  const token = {
+    address: toAddress(address),
+    chainID: chainID as number,
+    ...metadata
+  }
+  tokens.set(`${token.chainID}:${token.address}`, token)
+}
+
+export function getVaultTenderlyOverrideTokens({
+  currentVault,
+  stakingAddress
+}: {
+  currentVault: TTenderlyVaultBalanceOverrideVault
+  stakingAddress?: TAddress
+}): TUseBalancesTokens[] {
+  const tokens = new Map<string, TUseBalancesTokens>()
+
+  addTenderlyOverrideToken(tokens, currentVault.address, currentVault.chainID, {
+    decimals: currentVault.decimals,
+    name: currentVault.name,
+    symbol: currentVault.symbol,
+    isVaultToken: true
+  })
+  addTenderlyOverrideToken(tokens, currentVault.token.address, currentVault.chainID, {
+    decimals: currentVault.token.decimals,
+    name: currentVault.token.name,
+    symbol: currentVault.token.symbol
+  })
+  addTenderlyOverrideToken(tokens, stakingAddress, currentVault.chainID, {
+    decimals: currentVault.decimals,
+    name: currentVault.name,
+    symbol: currentVault.symbol,
+    isStakingToken: true
+  })
+
+  if (isYvUsdAddress(currentVault.address)) {
+    addTenderlyOverrideToken(tokens, YVUSD_UNLOCKED_ADDRESS, YVUSD_CHAIN_ID, {
+      decimals: YVUSD_DECIMALS,
+      name: 'yvUSD',
+      symbol: 'yvUSD',
+      isVaultToken: true
+    })
+    addTenderlyOverrideToken(tokens, YVUSD_LOCKED_ADDRESS, YVUSD_CHAIN_ID, {
+      decimals: YVUSD_DECIMALS,
+      name: 'yvUSD (Locked)',
+      symbol: 'yvUSD',
+      isVaultToken: true
+    })
+  }
+
+  if (isYvBtcAddress(currentVault.address)) {
+    addTenderlyOverrideToken(tokens, YVBTC_UNLOCKED_ADDRESS, currentVault.chainID, {
+      decimals: currentVault.decimals,
+      name: currentVault.name,
+      symbol: currentVault.symbol,
+      isVaultToken: true
+    })
+    addTenderlyOverrideToken(tokens, YVBTC_LOCKED_ADDRESS, currentVault.chainID, {
+      decimals: currentVault.decimals,
+      name: currentVault.name,
+      symbol: currentVault.symbol,
+      isVaultToken: true
+    })
+  }
+
+  return [...tokens.values()]
+}
+
+export function getTenderlyVaultOverrideRefreshKey({
+  account,
+  currentVault,
+  refreshRevision = 0,
+  stakingAddress
+}: {
+  account: TAddress
+  currentVault: TTenderlyVaultBalanceOverrideVault
+  refreshRevision?: number
+  stakingAddress?: TAddress
+}): string {
+  return [
+    account,
+    currentVault.chainID,
+    currentVault.address,
+    currentVault.token.address,
+    stakingAddress ?? '',
+    refreshRevision
+  ].join(':')
+}
+
+export function getTenderlyVaultBalanceOverrideScopeId({
+  account,
+  currentVault,
+  stakingAddress
+}: {
+  account: TAddress
+  currentVault: TTenderlyVaultBalanceOverrideVault
+  stakingAddress?: TAddress
+}): string {
+  return ['tenderly-vault', account, currentVault.chainID, currentVault.address, stakingAddress ?? ''].join(':')
+}
+
+export async function fetchTenderlyVaultBalanceOverrides({
+  account,
+  fetchBalances = fetchTokenBalances,
+  tokens
+}: {
+  account: TAddress
+  fetchBalances?: TFetchTokenBalances
+  tokens: TUseBalancesTokens[]
+}): Promise<TChainTokens> {
+  const chainIds = [...new Set(tokens.map((token) => token.chainID))]
+  const tokensByChain = Object.fromEntries(
+    chainIds.map((chainId) => [chainId, tokens.filter((token) => token.chainID === chainId)])
+  )
+  const balancesByChain = await Promise.all(
+    Object.entries(tokensByChain).map(
+      async ([chainId, chainTokens]) =>
+        [Number(chainId), await fetchBalances(Number(chainId), account, chainTokens, true)] as const
+    )
+  )
+
+  return Object.fromEntries(balancesByChain)
+}
+
+export function useTenderlyVaultBalanceOverrides({
+  account,
+  currentVault,
+  refreshRevision = 0,
+  stakingAddress
+}: TUseTenderlyVaultBalanceOverridesProps): TUseTenderlyVaultBalanceOverridesResult {
+  const { clearBalanceOverride, registerBalanceOverrideRefresher, setBalanceOverride } = useWalletActions()
+  const activeScopeIdRef = useRef<string | null>(null)
+  const refreshKeyRef = useRef<string | null>(null)
+  const registeredRefreshRef = useRef<() => Promise<TChainTokens>>(async () => ({}))
+  const isTenderlyMode = isTenderlyModeEnabled()
+  const tokensToRefresh = useMemo(
+    () =>
+      currentVault
+        ? getVaultTenderlyOverrideTokens({
+            currentVault,
+            stakingAddress
+          })
+        : [],
+    [currentVault, stakingAddress]
+  )
+  const scopeId = useMemo(
+    () =>
+      isTenderlyMode && account && currentVault
+        ? getTenderlyVaultBalanceOverrideScopeId({
+            account,
+            currentVault,
+            stakingAddress
+          })
+        : undefined,
+    [account, currentVault, isTenderlyMode, stakingAddress]
+  )
+  const refresh = useCallback(async (): Promise<TChainTokens> => {
+    if (!account || !scopeId || tokensToRefresh.length === 0) {
+      return {}
+    }
+
+    const nextBalances = await fetchTenderlyVaultBalanceOverrides({
+      account,
+      tokens: tokensToRefresh
+    })
+    if (activeScopeIdRef.current === scopeId) {
+      setBalanceOverride(scopeId, nextBalances)
+    }
+    return nextBalances
+  }, [account, scopeId, setBalanceOverride, tokensToRefresh])
+  registeredRefreshRef.current = refresh
+  const registeredRefresh = useCallback(async (): Promise<TChainTokens> => await registeredRefreshRef.current(), [])
+
+  // The wallet override registry is imperative external state, so it must follow this route scope's lifecycle.
+  useEffect(() => {
+    if (!scopeId) {
+      return
+    }
+
+    activeScopeIdRef.current = scopeId
+    registerBalanceOverrideRefresher(scopeId, registeredRefresh)
+
+    return () => {
+      if (activeScopeIdRef.current === scopeId) {
+        activeScopeIdRef.current = null
+      }
+      refreshKeyRef.current = null
+      clearBalanceOverride(scopeId)
+    }
+  }, [clearBalanceOverride, registerBalanceOverrideRefresher, registeredRefresh, scopeId])
+
+  useEffect(() => {
+    if (!scopeId || !account || !currentVault) {
+      return
+    }
+
+    const refreshKey = getTenderlyVaultOverrideRefreshKey({
+      account,
+      currentVault,
+      refreshRevision,
+      stakingAddress
+    })
+    if (refreshKeyRef.current === refreshKey) {
+      return
+    }
+    refreshKeyRef.current = refreshKey
+
+    // Tenderly mutations are external to TanStack Query, so the active workflow needs an imperative VNet refresh.
+    void refresh().catch((error) => {
+      console.error('Failed to refresh Tenderly vault override balances:', error)
+      refreshKeyRef.current = null
+    })
+  }, [account, currentVault, refresh, refreshRevision, scopeId, stakingAddress])
+
+  return { refresh }
+}

--- a/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.ts
+++ b/src/components/pages/vaults/hooks/useTenderlyVaultBalanceOverrides.ts
@@ -177,6 +177,7 @@ export function useTenderlyVaultBalanceOverrides({
 }: TUseTenderlyVaultBalanceOverridesProps): TUseTenderlyVaultBalanceOverridesResult {
   const { clearBalanceOverride, registerBalanceOverrideRefresher, setBalanceOverride } = useWalletActions()
   const activeScopeIdRef = useRef<string | null>(null)
+  const automaticRefreshGenerationRef = useRef(0)
   const refreshGenerationRef = useRef(0)
   const refreshKeyRef = useRef<string | null>(null)
   const registeredRefreshRef = useRef<() => Promise<TChainTokens>>(async () => ({}))
@@ -231,6 +232,7 @@ export function useTenderlyVaultBalanceOverrides({
     registerBalanceOverrideRefresher(scopeId, registeredRefresh)
 
     return () => {
+      automaticRefreshGenerationRef.current += 1
       refreshGenerationRef.current += 1
       if (activeScopeIdRef.current === scopeId) {
         activeScopeIdRef.current = null
@@ -255,11 +257,15 @@ export function useTenderlyVaultBalanceOverrides({
       return
     }
     refreshKeyRef.current = refreshKey
+    automaticRefreshGenerationRef.current += 1
+    const automaticRefreshGeneration = automaticRefreshGenerationRef.current
 
     // Tenderly mutations are external to TanStack Query, so the active workflow needs an imperative VNet refresh.
     void refresh().catch((error) => {
       console.error('Failed to refresh Tenderly vault override balances:', error)
-      refreshKeyRef.current = null
+      if (automaticRefreshGenerationRef.current === automaticRefreshGeneration) {
+        refreshKeyRef.current = null
+      }
     })
   }, [account, currentVault, refresh, refreshRevision, scopeId, stakingAddress])
 

--- a/src/components/shared/contexts/useTenderlyPanel.tsx
+++ b/src/components/shared/contexts/useTenderlyPanel.tsx
@@ -1,6 +1,5 @@
 import { useLocalStorageValue } from '@react-hookz/web'
 import { toast } from '@shared/components/yToast'
-import { useWalletActions } from '@shared/contexts/useWallet'
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { useYearn } from '@shared/contexts/useYearn'
 import { useTokenList } from '@shared/contexts/WithTokenList'
@@ -52,6 +51,7 @@ type TTenderlyPanelContext = {
   fundableAssets: TTenderlyFundableAsset[]
   connectedWalletAddress?: `0x${string}`
   pendingAction: string | null
+  stateRevision: number
   openPanel: () => void
   closePanel: () => void
   togglePanel: () => void
@@ -73,6 +73,7 @@ const TenderlyPanelContext = createContext<TTenderlyPanelContext>({
   snapshotRecords: [],
   fundableAssets: [],
   pendingAction: null,
+  stateRevision: 0,
   openPanel: (): void => undefined,
   closePanel: (): void => undefined,
   togglePanel: (): void => undefined,
@@ -111,7 +112,6 @@ export function TenderlyPanelProvider({ children }: { children: ReactNode }): Re
   const queryClient = useQueryClient()
   const { chainIdIntent } = useChains()
   const { chainID, address } = useWeb3()
-  const { onRefresh } = useWalletActions()
   const { allVaults, enableVaultListFetch } = useYearn()
   const { tokenLists } = useTokenList()
   const [status, setStatus] = useState<TTenderlyPanelStatus | undefined>(undefined)
@@ -119,6 +119,7 @@ export function TenderlyPanelProvider({ children }: { children: ReactNode }): Re
   const [isOpen, setIsOpen] = useState(false)
   const [selectedCanonicalChainId, setSelectedCanonicalChainIdState] = useState<number | undefined>(undefined)
   const [pendingAction, setPendingAction] = useState<string | null>(null)
+  const [stateRevision, setStateRevision] = useState(0)
   const { value: snapshotStorageValue, set: setSnapshotStorage } = useLocalStorageValue<TTenderlySnapshotStorage>(
     TENDERLY_SNAPSHOT_STORAGE_KEY,
     {
@@ -206,12 +207,8 @@ export function TenderlyPanelProvider({ children }: { children: ReactNode }): Re
 
   const refreshTenderlyDependentState = useCallback(async (): Promise<void> => {
     await queryClient.invalidateQueries()
-    if (address) {
-      await onRefresh().catch((error) => {
-        console.error('Failed to refresh wallet balances after Tenderly action:', error)
-      })
-    }
-  }, [address, onRefresh, queryClient])
+    setStateRevision((currentRevision) => currentRevision + 1)
+  }, [queryClient])
 
   const updateSnapshotStorage = useCallback(
     (updater: (snapshotStorage: TTenderlySnapshotStorage) => TTenderlySnapshotStorage): void => {
@@ -471,6 +468,7 @@ export function TenderlyPanelProvider({ children }: { children: ReactNode }): Re
       fundableAssets,
       connectedWalletAddress: address,
       pendingAction,
+      stateRevision,
       openPanel: (): void => setIsOpen(true),
       closePanel: (): void => setIsOpen(false),
       togglePanel: (): void => setIsOpen((current) => !current),
@@ -496,6 +494,7 @@ export function TenderlyPanelProvider({ children }: { children: ReactNode }): Re
       fundableAssets,
       address,
       pendingAction,
+      stateRevision,
       refetchStatus,
       createBaselineSnapshot,
       createSnapshot,

--- a/src/components/shared/contexts/useWallet.helpers.test.ts
+++ b/src/components/shared/contexts/useWallet.helpers.test.ts
@@ -5,7 +5,8 @@ import {
   applyTokenListMetadataToBalances,
   hasWalletBalanceSnapshot,
   shouldExposeWalletLoading,
-  shouldUpdateVisibleBalanceSnapshot
+  shouldUpdateVisibleBalanceSnapshot,
+  shouldUseEnsoWalletBalances
 } from './useWallet.helpers'
 
 const TOKEN_BALANCE_SNAPSHOT = {
@@ -24,6 +25,11 @@ const TOKEN_BALANCE_SNAPSHOT = {
 const TOKEN_LIST_METADATA_ADDRESS = '0x0000000000000000000000000000000000000123'
 
 describe('useWallet.helpers', () => {
+  it('forces the Enso balance path in Tenderly mode even when multicall is configured', () => {
+    expect(shouldUseEnsoWalletBalances({ isTenderlyMode: true, prefersEnso: false })).toBe(true)
+    expect(shouldUseEnsoWalletBalances({ isTenderlyMode: false, prefersEnso: false })).toBe(false)
+  })
+
   it('overlays token-list metadata without changing wallet balance data', () => {
     const balances = {
       1: {

--- a/src/components/shared/contexts/useWallet.helpers.ts
+++ b/src/components/shared/contexts/useWallet.helpers.ts
@@ -16,6 +16,16 @@ type TShouldUpdateVisibleBalanceSnapshotParams = {
   isLoading: boolean
 }
 
+export function shouldUseEnsoWalletBalances({
+  isTenderlyMode,
+  prefersEnso
+}: {
+  isTenderlyMode: boolean
+  prefersEnso: boolean
+}): boolean {
+  return isTenderlyMode || prefersEnso
+}
+
 export function hasWalletBalanceSnapshot(balances: TChainTokens): boolean {
   return Object.values(balances).some((tokensByChain) => Object.keys(tokensByChain || {}).length > 0)
 }

--- a/src/components/shared/contexts/useWallet.tsx
+++ b/src/components/shared/contexts/useWallet.tsx
@@ -2,10 +2,11 @@ import type { TKongVaultInput } from '@pages/vaults/domain/kongVaultSelectors'
 import type { QueryKey } from '@tanstack/react-query'
 import { useQueryClient } from '@tanstack/react-query'
 import type { ReactElement } from 'react'
-import { createContext, memo, useCallback, useContext, useDeferredValue, useMemo, useRef } from 'react'
+import { createContext, memo, useCallback, useContext, useDeferredValue, useMemo, useRef, useState } from 'react'
+import { isTenderlyModeEnabled } from '@/config/tenderly'
 import { env } from '@/env'
 import type { TUseBalancesTokens } from '../hooks/useBalances.multichains'
-import { useBalancesCombined } from '../hooks/useBalancesCombined'
+import { mergeBalanceSources, useBalancesCombined } from '../hooks/useBalancesCombined'
 import { useBalancesWithQuery } from '../hooks/useBalancesWithQuery'
 import type { TFetchQueryKey } from '../hooks/useFetch'
 import { useStakingAssetConversions } from '../hooks/useStakingAssetConversions'
@@ -16,7 +17,8 @@ import {
   applyTokenListMetadataToBalances,
   hasWalletBalanceSnapshot,
   shouldExposeWalletLoading,
-  shouldUpdateVisibleBalanceSnapshot
+  shouldUpdateVisibleBalanceSnapshot,
+  shouldUseEnsoWalletBalances
 } from './useWallet.helpers'
 import { useWeb3 } from './useWeb3'
 import { useYearn } from './useYearn'
@@ -26,6 +28,7 @@ import { useTokenList } from './WithTokenList'
 const USE_ENSO_BALANCES = env.NEXT_PUBLIC_BALANCE_SOURCE !== 'multicall'
 
 type TTokenAndChain = { address: TAddress; chainID: number }
+type TBalanceOverrideRefresher = () => Promise<TChainTokens>
 
 type TWalletContext = {
   getToken: ({ address, chainID }: TTokenAndChain) => TToken
@@ -39,12 +42,18 @@ type TWalletContext = {
     shouldSaveInStorage?: boolean,
     shouldForceFetch?: boolean
   ) => Promise<TChainTokens>
+  clearBalanceOverride: (scopeId: string) => void
+  registerBalanceOverrideRefresher: (scopeId: string, refresher: TBalanceOverrideRefresher) => void
+  setBalanceOverride: (scopeId: string, balances: TChainTokens) => void
 }
 
 type TWalletTokensContext = Pick<TWalletContext, 'getToken' | 'getBalance' | 'balances'>
 type TWalletStatusContext = Pick<TWalletContext, 'isLoading' | 'hasCompletedBalanceLoad'>
 type TWalletHoldingsContext = Pick<TWalletContext, 'getVaultHoldingsUsd'>
-type TWalletActionsContext = Pick<TWalletContext, 'onRefresh'>
+type TWalletActionsContext = Pick<
+  TWalletContext,
+  'clearBalanceOverride' | 'onRefresh' | 'registerBalanceOverrideRefresher' | 'setBalanceOverride'
+>
 
 const defaultProps = {
   getToken: (): TToken => DEFAULT_ERC20,
@@ -53,7 +62,10 @@ const defaultProps = {
   balances: {},
   isLoading: true,
   hasCompletedBalanceLoad: false,
-  onRefresh: async (): Promise<TChainTokens> => ({})
+  onRefresh: async (): Promise<TChainTokens> => ({}),
+  clearBalanceOverride: (): void => undefined,
+  registerBalanceOverrideRefresher: (): void => undefined,
+  setBalanceOverride: (): void => undefined
 }
 
 /*******************************************************************************
@@ -79,7 +91,14 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
     isEnabled: Boolean(userAddress)
   })
   const { getToken: getTokenListToken, tokenLists } = useTokenList()
-  const useBalancesHook = USE_ENSO_BALANCES ? useBalancesCombined : useBalancesWithQuery
+  const [balanceOverrides, setBalanceOverrides] = useState<Record<string, TChainTokens>>({})
+  const balanceOverrideRefreshersRef = useRef(new Map<string, TBalanceOverrideRefresher>())
+  const useBalancesHook = shouldUseEnsoWalletBalances({
+    isTenderlyMode: isTenderlyModeEnabled(),
+    prefersEnso: USE_ENSO_BALANCES
+  })
+    ? useBalancesCombined
+    : useBalancesWithQuery
   const {
     data: tokensRaw, // Expected to be TDict<TNormalizedBN | undefined>
     onUpdate,
@@ -116,13 +135,25 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
   }
   const visibleTokensRaw = settledTokensRawRef.current
   const deferredTokensRaw = useDeferredValue(visibleTokensRaw)
-  const balances = useMemo(
+  const canonicalBalances = useMemo(
     (): TNDict<TDict<TToken>> =>
       applyTokenListMetadataToBalances({
         balances: deferredTokensRaw as TYChainTokens,
         tokenLists
       }),
     [deferredTokensRaw, tokenLists]
+  )
+  const balancesWithOverrides = useMemo(
+    () => mergeBalanceSources(deferredTokensRaw as TChainTokens, ...Object.values(balanceOverrides)),
+    [balanceOverrides, deferredTokensRaw]
+  )
+  const balances = useMemo(
+    (): TNDict<TDict<TToken>> =>
+      applyTokenListMetadataToBalances({
+        balances: balancesWithOverrides as TYChainTokens,
+        tokenLists
+      }),
+    [balancesWithOverrides, tokenLists]
   )
   const isBalancesPending = deferredTokensRaw !== visibleTokensRaw
   const hasVisibleBalances = hasWalletBalanceSnapshot(visibleTokensRaw)
@@ -148,6 +179,30 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
     onUpdateSome,
     userAddress
   }
+
+  const setBalanceOverride = useCallback((scopeId: string, nextBalances: TChainTokens): void => {
+    setBalanceOverrides((currentOverrides) => ({
+      ...currentOverrides,
+      [scopeId]: nextBalances
+    }))
+  }, [])
+
+  const registerBalanceOverrideRefresher = useCallback(
+    (scopeId: string, refresher: TBalanceOverrideRefresher): void => {
+      balanceOverrideRefreshersRef.current.set(scopeId, refresher)
+    },
+    []
+  )
+
+  const clearBalanceOverride = useCallback((scopeId: string): void => {
+    balanceOverrideRefreshersRef.current.delete(scopeId)
+    setBalanceOverrides((currentOverrides) => {
+      if (!(scopeId in currentOverrides)) {
+        return currentOverrides
+      }
+      return Object.fromEntries(Object.entries(currentOverrides).filter(([key]) => key !== scopeId))
+    })
+  }, [])
 
   const onRefresh = useCallback(
     async (tokenToUpdate?: TUseBalancesTokens[]): Promise<TYChainTokens> => {
@@ -180,6 +235,17 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
         })
       }
 
+      if (isTenderlyModeEnabled()) {
+        const { onUpdate } = refreshSourcesRef.current
+        const overrideRefreshers = [...balanceOverrideRefreshersRef.current.values()]
+        const [canonicalBalances, refreshedOverrides] = await Promise.all([
+          onUpdate(tokenToUpdate === undefined),
+          Promise.all(overrideRefreshers.map(async (refreshOverride) => await refreshOverride()))
+        ])
+        await invalidateHoldingsQueries()
+        return mergeBalanceSources(canonicalBalances, ...refreshedOverrides) as TYChainTokens
+      }
+
       if (tokenToUpdate) {
         const { onUpdateSome } = refreshSourcesRef.current
         const updatedBalances = await onUpdateSome(tokenToUpdate)
@@ -204,16 +270,19 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
     ({ address, chainID }: TTokenAndChain): TToken => {
       const cacheKey = `${userAddress || 'disconnected'}-${chainID || 1}-${address}`
       const token = balances?.[chainID || 1]?.[address]
+      const canonicalToken = canonicalBalances?.[chainID || 1]?.[address]
 
-      // If we have a valid token from balances, update the cache
+      // Route-scoped overrides are returned to the active workflow but never persisted beyond its lifetime.
       if (token && token.address !== DEFAULT_ERC20.address) {
-        tokenCache.current[cacheKey] = token
+        if (canonicalToken && canonicalToken.address !== DEFAULT_ERC20.address) {
+          tokenCache.current[cacheKey] = canonicalToken
+        }
         return token
       }
       // If balances is empty (during refetch), return cached token if available
       return tokenCache.current[cacheKey] || getTokenListToken({ address, chainID })
     },
-    [balances, userAddress, getTokenListToken]
+    [balances, canonicalBalances, userAddress, getTokenListToken]
   )
 
   /**************************************************************************
@@ -268,9 +337,12 @@ export const WalletContextApp = memo(function WalletContextApp(props: {
   )
   const actionsValue = useMemo(
     (): TWalletActionsContext => ({
-      onRefresh
+      clearBalanceOverride,
+      onRefresh,
+      registerBalanceOverrideRefresher,
+      setBalanceOverride
     }),
-    [onRefresh]
+    [clearBalanceOverride, onRefresh, registerBalanceOverrideRefresher, setBalanceOverride]
   )
 
   return (

--- a/src/components/shared/hooks/useBalancesCombined.test.ts
+++ b/src/components/shared/hooks/useBalancesCombined.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest'
 import type { TChainTokens, TToken } from '../types/mixed'
 import { shouldUseDiscoveryFallbackToken } from './balanceDiscoveryFallback'
 import type { TUseBalancesTokens } from './useBalances.multichains'
-import { getRequiredMulticallTokens, mergeBalanceSources } from './useBalancesCombined'
+import {
+  areCombinedBalanceMulticallFallbacksEnabled,
+  getCombinedBalanceUnsupportedNetworkIds,
+  getRequiredMulticallTokens,
+  mergeBalanceSources
+} from './useBalancesCombined'
 
 const TOKEN_ADDRESS = '0x1111111111111111111111111111111111111111' as const
 const STAKING_ADDRESS = '0x2222222222222222222222222222222222222222' as const
@@ -65,8 +70,24 @@ describe('shouldUseDiscoveryFallbackToken', () => {
   })
 })
 
+describe('getCombinedBalanceUnsupportedNetworkIds', () => {
+  it('does not force Enso-supported Tenderly canonical chains through the VNet', () => {
+    const unsupportedNetworkIds = getCombinedBalanceUnsupportedNetworkIds()
+
+    expect(unsupportedNetworkIds).not.toContain(1)
+    expect(unsupportedNetworkIds).not.toContain(10)
+    expect(unsupportedNetworkIds).not.toContain(8453)
+    expect(unsupportedNetworkIds).not.toContain(42161)
+  })
+
+  it('disables multicall fallbacks entirely in Tenderly mode', () => {
+    expect(areCombinedBalanceMulticallFallbacksEnabled(true)).toBe(false)
+    expect(areCombinedBalanceMulticallFallbacksEnabled(false)).toBe(true)
+  })
+})
+
 describe('mergeBalanceSources', () => {
-  it('keeps an earlier non-zero USD value when multicall refreshes the same token balance without a price', () => {
+  it('applies the earlier Enso unit price to an updated raw balance', () => {
     const ensoBalances: TChainTokens = {
       1: {
         [TOKEN_ADDRESS]: token({
@@ -96,7 +117,7 @@ describe('mergeBalanceSources', () => {
 
     const merged = mergeBalanceSources(ensoBalances, multicallBalances)
 
-    expect(merged[1][TOKEN_ADDRESS].value).toBe(42)
+    expect(merged[1][TOKEN_ADDRESS].value).toBe(84)
     expect(merged[1][TOKEN_ADDRESS].balance.raw).toBe(2n)
   })
 

--- a/src/components/shared/hooks/useBalancesCombined.ts
+++ b/src/components/shared/hooks/useBalancesCombined.ts
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useMemo } from 'react'
-import { getTenderlyBackedCanonicalChainIds, resolveExecutionChainId } from '@/config/tenderly'
+import { isTenderlyModeEnabled, resolveExecutionChainId } from '@/config/tenderly'
 import { useWeb3 } from '../contexts/useWeb3'
 import type { TChainTokens, TDict, TNDict, TToken } from '../types/mixed'
 import { toAddress } from '../utils/tools.address'
@@ -38,7 +38,9 @@ function mergeBalanceToken(existing: TToken | undefined, incoming: TToken): TTok
 
   const incomingValue = Number.isFinite(incoming.value) ? incoming.value : 0
   const existingValue = Number.isFinite(existing.value) ? existing.value : 0
-  const fallbackValue = incoming.balance.raw > 0n ? existingValue : 0
+  const existingUnitPrice =
+    existing.balance.normalized > 0 && existingValue > 0 ? existingValue / existing.balance.normalized : 0
+  const fallbackValue = incoming.balance.raw > 0n ? incoming.balance.normalized * existingUnitPrice : 0
 
   return {
     ...existing,
@@ -98,6 +100,14 @@ export function getRequiredMulticallTokens(params: {
   })
 }
 
+export function getCombinedBalanceUnsupportedNetworkIds(): number[] {
+  return [...ENSO_UNSUPPORTED_NETWORKS]
+}
+
+export function areCombinedBalanceMulticallFallbacksEnabled(isTenderlyMode: boolean): boolean {
+  return !isTenderlyMode
+}
+
 /*******************************************************************************
  ** Combined balance hook that uses Enso API for supported chains
  ** and falls back to multicall (RPC) for unsupported chains like Fantom
@@ -111,17 +121,18 @@ export function getRequiredMulticallTokens(params: {
 export function useBalancesCombined(props?: TUseBalancesReq): TUseBalancesRes {
   const { address: userAddress } = useWeb3()
   const queryClient = useQueryClient()
-  const ensoUnsupportedNetworks = useMemo(
-    () => [...new Set([...ENSO_UNSUPPORTED_NETWORKS, ...getTenderlyBackedCanonicalChainIds()])],
-    []
-  )
+  const isTenderlyMode = isTenderlyModeEnabled()
+  const multicallFallbacksEnabled = areCombinedBalanceMulticallFallbacksEnabled(isTenderlyMode)
+  const ensoUnsupportedNetworks = useMemo(getCombinedBalanceUnsupportedNetworkIds, [])
 
   const tokens = useMemo(() => (userAddress ? props?.tokens || [] : []), [props?.tokens, userAddress])
 
   // Split tokens into Enso-supported and multicall-required groups
   const { ensoTokens, multicallTokens } = useMemo(() => {
-    return partitionTokensByBalanceSource(tokens, ensoUnsupportedNetworks)
-  }, [ensoUnsupportedNetworks, tokens])
+    return partitionTokensByBalanceSource(tokens, ensoUnsupportedNetworks, {
+      multicallFallbacksEnabled
+    })
+  }, [ensoUnsupportedNetworks, multicallFallbacksEnabled, tokens])
   const hasDisabledVeyfiGaugeMulticallTokens = useMemo(
     () => multicallTokens.some(isDisabledVeyfiGaugeBalanceToken),
     [multicallTokens]
@@ -153,6 +164,9 @@ export function useBalancesCombined(props?: TUseBalancesReq): TUseBalancesRes {
   }, [ensoBalances, ensoError, ensoSuccess, multicallTokens])
 
   const discoveryFallbackTokens = useMemo((): TUseBalancesTokens[] => {
+    if (!multicallFallbacksEnabled) {
+      return []
+    }
     if (ensoTokens.length === 0) {
       return []
     }
@@ -175,7 +189,7 @@ export function useBalancesCombined(props?: TUseBalancesReq): TUseBalancesRes {
         hasPositiveBalanceCache: hasPositiveCachedBalance(token.chainID, tokenAddress, userAddress)
       })
     })
-  }, [ensoBalances, ensoError, ensoSuccess, ensoTokens, userAddress])
+  }, [ensoBalances, ensoError, ensoSuccess, ensoTokens, multicallFallbacksEnabled, userAddress])
 
   const {
     data: requiredMulticallBalances,
@@ -303,6 +317,10 @@ export function useBalancesCombined(props?: TUseBalancesReq): TUseBalancesRes {
 
   const onUpdateSome = useCallback(
     async (tokenList: TUseBalancesTokens[]): Promise<TChainTokens> => {
+      if (!multicallFallbacksEnabled) {
+        return {}
+      }
+
       const validTokens = tokenList.filter(({ address }) => !isZeroAddress(address))
       if (validTokens.length === 0) return {}
 
@@ -343,22 +361,16 @@ export function useBalancesCombined(props?: TUseBalancesReq): TUseBalancesRes {
       const currentEnsoData = queryClient.getQueryData<TChainTokens>(ensoQueryKey)
 
       if (currentEnsoData) {
-        const mergedEnsoData = { ...currentEnsoData }
-        for (const [chainIdStr, tokens] of Object.entries(updatedBalances)) {
-          const chainId = Number(chainIdStr)
-          if (!ensoUnsupportedNetworks.includes(chainId)) {
-            if (!mergedEnsoData[chainId]) {
-              mergedEnsoData[chainId] = {}
-            }
-            mergedEnsoData[chainId] = { ...mergedEnsoData[chainId], ...tokens }
-          }
-        }
+        const ensoEligibleUpdates = Object.fromEntries(
+          Object.entries(updatedBalances).filter(([chainId]) => !ensoUnsupportedNetworks.includes(Number(chainId)))
+        )
+        const mergedEnsoData = mergeBalanceSources(currentEnsoData, ensoEligibleUpdates)
         queryClient.setQueryData(ensoQueryKey, mergedEnsoData)
       }
 
       return updatedBalances
     },
-    [ensoUnsupportedNetworks, queryClient, userAddress]
+    [ensoUnsupportedNetworks, multicallFallbacksEnabled, queryClient, userAddress]
   )
 
   const status = useMemo((): 'error' | 'loading' | 'success' | 'unknown' => {

--- a/src/components/shared/hooks/useBalancesRouting.test.ts
+++ b/src/components/shared/hooks/useBalancesRouting.test.ts
@@ -81,6 +81,40 @@ describe('partitionTokensByBalanceSource', () => {
     expect(multicallTokens.map(tokenKey)).toEqual([`250:${getAddress(STAKING_B)}`])
   })
 
+  it('routes every token to Enso when multicall fallbacks are disabled', () => {
+    const tokens: TUseBalancesTokens[] = [
+      {
+        address: VAULT_A,
+        chainID: 1,
+        isStakingOnlyPair: true,
+        pairedStakingAddress: STAKING_A
+      },
+      {
+        address: STAKING_A,
+        chainID: 1,
+        isStakingOnlyPair: true,
+        isStakingToken: true,
+        pairedVaultAddress: VAULT_A
+      },
+      {
+        address: STAKING_B,
+        chainID: 250,
+        isStakingToken: true
+      }
+    ]
+
+    const { ensoTokens, multicallTokens } = partitionTokensByBalanceSource(tokens, [250], {
+      multicallFallbacksEnabled: false
+    })
+
+    expect(multicallTokens).toEqual([])
+    expect(ensoTokens.map(tokenKey)).toEqual([
+      `1:${getAddress(VAULT_A)}`,
+      `1:${getAddress(STAKING_A)}`,
+      `250:${getAddress(STAKING_B)}`
+    ])
+  })
+
   it('routes Tenderly-backed canonical chains to multicall when Enso is disabled for them', () => {
     const tokens: TUseBalancesTokens[] = [
       {

--- a/src/components/shared/hooks/useBalancesRouting.ts
+++ b/src/components/shared/hooks/useBalancesRouting.ts
@@ -6,6 +6,10 @@ type TBalanceSourcePartition = {
   multicallTokens: TUseBalancesTokens[]
 }
 
+type TBalanceSourcePartitionOptions = {
+  multicallFallbacksEnabled?: boolean
+}
+
 function normalizeBalanceToken(token: TUseBalancesTokens): TUseBalancesTokens {
   return {
     ...token,
@@ -76,14 +80,15 @@ function shouldUseMulticall(token: TUseBalancesTokens, unsupportedChains: Set<nu
 
 export function partitionTokensByBalanceSource(
   tokens: TUseBalancesTokens[],
-  unsupportedNetworkIds: number[]
+  unsupportedNetworkIds: number[],
+  options?: TBalanceSourcePartitionOptions
 ): TBalanceSourcePartition {
   const unsupportedChains = new Set(unsupportedNetworkIds)
   const ensoTokens: TUseBalancesTokens[] = []
   const multicallTokens: TUseBalancesTokens[] = []
 
   for (const token of dedupeBalanceTokens(tokens)) {
-    if (shouldUseMulticall(token, unsupportedChains)) {
+    if (options?.multicallFallbacksEnabled !== false && shouldUseMulticall(token, unsupportedChains)) {
       multicallTokens.push(token)
     } else {
       ensoTokens.push(token)


### PR DESCRIPTION
### Summary
Keep global wallet balances canonical through Enso in Tenderly mode while refreshing only the tokens required by the active vault workflow from the VNet. This also bounds VNet status transaction-history requests, rejects unsuccessful snapshot reverts in the admin CLI, and adds the reference branch's Tenderly script safety guidance.

Standalone vault-widget application files, QA runners, and package commands remain intentionally excluded because the widget does not exist on `main`. The `scripts/AGENTS.md` guidance is included verbatim from the reference branch as requested.

### How to review
Start with `useTenderlyVaultBalanceOverrides.ts` and `useWallet.tsx` to review the route-scoped override lifecycle, including reconnect cleanup. Then review `useBalancesCombined.ts` and `useBalancesRouting.ts` for the Tenderly-mode Enso routing, followed by the VNet status and CLI changes under `scripts/`.

Review `scripts/AGENTS.md` separately as operational guidance copied from the reference branch. It includes safety rules for the future vault-widget QA runner, while that runner itself is not part of this PR.

For a smoke test, enable Tenderly mode in a non-production environment, open a vault detail route, fund or revert the connected wallet, and confirm the active vault balances refresh while portfolio balances remain canonical. Leaving the route or reconnecting should clear and rebuild the scoped override.

### Test plan
- [x] Automated: focused Vitest suite covering 6 files and 52 tests
- [x] Automated: full Tenderly-disabled Vitest suite covering 165 files and 882 tests
- [x] Automated: `bun run lint:fix` and `bun run lint`
- [x] Automated: `bun run tslint`
- [x] Automated: `NEXT_PUBLIC_TENDERLY_MODE=false bun run build`
- [x] Automated: commit hooks after adding `scripts/AGENTS.md`
- [x] Manual: production preview returned HTTP 200 for `/` and `/vaults` with Tenderly mode disabled
- [ ] Manual: live Tenderly vault mutation flow; intentionally not run to avoid consuming Tenderly Units

### Risk / impact
The wallet routing and scoped overrides affect Tenderly mode only; normal production balance behavior is unchanged. The primary risk is stale or incorrectly scoped simulated balances on vault routes, covered by unit tests for refresh, cleanup, reconnect, and pricing behavior. The copied script guidance references vault-widget QA commands that are not yet available on `main`; it is non-runtime documentation for that future workflow. There are no migrations or production fund movements. Reverting commits `662e2b98`, `9f2eefba`, and `3a4952d3` restores the prior behavior.
