### PR TITLE
Add historical optimization allocations

### DIFF
--- a/docs/manual-allocation-reallocation-data-spec.md
+++ b/docs/manual-allocation-reallocation-data-spec.md
@@ -1,6 +1,6 @@
 # Manual Allocation And Reallocation Data Spec
 
-Initial pass as of 2026-04-24.
+Initial pass as of 2026-04-24. Optimization coverage contract revised 2026-07-28.
 
 ## Goal
 
@@ -50,6 +50,40 @@ type DoaOptimizationRecord = {
     timestampUtc: string | null
     latestMatchedTimestampUtc: string | null
   }
+  allocationCoverage: {
+    currentIncludedBps: number
+    targetIncludedBps: number
+    currentResidualBps: number
+    targetResidualBps: number
+    currentComplete: boolean
+    targetComplete: boolean
+    classification: 'complete' | 'partial-optimizer-scope' | 'unknown'
+    unallocatedBps: number | null
+    unallocatedSource: 'same-timestamp-onchain' | 'same-timestamp-indexed' | null
+  }
+  freshness: {
+    optimizationTimestampUtc: string | null
+    latestAvailableTimestampUtc: string | null
+  }
+  allocationSnapshot: {
+    timestampUtc: string | null
+    blockNumber: number | null
+    blockTimestampUtc: string | null
+    source: 'archive-rpc' | null
+    strategyUniverseSource: 'envio-strategy-changed' | null
+    complete: boolean
+    strategies: Array<{
+      address: `0x${string}`
+      name: string | null
+      nameSource: 'optimizer' | 'current-metadata-catalog' | null
+      currentBps: number
+      targetBps: number | null
+      optimizerScope: 'optimized' | 'outside-optimizer-scope' | 'unknown'
+      targetSource: 'optimizer' | 'unchanged-outside-scope' | 'unavailable'
+    }>
+    unallocatedBps: number | null
+    unallocatedSource: 'same-timestamp-onchain' | null
+  }
 }
 ```
 
@@ -59,6 +93,142 @@ What it means:
 - `currentRatio` is the optimizer's observed starting state.
 - `targetRatio` is the optimizer's proposed target.
 - It is not proof that a vault debt update happened on-chain.
+
+Allocation coverage semantics:
+
+- `currentIncludedBps` and `targetIncludedBps` are independent sums of the raw `strategyDebtRatios`.
+- `currentResidualBps` and `targetResidualBps` describe how much of 10,000 bps is not represented in that optimizer payload. A residual does not establish why allocation is absent from the payload.
+- Totals within 5 bps of 10,000 are complete. A small overflow is retained in the included total and its residual is clamped to zero. Totals above 10,005 bps are invalid.
+- `classification` is `complete` only when both current and target totals are complete, `unknown` when both totals are zero, and `partial-optimizer-scope` otherwise.
+- `unallocatedBps` remains `null` and `unallocatedSource` remains `null` for DOA-only records. They may only be populated from authoritative vault state at the same timestamp, from either on-chain reads or an indexed state snapshot.
+- Therefore `currentResidualBps` and `targetResidualBps` must not be presented as confirmed unallocated capital.
+
+Freshness semantics:
+
+- `optimizationTimestampUtc` is the individual record's source timestamp. For a `latest` alias, it is the newest timestamped Redis payload whose raw content matches that alias; it is `null` when no match exists.
+- `latestAvailableTimestampUtc` is the newest known optimization timestamp for the same vault and chain in the current Redis read. Consumers can compare it with their own freshness policy, but the API does not declare a record stale using a hard-coded age.
+- History records retain their own `optimizationTimestampUtc`; current live vault state is never copied into historical optimizer records.
+
+Historical allocation reconciliation:
+
+- Envio `StrategyChanged` lifecycle events establish the strategy-address universe at the optimizer timestamp. Coverage is accepted only when each observed lifecycle starts with an add event, every optimizer strategy is represented, and the query is not truncated.
+- Archive RPC resolves the last block at or before the optimizer timestamp, then reads `totalAssets()` and every known `strategies(address)` entry in one Multicall request. These block-aligned values own `currentBps` and true `unallocatedBps`.
+- Kong's current snapshot composition may supply a useful strategy name, but never an allocation value. Such names are marked `nameSource: 'current-metadata-catalog'`.
+- A strategy in `strategyDebtRatios` is `optimized`, and its `targetBps` retains the optimizer target.
+- A strategy omitted from today's DOA payload is `unknown` with `targetBps: null`. The current payload has no machine-readable exclusion contract, so omission alone does not prove `outside-optimizer-scope`.
+- `outside-optimizer-scope` and `targetSource: 'unchanged-outside-scope'` are reserved for a future authoritative scope input that explicitly guarantees the strategy remains unchanged.
+- If Envio lifecycle coverage, timestamp resolution, or archive RPC is unavailable, `allocationSnapshot.complete` is `false`, its strategy list is empty, and the aggregate `allocationCoverage` residual remains the honest fallback.
+- Requested-vault history enrichment resolves block timestamps in batched search rounds, batches archive multicalls, retries transient rate limits, and caches by vault/timestamp/optimizer-address set. The unscoped all-vault response gets the explicit fallback shape without archive fan-out.
+- Production deployments may configure `OPTIMIZATION_ARCHIVE_RPC_URL_<chainId>` (for example `OPTIMIZATION_ARCHIVE_RPC_URL_1`) to put a dedicated archive provider ahead of the existing public RPC fallbacks. Large histories should not depend on public-provider rate limits.
+
+Source authority:
+
+| Data | Authority | Notes |
+| --- | --- | --- |
+| Optimizer intent, included strategies, and targets | DOA Redis payload | Raw fields are preserved unchanged. Omission is not an exclusion guarantee. |
+| Historical current allocations | Archive RPC at the last block at or before the optimizer timestamp | Envio supplies and validates the historical strategy universe. |
+| True historical unallocated capital | Same archive-RPC snapshot | Calculated from `totalAssets - sum(strategy current debt)` at the same block. |
+| Strategy names | Optimizer payload, then current Kong metadata catalog | Kong names are convenience metadata with explicit current-catalog provenance. |
+| Current/live allocation | Kong or live RPC | Must not be copied into a historical optimizer record. |
+
+### yvWETH-1 Example: Successful Historical Enrichment
+
+Read-only validation for the `2026-07-25 00:15:29 UTC` recommendation resolved Ethereum block `25,606,129`, whose timestamp is `2026-07-25 00:15:23 UTC`:
+
+```json
+{
+  "allocationCoverage": {
+    "currentIncludedBps": 4157,
+    "targetIncludedBps": 4157,
+    "currentResidualBps": 5843,
+    "targetResidualBps": 5843,
+    "currentComplete": false,
+    "targetComplete": false,
+    "classification": "partial-optimizer-scope",
+    "unallocatedBps": 2,
+    "unallocatedSource": "same-timestamp-onchain"
+  },
+  "allocationSnapshot": {
+    "timestampUtc": "2026-07-25 00:15:29 UTC",
+    "blockNumber": 25606129,
+    "blockTimestampUtc": "2026-07-25 00:15:23 UTC",
+    "source": "archive-rpc",
+    "strategyUniverseSource": "envio-strategy-changed",
+    "complete": true,
+    "strategies": [
+      {
+        "address": "0x470e0e048f85cfd72eef325895e02c8d297e7435",
+        "name": "stETH Accumulator",
+        "nameSource": "current-metadata-catalog",
+        "currentBps": 4722,
+        "targetBps": null,
+        "optimizerScope": "unknown",
+        "targetSource": "unavailable"
+      },
+      {
+        "address": "0xe89371eaaac6d46d4c3ed23453241987916224fc",
+        "name": "Yearn OG WETH",
+        "nameSource": "current-metadata-catalog",
+        "currentBps": 178,
+        "targetBps": 91,
+        "optimizerScope": "optimized",
+        "targetSource": "optimizer"
+      },
+      {
+        "address": "0x68a14629cb07c74259f481382fe8b6cfd8970121",
+        "name": "wstETH/WETH Spark Looper",
+        "nameSource": "current-metadata-catalog",
+        "currentBps": 1152,
+        "targetBps": null,
+        "optimizerScope": "unknown",
+        "targetSource": "unavailable"
+      },
+      {
+        "address": "0xfca3f21d60d5bc8b4c5c35f169bb5b6402510151",
+        "name": "Spark WETH Lender",
+        "nameSource": "current-metadata-catalog",
+        "currentBps": 3947,
+        "targetBps": 4066,
+        "optimizerScope": "optimized",
+        "targetSource": "optimizer"
+      }
+    ],
+    "unallocatedBps": 2,
+    "unallocatedSource": "same-timestamp-onchain"
+  }
+}
+```
+
+The strategy bps values are independently rounded against same-block `totalAssets`, so their displayed sum plus unallocated may differ from 10,000 by a few bps. Raw debts and optimizer ratios are not rescaled.
+
+### yvWETH-1 Example: Supported Fallback
+
+```json
+{
+  "allocationCoverage": {
+    "currentIncludedBps": 4157,
+    "targetIncludedBps": 4157,
+    "currentResidualBps": 5843,
+    "targetResidualBps": 5843,
+    "classification": "partial-optimizer-scope",
+    "unallocatedBps": null,
+    "unallocatedSource": null
+  },
+  "allocationSnapshot": {
+    "timestampUtc": "2026-07-25 00:15:29 UTC",
+    "blockNumber": null,
+    "blockTimestampUtc": null,
+    "source": null,
+    "strategyUniverseSource": null,
+    "complete": false,
+    "strategies": [],
+    "unallocatedBps": null,
+    "unallocatedSource": null
+  }
+}
+```
+
+In fallback mode, Powerglove should render the raw optimizer strategies and an aggregate “Outside optimizer scope / composition unavailable” residual. It must not label that residual `Unallocated`.
 
 ### Current Kong Vault Snapshot
 
@@ -220,6 +390,16 @@ Suggested DOA matching signals:
 - `DebtUpdated` transaction sender or wrapper is a known DOA keeper/applicator path.
 
 If DOA exists but no matching on-chain transition exists, it should be modeled as a proposal/pending annotation, not as an executed allocation state.
+
+## Downstream Normalization Dependency
+
+The private `optimization-visualizer` repository has a separate `lib/normalize.ts` implementation that rescales or synthesizes missing allocation and an on-chain patching path in `app/hooks/useOptimizations.ts`. It must adopt this coverage contract separately. That repository is intentionally out of scope for this change.
+
+Until that follow-up is complete, consumers should use `allocationCoverage` from this API and must not infer `Unallocated` as `10,000 - sum(strategyDebtRatios)`.
+
+## Upstream Publisher Dependency
+
+The API can only report the newest DOA snapshot present under `doa:optimizations:*`; it does not repair or infer missing optimizer history. Ethereum yvUSDC-1 (`0xBe53A109B494E5c9f97b9Cd39Fe969BE68BF6204`) had no July 2026 records when this contract was revised, despite later vault strategy-state changes. Restoring that missing history is a separate DOA Redis publisher investigation. Consumers should use `freshness.latestAvailableTimestampUtc` to apply their own stale-recommendation warning policy.
 
 ## Classification
 

--- a/src/server/optimization/_lib/allocationCoverage.test.ts
+++ b/src/server/optimization/_lib/allocationCoverage.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { calculateAllocationCoverage } from './allocationCoverage'
+
+function ratio(currentRatio: number, targetRatio = currentRatio) {
+  return { currentRatio, targetRatio }
+}
+
+describe('calculateAllocationCoverage', () => {
+  it('classifies exact 10,000 bps records as complete', () => {
+    expect(calculateAllocationCoverage([ratio(6000), ratio(4000)])).toEqual({
+      currentIncludedBps: 10000,
+      targetIncludedBps: 10000,
+      currentResidualBps: 0,
+      targetResidualBps: 0,
+      currentComplete: true,
+      targetComplete: true,
+      classification: 'complete',
+      unallocatedBps: null,
+      unallocatedSource: null
+    })
+  })
+
+  it.each([
+    [9998, 10002, 2, 0],
+    [10002, 9998, 0, 2]
+  ])('accepts rounding-tolerant totals and clamps minor overflow residuals', (currentIncludedBps, targetIncludedBps, currentResidualBps, targetResidualBps) => {
+    expect(calculateAllocationCoverage([ratio(currentIncludedBps, targetIncludedBps)])).toMatchObject({
+      currentIncludedBps,
+      targetIncludedBps,
+      currentResidualBps,
+      targetResidualBps,
+      currentComplete: true,
+      targetComplete: true,
+      classification: 'complete'
+    })
+  })
+
+  it('reports a yvWETH-style record as partial optimizer scope, not unallocated', () => {
+    expect(calculateAllocationCoverage([ratio(2000), ratio(2157)])).toEqual({
+      currentIncludedBps: 4157,
+      targetIncludedBps: 4157,
+      currentResidualBps: 5843,
+      targetResidualBps: 5843,
+      currentComplete: false,
+      targetComplete: false,
+      classification: 'partial-optimizer-scope',
+      unallocatedBps: null,
+      unallocatedSource: null
+    })
+  })
+
+  it('keeps current and target coverage separate', () => {
+    expect(calculateAllocationCoverage([ratio(6000, 5000), ratio(4000, 2500)])).toMatchObject({
+      currentIncludedBps: 10000,
+      targetIncludedBps: 7500,
+      currentResidualBps: 0,
+      targetResidualBps: 2500,
+      currentComplete: true,
+      targetComplete: false,
+      classification: 'partial-optimizer-scope'
+    })
+  })
+
+  it('classifies an empty optimizer scope as unknown', () => {
+    expect(calculateAllocationCoverage([])).toMatchObject({
+      currentIncludedBps: 0,
+      targetIncludedBps: 0,
+      currentResidualBps: 10000,
+      targetResidualBps: 10000,
+      currentComplete: false,
+      targetComplete: false,
+      classification: 'unknown',
+      unallocatedBps: null,
+      unallocatedSource: null
+    })
+  })
+
+  it('rejects materially invalid totals', () => {
+    expect(() => calculateAllocationCoverage([ratio(10006)])).toThrow(
+      'current ratios total 10006 bps, exceeding 10000 bps'
+    )
+  })
+})

--- a/src/server/optimization/_lib/allocationCoverage.ts
+++ b/src/server/optimization/_lib/allocationCoverage.ts
@@ -1,0 +1,54 @@
+import type { StrategyDebtRatio } from './schema'
+
+const TOTAL_ALLOCATION_BPS = 10000
+export const ALLOCATION_COMPLETENESS_TOLERANCE_BPS = 5
+
+export type AllocationCoverageClassification = 'complete' | 'partial-optimizer-scope' | 'unknown'
+
+export interface AllocationCoverage {
+  currentIncludedBps: number
+  targetIncludedBps: number
+  currentResidualBps: number
+  targetResidualBps: number
+  currentComplete: boolean
+  targetComplete: boolean
+  classification: AllocationCoverageClassification
+  unallocatedBps: number | null
+  unallocatedSource: 'same-timestamp-onchain' | 'same-timestamp-indexed' | null
+}
+
+function validateIncludedBps(label: 'current' | 'target', includedBps: number): void {
+  if (includedBps > TOTAL_ALLOCATION_BPS + ALLOCATION_COMPLETENESS_TOLERANCE_BPS) {
+    throw new Error(
+      `Invalid optimizer allocation coverage: ${label} ratios total ${includedBps} bps, exceeding ${TOTAL_ALLOCATION_BPS} bps`
+    )
+  }
+}
+
+export function calculateAllocationCoverage(
+  strategyDebtRatios: readonly Pick<StrategyDebtRatio, 'currentRatio' | 'targetRatio'>[]
+): AllocationCoverage {
+  const currentIncludedBps = strategyDebtRatios.reduce((sum, strategy) => sum + strategy.currentRatio, 0)
+  const targetIncludedBps = strategyDebtRatios.reduce((sum, strategy) => sum + strategy.targetRatio, 0)
+
+  validateIncludedBps('current', currentIncludedBps)
+  validateIncludedBps('target', targetIncludedBps)
+
+  const currentComplete = Math.abs(TOTAL_ALLOCATION_BPS - currentIncludedBps) <= ALLOCATION_COMPLETENESS_TOLERANCE_BPS
+  const targetComplete = Math.abs(TOTAL_ALLOCATION_BPS - targetIncludedBps) <= ALLOCATION_COMPLETENESS_TOLERANCE_BPS
+  const hasIncludedAllocation = currentIncludedBps > 0 || targetIncludedBps > 0
+  const classification: AllocationCoverageClassification =
+    currentComplete && targetComplete ? 'complete' : hasIncludedAllocation ? 'partial-optimizer-scope' : 'unknown'
+
+  return {
+    currentIncludedBps,
+    targetIncludedBps,
+    currentResidualBps: Math.max(0, TOTAL_ALLOCATION_BPS - currentIncludedBps),
+    targetResidualBps: Math.max(0, TOTAL_ALLOCATION_BPS - targetIncludedBps),
+    currentComplete,
+    targetComplete,
+    classification,
+    unallocatedBps: null,
+    unallocatedSource: null
+  }
+}

--- a/src/server/optimization/_lib/envio.test.ts
+++ b/src/server/optimization/_lib/envio.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchHistoricalStrategyUniverse } from './envio'
+
+const VAULT = '0x1111111111111111111111111111111111111111'
+const FIRST_STRATEGY = '0x2222222222222222222222222222222222222222'
+const SECOND_STRATEGY = '0x3333333333333333333333333333333333333333'
+
+describe('fetchHistoricalStrategyUniverse', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('deduplicates lifecycle events and confirms complete indexed coverage', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          strategyChanges: [
+            { strategy: FIRST_STRATEGY, change_type: '1', blockNumber: 1, blockTimestamp: 100 },
+            { strategy: FIRST_STRATEGY, change_type: '2', blockNumber: 2, blockTimestamp: 200 },
+            { strategy: SECOND_STRATEGY, change_type: '1', blockNumber: 3, blockTimestamp: 300 }
+          ]
+        }
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const universe = await fetchHistoricalStrategyUniverse('https://envio.example/graphql', VAULT, 1, 400, [
+      FIRST_STRATEGY,
+      SECOND_STRATEGY
+    ])
+
+    expect(universe).toEqual({
+      strategyAddresses: [FIRST_STRATEGY.toLowerCase(), SECOND_STRATEGY.toLowerCase()],
+      firstSeenTimestampByAddress: {
+        [FIRST_STRATEGY.toLowerCase()]: 100,
+        [SECOND_STRATEGY.toLowerCase()]: 300
+      },
+      complete: true,
+      source: 'envio-strategy-changed',
+      eventCount: 3
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks lifecycle coverage incomplete when an optimizer strategy lacks an indexed add event', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: {
+            strategyChanges: [{ strategy: FIRST_STRATEGY, change_type: '2' }]
+          }
+        })
+      })
+    )
+
+    await expect(
+      fetchHistoricalStrategyUniverse('https://envio.example/graphql', VAULT, 1, 400, [FIRST_STRATEGY, SECOND_STRATEGY])
+    ).resolves.toMatchObject({
+      complete: false,
+      eventCount: 1
+    })
+  })
+})

--- a/src/server/optimization/_lib/envio.ts
+++ b/src/server/optimization/_lib/envio.ts
@@ -32,6 +32,30 @@ query DebtUpdatesForVault(
 }
 `
 
