### PR TITLE
security: enforce frame-ancestors CSP and add security.txt

### DIFF
--- a/docs/csp.md
+++ b/docs/csp.md
@@ -1,0 +1,34 @@
+# Content Security Policy
+
+yearn.fi enforces one CSP directive: `frame-ancestors`, defined in `next.config.ts`
+(`FRAME_ANCESTORS`) and applied to every route via `headers()`.
+
+```
+Content-Security-Policy: frame-ancestors 'self' <allowlist>; report-uri <sentry>
+```
+
+## What it does
+
+`frame-ancestors` controls who may embed yearn.fi in their iframe. It is the anti-clickjacking
+control: without it, a phishing site can frame the real app so a user signs a transaction while
+looking at an attacker-controlled page.
+
+The allowlist covers the integrations that legitimately embed us — the Safe App, Blockscout
+explorers, Coin98 — and was derived from several months of report-only telemetry in the Sentry
+`yearnfi` project. `report-uri` stays attached to the enforced policy so blocked framing keeps
+arriving in Sentry instead of failing silently.
+
+Not to be confused with `frame-src`, which controls the opposite direction — which iframes *we* may
+open. `frame-src` offers no clickjacking protection, since an attacker sets their own policy. Only
+the header on the framed page can stop them.
+
+## What about other CSP headers
+
+**`X-Frame-Options`** only accepts `DENY` or `SAMEORIGIN`, so it cannot express a multi-origin
+allowlist. Setting it would break the same embeds `frame-ancestors` exists to permit.
+
+**Resource directives** (`script-src`, `connect-src`, `img-src`, …) will be addressed in follow-up
+work.
+
+`report-uri` is formally deprecated in favour of the Reporting API, but has wider browser support and
+is what the Sentry security endpoint accepts.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,26 @@
 import type { NextConfig } from 'next'
 
+const CSP_REPORT_URI =
+  'https://o4510960324837376.ingest.us.sentry.io/api/4510960614375424/security/?sentry_key=6b1b2932f1532eff2227d01a122adbb4'
+
+/**
+ * Origins allowed to frame yearn.fi.
+ *
+ * Derived from `Content-Security-Policy-Report-Only` telemetry in the Sentry `yearnfi` project.
+ * Only vetted integrations are listed; other observed origins were reviewed and excluded.
+ * Additions should be verified individually, not bulk-added from reports.
+ */
+const FRAME_ANCESTORS = [
+  "'self'",
+  'https://app.safe.global',
+  'https://eth.blockscout.com',
+  'https://polygon.blockscout.com',
+  'https://base.blockscout.com',
+  'https://arbitrum.blockscout.com',
+  'https://explorer.optimism.io',
+  'https://dapps.coin98.com'
+]
+
 const securityHeaders = [
   {
     key: 'Strict-Transport-Security',
@@ -14,9 +35,10 @@ const securityHeaders = [
     value: 'strict-origin-when-cross-origin'
   },
   {
-    key: 'Content-Security-Policy-Report-Only',
-    value:
-      "frame-ancestors 'self'; report-uri https://o4510960324837376.ingest.us.sentry.io/api/4510960614375424/security/?sentry_key=6b1b2932f1532eff2227d01a122adbb4;"
+    // X-Frame-Options is intentionally omitted: it cannot express a multi-origin allowlist and
+    // would break the Safe App and Blockscout embeds.
+    key: 'Content-Security-Policy',
+    value: [`frame-ancestors ${FRAME_ANCESTORS.join(' ')}`, `report-uri ${CSP_REPORT_URI}`].join('; ')
   }
 ]
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -80,7 +80,8 @@ const nextConfig: NextConfig = {
       { source: '/medium', destination: 'https://medium.com/iearn', permanent: false },
       { source: '/governance', destination: 'https://gov.yearn.fi/', permanent: false },
       { source: '/snapshot', destination: 'https://snapshot.org/#/styfi.eth', permanent: false },
-      { source: '/github', destination: 'https://github.com/yearn/yearn.fi', permanent: false }
+      { source: '/github', destination: 'https://github.com/yearn/yearn.fi', permanent: false },
+      { source: '/security.txt', destination: '/.well-known/security.txt', permanent: false }
     ]
   },
   async rewrites() {

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@yearn.finance
+Policy: https://github.com/yearn/yearn-security/blob/master/SECURITY.md
+Canonical: https://yearn.fi/.well-known/security.txt
+Preferred-Languages: en
+Expires: 2027-06-01T00:00:00Z


### PR DESCRIPTION
## Description

Three commits:

- **Enforce `frame-ancestors`.** The policy has been running report-only; this promotes it to enforced with an allowlist of the integrations that embed us. `report-uri` stays attached so new integrators surface in Sentry rather than failing silently.
- **Add `/.well-known/security.txt`** (RFC 9116) pointing at the yearn-security policy, plus a redirect from the legacy `/security.txt` path.
- **Add `docs/csp.md`** covering what we enforce and why `X-Frame-Options` is deliberately omitted.

## Related Issue

BE-88, BE-75

## Motivation and Context

`frame-ancestors` restricts which origins may embed the app. Report-only telemetry has been collecting the necessary data; this promotes the policy to enforced with an allowlist.

`X-Frame-Options` is intentionally not set: it only accepts `DENY`/`SAMEORIGIN`, so it can't express a multi-origin allowlist.

## How Has This Been Tested?

Verified against a local dev server:

```
curl -sI http://127.0.0.1:3000/ | grep -i content-security-policy
curl -sI http://127.0.0.1:3000/.well-known/security.txt   # 200, text/plain; charset=UTF-8
curl -sI http://127.0.0.1:3000/security.txt               # 307 -> /.well-known/security.txt
```

`bun run tslint` and `bun run lint:fix` pass.

**Reviewer note:** worth confirming the Safe App still loads on a preview deploy before merge — that's the embed most likely to break if an origin is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
