### PR TITLE
Classify DUSD vaults as stablecoins

### DIFF
--- a/src/components/pages/vaults/utils/vaultListFacets.test.ts
+++ b/src/components/pages/vaults/utils/vaultListFacets.test.ts
@@ -24,19 +24,12 @@ const STANDARD_V3_VAULT = {
 const DUSD_FRXUSD_CURVE_VAULT = {
   version: '0.4.6',
   chainID: 1,
-  address: '0xb53b70cb960feeaf2093df3c733e368f6d254898',
   name: 'Curve frxUSDDUSD Factory yVault',
   symbol: 'yvCurve-frxUSDDUSD-f',
   category: 'Curve',
-  kind: 'Legacy',
   token: {
-    address: '0x104d6a1b97a6cef88d905d7b865a378d90be932a',
     name: 'Curve DUSD-frxUSD LP',
-    symbol: 'frxUSDDUSD-f',
-    decimals: 18
-  },
-  info: {
-    riskLevel: 2
+    symbol: 'frxUSDDUSD-f'
   }
 } as unknown as TKongVaultInput
 

--- a/src/components/pages/vaults/utils/vaultListFacets.test.ts
+++ b/src/components/pages/vaults/utils/vaultListFacets.test.ts
@@ -2,7 +2,7 @@ import type { TKongVaultInput } from '@pages/vaults/domain/kongVaultSelectors'
 import { YVBTC_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvBtc'
 import { describe, expect, it } from 'vitest'
 
-import { deriveListKind } from './vaultListFacets'
+import { deriveAssetCategory, deriveListKind } from './vaultListFacets'
 
 const STANDARD_V3_VAULT = {
   version: '3.0.4',
@@ -20,6 +20,32 @@ const STANDARD_V3_VAULT = {
     riskLevel: 2
   }
 } as unknown as TKongVaultInput
+
+const DUSD_FRXUSD_CURVE_VAULT = {
+  version: '0.4.6',
+  chainID: 1,
+  address: '0xb53b70cb960feeaf2093df3c733e368f6d254898',
+  name: 'Curve frxUSDDUSD Factory yVault',
+  symbol: 'yvCurve-frxUSDDUSD-f',
+  category: 'Curve',
+  kind: 'Legacy',
+  token: {
+    address: '0x104d6a1b97a6cef88d905d7b865a378d90be932a',
+    name: 'Curve DUSD-frxUSD LP',
+    symbol: 'frxUSDDUSD-f',
+    decimals: 18
+  },
+  info: {
+    riskLevel: 2
+  }
+} as unknown as TKongVaultInput
+
+describe('deriveAssetCategory', () => {
+  it('classifies the DUSD-frxUSD Curve LP as a stablecoin vault', () => {
+    expect(DUSD_FRXUSD_CURVE_VAULT.category).toBe('Curve')
+    expect(deriveAssetCategory(DUSD_FRXUSD_CURVE_VAULT)).toBe('Stablecoin')
+  })
+})
 
 describe('deriveListKind', () => {
   it('keeps yvBTC as a strategy before launch so it is not pinned with allocator vaults', () => {

--- a/src/components/pages/vaults/utils/vaultListFacets.ts
+++ b/src/components/pages/vaults/utils/vaultListFacets.ts
@@ -45,6 +45,7 @@ const KNOWN_STABLECOIN_SYMBOLS = new Set([
   'USDC',
   'USDT',
   'DAI',
+  'DUSD',
   'FRAX',
   'LUSD',
   'TUSD',


### PR DESCRIPTION
## Description

Adds DUSD to the known stablecoin symbols and adds regression coverage for the DUSD/frxUSD Curve LP vault.

## Related Issue

N/A

## Motivation and Context

DUSD-based vaults were not included when filtering vaults by Stablecoin. This change classifies the DUSD/frxUSD Curve LP vault as a stablecoin while preserving its Curve category.

## How Has This Been Tested?

- Verified the TypeScript typecheck passes
- Verified the vault list facet tests pass
- Verified the changed files pass Biome checks
- Added a unit test confirming the DUSD/frxUSD Curve LP derives the Stablecoin asset category

## Screenshots (if appropriate):

no visual or layout changes