+const HISTORICAL_STRATEGY_UNIVERSE_QUERY = `
+query HistoricalStrategyUniverse(
+  $vaultAddress: String!,
+  $chainId: Int!,
+  $toTs: Int!,
+  $limit: Int!
+) {
+  strategyChanges: StrategyChanged(
+    where: {
+      vaultAddress: { _ilike: $vaultAddress },
+      chainId: { _eq: $chainId },
+      blockTimestamp: { _lte: $toTs }
+    }
+    order_by: { blockNumber: asc, logIndex: asc }
+    limit: $limit
+  ) {
+    strategy
+    change_type
+    blockNumber
+    blockTimestamp
+  }
+}
+`
+
 export interface DebtUpdatedEvent {
   transactionHash: string
   strategy: string
@@ -55,6 +79,21 @@ interface StrategyDebtRatio {
   strategy: string
   currentRatio: number
   targetRatio: number
+}
+
+interface RawStrategyChangedEvent {
+  strategy?: string | null
+  change_type?: string | number | null
+  blockNumber?: string | number | null
+  blockTimestamp?: string | number | null
+}
+
+export interface HistoricalStrategyUniverse {
+  strategyAddresses: string[]
+  firstSeenTimestampByAddress: Record<string, number>
+  complete: boolean
+  source: 'envio-strategy-changed'
+  eventCount: number
 }
 
 const ADDRESS_PATTERN = /^0x[a-fA-F0-9]{40}$/i
@@ -93,19 +132,24 @@ async function graphqlPost(
   query: string,
   variables: Record<string, unknown>
 ): Promise<Record<string, unknown>> {
-  const headers: Record<string, string> = {
+  const publicHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
     Accept: 'application/json'
   }
-  if (process.env.ENVIO_PASSWORD) {
-    headers.Authorization = `Bearer ${process.env.ENVIO_PASSWORD}`
-  }
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({ query, variables })
-  })
+  const request = (headers: Record<string, string>) =>
+    fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ query, variables })
+    })
+  const publicResponse = await request(publicHeaders)
+  const response =
+    (publicResponse.status === 401 || publicResponse.status === 403) && process.env.ENVIO_PASSWORD
+      ? await request({
+          ...publicHeaders,
+          Authorization: `Bearer ${process.env.ENVIO_PASSWORD}`
+        })
+      : publicResponse
 
   if (!response.ok) {
     throw new Error(`Envio GraphQL request failed: HTTP ${response.status}`)
@@ -216,4 +260,50 @@ export async function fetchAlignedEvents(
   }
 
   return matched
+}
+
+export async function fetchHistoricalStrategyUniverse(
+  envioUrl: string,
+  vault: string,
+  chainId: number,
+  timestamp: number,
+  optimizerStrategyAddresses: readonly string[],
+  limit = 1000
+): Promise<HistoricalStrategyUniverse> {
+  const data = await graphqlPost(envioUrl, HISTORICAL_STRATEGY_UNIVERSE_QUERY, {
+    vaultAddress: vault,
+    chainId,
+    toTs: timestamp,
+    limit
+  })
+  const events = Array.isArray(data.strategyChanges)
+    ? (data.strategyChanges as RawStrategyChangedEvent[]).filter(
+        (event) => typeof event.strategy === 'string' && isAddress(event.strategy)
+      )
+    : []
+  const firstEventByAddress = events.reduce((firstEvents, event) => {
+    const address = event.strategy!.toLowerCase()
+    if (!firstEvents.has(address)) {
+      firstEvents.set(address, event)
+    }
+    return firstEvents
+  }, new Map<string, RawStrategyChangedEvent>())
+  const strategyAddresses = Array.from(firstEventByAddress.keys())
+  const firstSeenTimestampByAddress = Object.fromEntries(
+    Array.from(firstEventByAddress, ([address, event]) => [address, Number(event.blockTimestamp)])
+  )
+  const everyLifecycleStartsWithAdd = Array.from(firstEventByAddress.values()).every(
+    (event) => String(event.change_type) === '1'
+  )
+  const optimizerStrategiesCovered = optimizerStrategyAddresses.every((address) =>
+    firstEventByAddress.has(address.toLowerCase())
+  )
+
+  return {
+    strategyAddresses,
+    firstSeenTimestampByAddress,
+    complete: events.length > 0 && events.length < limit && everyLifecycleStartsWithAdd && optimizerStrategiesCovered,
+    source: 'envio-strategy-changed',
+    eventCount: events.length
+  }
 }

