### PR TITLE
Use sequential portfolio event fetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ _app
 /docs/plans
 /docs/temp
 /docs/performance
+/docs/benchmark
 
 # playwright
 .playwright-mcp

--- a/src/components/pages/portfolio/hooks/usePortfolioBreakdown.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioBreakdown.ts
@@ -11,7 +11,7 @@ export function usePortfolioBreakdown(date: string | null, enabled = true) {
       return null
     }
 
-    return `/api/holdings/breakdown?address=${address}&date=${date}&fetchType=parallel`
+    return `/api/holdings/breakdown?address=${address}&date=${date}&fetchType=seq`
   }, [address, date, enabled])
 
   const { data, isLoading, isFetching, error } = useFetch<TPortfolioBreakdownResponse>({

--- a/src/components/pages/portfolio/hooks/usePortfolioHistory.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioHistory.ts
@@ -33,7 +33,7 @@ export function usePortfolioHistory(
     if (!address || !enabled || !progressId) {
       return null
     }
-    return `/api/holdings/history?address=${address}&denomination=${denomination}&timeframe=${timeframe}&fetchType=parallel&progressId=${encodeURIComponent(progressId)}`
+    return `/api/holdings/history?address=${address}&denomination=${denomination}&timeframe=${timeframe}&fetchType=seq&progressId=${encodeURIComponent(progressId)}`
   }, [address, denomination, enabled, progressId, timeframe])
   const cacheKey = useMemo(
     () =>

--- a/src/components/pages/portfolio/hooks/usePortfolioProtocolReturnHistory.ts
+++ b/src/components/pages/portfolio/hooks/usePortfolioProtocolReturnHistory.ts
@@ -27,7 +27,7 @@ export function usePortfolioProtocolReturnHistory(timeframe: TPortfolioHistoryTi
       return null
     }
 
-    return `/api/holdings/protocol-return/history?address=${address}&timeframe=${timeframe}&fetchType=parallel&progressId=${encodeURIComponent(progressId)}`
+    return `/api/holdings/protocol-return/history?address=${address}&timeframe=${timeframe}&fetchType=seq&progressId=${encodeURIComponent(progressId)}`
   }, [address, enabled, progressId, timeframe])
   const cacheKey = useMemo(
     () => (address && enabled ? ['fetch', 'portfolio-protocol-history', address.toLowerCase(), timeframe] : undefined),

--- a/src/components/pages/vaults/hooks/useVaultUserHistory.ts
+++ b/src/components/pages/vaults/hooks/useVaultUserHistory.ts
@@ -72,7 +72,7 @@ export function useVaultUserHistory({
       return null
     }
 
-    return `/api/holdings/protocol-return/history?address=${address}&${vaultFilter}&timeframe=${apiTimeframe}&fetchType=parallel`
+    return `/api/holdings/protocol-return/history?address=${address}&${vaultFilter}&timeframe=${apiTimeframe}&fetchType=seq`
   }, [address, apiTimeframe, enabled, vaultFilter])
 
   const balanceEndpoint = useMemo(() => {
@@ -80,7 +80,7 @@ export function useVaultUserHistory({
       return null
     }
 
-    return `/api/holdings/history?address=${address}&${vaultFilter}&denomination=usd&timeframe=${apiTimeframe}&fetchType=parallel`
+    return `/api/holdings/history?address=${address}&${vaultFilter}&denomination=usd&timeframe=${apiTimeframe}&fetchType=seq`
   }, [address, apiTimeframe, enabled, valueMode, vaultFilter])
 
   const {


### PR DESCRIPTION
Use sequential event fetching for portfolio and vault history requests.

Prevent the hosted 1,000-row cap from truncating charts.

Keep local benchmark reports out of version control.

## Description

This PR changes fetch type so we could make use of new envio-hosted indexer which has some limitations:
1. Limit is capped to 1000 by default
2. No aggregate_ fields, which means parallel fetch is not possible.

tldr we have to change fetch type to sequential, which worked better for smaller accounts and little bit worse for heavy, but that's fine imo
benchmark here - https://hackmd.io/@6zU9iApXRpm0RlHWz19Z_Q/ryhgij18Gx

## Testing
Just go to portfolio page and make sure charts load  
