### PR TITLE
Batch the timelock strategies RPC client

### DIFF
--- a/src/server/lib/timelockStrategies/rpc.ts
+++ b/src/server/lib/timelockStrategies/rpc.ts
@@ -78,7 +78,7 @@ const resolveRpcUrl = (chainId: number): string | undefined =>
 function createTimelockClient(chainId: number, rpcUrl: string): TTimelockPublicClient {
   return createPublicClient({
     chain: CHAINS_BY_ID.get(chainId),
-    transport: http(rpcUrl)
+    transport: http(rpcUrl, { batch: true })
   }) as TTimelockPublicClient
 }
 


### PR DESCRIPTION
### Summary
`createTimelockClient` built its viem transport without batching, so each `/api/vaults/timelock-strategies` call fanned out into one HTTP request per RPC call. On L2s the block-log scan chunks into 25 `eth_getLogs`, all fired in parallel — measured at 26 requests in 133ms, an instantaneous ~195 req/s against `rpc.yearn.fi`. This route runs server-side from shared Vercel egress IPs and is polled every 60s by every open vault page, so that burst is charged to a handful of IPs on behalf of all users.

Adding `{ batch: true }` collapses it to 2 requests. This matches what the client-side transport already does (`src/config/wagmiTransports.ts:36`).

| | HTTP requests | Shape |
|---|---|---|
| before | 26 | 1 `eth_blockNumber` + 25 separate `eth_getLogs` |
| after | 2 | 1 `eth_blockNumber` + 1 batch carrying 25 `eth_getLogs` |

### How to review
One line in `src/server/lib/timelockStrategies/rpc.ts`. Worth confirming the three `Promise.all` fan-outs (lines 113, 179, 250) are all same-tick — that is what lets viem's scheduler coalesce them into a single JSON-RPC array request.

### Test plan
- [x] `bunx vitest run src/server/lib/timelockStrategies/rpc.test.ts` — 4/4 pass
- [x] `bun run tslint`, `bun run lint:fix`
- [x] Manual: called `fetchPendingTimelockStrategies` for an Optimism vault through a logging proxy in front of `rpc.yearn.fi` — 26 requests collapsed to 2, identical result (0 pending items, 644ms)
- [ ] After deploy: load an L2 vault page and confirm the timelock section still renders pending operations correctly

### Risk / impact
Low, but not zero. Batching means a failure anywhere in the batch fails the whole batch rather than a single call. The route already catches and returns empty on error, so the degraded mode is unchanged.

viem's default `batchSize` is 1000. A vault with an unusually large number of pending operations would send one large batch (4 calls per operation). If that becomes a concern, cap it with `batch: { batchSize: 25 }`.

Rollback is a one-line revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)