--- a/src/server/optimization/_lib/historicalAllocation.test.ts
+++ b/src/server/optimization/_lib/historicalAllocation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { fetchCurrentStrategyMetadataMock, fetchHistoricalStrategyUniverseMock, fetchStatesMock } = vi.hoisted(() => ({
+  fetchCurrentStrategyMetadataMock: vi.fn(),
+  fetchHistoricalStrategyUniverseMock: vi.fn(),
+  fetchStatesMock: vi.fn()
+}))
+
+vi.mock('./envio', () => ({
+  fetchHistoricalStrategyUniverse: fetchHistoricalStrategyUniverseMock
+}))
+
+vi.mock('./rpc', () => ({
+  fetchVaultOnChainStatesAtTimestamps: fetchStatesMock
+}))
+
+vi.mock('./strategyMetadata', () => ({
+  fetchCurrentStrategyMetadata: fetchCurrentStrategyMetadataMock
+}))
+
+import { fetchHistoricalAllocationGroup } from './historicalAllocation'
+
+const VAULT = '0x1111111111111111111111111111111111111111'
+const OPTIMIZED = '0x2222222222222222222222222222222222222222'
+const OMITTED = '0x3333333333333333333333333333333333333333'
+
+describe('fetchHistoricalAllocationGroup', () => {
+  it('batches timestamp reads and leaves records with insufficient lifecycle coverage unavailable', async () => {
+    vi.stubEnv('ENVIO_GRAPHQL_URL', 'https://envio.example/graphql')
+    fetchHistoricalStrategyUniverseMock.mockResolvedValue({
+      strategyAddresses: [OPTIMIZED, OMITTED],
+      firstSeenTimestampByAddress: {
+        [OPTIMIZED]: 100,
+        [OMITTED]: 20
+      },
+      complete: true,
+      source: 'envio-strategy-changed',
+      eventCount: 2
+    })
+    fetchStatesMock.mockResolvedValue([
+      {
+        blockNumber: 123,
+        blockTimestamp: 199,
+        totalAssets: 1000n,
+        strategyDebts: new Map([
+          [OPTIMIZED, 400n],
+          [OMITTED, 500n]
+        ]),
+        unallocatedBps: 1000
+      }
+    ])
+    fetchCurrentStrategyMetadataMock.mockResolvedValue(
+      new Map([
+        [OPTIMIZED, { name: 'Current optimized name', source: 'current-metadata-catalog' }],
+        [OMITTED, { name: 'Current omitted name', source: 'current-metadata-catalog' }]
+      ])
+    )
+
+    const availableRequest = {
+      chainId: 1,
+      vault: VAULT,
+      timestampUtc: '1970-01-01 00:03:20 UTC',
+      optimizerStrategies: [{ strategy: OPTIMIZED }]
+    }
+    const unavailableRequest = {
+      chainId: 1,
+      vault: VAULT,
+      timestampUtc: '1970-01-01 00:00:50 UTC',
+      optimizerStrategies: [{ strategy: OPTIMIZED }]
+    }
+    const snapshots = await fetchHistoricalAllocationGroup([availableRequest, unavailableRequest])
+    const values = Array.from(snapshots.values())
+
+    expect(fetchStatesMock).toHaveBeenCalledWith(1, VAULT, [
+      {
+        timestamp: 200,
+        strategyAddresses: [OPTIMIZED, OMITTED]
+      }
+    ])
+    expect(values[0]).toMatchObject({
+      blockNumber: 123,
+      complete: true,
+      strategies: [
+        {
+          address: OPTIMIZED,
+          name: 'Current optimized name',
+          nameSource: 'current-metadata-catalog',
+          currentBps: 4000
+        },
+        {
+          address: OMITTED,
+          name: 'Current omitted name',
+          nameSource: 'current-metadata-catalog',
+          currentBps: 5000
+        }
+      ],
+      unallocatedBps: 1000
+    })
+    expect(values[1]).toBeNull()
+  })
+})

--- a/src/server/optimization/_lib/historicalAllocation.ts
+++ b/src/server/optimization/_lib/historicalAllocation.ts
@@ -1,0 +1,228 @@
+import { fetchHistoricalStrategyUniverse } from './envio'
+import { fetchVaultOnChainStatesAtTimestamps } from './rpc'
+import { fetchCurrentStrategyMetadata, type StrategyNameSource } from './strategyMetadata'
+
+export interface HistoricalAllocationStrategy {
+  address: string
+  name: string | null
+  nameSource: StrategyNameSource | null
+  currentBps: number
+}
+
+export interface HistoricalAllocationSnapshot {
+  timestampUtc: string
+  blockNumber: number
+  blockTimestampUtc: string
+  source: 'archive-rpc'
+  strategyUniverseSource: 'envio-strategy-changed'
+  complete: true
+  strategies: HistoricalAllocationStrategy[]
+  unallocatedBps: number
+  unallocatedSource: 'same-timestamp-onchain'
+}
+
+export interface HistoricalAllocationRequest {
+  chainId: number
+  vault: string
+  timestampUtc: string
+  optimizerStrategies: Array<{ strategy: string; name?: string }>
+}
+
+const HISTORICAL_ALLOCATION_CACHE_TTL_MS = 10 * 60 * 1000
+const historicalAllocationCache = new Map<
+  string,
+  { expiresAt: number; value: Promise<HistoricalAllocationSnapshot | null> }
+>()
+
+function requestKey(request: HistoricalAllocationRequest): string {
+  const optimizerScopeKey = Array.from(
+    new Set(request.optimizerStrategies.map((strategy) => strategy.strategy.toLowerCase()))
+  )
+    .sort()
+    .join(',')
+  return `${request.chainId}:${request.vault.toLowerCase()}:${request.timestampUtc}:${optimizerScopeKey}`
+}
+
+function parseTimestampUtc(timestampUtc: string): number | null {
+  const milliseconds = new Date(timestampUtc.replace(' UTC', 'Z').replace(' ', 'T')).getTime()
+  return Number.isFinite(milliseconds) ? Math.floor(milliseconds / 1000) : null
+}
+
+function formatTimestampUtc(timestamp: number): string {
+  return `${new Date(timestamp * 1000).toISOString().slice(0, 19).replace('T', ' ')} UTC`
+}
+
+function calculateBps(amount: bigint, totalAssets: bigint): number {
+  return totalAssets > 0n ? Number((amount * 10000n + totalAssets / 2n) / totalAssets) : 0
+}
+
+function buildHistoricalStrategies(
+  strategyAddresses: readonly string[],
+  strategyDebts: Map<string, bigint>,
+  totalAssets: bigint,
+  currentMetadata: Awaited<ReturnType<typeof fetchCurrentStrategyMetadata>>
+): HistoricalAllocationStrategy[] {
+  return strategyAddresses
+    .map((address) => {
+      const normalizedAddress = address.toLowerCase()
+      const debt = strategyDebts.get(normalizedAddress) ?? 0n
+      const catalogMetadata = currentMetadata.get(normalizedAddress)
+
+      return {
+        address,
+        name: catalogMetadata?.name ?? null,
+        nameSource: catalogMetadata?.source ?? null,
+        currentBps: calculateBps(debt, totalAssets),
+        hasDebt: debt > 0n
+      }
+    })
+    .filter((strategy) => strategy.hasDebt)
+    .map(({ hasDebt: _hasDebt, ...strategy }) => strategy)
+}
+
+export async function fetchHistoricalAllocationGroup(
+  requests: readonly HistoricalAllocationRequest[]
+): Promise<Map<string, HistoricalAllocationSnapshot | null>> {
+  const firstRequest = requests[0]
+  const envioUrl = process.env.ENVIO_GRAPHQL_URL
+  if (!firstRequest || !envioUrl) {
+    return new Map(requests.map((request) => [requestKey(request), null]))
+  }
+
+  const parsedRequests = requests.map((request) => ({
+    request,
+    timestamp: parseTimestampUtc(request.timestampUtc)
+  }))
+  const validParsedRequests = parsedRequests.filter(
+    (item): item is { request: HistoricalAllocationRequest; timestamp: number } => item.timestamp !== null
+  )
+  if (validParsedRequests.length === 0) {
+    return new Map(requests.map((request) => [requestKey(request), null]))
+  }
+
+  const latestTimestamp = Math.max(...validParsedRequests.map((item) => item.timestamp))
+  const universe = await fetchHistoricalStrategyUniverse(
+    envioUrl,
+    firstRequest.vault,
+    firstRequest.chainId,
+    latestTimestamp,
+    []
+  )
+  if (!universe.complete) {
+    return new Map(requests.map((request) => [requestKey(request), null]))
+  }
+
+  const reconstructableRequests = validParsedRequests.filter(({ request, timestamp }) =>
+    request.optimizerStrategies.every((strategy) => {
+      const firstSeenTimestamp = universe.firstSeenTimestampByAddress[strategy.strategy.toLowerCase()]
+      return firstSeenTimestamp !== undefined && firstSeenTimestamp <= timestamp
+    })
+  )
+  const uniqueReconstructableRequests = Array.from(
+    new Map(reconstructableRequests.map((item) => [item.request.timestampUtc, item])).values()
+  )
+  const [states, currentMetadata] = await Promise.all([
+    fetchVaultOnChainStatesAtTimestamps(
+      firstRequest.chainId,
+      firstRequest.vault,
+      uniqueReconstructableRequests.map((item) => ({
+        timestamp: item.timestamp,
+        strategyAddresses: universe.strategyAddresses
+      }))
+    ),
+    fetchCurrentStrategyMetadata(firstRequest.chainId, firstRequest.vault).catch(() => new Map())
+  ])
+  const snapshotByTimestamp = new Map(
+    uniqueReconstructableRequests.map((item, index) => {
+      const state = states[index]
+      const snapshot: HistoricalAllocationSnapshot | null =
+        state && state.totalAssets > 0n
+          ? {
+              timestampUtc: item.request.timestampUtc,
+              blockNumber: state.blockNumber,
+              blockTimestampUtc: formatTimestampUtc(state.blockTimestamp),
+              source: 'archive-rpc',
+              strategyUniverseSource: universe.source,
+              complete: true,
+              strategies: buildHistoricalStrategies(
+                universe.strategyAddresses,
+                state.strategyDebts,
+                state.totalAssets,
+                currentMetadata
+              ),
+              unallocatedBps: state.unallocatedBps,
+              unallocatedSource: 'same-timestamp-onchain'
+            }
+          : null
+      return [item.request.timestampUtc, snapshot] as const
+    })
+  )
+
+  return new Map(
+    requests.map((request) => [requestKey(request), snapshotByTimestamp.get(request.timestampUtc) ?? null])
+  )
+}
+
+export async function getHistoricalAllocationSnapshot(
+  request: HistoricalAllocationRequest
+): Promise<HistoricalAllocationSnapshot | null> {
+  const snapshots = await getHistoricalAllocationSnapshots([request])
+  return snapshots.get(requestKey(request)) ?? null
+}
+
+export async function getHistoricalAllocationSnapshots(
+  requests: readonly HistoricalAllocationRequest[]
+): Promise<Map<string, HistoricalAllocationSnapshot | null>> {
+  const cachedSnapshots = requests.reduce((snapshots, request) => {
+    const key = requestKey(request)
+    const cached = historicalAllocationCache.get(key)
+    if (cached && cached.expiresAt > Date.now()) {
+      snapshots.set(key, cached.value)
+    }
+    return snapshots
+  }, new Map<string, Promise<HistoricalAllocationSnapshot | null>>())
+  const uncachedRequests = requests.filter((request) => !cachedSnapshots.has(requestKey(request)))
+  const vaultRequestGroups = Array.from(
+    uncachedRequests
+      .reduce((groups, request) => {
+        const groupKey = `${request.chainId}:${request.vault.toLowerCase()}`
+        groups.set(groupKey, [...(groups.get(groupKey) ?? []), request])
+        return groups
+      }, new Map<string, HistoricalAllocationRequest[]>())
+      .values()
+  )
+  const requestGroups = vaultRequestGroups.flatMap((group) =>
+    Array.from({ length: Math.ceil(group.length / 20) }, (_value, index) => group.slice(index * 20, index * 20 + 20))
+  )
+  const fetchedGroups = await requestGroups.reduce<Promise<Array<Map<string, HistoricalAllocationSnapshot | null>>>>(
+    async (allGroupsPromise, group) => {
+      const allGroups = await allGroupsPromise
+      const fetchedGroup = await fetchHistoricalAllocationGroup(group).catch(
+        () => new Map(group.map((request) => [requestKey(request), null]))
+      )
+      return [...allGroups, fetchedGroup]
+    },
+    Promise.resolve([])
+  )
+  const fetchedSnapshots = new Map(fetchedGroups.flatMap((group) => Array.from(group.entries())))
+  fetchedSnapshots.forEach((snapshot, key) => {
+    const value = Promise.resolve(snapshot)
+    historicalAllocationCache.set(key, {
+      expiresAt: Date.now() + HISTORICAL_ALLOCATION_CACHE_TTL_MS,
+      value
+    })
+    cachedSnapshots.set(key, value)
+  })
+
+  const resolvedSnapshots = await Promise.all(
+    requests.map(async (request) => {
+      const key = requestKey(request)
+      return [key, (await cachedSnapshots.get(key)) ?? null] as const
+    })
+  )
+  return new Map(resolvedSnapshots)
+}
+
+export function getHistoricalAllocationRequestKey(request: HistoricalAllocationRequest): string {
+  return requestKey(request)
+}

--- a/src/server/optimization/_lib/normalize.test.ts
+++ b/src/server/optimization/_lib/normalize.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeChange } from './normalize'
+
+describe('normalizeChange allocation coverage', () => {
+  it('does not synthesize an Unallocated strategy from partial optimizer scope', () => {
+    const normalized = normalizeChange({
+      vault: '0xc56413869c6CDf96496f2b1eF801fEDBdFA7dDB0',
+      strategyDebtRatios: [
+        {
+          strategy: '0x1111111111111111111111111111111111111111',
+          name: 'First strategy',
+          currentRatio: 2000,
+          targetRatio: 2000
+        },
+        {
+          strategy: '0x2222222222222222222222222222222222222222',
+          name: 'Second strategy',
+          currentRatio: 2157,
+          targetRatio: 2157
+        }
+      ],
+      currentApr: 250,
+      proposedApr: 275,
+      explain: 'Optimizer recommendation'
+    })
+
+    expect(normalized.strategies).toHaveLength(2)
+    expect(normalized.strategies.some((strategy) => strategy.isUnallocated)).toBe(false)
+    expect(normalized.hasUnallocated).toBe(false)
+    expect(normalized.unallocatedBps).toBeNull()
+    expect(normalized.allocationCoverage).toMatchObject({
+      currentIncludedBps: 4157,
+      targetIncludedBps: 4157,
+      currentResidualBps: 5843,
+      targetResidualBps: 5843,
+      classification: 'partial-optimizer-scope',
+      unallocatedBps: null
+    })
+    expect(normalized.explain).toBe('Optimizer recommendation')
+    expect(normalized.vaultAprCurrentPct).toBe(2.5)
+    expect(normalized.vaultAprProposedPct).toBe(2.75)
+  })
+})

--- a/src/server/optimization/_lib/normalize.ts
+++ b/src/server/optimization/_lib/normalize.ts
@@ -1,3 +1,8 @@
+import {
+  ALLOCATION_COMPLETENESS_TOLERANCE_BPS,
+  type AllocationCoverage,
+  calculateAllocationCoverage
+} from './allocationCoverage'
 import { getChainLogoUrl, getTokenAddressForSymbol, getTokenLogoUrl, getVaultAssetToken } from './assetLogos'
 import { assignStrategyColors } from './colors'
 import { parseExplainMetadata, parseFilteredNoChangeStrategies } from './explain-parse'
@@ -6,7 +11,7 @@ import type { OptimizationSourceMeta } from './redis'
 import type { StrategyDebtRatio, VaultOptimization } from './schema'
 
 const TOTAL_BPS = 10000
-export const NORMALIZATION_TOLERANCE_BPS = 5
+export const NORMALIZATION_TOLERANCE_BPS = ALLOCATION_COMPLETENESS_TOLERANCE_BPS
 
 function buildSyntheticStrategyAddress(vaultAddress: string, strategyName: string, index: number, salt = 0): string {
   const seed = `${vaultAddress.toLowerCase()}|${strategyName.toLowerCase()}|${index}|${salt}`
@@ -64,7 +69,8 @@ export interface NormalizedChange {
   vaultAprDeltaPct: number
   vaultAprDeltaRelativePct: number | null
   hasUnallocated: boolean
-  unallocatedBps: number
+  unallocatedBps: number | null
+  allocationCoverage: AllocationCoverage
   tokenLogoUrl: string | null
   chainLogoUrl: string | null
   timestampUtc: string | null
@@ -165,32 +171,8 @@ export function normalizeChange(data: VaultOptimization, source?: OptimizationSo
   )
   const inputStrategies = normalizeStrategyNames(augmentedStrategies)
 
-  let strategies = inputStrategies
-  let hasUnallocated = false
-  let unallocatedBps = 0
-
-  const totalCurrentBps = strategies.reduce((sum, s) => sum + s.currentRatio, 0)
-  const totalTargetBps = strategies.reduce((sum, s) => sum + s.targetRatio, 0)
-
-  const unallocatedCurrentBps = Math.max(0, TOTAL_BPS - totalCurrentBps)
-  const unallocatedTargetBps = Math.max(0, TOTAL_BPS - totalTargetBps)
-
-  if (unallocatedCurrentBps > NORMALIZATION_TOLERANCE_BPS || unallocatedTargetBps > NORMALIZATION_TOLERANCE_BPS) {
-    hasUnallocated = unallocatedCurrentBps > NORMALIZATION_TOLERANCE_BPS
-    unallocatedBps = unallocatedCurrentBps
-
-    strategies = [
-      ...strategies,
-      {
-        strategy: 'unallocated',
-        name: 'Unallocated',
-        currentRatio: unallocatedCurrentBps,
-        targetRatio: unallocatedTargetBps,
-        currentApr: undefined,
-        targetApr: undefined
-      } as StrategyDebtRatio
-    ]
-  }
+  const strategies = inputStrategies
+  const allocationCoverage = calculateAllocationCoverage(data.strategyDebtRatios)
 
   const strategyKeys: string[] = []
   const usedKeys = new Set<string>()
@@ -281,8 +263,9 @@ export function normalizeChange(data: VaultOptimization, source?: OptimizationSo
     vaultAprProposedPct,
     vaultAprDeltaPct,
     vaultAprDeltaRelativePct,
-    hasUnallocated,
-    unallocatedBps,
+    hasUnallocated: allocationCoverage.unallocatedBps !== null,
+    unallocatedBps: allocationCoverage.unallocatedBps,
+    allocationCoverage,
     tokenLogoUrl,
     chainLogoUrl,
     timestampUtc,

--- a/src/server/optimization/_lib/reconcile.test.ts
+++ b/src/server/optimization/_lib/reconcile.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest'
+import { calculateAllocationCoverage } from './allocationCoverage'
+import type { HistoricalAllocationSnapshot } from './historicalAllocation'
+import { reconcileOptimizationRecord } from './reconcile'
+import type { VaultOptimizationRecord } from './redis'
+
+const VAULT = '0xc56413869c6CDf96496f2b1eF801fEDBdFA7dDB0'
+const OPTIMIZED = '0x1111111111111111111111111111111111111111'
+const OMITTED = '0x2222222222222222222222222222222222222222'
+
+function record(
+  strategies: VaultOptimizationRecord['strategyDebtRatios'] = [
+    {
+      strategy: OPTIMIZED,
+      name: 'Optimizer strategy',
+      currentRatio: 4157,
+      targetRatio: 4157
+    }
+  ]
+): VaultOptimizationRecord {
+  return {
+    vault: VAULT,
+    strategyDebtRatios: strategies,
+    currentApr: 250,
+    proposedApr: 275,
+    explain: 'optimizer recommendation',
+    source: {
+      key: 'doa:optimizations:1:latest',
+      chainId: 1,
+      revision: 'latest',
+      isLatestAlias: true,
+      timestampUtc: null,
+      latestMatchedTimestampUtc: '2026-07-25 00:15:29 UTC'
+    },
+    allocationCoverage: calculateAllocationCoverage(strategies),
+    freshness: {
+      optimizationTimestampUtc: '2026-07-25 00:15:29 UTC',
+      latestAvailableTimestampUtc: '2026-07-25 00:15:29 UTC'
+    }
+  }
+}
+
+function snapshot(
+  strategies: HistoricalAllocationSnapshot['strategies'] = [
+    {
+      address: OPTIMIZED,
+      name: 'Historical optimized strategy',
+      nameSource: 'current-metadata-catalog',
+      currentBps: 4157
+    },
+    {
+      address: OMITTED,
+      name: 'Omitted strategy',
+      nameSource: 'current-metadata-catalog',
+      currentBps: 5343
+    }
+  ],
+  unallocatedBps = 500
+): HistoricalAllocationSnapshot {
+  return {
+    timestampUtc: '2026-07-25 00:15:29 UTC',
+    blockNumber: 25_603_774,
+    blockTimestampUtc: '2026-07-25 00:15:23 UTC',
+    source: 'archive-rpc',
+    strategyUniverseSource: 'envio-strategy-changed',
+    complete: true,
+    strategies,
+    unallocatedBps,
+    unallocatedSource: 'same-timestamp-onchain'
+  }
+}
+
+describe('reconcileOptimizationRecord', () => {
+  it('keeps full optimizer coverage complete with optimizer targets', () => {
+    const completeRecord = record([
+      { strategy: OPTIMIZED, currentRatio: 6000, targetRatio: 5500 },
+      { strategy: OMITTED, currentRatio: 4000, targetRatio: 4500 }
+    ])
+    const reconciled = reconcileOptimizationRecord(
+      completeRecord,
+      snapshot([
+        { address: OPTIMIZED, name: null, nameSource: null, currentBps: 6000 },
+        { address: OMITTED, name: null, nameSource: null, currentBps: 4000 }
+      ])
+    )
+
+    expect(reconciled.allocationCoverage.classification).toBe('complete')
+    expect(reconciled.allocationSnapshot.strategies).toMatchObject([
+      { address: OPTIMIZED, currentBps: 6000, targetBps: 5500, optimizerScope: 'optimized' },
+      { address: OMITTED, currentBps: 4000, targetBps: 4500, optimizerScope: 'optimized' }
+    ])
+  })
+
+  it('adds omitted historical strategies without inventing targets or scope', () => {
+    const reconciled = reconcileOptimizationRecord(record(), snapshot())
+
+    expect(reconciled.strategyDebtRatios).toHaveLength(1)
+    expect(reconciled.allocationSnapshot.complete).toBe(true)
+    expect(reconciled.allocationSnapshot.strategies).toEqual([
+      {
+        address: OPTIMIZED,
+        name: 'Optimizer strategy',
+        nameSource: 'optimizer',
+        currentBps: 4157,
+        targetBps: 4157,
+        optimizerScope: 'optimized',
+        targetSource: 'optimizer'
+      },
+      {
+        address: OMITTED,
+        name: 'Omitted strategy',
+        nameSource: 'current-metadata-catalog',
+        currentBps: 5343,
+        targetBps: null,
+        optimizerScope: 'unknown',
+        targetSource: 'unavailable'
+      }
+    ])
+  })
+
+  it('only copies current allocation to target for authoritatively outside-scope strategies', () => {
+    const reconciled = reconcileOptimizationRecord(record(), snapshot(), [OMITTED])
+
+    expect(reconciled.allocationSnapshot.strategies[1]).toMatchObject({
+      currentBps: 5343,
+      targetBps: 5343,
+      optimizerScope: 'outside-optimizer-scope',
+      targetSource: 'unchanged-outside-scope'
+    })
+  })
+
+  it('returns an explicit fallback when a historical snapshot is unavailable', () => {
+    const sourceRecord = record()
+    const reconciled = reconcileOptimizationRecord(sourceRecord, null)
+
+    expect(reconciled.allocationCoverage).toEqual(sourceRecord.allocationCoverage)
+    expect(reconciled.allocationSnapshot).toEqual({
+      timestampUtc: '2026-07-25 00:15:29 UTC',
+      blockNumber: null,
+      blockTimestampUtc: null,
+      source: null,
+      strategyUniverseSource: null,
+      complete: false,
+      strategies: [],
+      unallocatedBps: null,
+      unallocatedSource: null
+    })
+  })
+
+  it('uses historical allocation instead of optimizer or current-catalog allocation values', () => {
+    const reconciled = reconcileOptimizationRecord(
+      record([{ strategy: OPTIMIZED, currentRatio: 7000, targetRatio: 5000 }]),
+      snapshot([
+        { address: OPTIMIZED, name: 'Current catalog name', nameSource: 'current-metadata-catalog', currentBps: 3000 }
+      ])
+    )
+
+    expect(reconciled.allocationSnapshot.strategies[0]).toMatchObject({
+      currentBps: 3000,
+      targetBps: 5000
+    })
+  })
+
+  it('exposes same-timestamp unallocated capital separately from optimizer residual', () => {
+    const reconciled = reconcileOptimizationRecord(record(), snapshot(undefined, 500))
+
+    expect(reconciled.allocationCoverage.currentResidualBps).toBe(5843)
+    expect(reconciled.allocationCoverage.unallocatedBps).toBe(500)
+    expect(reconciled.allocationCoverage.unallocatedSource).toBe('same-timestamp-onchain')
+    expect(reconciled.allocationSnapshot.unallocatedBps).toBe(500)
+  })
+
+  it('deduplicates addresses case-insensitively and preserves missing names', () => {
+    const reconciled = reconcileOptimizationRecord(
+      record([
+        { strategy: OPTIMIZED, currentRatio: 2000, targetRatio: 2100 },
+        { strategy: OPTIMIZED.toUpperCase(), currentRatio: 2157, targetRatio: 2057 }
+      ]),
+      snapshot([
+        { address: OPTIMIZED, name: null, nameSource: null, currentBps: 2000 },
+        { address: OPTIMIZED.toUpperCase(), name: null, nameSource: null, currentBps: 2157 }
+      ])
+    )
+
+    expect(reconciled.allocationSnapshot.strategies).toEqual([
+      {
+        address: OPTIMIZED,
+        name: null,
+        nameSource: null,
+        currentBps: 4157,
+        targetBps: 4157,
+        optimizerScope: 'optimized',
+        targetSource: 'optimizer'
+      }
+    ])
+  })
+})

--- a/src/server/optimization/_lib/reconcile.ts
+++ b/src/server/optimization/_lib/reconcile.ts
@@ -1,0 +1,189 @@
+import type { HistoricalAllocationSnapshot } from './historicalAllocation'
+import {
+  getHistoricalAllocationRequestKey,
+  getHistoricalAllocationSnapshot,
+  getHistoricalAllocationSnapshots,
+  type HistoricalAllocationRequest
+} from './historicalAllocation'
+import type { VaultOptimizationRecord } from './redis'
+import type { StrategyNameSource } from './strategyMetadata'
+
+export type OptimizerScope = 'optimized' | 'outside-optimizer-scope' | 'unknown'
+export type AllocationTargetSource = 'optimizer' | 'unchanged-outside-scope' | 'unavailable'
+
+export interface ReconciledAllocationStrategy {
+  address: string
+  name: string | null
+  nameSource: StrategyNameSource | null
+  currentBps: number
+  targetBps: number | null
+  optimizerScope: OptimizerScope
+  targetSource: AllocationTargetSource
+}
+
+export interface ReconciledAllocationSnapshot {
+  timestampUtc: string | null
+  blockNumber: number | null
+  blockTimestampUtc: string | null
+  source: 'archive-rpc' | null
+  strategyUniverseSource: 'envio-strategy-changed' | null
+  complete: boolean
+  strategies: ReconciledAllocationStrategy[]
+  unallocatedBps: number | null
+  unallocatedSource: 'same-timestamp-onchain' | null
+}
+
+export type ReconciledVaultOptimizationRecord = VaultOptimizationRecord & {
+  allocationSnapshot: ReconciledAllocationSnapshot
+}
+
+function fallbackSnapshot(record: VaultOptimizationRecord): ReconciledAllocationSnapshot {
+  return {
+    timestampUtc: record.freshness.optimizationTimestampUtc,
+    blockNumber: null,
+    blockTimestampUtc: null,
+    source: null,
+    strategyUniverseSource: null,
+    complete: false,
+    strategies: [],
+    unallocatedBps: null,
+    unallocatedSource: null
+  }
+}
+
+export function reconcileOptimizationRecord(
+  record: VaultOptimizationRecord,
+  historicalSnapshot: HistoricalAllocationSnapshot | null,
+  explicitOutsideScopeAddresses: readonly string[] = []
+): ReconciledVaultOptimizationRecord {
+  if (!historicalSnapshot) {
+    return {
+      ...record,
+      allocationSnapshot: fallbackSnapshot(record)
+    }
+  }
+
+  const optimizerStrategies = record.strategyDebtRatios.reduce((strategies, strategy) => {
+    const address = strategy.strategy.toLowerCase()
+    const existing = strategies.get(address)
+    strategies.set(address, {
+      targetBps: (existing?.targetBps ?? 0) + strategy.targetRatio,
+      name: existing?.name ?? strategy.name?.trim() ?? null
+    })
+    return strategies
+  }, new Map<string, { targetBps: number; name: string | null }>())
+  const outsideScopeAddresses = new Set(explicitOutsideScopeAddresses.map((address) => address.toLowerCase()))
+  const historicalStrategies = historicalSnapshot.strategies.reduce((strategies, strategy) => {
+    const address = strategy.address.toLowerCase()
+    const existing = strategies.get(address)
+    strategies.set(address, {
+      ...strategy,
+      address: existing?.address ?? strategy.address,
+      currentBps: (existing?.currentBps ?? 0) + strategy.currentBps,
+      name: existing?.name ?? strategy.name,
+      nameSource: existing?.nameSource ?? strategy.nameSource
+    })
+    return strategies
+  }, new Map<string, HistoricalAllocationSnapshot['strategies'][number]>())
+  const allAddresses = Array.from(new Set([...historicalStrategies.keys(), ...optimizerStrategies.keys()]))
+  const strategies = allAddresses.map((address) => {
+    const historical = historicalStrategies.get(address)
+    const optimizer = optimizerStrategies.get(address)
+    const optimizerScope: OptimizerScope = optimizer
+      ? 'optimized'
+      : outsideScopeAddresses.has(address)
+        ? 'outside-optimizer-scope'
+        : 'unknown'
+    const currentBps = historical?.currentBps ?? 0
+
+    return {
+      address: historical?.address ?? address,
+      name: optimizer?.name ?? historical?.name ?? null,
+      nameSource: optimizer?.name ? ('optimizer' as const) : (historical?.nameSource ?? null),
+      currentBps,
+      targetBps:
+        optimizerScope === 'optimized'
+          ? (optimizer?.targetBps ?? null)
+          : optimizerScope === 'outside-optimizer-scope'
+            ? currentBps
+            : null,
+      optimizerScope,
+      targetSource:
+        optimizerScope === 'optimized'
+          ? ('optimizer' as const)
+          : optimizerScope === 'outside-optimizer-scope'
+            ? ('unchanged-outside-scope' as const)
+            : ('unavailable' as const)
+    }
+  })
+
+  return {
+    ...record,
+    allocationCoverage: {
+      ...record.allocationCoverage,
+      unallocatedBps: historicalSnapshot.unallocatedBps,
+      unallocatedSource: historicalSnapshot.unallocatedSource
+    },
+    allocationSnapshot: {
+      timestampUtc: historicalSnapshot.timestampUtc,
+      blockNumber: historicalSnapshot.blockNumber,
+      blockTimestampUtc: historicalSnapshot.blockTimestampUtc,
+      source: historicalSnapshot.source,
+      strategyUniverseSource: historicalSnapshot.strategyUniverseSource,
+      complete: historicalSnapshot.complete,
+      strategies,
+      unallocatedBps: historicalSnapshot.unallocatedBps,
+      unallocatedSource: historicalSnapshot.unallocatedSource
+    }
+  }
+}
+
+export async function enrichOptimizationRecord(
+  record: VaultOptimizationRecord
+): Promise<ReconciledVaultOptimizationRecord> {
+  const timestampUtc = record.freshness.optimizationTimestampUtc
+  const chainId = record.source.chainId
+  if (!timestampUtc || chainId === null) {
+    return reconcileOptimizationRecord(record, null)
+  }
+
+  const snapshot = await getHistoricalAllocationSnapshot({
+    chainId,
+    vault: record.vault,
+    timestampUtc,
+    optimizerStrategies: record.strategyDebtRatios
+  })
+  return reconcileOptimizationRecord(record, snapshot)
+}
+
+export async function enrichOptimizationRecords(
+  records: readonly VaultOptimizationRecord[]
+): Promise<ReconciledVaultOptimizationRecord[]> {
+  const requestsByRecord = records.map((record): HistoricalAllocationRequest | null => {
+    const timestampUtc = record.freshness.optimizationTimestampUtc
+    const chainId = record.source.chainId
+    return timestampUtc && chainId !== null
+      ? {
+          chainId,
+          vault: record.vault,
+          timestampUtc,
+          optimizerStrategies: record.strategyDebtRatios
+        }
+      : null
+  })
+  const snapshots = await getHistoricalAllocationSnapshots(
+    requestsByRecord.filter((request): request is HistoricalAllocationRequest => request !== null)
+  )
+
+  return records.map((record, index) => {
+    const request = requestsByRecord[index]
+    const snapshot = request ? (snapshots.get(getHistoricalAllocationRequestKey(request)) ?? null) : null
+    return reconcileOptimizationRecord(record, snapshot)
+  })
+}
+
+export function addFallbackAllocationSnapshots(
+  records: readonly VaultOptimizationRecord[]
+): ReconciledVaultOptimizationRecord[] {
+  return records.map((record) => reconcileOptimizationRecord(record, null))
+}

--- a/src/server/optimization/_lib/redis.test.ts
+++ b/src/server/optimization/_lib/redis.test.ts
@@ -44,4 +44,76 @@ describe('readOptimizations', () => {
 
     await expect(readOptimizations()).rejects.toThrow(REDIS_MISSING_CONFIGURATION_MESSAGE)
   })
+
+  it('attaches individual coverage and freshness metadata to history records', async () => {
+    const { attachOptimizationMetadata } = await import('./redis')
+    const vault = '0x1111111111111111111111111111111111111111'
+    const strategy = '0x2222222222222222222222222222222222222222'
+    const records = attachOptimizationMetadata([
+      {
+        vault,
+        strategyDebtRatios: [{ strategy, currentRatio: 4157, targetRatio: 4157 }],
+        currentApr: 250,
+        proposedApr: 275,
+        explain: 'latest explain',
+        source: {
+          key: 'doa:optimizations:1:latest',
+          chainId: 1,
+          revision: 'latest',
+          isLatestAlias: true,
+          timestampUtc: null,
+          latestMatchedTimestampUtc: '2026-07-25 00:15:29 UTC'
+        }
+      },
+      {
+        vault,
+        strategyDebtRatios: [{ strategy, currentRatio: 10000, targetRatio: 10000 }],
+        currentApr: 200,
+        proposedApr: 240,
+        explain: 'older explain',
+        source: {
+          key: 'doa:optimizations:1:1753315200',
+          chainId: 1,
+          revision: '1753315200',
+          isLatestAlias: false,
+          timestampUtc: '2025-07-24 00:00:00 UTC',
+          latestMatchedTimestampUtc: null
+        }
+      }
+    ])
+
+    expect(records[0]).toMatchObject({
+      currentApr: 250,
+      proposedApr: 275,
+      explain: 'latest explain',
+      allocationCoverage: {
+        currentIncludedBps: 4157,
+        targetIncludedBps: 4157,
+        currentResidualBps: 5843,
+        targetResidualBps: 5843,
+        classification: 'partial-optimizer-scope',
+        unallocatedBps: null
+      },
+      freshness: {
+        optimizationTimestampUtc: '2026-07-25 00:15:29 UTC',
+        latestAvailableTimestampUtc: '2026-07-25 00:15:29 UTC'
+      }
+    })
+    expect(records[1]).toMatchObject({
+      currentApr: 200,
+      proposedApr: 240,
+      explain: 'older explain',
+      allocationCoverage: {
+        currentIncludedBps: 10000,
+        targetIncludedBps: 10000,
+        classification: 'complete'
+      },
+      freshness: {
+        optimizationTimestampUtc: '2025-07-24 00:00:00 UTC',
+        latestAvailableTimestampUtc: '2026-07-25 00:15:29 UTC'
+      }
+    })
+    expect(records[0].strategyDebtRatios).toEqual([{ strategy, currentRatio: 4157, targetRatio: 4157 }])
+    expect(records[0].source.key).toBe('doa:optimizations:1:latest')
+  })
 })

--- a/src/server/optimization/_lib/redis.ts
+++ b/src/server/optimization/_lib/redis.ts
@@ -1,4 +1,5 @@
 import { Redis } from '@upstash/redis'
+import { type AllocationCoverage, calculateAllocationCoverage } from './allocationCoverage'
 import type { VaultOptimization } from './schema'
 import { parseVaultOptimizations } from './schema'
 
@@ -36,8 +37,15 @@ export interface OptimizationSourceMeta {
   latestMatchedTimestampUtc: string | null
 }
 
+export interface OptimizationFreshness {
+  optimizationTimestampUtc: string | null
+  latestAvailableTimestampUtc: string | null
+}
+
 export type VaultOptimizationRecord = VaultOptimization & {
   source: OptimizationSourceMeta
+  allocationCoverage: AllocationCoverage
+  freshness: OptimizationFreshness
 }
 
 interface ReadOptimizationsCache {
@@ -264,7 +272,7 @@ async function fetchOptimizationsFromRedis(): Promise<VaultOptimizationRecord[] 
     })
   }
 
-  const optimizations: VaultOptimizationRecord[] = []
+  const optimizations: Array<VaultOptimization & { source: OptimizationSourceMeta }> = []
   for (const [index, rawPayload] of rawPayloads.entries()) {
     if (!rawPayload) {
       continue
@@ -293,7 +301,40 @@ async function fetchOptimizationsFromRedis(): Promise<VaultOptimizationRecord[] 
     }
   }
 
-  return optimizations.length > 0 ? optimizations : null
+  return optimizations.length > 0 ? attachOptimizationMetadata(optimizations) : null
+}
+
+function getOptimizationTimestamp(source: OptimizationSourceMeta): string | null {
+  return source.isLatestAlias ? source.latestMatchedTimestampUtc : source.timestampUtc
+}
+
+function getVaultChainKey(optimization: VaultOptimization & { source: OptimizationSourceMeta }): string {
+  return `${optimization.source.chainId ?? 'unknown'}:${optimization.vault.toLowerCase()}`
+}
+
+export function attachOptimizationMetadata(
+  optimizations: readonly (VaultOptimization & { source: OptimizationSourceMeta })[]
+): VaultOptimizationRecord[] {
+  const latestTimestampByVaultChain = optimizations.reduce((timestamps, optimization) => {
+    const timestamp = getOptimizationTimestamp(optimization.source)
+    const key = getVaultChainKey(optimization)
+    const previousTimestamp = timestamps.get(key)
+
+    if (timestamp !== null && (previousTimestamp === undefined || timestamp > previousTimestamp)) {
+      timestamps.set(key, timestamp)
+    }
+
+    return timestamps
+  }, new Map<string, string>())
+
+  return optimizations.map((optimization) => ({
+    ...optimization,
+    allocationCoverage: calculateAllocationCoverage(optimization.strategyDebtRatios),
+    freshness: {
+      optimizationTimestampUtc: getOptimizationTimestamp(optimization.source),
+      latestAvailableTimestampUtc: latestTimestampByVaultChain.get(getVaultChainKey(optimization)) ?? null
+    }
+  }))
 }
 
 export async function readOptimizations(): Promise<VaultOptimizationRecord[] | null> {

--- a/src/server/optimization/_lib/rpc.test.ts
+++ b/src/server/optimization/_lib/rpc.test.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { fetchVaultOnChainState } from './rpc'
+import { fetchVaultOnChainState, fetchVaultOnChainStatesAtTimestamps, getAllRpcEndpoints } from './rpc'
 
 const VAULT_ADDRESS = '0x1111111111111111111111111111111111111111'
 const STRATEGY_ADDRESSES = ['0x2222222222222222222222222222222222222222', '0x3333333333333333333333333333333333333333']
@@ -8,6 +8,13 @@ const STRATEGY_ADDRESSES = ['0x2222222222222222222222222222222222222222', '0x333
 describe('fetchVaultOnChainState', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+  })
+
+  it('prefers a configured dedicated archive endpoint', () => {
+    vi.stubEnv('OPTIMIZATION_ARCHIVE_RPC_URL_1', 'https://archive.example')
+
+    expect(getAllRpcEndpoints(1)[0]).toBe('https://archive.example')
   })
 
   it('decodes multicall bytes[] results from the array body offsets', async () => {
@@ -42,5 +49,62 @@ describe('fetchVaultOnChainState', () => {
     })
     expect(state.unallocatedBps).toBe(6000)
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves the last block at or before a timestamp and reads one historical multicall', async () => {
+    const result = ethers.utils.defaultAbiCoder.encode(
+      ['uint256', 'bytes[]'],
+      [
+        5,
+        [
+          ethers.utils.defaultAbiCoder.encode(['uint256'], [1000]),
+          ethers.utils.defaultAbiCoder.encode(['uint256', 'uint256', 'uint256', 'uint256'], [0, 0, 400, 0]),
+          ethers.utils.defaultAbiCoder.encode(['uint256', 'uint256', 'uint256', 'uint256'], [0, 0, 100, 0])
+        ]
+      ]
+    )
+    const fetchMock = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(String(init.body)) as
+        | { id: number; method: string; params: string[] }
+        | Array<{ id: number; method: string; params: string[] }>
+      const buildResponse = (request: { id: number; method: string; params: string[] }) => {
+        if (request.method === 'eth_call') {
+          return { jsonrpc: '2.0', id: request.id, result }
+        }
+
+        const requestedBlock = request.params[0] === 'latest' ? 10 : Number(BigInt(request.params[0]))
+        return {
+          jsonrpc: '2.0',
+          id: request.id,
+          result: {
+            number: `0x${requestedBlock.toString(16)}`,
+            timestamp: `0x${(100 + requestedBlock * 10).toString(16)}`
+          }
+        }
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => (Array.isArray(body) ? body.map(buildResponse) : buildResponse(body))
+      }
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const [state] = await fetchVaultOnChainStatesAtTimestamps(1, VAULT_ADDRESS, [
+      { timestamp: 155, strategyAddresses: STRATEGY_ADDRESSES }
+    ])
+
+    expect(state).toMatchObject({
+      blockNumber: 5,
+      blockTimestamp: 150,
+      totalAssets: 1000n,
+      unallocatedBps: 5000
+    })
+    expect(
+      fetchMock.mock.calls.filter(([_url, init]) => {
+        const body = JSON.parse(String((init as RequestInit).body))
+        return Array.isArray(body) && body.some((request) => request.method === 'eth_call')
+      })
+    ).toHaveLength(1)
   })
 })

--- a/src/server/optimization/_lib/rpc.ts
+++ b/src/server/optimization/_lib/rpc.ts
@@ -48,8 +48,9 @@ export function getRpcConfig(chainId: number): RpcConfig | undefined {
 
 export function getAllRpcEndpoints(chainId: number): string[] {
   const config = RPC_CONFIG[chainId]
-  if (!config) return []
-  return [config.primary, ...config.fallbacks]
+  const configuredArchiveEndpoint = process.env[`OPTIMIZATION_ARCHIVE_RPC_URL_${chainId}`]
+  if (!config) return configuredArchiveEndpoint ? [configuredArchiveEndpoint] : []
+  return [...(configuredArchiveEndpoint ? [configuredArchiveEndpoint] : []), config.primary, ...config.fallbacks]
 }
 
 export function getRandomRpcEndpoint(chainId: number): string | undefined {
@@ -133,13 +134,17 @@ interface JsonRpcResponse<T = unknown> {
   error?: { code: number; message: string }
 }
 
-async function jsonRpcCall<T>(endpoint: string, method: string, params: unknown[]): Promise<T> {
+async function jsonRpcCall<T>(endpoint: string, method: string, params: unknown[], attempt = 0): Promise<T> {
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })
   })
 
+  if ((response.status === 429 || response.status === 503) && attempt < 3) {
+    await new Promise((resolve) => setTimeout(resolve, 200 * 2 ** attempt))
+    return jsonRpcCall(endpoint, method, params, attempt + 1)
+  }
   if (!response.ok) {
     throw new Error(`RPC HTTP ${response.status}`)
   }
@@ -156,6 +161,52 @@ async function jsonRpcCall<T>(endpoint: string, method: string, params: unknown[
   return data.result
 }
 
+async function jsonRpcBatchCall<T>(
+  endpoint: string,
+  calls: Array<{ method: string; params: unknown[] }>,
+  attempt = 0
+): Promise<T[]> {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(
+      calls.map((call, index) => ({
+        jsonrpc: '2.0',
+        id: index + 1,
+        method: call.method,
+        params: call.params
+      }))
+    )
+  })
+  if ((response.status === 429 || response.status === 503) && attempt < 3) {
+    await new Promise((resolve) => setTimeout(resolve, 200 * 2 ** attempt))
+    return jsonRpcBatchCall(endpoint, calls, attempt + 1)
+  }
+  if (!response.ok) {
+    throw new Error(`RPC HTTP ${response.status}`)
+  }
+
+  const payload = (await response.json()) as JsonRpcResponse<T>[]
+  if (!Array.isArray(payload)) {
+    throw new Error('RPC batch returned a non-array response')
+  }
+  const responseById = new Map(payload.map((item) => [item.id, item]))
+
+  return calls.map((_call, index) => {
+    const item = responseById.get(index + 1)
+    if (!item) {
+      throw new Error(`RPC batch response missing id ${index + 1}`)
+    }
+    if (item.error) {
+      throw new Error(`RPC error ${item.error.code}: ${item.error.message}`)
+    }
+    if (item.result === undefined) {
+      throw new Error(`RPC batch response ${index + 1} returned undefined result`)
+    }
+    return item.result
+  })
+}
+
 function decodeUint256(hex: string): bigint {
   return BigInt(hex)
 }
@@ -169,7 +220,8 @@ function extractCurrentDebtFromStrategiesResult(hex: string): bigint {
 async function fetchVaultStateViaMulticall(
   endpoint: string,
   vaultAddress: string,
-  strategyAddresses: string[]
+  strategyAddresses: string[],
+  blockTag = 'latest'
 ): Promise<{ totalAssets: bigint; strategyDebts: Map<string, bigint> }> {
   const calls = [
     { target: vaultAddress, callData: VAULT_SELECTORS.totalAssets },
@@ -180,7 +232,7 @@ async function fetchVaultStateViaMulticall(
   ]
 
   const calldata = encodeMulticallAggregate(calls)
-  const result = await jsonRpcCall<string>(endpoint, 'eth_call', [{ to: MULTICALL3_ADDRESS, data: calldata }, 'latest'])
+  const result = await jsonRpcCall<string>(endpoint, 'eth_call', [{ to: MULTICALL3_ADDRESS, data: calldata }, blockTag])
 
   const decoded = decodeMulticallAggregateResult(result)
 
@@ -261,6 +313,238 @@ export async function fetchVaultOnChainState(
   throw lastError ?? new Error('All RPC endpoints failed')
 }
 
+interface RpcBlock {
+  number: string
+  timestamp: string
+}
+
+export interface HistoricalVaultState {
+  blockNumber: number
+  blockTimestamp: number
+  totalAssets: bigint
+  strategyDebts: Map<string, bigint>
+  unallocatedBps: number
+}
+
+export interface HistoricalVaultStateRequest {
+  timestamp: number
+  strategyAddresses: string[]
+}
+
+function toBlockTag(blockNumber: number): string {
+  return `0x${blockNumber.toString(16)}`
+}
+
+interface BlockSearch {
+  timestamp: number
+  lowBlock: number
+  highBlock: number
+}
+
+function chunkItems<T>(items: readonly T[], chunkSize: number): T[][] {
+  return Array.from({ length: Math.ceil(items.length / chunkSize) }, (_value, index) =>
+    items.slice(index * chunkSize, index * chunkSize + chunkSize)
+  )
+}
+
+async function fetchBlockHeaders(endpoint: string, blockNumbers: readonly number[]): Promise<Map<number, RpcBlock>> {
+  const uniqueBlockNumbers = Array.from(new Set(blockNumbers))
+  const chunks = chunkItems(uniqueBlockNumbers, 100)
+  const chunkResults = await chunks.reduce<Promise<Array<readonly [number, RpcBlock]>>>(
+    async (allResultsPromise, chunk) => {
+      const allResults = await allResultsPromise
+      const blocks = await jsonRpcBatchCall<RpcBlock>(
+        endpoint,
+        chunk.map((blockNumber) => ({
+          method: 'eth_getBlockByNumber',
+          params: [toBlockTag(blockNumber), false]
+        }))
+      )
+      return [...allResults, ...blocks.map((block, index) => [chunk[index], block] as const)]
+    },
+    Promise.resolve([])
+  )
+  return new Map(chunkResults)
+}
+
+async function resolveBlockSearches(endpoint: string, searches: readonly BlockSearch[]): Promise<BlockSearch[]> {
+  const unresolvedSearches = searches.filter((search) => search.lowBlock < search.highBlock)
+  if (unresolvedSearches.length === 0) {
+    return [...searches]
+  }
+
+  const midpoints = unresolvedSearches.map((search) => Math.ceil((search.lowBlock + search.highBlock) / 2))
+  const blocksByNumber = await fetchBlockHeaders(endpoint, midpoints)
+  const nextSearches = searches.map((search) => {
+    if (search.lowBlock >= search.highBlock) {
+      return search
+    }
+
+    const midpoint = Math.ceil((search.lowBlock + search.highBlock) / 2)
+    const block = blocksByNumber.get(midpoint)
+    if (!block) {
+      throw new Error(`Missing block header for ${midpoint}`)
+    }
+
+    return Number(BigInt(block.timestamp)) <= search.timestamp
+      ? { ...search, lowBlock: midpoint }
+      : { ...search, highBlock: midpoint - 1 }
+  })
+  return resolveBlockSearches(endpoint, nextSearches)
+}
+
+async function fetchHistoricalStatesFromEndpoint(
+  endpoint: string,
+  chainId: number,
+  vaultAddress: string,
+  requests: readonly HistoricalVaultStateRequest[]
+): Promise<HistoricalVaultState[]> {
+  const latestBlock = await jsonRpcCall<RpcBlock>(endpoint, 'eth_getBlockByNumber', ['latest', false])
+  const latestBlockNumber = Number(BigInt(latestBlock.number))
+  const latestTimestamp = Number(BigInt(latestBlock.timestamp))
+  const estimatedBlockNumbers =
+    chainId === 1
+      ? requests.map((request) =>
+          Math.max(0, latestBlockNumber - Math.floor(Math.max(0, latestTimestamp - request.timestamp) / 12))
+        )
+      : []
+  const estimatedBlocks =
+    estimatedBlockNumbers.length > 0 ? await fetchBlockHeaders(endpoint, estimatedBlockNumbers) : new Map()
+  const searches = requests.map((request, index) => {
+    if (request.timestamp >= latestTimestamp) {
+      return {
+        timestamp: request.timestamp,
+        lowBlock: latestBlockNumber,
+        highBlock: latestBlockNumber
+      }
+    }
+
+    const estimatedBlockNumber = estimatedBlockNumbers[index]
+    const estimatedBlock = estimatedBlocks.get(estimatedBlockNumber)
+    if (!estimatedBlock) {
+      return {
+        timestamp: request.timestamp,
+        lowBlock: 0,
+        highBlock: latestBlockNumber
+      }
+    }
+
+    const estimatedTimestamp = Number(BigInt(estimatedBlock.timestamp))
+    const estimatedDistance = Math.ceil(Math.abs(request.timestamp - estimatedTimestamp) / 12) + 8
+    return estimatedTimestamp <= request.timestamp
+      ? {
+          timestamp: request.timestamp,
+          lowBlock: estimatedBlockNumber,
+          highBlock: Math.min(latestBlockNumber, estimatedBlockNumber + estimatedDistance)
+        }
+      : {
+          timestamp: request.timestamp,
+          lowBlock: Math.max(0, estimatedBlockNumber - estimatedDistance),
+          highBlock: estimatedBlockNumber - 1
+        }
+  })
+  const resolvedSearches = await resolveBlockSearches(endpoint, searches)
+  const resolvedBlocks = await fetchBlockHeaders(
+    endpoint,
+    resolvedSearches.map((search) => search.lowBlock)
+  )
+  const ethCallChunks = chunkItems(
+    requests.map((request, index) => {
+      const blockNumber = resolvedSearches[index].lowBlock
+      const calls = [
+        { target: vaultAddress, callData: VAULT_SELECTORS.totalAssets },
+        ...request.strategyAddresses.map((address) => ({
+          target: vaultAddress,
+          callData: VAULT_SELECTORS.strategies + encodeAddressParam(address)
+        }))
+      ]
+      return {
+        blockNumber,
+        request,
+        call: {
+          method: 'eth_call',
+          params: [{ to: MULTICALL3_ADDRESS, data: encodeMulticallAggregate(calls) }, toBlockTag(blockNumber)]
+        }
+      }
+    }),
+    5
+  )
+  const states = await ethCallChunks.reduce<Promise<HistoricalVaultState[]>>(async (allStatesPromise, chunk) => {
+    const allStates = await allStatesPromise
+    const results = await jsonRpcBatchCall<string>(
+      endpoint,
+      chunk.map((item) => item.call)
+    )
+    const states = chunk.map((item, index) => {
+      const decoded = decodeMulticallAggregateResult(results[index])
+      if (decoded.results.length !== item.request.strategyAddresses.length + 1) {
+        throw new Error('Historical multicall returned an unexpected result count')
+      }
+
+      const strategyDebts = new Map(
+        item.request.strategyAddresses.map((address, strategyIndex) => [
+          address.toLowerCase(),
+          extractCurrentDebtFromStrategiesResult(decoded.results[strategyIndex + 1])
+        ])
+      )
+      const block = resolvedBlocks.get(item.blockNumber)
+      if (!block) {
+        throw new Error(`Missing resolved block ${item.blockNumber}`)
+      }
+
+      return {
+        blockNumber: item.blockNumber,
+        blockTimestamp: Number(BigInt(block.timestamp)),
+        ...computeUnallocated(decodeUint256(decoded.results[0]), strategyDebts)
+      }
+    })
+    return [...allStates, ...states]
+  }, Promise.resolve([]))
+  return states
+}
+
+async function tryHistoricalBatchEndpoints(
+  endpoints: readonly string[],
+  chainId: number,
+  vaultAddress: string,
+  requests: readonly HistoricalVaultStateRequest[],
+  lastError?: Error
+): Promise<HistoricalVaultState[]> {
+  const [endpoint, ...remainingEndpoints] = endpoints
+  if (!endpoint) {
+    throw lastError ?? new Error('All RPC endpoints failed')
+  }
+
+  try {
+    return await fetchHistoricalStatesFromEndpoint(endpoint, chainId, vaultAddress, requests)
+  } catch (error) {
+    return tryHistoricalBatchEndpoints(
+      remainingEndpoints,
+      chainId,
+      vaultAddress,
+      requests,
+      error instanceof Error ? error : new Error(String(error))
+    )
+  }
+}
+
+export async function fetchVaultOnChainStatesAtTimestamps(
+  chainId: number,
+  vaultAddress: string,
+  requests: readonly HistoricalVaultStateRequest[]
+): Promise<HistoricalVaultState[]> {
+  if (requests.length === 0) {
+    return []
+  }
+
+  const endpoints = getAllRpcEndpoints(chainId)
+  if (endpoints.length === 0) {
+    throw new Error(`No RPC endpoints configured for chain ${chainId}`)
+  }
+
+  return tryHistoricalBatchEndpoints(endpoints, chainId, vaultAddress, requests)
+}
+
 function computeUnallocated(
   totalAssets: bigint,
   strategyDebts: Map<string, bigint>
@@ -269,7 +553,7 @@ function computeUnallocated(
 
   let unallocatedBps: number
   if (totalAssets > BigInt(0)) {
-    const unallocated = totalAssets - totalAllocated
+    const unallocated = totalAssets > totalAllocated ? totalAssets - totalAllocated : 0n
     unallocatedBps = Number((unallocated * BigInt(10000)) / totalAssets)
   } else {
     unallocatedBps = 10000

--- a/src/server/optimization/_lib/strategyMetadata.ts
+++ b/src/server/optimization/_lib/strategyMetadata.ts
@@ -1,0 +1,57 @@
+export type StrategyNameSource = 'optimizer' | 'current-metadata-catalog'
+
+export interface StrategyMetadata {
+  name: string
+  source: 'current-metadata-catalog'
+}
+
+interface KongCompositionStrategy {
+  address?: string | null
+  name?: string | null
+}
+
+interface KongVaultSnapshot {
+  composition?: KongCompositionStrategy[] | null
+}
+
+const STRATEGY_METADATA_CACHE_TTL_MS = 10 * 60 * 1000
+const strategyMetadataCache = new Map<string, { expiresAt: number; value: Map<string, StrategyMetadata> }>()
+
+export async function fetchCurrentStrategyMetadata(
+  chainId: number,
+  vaultAddress: string
+): Promise<Map<string, StrategyMetadata>> {
+  const cacheKey = `${chainId}:${vaultAddress.toLowerCase()}`
+  const cached = strategyMetadataCache.get(cacheKey)
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value
+  }
+
+  const kongRestUrl = process.env.NEXT_PUBLIC_KONG_REST_URL
+  if (!kongRestUrl) {
+    return new Map()
+  }
+
+  const response = await fetch(`${kongRestUrl}/snapshot/${chainId}/${vaultAddress}`, {
+    signal: AbortSignal.timeout(4000)
+  })
+  if (!response.ok) {
+    throw new Error(`Kong strategy metadata request failed: HTTP ${response.status}`)
+  }
+
+  const snapshot = (await response.json()) as KongVaultSnapshot
+  const metadata = (snapshot.composition ?? []).reduce((strategies, strategy) => {
+    const address = strategy.address?.toLowerCase()
+    const name = strategy.name?.trim()
+    if (address && name) {
+      strategies.set(address, { name, source: 'current-metadata-catalog' })
+    }
+    return strategies
+  }, new Map<string, StrategyMetadata>())
+
+  strategyMetadataCache.set(cacheKey, {
+    expiresAt: Date.now() + STRATEGY_METADATA_CACHE_TTL_MS,
+    value: metadata
+  })
+  return metadata
+}

--- a/src/server/optimization/change.ts
+++ b/src/server/optimization/change.ts
@@ -1,5 +1,6 @@
 import { GET_CORS_HEADERS, json, noContent, queryValue } from '../http'
 import { getVercelCdnCacheHeaders } from '../lib/cacheHeaders'
+import { addFallbackAllocationSnapshots, enrichOptimizationRecord, enrichOptimizationRecords } from './_lib/reconcile'
 import {
   findVaultOptimization,
   isRedisAuthenticationError,
@@ -48,7 +49,7 @@ export async function GET(request: Request): Promise<Response> {
           )
         }
 
-        return json(selectedHistory, { headers: RESPONSE_HEADERS })
+        return json(await enrichOptimizationRecords(selectedHistory), { headers: RESPONSE_HEADERS })
       }
 
       const selected = findVaultOptimization(optimizations, requestedVault)
@@ -59,10 +60,10 @@ export async function GET(request: Request): Promise<Response> {
         )
       }
 
-      return json(selected, { headers: RESPONSE_HEADERS })
+      return json(await enrichOptimizationRecord(selected), { headers: RESPONSE_HEADERS })
     }
 
-    return json(optimizations, { headers: RESPONSE_HEADERS })
+    return json(addFallbackAllocationSnapshots(optimizations), { headers: RESPONSE_HEADERS })
   } catch (error) {
     if (isRedisAuthenticationError(error)) {
       return json({ error: REDIS_AUTHENTICATION_ERROR_MESSAGE }, { status: 500, headers: GET_CORS_HEADERS })

--- a/src/server/optimization/handlers.test.ts
+++ b/src/server/optimization/handlers.test.ts
@@ -8,7 +8,10 @@ const {
   findVaultOptimizationMock,
   getVaultDecimalsMock,
   parseExplainMetadataMock,
-  readOptimizationsMock
+  readOptimizationsMock,
+  enrichOptimizationRecordMock,
+  enrichOptimizationRecordsMock,
+  addFallbackAllocationSnapshotsMock
 } = vi.hoisted(() => {
   class MockRedisAuthenticationError extends Error {}
   class MockRedisConnectivityError extends Error {}
@@ -21,7 +24,10 @@ const {
     findVaultOptimizationMock: vi.fn(),
     getVaultDecimalsMock: vi.fn(),
     parseExplainMetadataMock: vi.fn(),
-    readOptimizationsMock: vi.fn()
+    readOptimizationsMock: vi.fn(),
+    enrichOptimizationRecordMock: vi.fn(async (record: unknown) => record),
+    enrichOptimizationRecordsMock: vi.fn(async (records: unknown) => records),
+    addFallbackAllocationSnapshotsMock: vi.fn((records: unknown) => records)
   }
 })
 
@@ -45,6 +51,12 @@ vi.mock('./_lib/redis', () => ({
   isRedisAuthenticationError: (error: unknown) => error instanceof MockRedisAuthenticationError,
   isRedisConnectivityError: (error: unknown) => error instanceof MockRedisConnectivityError,
   readOptimizations: readOptimizationsMock
+}))
+
+vi.mock('./_lib/reconcile', () => ({
+  addFallbackAllocationSnapshots: addFallbackAllocationSnapshotsMock,
+  enrichOptimizationRecord: enrichOptimizationRecordMock,
+  enrichOptimizationRecords: enrichOptimizationRecordsMock
 }))
 
 vi.mock('./_lib/rpc', () => ({
@@ -199,6 +211,21 @@ describe('optimization handlers', () => {
         }
       }
     ])
+    const enrichedHistory = targetHistory.map((optimization, index) => ({
+      ...optimization,
+      allocationSnapshot: {
+        timestampUtc: optimization.source.latestMatchedTimestampUtc ?? optimization.source.timestampUtc,
+        blockNumber: index === 0 ? 123 : null,
+        blockTimestampUtc: index === 0 ? '2026-04-22 09:59:59 UTC' : null,
+        source: index === 0 ? 'archive-rpc' : null,
+        strategyUniverseSource: index === 0 ? 'envio-strategy-changed' : null,
+        complete: index === 0,
+        strategies: [],
+        unallocatedBps: index === 0 ? 250 : null,
+        unallocatedSource: index === 0 ? 'same-timestamp-onchain' : null
+      }
+    }))
+    enrichOptimizationRecordsMock.mockResolvedValue(enrichedHistory)
     const response = await changeHandler(
       createGetRequest('/api/optimization/change', {
         vault: targetVault,
@@ -209,8 +236,9 @@ describe('optimization handlers', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*')
     expectPublicCdnCacheHeaders(response, 'public, s-maxage=600, stale-while-revalidate=60')
-    await expect(response.json()).resolves.toEqual(targetHistory)
+    await expect(response.json()).resolves.toEqual(enrichedHistory)
     expect(findVaultOptimizationMock).not.toHaveBeenCalled()
+    expect(enrichOptimizationRecordsMock).toHaveBeenCalledWith(targetHistory)
   })
 
   it('keeps split CDN and browser cache headers on alignment responses', async () => {


### PR DESCRIPTION
### Summary

Strengthen the optimization API's allocation-completeness contract without changing the raw DOA optimizer fields. Records now distinguish optimizer coverage residuals from authoritative idle capital, expose freshness metadata, and add timestamp-aligned historical allocation snapshots when Envio and archive RPC data are available.

Historical snapshots use Envio `StrategyChanged` events to establish the strategy universe, archive RPC multicalls for same-block debt and idle-capital values, and Kong only as a provenance-tagged strategy-name catalog. When those sources are incomplete or unavailable, the API returns an explicit incomplete fallback instead of copying current state or synthesizing `Unallocated`.

### How to review

1. Start with `allocationCoverage.ts` and `reconcile.ts` for the public semantics and unknown/outside-scope handling.
2. Review `historicalAllocation.ts`, `envio.ts`, and `rpc.ts` for source authority, batching, caching, retries, and bounded fallback behavior.
3. Check `change.ts` for requested-vault enrichment versus the no-fan-out unscoped response.
4. Use `manual-allocation-reallocation-data-spec.md` as the consumer contract and worked yvWETH example.

### Test plan

- [x] Automated: `bun run test` — 176 files, 929 tests passed
- [x] Automated: focused optimization suite — 8 files, 31 tests passed
- [x] Automated: `bun run tslint`
- [x] Automated: `bun run lint`
- [x] Automated: `bun run build`
- [x] Commit hooks: Biome format/lint, client/server boundary check, and TypeScript
- [x] Manual: validated a yvWETH recommendation at `2026-07-25 00:15:29 UTC` against Ethereum block `25,606,129`, including its full strategy composition and 2 bps of same-block idle capital

### Risk / impact

This changes additive API metadata and historical enrichment only; raw optimizer fields remain intact. Historical enrichment depends on Envio lifecycle completeness and archive-capable RPC access, so failures intentionally degrade to `allocationSnapshot.complete: false` with unknown true idle capital. A dedicated provider can be configured with `OPTIMIZATION_ARCHIVE_RPC_URL_<chainId>` to avoid public-provider rate limits.

The downstream optimization visualizer must adopt the new fields separately and stop treating optimizer residuals as confirmed unallocated capital.
