### PR TITLE
Add Enso-powered swap page

### DIFF
--- a/app/(wallet)/swap/page-client.tsx
+++ b/app/(wallet)/swap/page-client.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import SwapPage from '@pages/swap/index'
+import type { ReactElement } from 'react'
+
+export default function SwapPageClient(): ReactElement {
+  return <SwapPage />
+}

--- a/app/(wallet)/swap/page.tsx
+++ b/app/(wallet)/swap/page.tsx
@@ -1,0 +1,9 @@
+import type { ReactElement } from 'react'
+import { swapMetadata } from '../../metadata'
+import SwapPageClient from './page-client'
+
+export const metadata = swapMetadata
+
+export default function Page(): ReactElement {
+  return <SwapPageClient />
+}

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -303,3 +303,11 @@ export const portfolioMetadata: Metadata = {
     canonical: '/portfolio'
   }
 }
+export const swapMetadata: Metadata = {
+  ...vaultsMetadata,
+  title: 'Yearn Swap',
+  description: 'Swap tokens across supported networks with Enso routing.',
+  alternates: {
+    canonical: '/swap'
+  }
+}

--- a/src/appRouteDataLoading.test.ts
+++ b/src/appRouteDataLoading.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { isVaultDetailPathname, isVaultsListPathname, shouldLoadAppTokenLists } from '@/appRouteDataLoading'
+import {
+  isVaultDetailPathname,
+  isVaultsListPathname,
+  shouldLoadAppTokenLists,
+  shouldLoadAppVaultList
+} from '@/appRouteDataLoading'
 
 describe('app route data loading', () => {
   it('identifies vault list routes', () => {
@@ -20,5 +25,11 @@ describe('app route data loading', () => {
     expect(shouldLoadAppTokenLists('/vaults')).toBe(false)
     expect(shouldLoadAppTokenLists('/vaults/1/0x0000000000000000000000000000000000000001')).toBe(false)
     expect(shouldLoadAppTokenLists('/portfolio')).toBe(true)
+  })
+
+  it('loads vault metadata for portfolio and swap surfaces', () => {
+    expect(shouldLoadAppVaultList('/portfolio')).toBe(true)
+    expect(shouldLoadAppVaultList('/swap?fromChain=1')).toBe(true)
+    expect(shouldLoadAppVaultList('/vaults')).toBe(false)
   })
 })

--- a/src/appRouteDataLoading.ts
+++ b/src/appRouteDataLoading.ts
@@ -21,3 +21,8 @@ export function isVaultsListPathname(pathname: string): boolean {
 export function shouldLoadAppTokenLists(pathname: string): boolean {
   return !isVaultDetailPathname(pathname) && !isVaultsListPathname(pathname)
 }
+
+export function shouldLoadAppVaultList(pathname: string): boolean {
+  const [section] = getPathSegments(pathname)
+  return section === 'portfolio' || section === 'swap'
+}

--- a/src/components/pages/portfolio/activity.helpers.ts
+++ b/src/components/pages/portfolio/activity.helpers.ts
@@ -61,6 +61,9 @@ export function getNotificationActivityAction(notification: TNotification): TPor
     case 'zap':
     case 'crosschain zap':
       return 'deposit'
+    case 'swap':
+    case 'crosschain swap':
+      return 'swap'
     case 'withdraw':
     case 'withdraw zap':
     case 'crosschain withdraw zap':
@@ -108,6 +111,8 @@ export function isZapNotification(notification: TNotification): boolean {
   return (
     notification.type === 'zap' ||
     notification.type === 'crosschain zap' ||
+    notification.type === 'swap' ||
+    notification.type === 'crosschain swap' ||
     notification.type === 'withdraw zap' ||
     notification.type === 'crosschain withdraw zap'
   )

--- a/src/components/pages/swap/SwapVaultDetails.test.tsx
+++ b/src/components/pages/swap/SwapVaultDetails.test.tsx
@@ -1,0 +1,36 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { SwapVaultAnnualReturnRow, SwapVaultWorthRow } from './SwapVaultDetails'
+import type { TSwapVaultEstimate } from './swapVaultEstimate'
+
+const estimate: TSwapVaultEstimate = {
+  expectedUnderlying: 12.5,
+  minimumUnderlying: 12,
+  expectedUnderlyingUsd: 25,
+  minimumUnderlyingUsd: 24,
+  estimatedAnnualReturn: 1.2,
+  estimatedAnnualReturnUsd: 2.4
+}
+
+describe('SwapVaultDetails', () => {
+  it('shows only the minimum underlying value in the worth row', () => {
+    const html = renderToStaticMarkup(
+      <SwapVaultWorthRow estimate={estimate} underlyingSymbol="USDC" isLoading={false} />
+    )
+
+    expect(html).toContain('Worth at least:')
+    expect(html).toContain('12.0 USDC')
+    expect(html).toContain('$24.00')
+    expect(html).not.toContain('12.5')
+  })
+
+  it('shows the annual return and APR independently', () => {
+    const html = renderToStaticMarkup(
+      <SwapVaultAnnualReturnRow estimate={estimate} underlyingSymbol="USDC" annualRate={0.1} isLoading={false} />
+    )
+
+    expect(html).toContain('Est. Annual Return')
+    expect(html).toContain('1.20 USDC')
+    expect(html).toContain('10.00% APR')
+  })
+})

--- a/src/components/pages/swap/SwapVaultDetails.tsx
+++ b/src/components/pages/swap/SwapVaultDetails.tsx
@@ -1,0 +1,67 @@
+import { formatWidgetValue } from '@pages/vaults/components/widget/shared/valueDisplay'
+import { formatUSD } from '@shared/utils/format'
+import type { ReactElement } from 'react'
+import type { TSwapVaultEstimate } from './swapVaultEstimate'
+
+function formatMinimumUnderlying({ estimate, symbol }: { estimate: TSwapVaultEstimate; symbol: string }): string {
+  if (estimate.minimumUnderlying === null) {
+    return 'Unavailable'
+  }
+
+  const tokenValue = `${formatWidgetValue(estimate.minimumUnderlying)} ${symbol}`
+  if (estimate.minimumUnderlyingUsd === null) {
+    return tokenValue
+  }
+
+  return `${tokenValue} (${formatUSD(estimate.minimumUnderlyingUsd)})`
+}
+
+export function SwapVaultWorthRow({
+  estimate,
+  underlyingSymbol,
+  isLoading
+}: {
+  estimate: TSwapVaultEstimate
+  underlyingSymbol: string
+  isLoading: boolean
+}): ReactElement {
+  return (
+    <div className="flex items-start justify-between gap-4 text-sm">
+      <span className="text-text-secondary">Worth at least:</span>
+      <span className="max-w-[68%] text-right font-semibold text-text-primary">
+        {isLoading ? 'Finding route...' : formatMinimumUnderlying({ estimate, symbol: underlyingSymbol })}
+      </span>
+    </div>
+  )
+}
+
+export function SwapVaultAnnualReturnRow({
+  estimate,
+  underlyingSymbol,
+  annualRate,
+  isLoading
+}: {
+  estimate: TSwapVaultEstimate
+  underlyingSymbol: string
+  annualRate?: number
+  isLoading: boolean
+}): ReactElement {
+  const annualReturn =
+    estimate.estimatedAnnualReturn === null
+      ? 'Unavailable'
+      : `${formatWidgetValue(estimate.estimatedAnnualReturn)} ${underlyingSymbol}${
+          estimate.estimatedAnnualReturnUsd === null ? '' : ` (${formatUSD(estimate.estimatedAnnualReturnUsd)})`
+        }`
+
+  return (
+    <div className="flex items-start justify-between gap-4 text-sm">
+      <span className="text-text-secondary">Est. Annual Return</span>
+      <span className="text-right font-semibold text-text-primary">
+        {isLoading ? 'Finding route...' : annualReturn}
+        {!isLoading && annualRate !== undefined ? (
+          <span className="ml-1 font-normal text-text-secondary">({(annualRate * 100).toFixed(2)}% APR)</span>
+        ) : null}
+      </span>
+    </div>
+  )
+}

--- a/src/components/pages/swap/SwapWalletPanel.tsx
+++ b/src/components/pages/swap/SwapWalletPanel.tsx
@@ -1,0 +1,270 @@
+import { getTokenLogoSources } from '@pages/vaults/components/widget/tokenLogo.utils'
+import {
+  getVaultAddress,
+  getVaultChainID,
+  getVaultInfo,
+  getVaultStakingAddress
+} from '@pages/vaults/domain/kongVaultSelectors'
+import { ImageWithFallback } from '@shared/components/ImageWithFallback'
+import { TokenLogoV2 } from '@shared/components/TokenLogoV2'
+import { useWalletStatus, useWalletTokens } from '@shared/contexts/useWallet'
+import { useWeb3 } from '@shared/contexts/useWeb3'
+import { useYearn } from '@shared/contexts/useYearn'
+import { useTokenList } from '@shared/contexts/WithTokenList'
+import { cl, formatTAmount, toAddress } from '@shared/utils'
+import { formatUSD } from '@shared/utils/format'
+import { getNetwork } from '@shared/utils/wagmi'
+import { type ReactElement, useMemo, useState } from 'react'
+import { type Address, zeroAddress } from 'viem'
+import { env } from '@/env'
+import { MAJOR_SWAP_TOKENS, SWAP_CHAIN_IDS } from './constants'
+import { getSwapWalletAssets } from './walletAssets'
+
+type TSwapWalletPanelProps = {
+  onSelectToken: (address: Address, chainId: number) => void
+}
+
+export function SwapWalletPanel({ onSelectToken }: TSwapWalletPanelProps): ReactElement {
+  const { address: account, openLoginModal } = useWeb3()
+  const { balances } = useWalletTokens()
+  const { isLoading } = useWalletStatus()
+  const { allVaults, isLoadingVaultList } = useYearn()
+  const { tokenLists } = useTokenList()
+  const [search, setSearch] = useState('')
+  const [showUnverified, setShowUnverified] = useState(false)
+
+  const vaultAddressesByChain = useMemo(
+    () =>
+      Object.fromEntries(
+        SWAP_CHAIN_IDS.map((chainId) => [
+          chainId,
+          new Set(
+            Object.values(allVaults)
+              .filter((vault) => getVaultChainID(vault) === chainId && !getVaultInfo(vault).isHidden)
+              .map((vault) => toAddress(getVaultAddress(vault)).toLowerCase())
+          )
+        ])
+      ) as Record<number, Set<string>>,
+    [allVaults]
+  )
+  const hiddenVaultAddressesByChain = useMemo(
+    () =>
+      Object.fromEntries(
+        SWAP_CHAIN_IDS.map((chainId) => {
+          const addresses = Object.values(allVaults).flatMap((vault) => {
+            if (getVaultChainID(vault) !== chainId || !getVaultInfo(vault).isHidden) {
+              return []
+            }
+
+            const hiddenAddresses = [toAddress(getVaultAddress(vault)).toLowerCase()]
+            const stakingAddress = getVaultStakingAddress(vault)
+            if (stakingAddress !== zeroAddress) {
+              hiddenAddresses.push(stakingAddress.toLowerCase())
+            }
+            return hiddenAddresses
+          })
+          return [chainId, new Set(addresses)]
+        })
+      ) as Record<number, Set<string>>,
+    [allVaults]
+  )
+
+  const assetsByChain = useMemo(
+    () =>
+      Object.fromEntries(
+        SWAP_CHAIN_IDS.map((chainId) => {
+          const knownAddresses = new Set(
+            Object.keys(tokenLists[chainId] || {}).map((address) => toAddress(address).toLowerCase())
+          )
+          const majorAddresses = new Set(MAJOR_SWAP_TOKENS[chainId].map((address) => address.toLowerCase()))
+          const yearnAddresses = vaultAddressesByChain[chainId] ?? new Set<string>()
+          const assets = getSwapWalletAssets({
+            tokens: Object.values(balances[chainId] || {}),
+            knownAddresses,
+            majorAddresses,
+            yearnAddresses,
+            excludedAddresses: hiddenVaultAddressesByChain[chainId] ?? new Set<string>(),
+            showUnverified
+          }).filter(({ token }) => {
+            const query = search.trim().toLowerCase()
+            return (
+              !query ||
+              token.symbol.toLowerCase().includes(query) ||
+              token.name.toLowerCase().includes(query) ||
+              token.address.toLowerCase().includes(query)
+            )
+          })
+
+          return [chainId, assets] as const
+        })
+      ),
+    [balances, hiddenVaultAddressesByChain, search, showUnverified, tokenLists, vaultAddressesByChain]
+  )
+
+  const unverifiedCount = useMemo(
+    () =>
+      SWAP_CHAIN_IDS.reduce((count, chainId) => {
+        const knownAddresses = new Set(
+          Object.keys(tokenLists[chainId] || {}).map((address) => toAddress(address).toLowerCase())
+        )
+        const majorAddresses = new Set(MAJOR_SWAP_TOKENS[chainId].map((address) => address.toLowerCase()))
+        const yearnAddresses = vaultAddressesByChain[chainId] ?? new Set<string>()
+        const allAssets = getSwapWalletAssets({
+          tokens: Object.values(balances[chainId] || {}),
+          knownAddresses,
+          majorAddresses,
+          yearnAddresses,
+          excludedAddresses: hiddenVaultAddressesByChain[chainId] ?? new Set<string>(),
+          showUnverified: true
+        })
+        return count + allAssets.filter((asset) => !asset.isVerified).length
+      }, 0),
+    [balances, hiddenVaultAddressesByChain, tokenLists, vaultAddressesByChain]
+  )
+
+  if (!account) {
+    return (
+      <div className="flex min-h-[430px] flex-col items-center justify-center gap-4 p-8 text-center">
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold text-text-primary">Connect to view your wallet</h3>
+          <p className="text-sm text-text-secondary">Balances from supported networks will appear here.</p>
+        </div>
+        <button
+          type="button"
+          onClick={openLoginModal}
+          className="yearn--button--nextgen rounded-md bg-text-primary px-5 py-2.5 text-sm text-surface"
+        >
+          Connect Wallet
+        </button>
+      </div>
+    )
+  }
+
+  const visibleAssetCount = Object.values(assetsByChain).reduce((count, assets) => count + assets.length, 0)
+
+  return (
+    <div className="flex min-h-[430px] flex-col">
+      <div className="space-y-3 border-b border-border p-5">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h3 className="text-base font-semibold text-text-primary">Wallet balances</h3>
+            <p className="text-xs text-text-secondary">Verified assets and Yearn vault shares across all networks.</p>
+          </div>
+          {unverifiedCount > 0 ? (
+            <button
+              type="button"
+              onClick={() => setShowUnverified((current) => !current)}
+              aria-pressed={showUnverified}
+              className={cl(
+                'shrink-0 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors',
+                showUnverified
+                  ? 'border-border bg-surface-secondary text-text-primary'
+                  : 'border-transparent text-text-secondary hover:bg-surface-secondary hover:text-text-primary'
+              )}
+            >
+              {showUnverified ? 'Hide unverified' : `Show unverified (${unverifiedCount})`}
+            </button>
+          ) : null}
+        </div>
+        <input
+          type="search"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search wallet assets"
+          className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-primary outline-none placeholder:text-text-tertiary focus:border-text-secondary"
+        />
+      </div>
+
+      <div className="max-h-[520px] flex-1 overflow-y-auto p-3">
+        {isLoading || isLoadingVaultList ? (
+          <div className="flex min-h-64 items-center justify-center text-sm text-text-secondary">
+            Loading balances...
+          </div>
+        ) : visibleAssetCount === 0 ? (
+          <div className="flex min-h-64 items-center justify-center px-6 text-center text-sm text-text-secondary">
+            {search ? 'No wallet assets match this search.' : 'No verified token balances found.'}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {SWAP_CHAIN_IDS.map((chainId) => {
+              const assets = assetsByChain[chainId] || []
+              if (assets.length === 0) return null
+              const network = getNetwork(chainId)
+
+              return (
+                <section key={chainId} className="space-y-1">
+                  <div className="flex items-center gap-2 px-2 py-1 text-xs font-semibold text-text-secondary">
+                    <ImageWithFallback
+                      src={`${env.NEXT_PUBLIC_BASE_YEARN_ASSETS_URI}/chains/${chainId}/logo.svg`}
+                      alt=""
+                      width={16}
+                      height={16}
+                      className="rounded-full"
+                    />
+                    <span>{network.name}</span>
+                  </div>
+                  {assets.map(({ token, isMajor, isYearn, isVerified }) => {
+                    const logo = getTokenLogoSources({
+                      address: token.address,
+                      chainId,
+                      logoURI: token.logoURI,
+                      size: 32
+                    })
+                    return (
+                      <button
+                        key={`${chainId}-${token.address}`}
+                        type="button"
+                        onClick={() => onSelectToken(toAddress(token.address), chainId)}
+                        className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-surface-secondary"
+                      >
+                        <div className="flex min-w-0 items-center gap-3">
+                          <TokenLogoV2
+                            src={logo.src}
+                            altSrc={logo.altSrc}
+                            tokenSymbol={token.symbol}
+                            tokenName={token.name}
+                            chainId={chainId}
+                            width={32}
+                            height={32}
+                            className="rounded-full"
+                          />
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-1.5">
+                              <span className="truncate text-sm font-semibold text-text-primary">{token.symbol}</span>
+                              {isYearn ? (
+                                <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
+                                  Yearn
+                                </span>
+                              ) : isMajor ? (
+                                <span className="rounded bg-surface-tertiary px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
+                                  Major
+                                </span>
+                              ) : !isVerified ? (
+                                <span className="rounded bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-500">
+                                  Unverified
+                                </span>
+                              ) : null}
+                            </div>
+                            <p className="truncate text-xs text-text-secondary">{token.name}</p>
+                          </div>
+                        </div>
+                        <div className="shrink-0 text-right">
+                          <p className="text-sm font-medium text-text-primary">
+                            {formatTAmount({ value: token.balance.raw, decimals: token.decimals })}
+                          </p>
+                          <p className="text-xs text-text-secondary">
+                            {token.value > 0 ? formatUSD(token.value) : 'Unavailable'}
+                          </p>
+                        </div>
+                      </button>
+                    )
+                  })}
+                </section>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/pages/swap/SwapWalletPanel.tsx
+++ b/src/components/pages/swap/SwapWalletPanel.tsx
@@ -11,7 +11,7 @@ import { useWalletStatus, useWalletTokens } from '@shared/contexts/useWallet'
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { useYearn } from '@shared/contexts/useYearn'
 import { useTokenList } from '@shared/contexts/WithTokenList'
-import { cl, formatTAmount, toAddress } from '@shared/utils'
+import { formatTAmount, toAddress } from '@shared/utils'
 import { formatUSD } from '@shared/utils/format'
 import { getNetwork } from '@shared/utils/wagmi'
 import { type ReactElement, useMemo, useState } from 'react'
@@ -143,29 +143,8 @@ export function SwapWalletPanel({ onSelectToken }: TSwapWalletPanelProps): React
   const visibleAssetCount = Object.values(assetsByChain).reduce((count, assets) => count + assets.length, 0)
 
   return (
-    <div className="flex min-h-[430px] flex-col">
-      <div className="space-y-3 border-b border-border p-5">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <h3 className="text-base font-semibold text-text-primary">Wallet balances</h3>
-            <p className="text-xs text-text-secondary">Verified assets and Yearn vault shares across all networks.</p>
-          </div>
-          {unverifiedCount > 0 ? (
-            <button
-              type="button"
-              onClick={() => setShowUnverified((current) => !current)}
-              aria-pressed={showUnverified}
-              className={cl(
-                'shrink-0 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors',
-                showUnverified
-                  ? 'border-border bg-surface-secondary text-text-primary'
-                  : 'border-transparent text-text-secondary hover:bg-surface-secondary hover:text-text-primary'
-              )}
-            >
-              {showUnverified ? 'Hide unverified' : `Show unverified (${unverifiedCount})`}
-            </button>
-          ) : null}
-        </div>
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="space-y-2 border-b border-border p-5">
         <input
           type="search"
           value={search}
@@ -173,9 +152,19 @@ export function SwapWalletPanel({ onSelectToken }: TSwapWalletPanelProps): React
           placeholder="Search wallet assets"
           className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-primary outline-none placeholder:text-text-tertiary focus:border-text-secondary"
         />
+        <label className="inline-flex min-h-6 cursor-pointer items-center gap-2 text-xs text-text-secondary">
+          <input
+            type="checkbox"
+            checked={showUnverified}
+            disabled={unverifiedCount === 0}
+            onChange={(event) => setShowUnverified(event.target.checked)}
+            className="size-4 cursor-pointer accent-primary disabled:cursor-not-allowed disabled:opacity-50"
+          />
+          <span>Show unverified assets</span>
+        </label>
       </div>
 
-      <div className="max-h-[520px] flex-1 overflow-y-auto p-3">
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
         {isLoading || isLoadingVaultList ? (
           <div className="flex min-h-64 items-center justify-center text-sm text-text-secondary">
             Loading balances...
@@ -203,7 +192,7 @@ export function SwapWalletPanel({ onSelectToken }: TSwapWalletPanelProps): React
                     />
                     <span>{network.name}</span>
                   </div>
-                  {assets.map(({ token, isMajor, isYearn, isVerified }) => {
+                  {assets.map(({ token, isYearn, isVerified }) => {
                     const logo = getTokenLogoSources({
                       address: token.address,
                       chainId,
@@ -233,11 +222,7 @@ export function SwapWalletPanel({ onSelectToken }: TSwapWalletPanelProps): React
                               <span className="truncate text-sm font-semibold text-text-primary">{token.symbol}</span>
                               {isYearn ? (
                                 <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
-                                  Yearn
-                                </span>
-                              ) : isMajor ? (
-                                <span className="rounded bg-surface-tertiary px-1.5 py-0.5 text-[10px] font-medium text-text-secondary">
-                                  Major
+                                  Yearn Vault
                                 </span>
                               ) : !isVerified ? (
                                 <span className="rounded bg-red-500/10 px-1.5 py-0.5 text-[10px] font-medium text-red-500">

--- a/src/components/pages/swap/constants.ts
+++ b/src/components/pages/swap/constants.ts
@@ -1,0 +1,25 @@
+import { DEPOSIT_COMMON_TOKENS_BY_CHAIN } from '@pages/vaults/components/widget/withdraw/constants'
+import { ETH_TOKEN_ADDRESS, toAddress } from '@shared/utils'
+import type { Address } from 'viem'
+
+export const SWAP_CHAIN_IDS = [1, 10, 137, 42161, 8453, 747474] as const
+
+export type TSwapChainId = (typeof SWAP_CHAIN_IDS)[number]
+
+export const DEFAULT_SWAP_FROM_CHAIN_ID: TSwapChainId = 1
+export const DEFAULT_SWAP_TO_CHAIN_ID: TSwapChainId = 1
+export const DEFAULT_SWAP_FROM_TOKEN = toAddress('0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48')
+export const DEFAULT_SWAP_TO_TOKEN = ETH_TOKEN_ADDRESS
+
+export const MAJOR_SWAP_TOKENS: Record<TSwapChainId, Address[]> = {
+  1: [ETH_TOKEN_ADDRESS, ...DEPOSIT_COMMON_TOKENS_BY_CHAIN[1]],
+  10: [ETH_TOKEN_ADDRESS, ...DEPOSIT_COMMON_TOKENS_BY_CHAIN[10]],
+  137: [ETH_TOKEN_ADDRESS, ...DEPOSIT_COMMON_TOKENS_BY_CHAIN[137]],
+  42161: [ETH_TOKEN_ADDRESS, ...DEPOSIT_COMMON_TOKENS_BY_CHAIN[42161]],
+  8453: [ETH_TOKEN_ADDRESS, ...DEPOSIT_COMMON_TOKENS_BY_CHAIN[8453]],
+  747474: [ETH_TOKEN_ADDRESS, ...DEPOSIT_COMMON_TOKENS_BY_CHAIN[747474]]
+}
+
+export function isSwapChainId(value: number): value is TSwapChainId {
+  return SWAP_CHAIN_IDS.includes(value as TSwapChainId)
+}

--- a/src/components/pages/swap/index.test.tsx
+++ b/src/components/pages/swap/index.test.tsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+
+import type { TransactionStep } from '@pages/vaults/components/widget/shared/TransactionOverlay'
+import { ETH_TOKEN_ADDRESS, toNormalizedBN } from '@shared/utils'
+import { act, render, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import SwapPage from './index'
+
+const ACCOUNT = '0x1111111111111111111111111111111111111111' as const
+const USDC = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as const
+const ROUTER = '0x2222222222222222222222222222222222222222' as const
+const TX_HASH = `0x${'a'.repeat(64)}` as const
+
+type TTransactionOverlayProps = {
+  step?: TransactionStep
+  onStepSuccess?: (label: string) => void
+  onBeforeSuccess?: (label: string) => Promise<void>
+  onAllComplete?: () => void
+}
+
+const mocks = vi.hoisted(() => ({
+  routerReplace: vi.fn(),
+  onRefresh: vi.fn(async (_tokens?: unknown[]) => ({})),
+  setInputValue: vi.fn(),
+  refetchAllowance: vi.fn(async () => undefined),
+  getRoute: vi.fn(async () => undefined),
+  resetRoute: vi.fn(),
+  searchParams: '',
+  transactionOverlayProps: undefined as TTransactionOverlayProps | undefined,
+  solverAllowsExecution: false,
+  minExpectedOut: 4_900_000_000_000_000n,
+  ensoOrder: {
+    receiptSuccess: false,
+    txHash: undefined as `0x${string}` | undefined
+  }
+}))
+
+const prepareApprove = {
+  data: { request: { chainId: 1 } },
+  error: null,
+  isError: false,
+  isLoading: false,
+  isSuccess: true,
+  isFetching: false,
+  status: 'success',
+  refetch: vi.fn(async () => undefined)
+} as never
+
+const prepareSwap = {
+  data: { request: { chainId: 1 } },
+  error: null,
+  isError: false,
+  isLoading: false,
+  isSuccess: true,
+  isFetching: false,
+  status: 'success',
+  refetch: vi.fn(async () => undefined)
+} as never
+
+function token(address: `0x${string}`, chainID: number, symbol: string, decimals: number, raw: bigint) {
+  return {
+    address,
+    chainID,
+    symbol,
+    name: symbol,
+    decimals,
+    value: 10,
+    balance: toNormalizedBN(raw, decimals)
+  }
+}
+
+const usdcToken = token(USDC, 1, 'USDC', 6, 100_000_000n)
+const ethToken = token(ETH_TOKEN_ADDRESS, 1, 'ETH', 18, 2_000_000_000_000_000_000n)
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/swap',
+  useRouter: () => ({ replace: mocks.routerReplace }),
+  useSearchParams: () => new URLSearchParams(mocks.searchParams)
+}))
+
+vi.mock('@shared/contexts/useWeb3', () => ({
+  useWeb3: () => ({ address: ACCOUNT, openLoginModal: vi.fn() })
+}))
+
+vi.mock('@shared/contexts/useWallet', () => ({
+  useWalletActions: () => ({ onRefresh: mocks.onRefresh }),
+  useWalletTokens: () => ({
+    balances: { 1: { [USDC]: usdcToken, [ETH_TOKEN_ADDRESS]: ethToken } },
+    getToken: ({ address, chainID }: { address: `0x${string}`; chainID: number }) =>
+      address.toLowerCase() === USDC.toLowerCase()
+        ? token(USDC, chainID, 'USDC', 6, 100_000_000n)
+        : token(address, chainID, 'ETH', 18, 2_000_000_000_000_000_000n)
+  })
+}))
+
+vi.mock('@shared/contexts/useYearn', () => ({
+  useYearn: () => ({ allVaults: {}, isLoadingVaultList: false, zapSlippage: 1 })
+}))
+
+vi.mock('@shared/contexts/WithTokenList', () => ({
+  useTokenList: () => ({
+    getToken: ({ address, chainID }: { address: `0x${string}`; chainID: number }) =>
+      address.toLowerCase() === USDC.toLowerCase()
+        ? token(USDC, chainID, 'USDC', 6, 0n)
+        : token(address, chainID, 'ETH', 18, 0n)
+  })
+}))
+
+vi.mock('@shared/hooks/useYearnSpotPrices', () => ({
+  useYearnSpotPrices: () => ({ getPrice: () => toNormalizedBN(1_000_000n, 6) })
+}))
+
+vi.mock('@pages/vaults/hooks/useTokens', () => ({
+  fetchTokenData: vi.fn(async () => []),
+  useTokens: () => ({ tokens: [], isLoading: false, refetch: vi.fn() })
+}))
+
+vi.mock('@pages/vaults/hooks/useDebouncedInput', () => ({
+  useDebouncedInput: () => [
+    {
+      bn: 10_000_000n,
+      debouncedBn: 10_000_000n,
+      debouncedSimple: 10,
+      isDebouncing: false
+    },
+    '',
+    mocks.setInputValue
+  ]
+}))
+
+vi.mock('@pages/vaults/hooks/useEnsoEnabled', () => ({ useEnsoEnabled: () => true }))
+
+vi.mock('@pages/vaults/hooks/solvers/useSolverEnso', () => ({
+  useSolverEnso: () => ({
+    actions: { prepareApprove },
+    methods: { getRoute: mocks.getRoute, resetRoute: mocks.resetRoute },
+    periphery: {
+      allowance: mocks.solverAllowsExecution ? 10_000_000n : 0n,
+      approvalWarning: undefined,
+      error: undefined,
+      expectedOut: toNormalizedBN(5_000_000_000_000_000n, 18),
+      minExpectedOut: toNormalizedBN(mocks.minExpectedOut, 18),
+      isAllowanceSufficient: mocks.solverAllowsExecution,
+      isLoadingAllowance: false,
+      isLoadingRoute: false,
+      needsAllowanceResetBeforeApproval: false,
+      prepareApproveEnabled: true,
+      priceImpact: 10,
+      refetchAllowance: mocks.refetchAllowance,
+      route: {
+        tx: {
+          chainId: 1,
+          data: '0x',
+          from: ACCOUNT,
+          to: ROUTER,
+          value: '0'
+        }
+      },
+      routerAddress: ROUTER
+    }
+  })
+}))
+
+vi.mock('@pages/vaults/hooks/useEnsoOrder', () => ({
+  useEnsoOrder: () => ({ prepareEnsoOrder: prepareSwap, ...mocks.ensoOrder })
+}))
+
+vi.mock('@pages/vaults/components/widget/shared/useProtectedEnsoQuoteState', () => ({
+  useProtectedEnsoQuoteState: (params: { display: { expectedOut: bigint; minExpectedOut: bigint }; tx?: unknown }) => ({
+    display: params.display,
+    executableTx: params.tx,
+    estimatedPriceImpactPercentage: 0.1,
+    hasUnpricedQuoteError: false,
+    isDisplayLoading: false,
+    isPreparing: false,
+    priceImpactInfo: { isAboveTolerance: false, isBlocking: false },
+    worstCaseRouteImpactPercentage: 0.2
+  })
+}))
+
+vi.mock('@pages/vaults/components/widget/shared/TransactionOverlay', () => ({
+  TransactionOverlay: (props: TTransactionOverlayProps) => {
+    mocks.transactionOverlayProps = props
+    return <div data-testid="transaction-overlay" />
+  }
+}))
+
+vi.mock('@pages/vaults/components/widget/InputTokenAmount', () => ({
+  InputTokenAmount: () => <div data-testid="input-token" />
+}))
+vi.mock('@pages/vaults/components/widget/SettingsPanel', () => ({ SettingsPanel: () => null }))
+vi.mock('@pages/vaults/components/widget/deposit/ApprovalOverlay', () => ({ ApprovalOverlay: () => null }))
+vi.mock('@pages/vaults/components/widget/deposit/ApprovalResetWarning', () => ({
+  ApprovalResetWarning: () => null
+}))
+vi.mock('@pages/vaults/components/widget/shared/PriceImpactWarning', () => ({ PriceImpactWarning: () => null }))
+vi.mock('@pages/vaults/components/widget/shared/TokenSelectorOverlay', () => ({ TokenSelectorOverlay: () => null }))
+vi.mock('@shared/components/TokenLogoV2', () => ({ TokenLogoV2: () => null }))
+vi.mock('@shared/components/Button', () => ({
+  Button: ({ children, onClick, disabled }: { children: ReactNode; onClick?: () => void; disabled?: boolean }) => (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  )
+}))
+vi.mock('./SwapVaultDetails', () => ({ SwapVaultAnnualReturnRow: () => null, SwapVaultWorthRow: () => null }))
+vi.mock('./SwapWalletPanel', () => ({ SwapWalletPanel: () => <div data-testid="wallet-panel" /> }))
+vi.mock('wagmi', () => ({ useConfig: () => ({}) }))
+
+describe('SwapPage orchestration', () => {
+  beforeEach(() => {
+    mocks.routerReplace.mockClear()
+    mocks.onRefresh.mockClear()
+    mocks.setInputValue.mockClear()
+    mocks.refetchAllowance.mockClear()
+    mocks.getRoute.mockClear()
+    mocks.resetRoute.mockClear()
+    mocks.searchParams = ''
+    mocks.transactionOverlayProps = undefined
+    mocks.solverAllowsExecution = false
+    mocks.minExpectedOut = 4_900_000_000_000_000n
+    mocks.ensoOrder.receiptSuccess = false
+    mocks.ensoOrder.txHash = undefined
+  })
+
+  it('canonicalizes the route and advances approval into a refreshable swap step', async () => {
+    const view = render(<SwapPage />)
+
+    await waitFor(() => expect(mocks.routerReplace).toHaveBeenCalled())
+    expect(mocks.transactionOverlayProps?.step?.label).toBe('Approve')
+    expect(mocks.transactionOverlayProps?.step?.completesFlow).toBe(false)
+
+    act(() => {
+      mocks.transactionOverlayProps?.onStepSuccess?.('Approve')
+    })
+    expect(mocks.refetchAllowance).toHaveBeenCalledTimes(1)
+
+    mocks.solverAllowsExecution = true
+    view.rerender(<SwapPage />)
+
+    expect(mocks.transactionOverlayProps?.step?.label).toBe('Swap')
+    expect(mocks.transactionOverlayProps?.step?.notification?.toAmountType).toBe('expected')
+    expect(mocks.transactionOverlayProps?.step?.successMessage).toContain('Expected output:')
+
+    await act(async () => {
+      await mocks.transactionOverlayProps?.onBeforeSuccess?.('Swap')
+    })
+    expect(mocks.onRefresh).toHaveBeenCalledWith([
+      expect.objectContaining({ address: USDC, chainID: 1 }),
+      expect.objectContaining({ address: ETH_TOKEN_ADDRESS, chainID: 1 })
+    ])
+
+    act(() => {
+      mocks.transactionOverlayProps?.onAllComplete?.()
+    })
+    expect(mocks.setInputValue).toHaveBeenCalledWith('')
+  })
+
+  it('refreshes only the original source asset after a cross-chain source receipt', async () => {
+    mocks.searchParams = `fromChain=1&from=${USDC}&toChain=10&to=${ETH_TOKEN_ADDRESS}`
+    mocks.solverAllowsExecution = true
+    mocks.ensoOrder.txHash = TX_HASH
+
+    const view = render(<SwapPage />)
+
+    expect(mocks.transactionOverlayProps?.onBeforeSuccess).toBeUndefined()
+    expect(mocks.onRefresh).not.toHaveBeenCalled()
+
+    mocks.searchParams = ''
+    view.rerender(<SwapPage />)
+    mocks.ensoOrder.receiptSuccess = true
+    view.rerender(<SwapPage />)
+
+    await waitFor(() =>
+      expect(mocks.onRefresh).toHaveBeenCalledWith([expect.objectContaining({ address: USDC, chainID: 1 })])
+    )
+    expect(mocks.onRefresh.mock.calls[0]?.[0]).toHaveLength(1)
+  })
+
+  it('does not expose an executable swap step when the route has no minimum output', () => {
+    mocks.solverAllowsExecution = true
+    mocks.minExpectedOut = 0n
+
+    const view = render(<SwapPage />)
+
+    expect(mocks.transactionOverlayProps?.step?.label).toBe('Swap')
+    expect(mocks.transactionOverlayProps?.step?.isEnabled).toBe(false)
+    expect(view.getByText('This route has no enforceable minimum output, so execution is blocked.')).toBeTruthy()
+    expect(view.getByRole('button', { name: 'Route unavailable' }).hasAttribute('disabled')).toBe(true)
+  })
+})

--- a/src/components/pages/swap/index.tsx
+++ b/src/components/pages/swap/index.tsx
@@ -1,36 +1,43 @@
 'use client'
 
+import { ApprovalOverlay } from '@pages/vaults/components/widget/deposit/ApprovalOverlay'
 import { InputTokenAmount } from '@pages/vaults/components/widget/InputTokenAmount'
 import { SettingsPanel } from '@pages/vaults/components/widget/SettingsPanel'
 import { PriceImpactWarning } from '@pages/vaults/components/widget/shared/PriceImpactWarning'
 import { TokenSelectorOverlay } from '@pages/vaults/components/widget/shared/TokenSelectorOverlay'
 import { TransactionOverlay, type TransactionStep } from '@pages/vaults/components/widget/shared/TransactionOverlay'
 import { useProtectedEnsoQuoteState } from '@pages/vaults/components/widget/shared/useProtectedEnsoQuoteState'
-import { formatWidgetPreciseValue } from '@pages/vaults/components/widget/shared/valueDisplay'
+import { formatWidgetAllowance, formatWidgetPreciseValue } from '@pages/vaults/components/widget/shared/valueDisplay'
 import { getTokenLogoSources } from '@pages/vaults/components/widget/tokenLogo.utils'
 import {
   getVaultAddress,
+  getVaultAPR,
   getVaultChainID,
   getVaultDecimals,
   getVaultInfo,
   getVaultName,
-  getVaultSymbol
+  getVaultSymbol,
+  getVaultToken,
+  getVaultTVL
 } from '@pages/vaults/domain/kongVaultSelectors'
 import { useSolverEnso } from '@pages/vaults/hooks/solvers/useSolverEnso'
 import { useDebouncedInput } from '@pages/vaults/hooks/useDebouncedInput'
 import { useEnsoEnabled } from '@pages/vaults/hooks/useEnsoEnabled'
 import { useEnsoOrder } from '@pages/vaults/hooks/useEnsoOrder'
 import { fetchTokenData, useTokens } from '@pages/vaults/hooks/useTokens'
+import { getKnownEnsoRouterAddress } from '@pages/vaults/utils/ensoRouters'
 import { Button } from '@shared/components/Button'
 import { TokenLogoV2 } from '@shared/components/TokenLogoV2'
 import { useWalletActions, useWalletTokens } from '@shared/contexts/useWallet'
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { useYearn } from '@shared/contexts/useYearn'
 import { useTokenList } from '@shared/contexts/WithTokenList'
+import { useYearnSpotPrices } from '@shared/hooks/useYearnSpotPrices'
 import { IconSettings } from '@shared/icons/IconSettings'
 import type { TToken } from '@shared/types'
 import type { TCreateNotificationParams } from '@shared/types/notifications'
 import { cl, ETH_TOKEN_ADDRESS, formatTAmount, toAddress, toNormalizedBN } from '@shared/utils'
+import { requiresAllowanceResetBeforeApproval } from '@shared/utils/approve'
 import { formatUSD } from '@shared/utils/format'
 import { toBasisPoints } from '@shared/utils/slippage'
 import { getNetwork } from '@shared/utils/wagmi'
@@ -40,8 +47,11 @@ import { type Address, formatUnits, isAddressEqual } from 'viem'
 import { useConfig } from 'wagmi'
 import { resolveExecutionChainId } from '@/config/tenderly'
 import { isSwapChainId, MAJOR_SWAP_TOKENS } from './constants'
+import { SwapVaultAnnualReturnRow, SwapVaultWorthRow } from './SwapVaultDetails'
 import { SwapWalletPanel } from './SwapWalletPanel'
 import { buildSwapSearchParams, parseSwapSelection, type TSwapSelection } from './swapParams'
+import { resolveSwapTokenPrice } from './swapTokenPrice'
+import { getSwapVaultEstimate } from './swapVaultEstimate'
 
 type TSwapTab = 'swap' | 'wallet'
 type TSelectorTarget = 'from' | 'to' | null
@@ -50,25 +60,40 @@ function useResolvedSwapToken(address: Address, chainId: number): { token: TToke
   const { address: account } = useWeb3()
   const { balances, getToken: getWalletToken } = useWalletTokens()
   const { getToken: getListedToken } = useTokenList()
-  const { allVaults, getPrice } = useYearn()
+  const { allVaults } = useYearn()
   const isNative = isAddressEqual(address, ETH_TOKEN_ADDRESS)
-  const { tokens } = useTokens([isNative ? undefined : address], chainId, account)
-  const rpcToken = tokens[0]
   const normalizedAddress = toAddress(address)
-  const walletToken = balances[chainId]?.[normalizedAddress] ?? getWalletToken({ address, chainID: chainId })
-  const listedToken = getListedToken({ address, chainID: chainId })
   const vault = Object.values(allVaults).find(
     (candidate) =>
       getVaultChainID(candidate) === chainId &&
       !getVaultInfo(candidate).isHidden &&
       isAddressEqual(toAddress(getVaultAddress(candidate)), normalizedAddress)
   )
+  const vaultUnderlying = vault ? getVaultToken(vault) : undefined
+  const { getPrice } = useYearnSpotPrices([
+    { address: normalizedAddress, chainID: chainId },
+    vaultUnderlying ? { address: vaultUnderlying.address, chainID: chainId } : undefined
+  ])
+  const { tokens } = useTokens([isNative ? undefined : address], chainId, account)
+  const rpcToken = tokens[0]
+  const walletToken = balances[chainId]?.[normalizedAddress] ?? getWalletToken({ address, chainID: chainId })
+  const listedToken = getListedToken({ address, chainID: chainId })
   const network = getNetwork(chainId)
-  const price = getPrice({ address: normalizedAddress, chainID: chainId }).normalized
   const balance =
     walletToken.address && isAddressEqual(walletToken.address, normalizedAddress)
       ? walletToken.balance
       : toNormalizedBN(0n, rpcToken?.decimals ?? (isNative ? network.nativeCurrency.decimals : 18))
+  const vaultApr = vault ? getVaultAPR(vault) : undefined
+  const price = resolveSwapTokenPrice({
+    contextPrice: getPrice({ address: normalizedAddress, chainID: chainId }).normalized,
+    walletValue: walletToken.value,
+    walletBalance: walletToken.balance.normalized,
+    vaultUnderlyingPrice:
+      vault && vaultUnderlying
+        ? getPrice({ address: vaultUnderlying.address, chainID: chainId }).normalized || getVaultTVL(vault).price
+        : undefined,
+    vaultPricePerShare: vaultApr?.pricePerShare.today
+  })
   const nativeToken: TToken | undefined = isNative
     ? {
         address: ETH_TOKEN_ADDRESS,
@@ -210,15 +235,43 @@ export default function SwapPage(): ReactElement {
   const [activeTab, setActiveTab] = useState<TSwapTab>('swap')
   const [selectorTarget, setSelectorTarget] = useState<TSelectorTarget>(null)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [isApprovalOpen, setIsApprovalOpen] = useState(false)
   const [customRecipient, setCustomRecipient] = useState<Address | undefined>()
   const [requestedSlippage, setRequestedSlippage] = useState(0)
   const { address: account, openLoginModal } = useWeb3()
   const wagmiConfig = useConfig()
   const { onRefresh } = useWalletActions()
-  const { zapSlippage } = useYearn()
+  const { allVaults, zapSlippage } = useYearn()
   const ensoEnabled = useEnsoEnabled()
   const { token: fromToken, price: fromTokenPrice } = useResolvedSwapToken(selection.fromToken, selection.fromChainId)
   const { token: toToken, price: toTokenPrice } = useResolvedSwapToken(selection.toToken, selection.toChainId)
+  const destinationVault = useMemo(
+    () =>
+      Object.values(allVaults).find(
+        (vault) =>
+          getVaultChainID(vault) === selection.toChainId &&
+          !getVaultInfo(vault).isHidden &&
+          !getVaultInfo(vault).isRetired &&
+          isAddressEqual(toAddress(getVaultAddress(vault)), selection.toToken)
+      ),
+    [allVaults, selection.toChainId, selection.toToken]
+  )
+  const destinationVaultMetadata = useMemo(() => {
+    if (!destinationVault) return undefined
+
+    const apr = getVaultAPR(destinationVault)
+    const underlying = getVaultToken(destinationVault)
+    const vaultTvlPrice = getVaultTVL(destinationVault).price
+    const underlyingPrice =
+      toTokenPrice > 0 && apr.pricePerShare.today > 0 ? toTokenPrice / apr.pricePerShare.today : vaultTvlPrice
+
+    return {
+      annualRate: apr.forwardAPR.type ? apr.forwardAPR.netAPR : undefined,
+      pricePerShare: apr.pricePerShare.today,
+      underlyingPrice: underlyingPrice > 0 ? underlyingPrice : undefined,
+      underlyingSymbol: underlying.symbol
+    }
+  }, [destinationVault, toTokenPrice])
   const input = useDebouncedInput(fromToken.decimals)
   const [inputValue, , setInputValue] = input
   const receiver = customRecipient ?? account
@@ -270,6 +323,7 @@ export default function SwapPage(): ReactElement {
 
   useEffect(() => {
     setRequestedSlippage(0)
+    setIsApprovalOpen(false)
   }, [routeKey])
 
   const solver = useSolverEnso({
@@ -307,6 +361,20 @@ export default function SwapPage(): ReactElement {
 
   const expectedOut = solver.periphery.expectedOut.raw
   const minExpectedOut = solver.periphery.minExpectedOut.raw
+  const destinationVaultEstimate = useMemo(
+    () =>
+      destinationVaultMetadata
+        ? getSwapVaultEstimate({
+            expectedShares: expectedOut,
+            minimumShares: minExpectedOut,
+            shareDecimals: toToken.decimals,
+            pricePerShare: destinationVaultMetadata.pricePerShare,
+            underlyingPrice: destinationVaultMetadata.underlyingPrice,
+            annualRate: destinationVaultMetadata.annualRate
+          })
+        : undefined,
+    [destinationVaultMetadata, expectedOut, minExpectedOut, toToken.decimals]
+  )
   const inputUsd = inputValue.debouncedSimple * fromTokenPrice
   const expectedOutUsd = Number(formatUnits(expectedOut, toToken.decimals)) * toTokenPrice
   const minExpectedOutUsd = Number(formatUnits(minExpectedOut, toToken.decimals)) * toTokenPrice
@@ -359,6 +427,11 @@ export default function SwapPage(): ReactElement {
   })
   const isCrossChain = selection.fromChainId !== selection.toChainId
   const needsApproval = !solver.periphery.isAllowanceSufficient
+  const isNativeInput = isAddressEqual(fromToken.address, ETH_TOKEN_ADDRESS)
+  const approvalSpenderAddress = solver.periphery.approvalWarning
+    ? undefined
+    : (solver.periphery.routerAddress ?? getKnownEnsoRouterAddress(selection.fromChainId))
+  const allowanceDisplay = formatWidgetAllowance(solver.periphery.allowance, fromToken.decimals) ?? '0'
 
   const approveNotification = useMemo<TCreateNotificationParams | undefined>(
     () =>
@@ -554,7 +627,7 @@ export default function SwapPage(): ReactElement {
         </div>
 
         {activeTab === 'wallet' ? (
-          <div id="swap-wallet-panel" role="tabpanel" aria-labelledby="swap-wallet-tab">
+          <div id="swap-wallet-panel" role="tabpanel" aria-labelledby="swap-wallet-tab" className="h-[600px]">
             <SwapWalletPanel
               onSelectToken={(address, chainId) => {
                 if (!isSwapChainId(chainId)) return
@@ -564,8 +637,13 @@ export default function SwapPage(): ReactElement {
             />
           </div>
         ) : (
-          <div id="swap-swap-panel" role="tabpanel" aria-labelledby="swap-swap-tab" className="relative">
-            <div className="flex items-center justify-between px-6 pt-4">
+          <div
+            id="swap-swap-panel"
+            role="tabpanel"
+            aria-labelledby="swap-swap-tab"
+            className="relative flex h-[600px] flex-col overflow-y-auto"
+          >
+            <div className="flex shrink-0 items-center justify-between px-6 pt-4">
               <div>
                 <h1 className="text-base font-semibold text-text-primary">Swap</h1>
                 <p className="text-xs text-text-secondary">Best available route, powered by Enso.</p>
@@ -574,7 +652,7 @@ export default function SwapPage(): ReactElement {
                 <span className="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">Cross-chain</span>
               ) : null}
             </div>
-            <div className="flex flex-col gap-3 p-6 pt-3">
+            <div className="flex min-h-0 flex-1 flex-col gap-3 p-6 pt-3">
               <InputTokenAmount
                 input={input}
                 title="You pay"
@@ -618,7 +696,7 @@ export default function SwapPage(): ReactElement {
                 tokenPrice={toTokenPrice}
               />
 
-              <div className="space-y-2 border-t border-border pt-3">
+              <div className="min-h-[201px] space-y-2 border-t border-border pt-3">
                 <DetailRow
                   label="Minimum received"
                   value={
@@ -627,6 +705,13 @@ export default function SwapPage(): ReactElement {
                       : 'Unavailable'
                   }
                 />
+                {destinationVaultEstimate && destinationVaultMetadata ? (
+                  <SwapVaultWorthRow
+                    estimate={destinationVaultEstimate}
+                    underlyingSymbol={destinationVaultMetadata.underlyingSymbol}
+                    isLoading={protectedQuote.isDisplayLoading}
+                  />
+                ) : null}
                 <DetailRow
                   label="Est. / Worst price impact"
                   value={
@@ -635,12 +720,48 @@ export default function SwapPage(): ReactElement {
                       : 'Unavailable'
                   }
                 />
+                {destinationVaultEstimate && destinationVaultMetadata ? (
+                  <SwapVaultAnnualReturnRow
+                    estimate={destinationVaultEstimate}
+                    underlyingSymbol={destinationVaultMetadata.underlyingSymbol}
+                    annualRate={destinationVaultMetadata.annualRate}
+                    isLoading={protectedQuote.isDisplayLoading}
+                  />
+                ) : null}
                 <DetailRow label="Routing" value="Enso" />
                 {customRecipient ? (
                   <DetailRow
                     label="Recipient"
                     value={`${customRecipient.slice(0, 6)}...${customRecipient.slice(-4)}`}
                   />
+                ) : null}
+                {account && !isNativeInput && approvalSpenderAddress ? (
+                  <div className="flex items-start justify-between gap-4 text-sm">
+                    <button
+                      type="button"
+                      onClick={() => setIsApprovalOpen(true)}
+                      className="yearn--link-dots text-left text-text-secondary transition-colors hover:text-text-primary"
+                    >
+                      Existing Approval (Enso Router)
+                    </button>
+                    {solver.periphery.isLoadingAllowance ? (
+                      <span className="inline-block h-4 w-20 animate-pulse rounded bg-surface-secondary" />
+                    ) : solver.periphery.allowance > 0n && allowanceDisplay !== 'Unlimited' ? (
+                      <button
+                        type="button"
+                        onClick={() => setInputValue(formatUnits(solver.periphery.allowance, fromToken.decimals))}
+                        className="text-right font-semibold text-text-primary transition-colors hover:text-primary"
+                      >
+                        {allowanceDisplay} {fromToken.symbol}
+                      </button>
+                    ) : (
+                      <span className="text-right font-semibold text-text-primary">
+                        {allowanceDisplay === 'Unlimited'
+                          ? allowanceDisplay
+                          : `${allowanceDisplay} ${fromToken.symbol}`}
+                      </span>
+                    )}
+                  </div>
                 ) : null}
               </div>
 
@@ -669,7 +790,7 @@ export default function SwapPage(): ReactElement {
                 </p>
               ) : null}
 
-              <div className="flex items-center gap-2">
+              <div className="mt-auto flex items-center gap-2">
                 <div className="flex-1">
                   {!account ? (
                     <Button
@@ -734,25 +855,47 @@ export default function SwapPage(): ReactElement {
             resolveCustomToken={resolveCustomToken}
           />
         ) : null}
-      </div>
 
-      <TransactionOverlay
-        isOpen={isTransactionOpen}
-        onClose={() => setIsTransactionOpen(false)}
-        step={currentStep}
-        isLastStep={!needsApproval}
-        autoContinueToNextStep
-        autoContinueStepLabels={['Approve']}
-        onStepSuccess={(label) => {
-          if (label === 'Approve') void solver.periphery.refetchAllowance()
-        }}
-        onBeforeSuccess={async () => {
-          await onRefresh()
-        }}
-        onAllComplete={() => {
-          setInputValue('')
-        }}
-      />
+        {approvalSpenderAddress && !isNativeInput ? (
+          <ApprovalOverlay
+            isOpen={isApprovalOpen}
+            onClose={() => setIsApprovalOpen(false)}
+            onDone={async () => {
+              await solver.periphery.refetchAllowance()
+            }}
+            disableSetUnlimited={
+              solver.periphery.allowance > 0n && requiresAllowanceResetBeforeApproval(fromToken.address)
+            }
+            tokenSymbol={fromToken.symbol}
+            tokenAddress={toAddress(fromToken.address)}
+            tokenDecimals={fromToken.decimals}
+            spenderAddress={approvalSpenderAddress}
+            spenderName="Enso Router"
+            chainId={selection.fromChainId}
+            currentAllowance={allowanceDisplay}
+            approvalWarning={solver.periphery.approvalWarning}
+            actionLabel="swapping"
+          />
+        ) : null}
+
+        <TransactionOverlay
+          isOpen={isTransactionOpen}
+          onClose={() => setIsTransactionOpen(false)}
+          step={currentStep}
+          isLastStep={!needsApproval}
+          autoContinueToNextStep
+          autoContinueStepLabels={['Approve']}
+          onStepSuccess={(label) => {
+            if (label === 'Approve') void solver.periphery.refetchAllowance()
+          }}
+          onBeforeSuccess={async () => {
+            await onRefresh()
+          }}
+          onAllComplete={() => {
+            setInputValue('')
+          }}
+        />
+      </div>
     </div>
   )
 }

--- a/src/components/pages/swap/index.tsx
+++ b/src/components/pages/swap/index.tsx
@@ -38,14 +38,14 @@ import { useYearnSpotPrices } from '@shared/hooks/useYearnSpotPrices'
 import { IconSettings } from '@shared/icons/IconSettings'
 import type { TToken } from '@shared/types'
 import type { TCreateNotificationParams } from '@shared/types/notifications'
-import { cl, ETH_TOKEN_ADDRESS, formatTAmount, toAddress, toNormalizedBN } from '@shared/utils'
+import { cl, ETH_TOKEN_ADDRESS, formatTAmount, toAddress } from '@shared/utils'
 import { requiresAllowanceResetBeforeApproval } from '@shared/utils/approve'
 import { formatUSD } from '@shared/utils/format'
 import { toBasisPoints } from '@shared/utils/slippage'
 import { getNetwork } from '@shared/utils/wagmi'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { type ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
-import { type Address, formatUnits, isAddressEqual } from 'viem'
+import { type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type Address, formatUnits, type Hash, isAddressEqual } from 'viem'
 import { useConfig } from 'wagmi'
 import { resolveExecutionChainId } from '@/config/tenderly'
 import { isSwapChainId, MAJOR_SWAP_TOKENS } from './constants'
@@ -54,6 +54,12 @@ import { SwapWalletPanel } from './SwapWalletPanel'
 import { buildSwapSearchParams, parseSwapSelection, type TSwapSelection } from './swapParams'
 import { buildSwapVaultPolicyEntries, getSwapSelectionPolicy } from './swapPolicy'
 import { resolveSwapTokenPrice } from './swapTokenPrice'
+import {
+  getSwapSuccessMessage,
+  getSwapWorstCaseImpact,
+  hasExecutableSwapMinimum,
+  resolveSwapTokenBalance
+} from './swapTransaction'
 import { getSwapVaultEstimate } from './swapVaultEstimate'
 
 type TSwapTab = 'swap' | 'wallet'
@@ -79,13 +85,17 @@ function useResolvedSwapToken(address: Address, chainId: number): { token: TToke
   ])
   const { tokens } = useTokens([isNative ? undefined : address], chainId, account)
   const rpcToken = tokens[0]
-  const walletToken = balances[chainId]?.[normalizedAddress] ?? getWalletToken({ address, chainID: chainId })
+  const walletBalanceToken = balances[chainId]?.[normalizedAddress]
+  const walletToken = walletBalanceToken ?? getWalletToken({ address, chainID: chainId })
   const listedToken = getListedToken({ address, chainID: chainId })
   const network = getNetwork(chainId)
-  const balance =
-    walletToken.address && isAddressEqual(walletToken.address, normalizedAddress)
-      ? walletToken.balance
-      : toNormalizedBN(0n, rpcToken?.decimals ?? (isNative ? network.nativeCurrency.decimals : 18))
+  const balance = resolveSwapTokenBalance({
+    address: normalizedAddress,
+    walletBalanceToken,
+    rpcToken,
+    fallbackWalletToken: walletToken,
+    fallbackDecimals: isNative ? network.nativeCurrency.decimals : 18
+  })
   const vaultApr = vault ? getVaultAPR(vault) : undefined
   const price = resolveSwapTokenPrice({
     contextPrice: getPrice({ address: normalizedAddress, chainID: chainId }).normalized,
@@ -312,6 +322,7 @@ export default function SwapPage(): ReactElement {
   const input = useDebouncedInput(fromToken.decimals)
   const [inputValue, , setInputValue] = input
   const receiver = customRecipient ?? account
+  const isCrossChain = selection.fromChainId !== selection.toChainId
   const isSameToken =
     selection.fromChainId === selection.toChainId && isAddressEqual(selection.fromToken, selection.toToken)
   const routeKey = [
@@ -448,8 +459,8 @@ export default function SwapPage(): ReactElement {
   const minExpectedOutUsd = Number(formatUnits(minExpectedOut, toToken.decimals)) * toTokenPrice
   const localPriceImpact =
     inputUsd > 0 && expectedOutUsd > 0 ? Math.max(0, ((inputUsd - expectedOutUsd) / inputUsd) * 100) : 0
-  const localWorstCaseImpact =
-    inputUsd > 0 && minExpectedOutUsd > 0 ? Math.max(0, ((inputUsd - minExpectedOutUsd) / inputUsd) * 100) : 0
+  const localWorstCaseImpact = getSwapWorstCaseImpact({ inputUsd, expectedOutUsd, minExpectedOutUsd })
+  const hasSafeMinimumOutput = hasExecutableSwapMinimum(expectedOut, minExpectedOut)
   const protectedQuote = useProtectedEnsoQuoteState({
     stateKey: routeKey,
     isEnsoRoute: true,
@@ -464,7 +475,7 @@ export default function SwapPage(): ReactElement {
     ensoPriceImpact: solver.periphery.priceImpact,
     expectedOut,
     minExpectedOut,
-    tx: solver.periphery.route?.tx,
+    tx: hasSafeMinimumOutput ? solver.periphery.route?.tx : undefined,
     display: { expectedOut, minExpectedOut }
   })
   const getProtectedTransaction = useCallback(
@@ -477,23 +488,64 @@ export default function SwapPage(): ReactElement {
         : undefined,
     [protectedQuote.executableTx, selection.fromChainId, solver.periphery.route?.tx.chainId]
   )
-  const { prepareEnsoOrder } = useEnsoOrder({
+  const {
+    prepareEnsoOrder,
+    receiptSuccess: ensoReceiptSuccess,
+    txHash: ensoTxHash
+  } = useEnsoOrder({
     getEnsoTransaction: getProtectedTransaction,
     enabled: Boolean(protectedQuote.executableTx && solver.periphery.isAllowanceSufficient),
     chainId: selection.fromChainId
   })
+
+  const crossChainSourceRefreshRef = useRef<
+    | {
+        txHash: Hash
+        token: (typeof swapBalanceRefreshTokens)[number]
+        refreshed: boolean
+      }
+    | undefined
+  >(undefined)
+
+  // Cross-chain completion is external to this page, so refresh only the source asset when its on-chain receipt lands.
+  useEffect(() => {
+    if (!ensoTxHash) {
+      return
+    }
+
+    const existingRefresh =
+      crossChainSourceRefreshRef.current?.txHash === ensoTxHash ? crossChainSourceRefreshRef.current : undefined
+    if (!existingRefresh && !isCrossChain) {
+      return
+    }
+
+    const trackedRefresh = existingRefresh ?? {
+      txHash: ensoTxHash,
+      token: swapBalanceRefreshTokens[0],
+      refreshed: false
+    }
+    crossChainSourceRefreshRef.current = trackedRefresh
+
+    if (!ensoReceiptSuccess || trackedRefresh.refreshed) {
+      return
+    }
+
+    trackedRefresh.refreshed = true
+    void onRefresh([trackedRefresh.token]).catch((error) => {
+      console.error('[SwapPage] Cross-chain source balance refresh failed', error)
+    })
+  }, [ensoReceiptSuccess, ensoTxHash, isCrossChain, onRefresh, swapBalanceRefreshTokens])
 
   const formattedInput = formatTAmount({
     value: inputValue.debouncedBn,
     decimals: fromToken.decimals,
     options: { maximumFractionDigits: 8 }
   })
-  const formattedOutput = formatTAmount({
-    value: minExpectedOut,
+  const formattedExpectedOutput = formatTAmount({
+    value: expectedOut,
     decimals: toToken.decimals,
     options: { maximumFractionDigits: 8 }
   })
-  const isCrossChain = selection.fromChainId !== selection.toChainId
   const needsApproval = !solver.periphery.isAllowanceSufficient
   const inputExceedsBalance = inputValue.bn > fromToken.balance.raw
   const hasSyncedInput = !inputValue.isDebouncing && inputValue.bn === inputValue.debouncedBn
@@ -538,7 +590,8 @@ export default function SwapPage(): ReactElement {
             fromChainId: selection.fromChainId,
             toAddress: selection.toToken,
             toSymbol: toToken.symbol,
-            toAmount: formattedOutput,
+            toAmount: formattedExpectedOutput,
+            toAmountType: 'expected',
             toChainId: isCrossChain ? selection.toChainId : undefined
           }
         : undefined,
@@ -546,7 +599,7 @@ export default function SwapPage(): ReactElement {
       account,
       expectedOut,
       formattedInput,
-      formattedOutput,
+      formattedExpectedOutput,
       fromToken.symbol,
       isCrossChain,
       selection.fromChainId,
@@ -576,9 +629,13 @@ export default function SwapPage(): ReactElement {
       label: 'Swap',
       confirmMessage: `Swapping ${formattedInput} ${fromToken.symbol}`,
       successTitle: isCrossChain ? 'Swap submitted' : 'Swap successful',
-      successMessage: isCrossChain
-        ? `Your cross-chain swap to ${toToken.symbol} has been submitted. It may take a few minutes to arrive.`
-        : `Swapped ${formattedInput} ${fromToken.symbol} for ${formattedOutput} ${toToken.symbol}.`,
+      successMessage: getSwapSuccessMessage({
+        formattedInput,
+        fromSymbol: fromToken.symbol,
+        formattedExpectedOutput,
+        toSymbol: toToken.symbol,
+        isCrossChain
+      }),
       isEnabled: Boolean(protectedQuote.executableTx && prepareEnsoOrder.isSuccess),
       completesFlow: true,
       showConfetti: true,
@@ -587,7 +644,7 @@ export default function SwapPage(): ReactElement {
   }, [
     approveNotification,
     formattedInput,
-    formattedOutput,
+    formattedExpectedOutput,
     fromToken.symbol,
     isCrossChain,
     needsApproval,
@@ -603,6 +660,7 @@ export default function SwapPage(): ReactElement {
   const [isTransactionOpen, setIsTransactionOpen] = useState(false)
   const selectionPolicyError = selectionPolicy.message ?? selectionPolicyNotice
   const isQuoteBlocked =
+    !hasSafeMinimumOutput ||
     protectedQuote.priceImpactInfo.isBlocking ||
     protectedQuote.priceImpactInfo.isAboveTolerance ||
     protectedQuote.hasUnpricedQuoteError
@@ -667,11 +725,15 @@ export default function SwapPage(): ReactElement {
               ? 'Choose different assets'
               : isPreparing
                 ? 'Finding best route'
-                : shouldBlockApprovalForAllowanceReset
-                  ? `Reset ${fromToken.symbol} approval`
-                  : needsApproval
-                    ? `Approve ${fromToken.symbol}`
-                    : 'Swap'
+                : !hasSafeMinimumOutput
+                  ? expectedOut > 0n
+                    ? 'Route unavailable'
+                    : 'Finding best route'
+                  : shouldBlockApprovalForAllowanceReset
+                    ? `Reset ${fromToken.symbol} approval`
+                    : needsApproval
+                      ? `Approve ${fromToken.symbol}`
+                      : 'Swap'
 
   const selectedToken = selectorTarget === 'from' ? selection.fromToken : selection.toToken
   const selectedChainId = selectorTarget === 'from' ? selection.fromChainId : selection.toChainId
@@ -876,6 +938,11 @@ export default function SwapPage(): ReactElement {
                     Price impact cannot be verified for this pair, so execution is blocked.
                   </p>
                 ) : null}
+                {expectedOut > 0n && !hasSafeMinimumOutput ? (
+                  <p className="break-words rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
+                    This route has no enforceable minimum output, so execution is blocked.
+                  </p>
+                ) : null}
                 {routeError ? (
                   <p className="break-words rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
                     {routeError}
@@ -986,9 +1053,13 @@ export default function SwapPage(): ReactElement {
           onStepSuccess={(label) => {
             if (label === 'Approve') void solver.periphery.refetchAllowance()
           }}
-          onBeforeSuccess={async () => {
-            await onRefresh(swapBalanceRefreshTokens)
-          }}
+          onBeforeSuccess={
+            isCrossChain
+              ? undefined
+              : async () => {
+                  await onRefresh(swapBalanceRefreshTokens)
+                }
+          }
           onAllComplete={() => {
             setInputValue('')
           }}

--- a/src/components/pages/swap/index.tsx
+++ b/src/components/pages/swap/index.tsx
@@ -28,6 +28,7 @@ import { useEnsoOrder } from '@pages/vaults/hooks/useEnsoOrder'
 import { fetchTokenData, useTokens } from '@pages/vaults/hooks/useTokens'
 import { getKnownEnsoRouterAddress } from '@pages/vaults/utils/ensoRouters'
 import { Button } from '@shared/components/Button'
+import { OverflowMarqueeText } from '@shared/components/OverflowMarqueeText'
 import { TokenLogoV2 } from '@shared/components/TokenLogoV2'
 import { useWalletActions, useWalletTokens } from '@shared/contexts/useWallet'
 import { useWeb3 } from '@shared/contexts/useWeb3'
@@ -197,7 +198,7 @@ function SwapOutputField({
           onClick={onSelect}
           data-token-selector-button
           title={tokenSelectorTitle}
-          className="flex min-h-11 max-w-[50%] shrink-0 items-center gap-2 overflow-hidden rounded-lg px-2 py-1 text-xl font-medium text-text-primary transition-colors hover:bg-surface-secondary"
+          className="flex min-h-11 max-w-[60%] shrink-0 items-center gap-2 overflow-hidden rounded-lg px-2 py-1 text-xl font-medium text-text-primary transition-colors hover:bg-surface-secondary"
         >
           <TokenLogoV2
             src={logo.src}
@@ -209,7 +210,7 @@ function SwapOutputField({
             height={32}
             className="shrink-0 rounded-full"
           />
-          <span className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap scrollbar-none">{token.symbol}</span>
+          <OverflowMarqueeText>{token.symbol}</OverflowMarqueeText>
           <svg className="size-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m19 9-7 7-7-7" />
           </svg>

--- a/src/components/pages/swap/index.tsx
+++ b/src/components/pages/swap/index.tsx
@@ -251,6 +251,36 @@ export default function SwapPage(): ReactElement {
   const ensoEnabled = useEnsoEnabled()
   const { token: fromToken, price: fromTokenPrice } = useResolvedSwapToken(selection.fromToken, selection.fromChainId)
   const { token: toToken, price: toTokenPrice } = useResolvedSwapToken(selection.toToken, selection.toChainId)
+  const swapBalanceRefreshTokens = useMemo(
+    () => [
+      {
+        address: fromToken.address,
+        chainID: selection.fromChainId,
+        decimals: fromToken.decimals,
+        name: fromToken.name,
+        symbol: fromToken.symbol
+      },
+      {
+        address: toToken.address,
+        chainID: selection.toChainId,
+        decimals: toToken.decimals,
+        name: toToken.name,
+        symbol: toToken.symbol
+      }
+    ],
+    [
+      fromToken.address,
+      fromToken.decimals,
+      fromToken.name,
+      fromToken.symbol,
+      selection.fromChainId,
+      selection.toChainId,
+      toToken.address,
+      toToken.decimals,
+      toToken.name,
+      toToken.symbol
+    ]
+  )
   const destinationVault = useMemo(
     () =>
       Object.values(allVaults).find(
@@ -956,7 +986,7 @@ export default function SwapPage(): ReactElement {
             if (label === 'Approve') void solver.periphery.refetchAllowance()
           }}
           onBeforeSuccess={async () => {
-            await onRefresh()
+            await onRefresh(swapBalanceRefreshTokens)
           }}
           onAllComplete={() => {
             setInputValue('')

--- a/src/components/pages/swap/index.tsx
+++ b/src/components/pages/swap/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ApprovalOverlay } from '@pages/vaults/components/widget/deposit/ApprovalOverlay'
+import { ApprovalResetWarning } from '@pages/vaults/components/widget/deposit/ApprovalResetWarning'
 import { InputTokenAmount } from '@pages/vaults/components/widget/InputTokenAmount'
 import { SettingsPanel } from '@pages/vaults/components/widget/SettingsPanel'
 import { PriceImpactWarning } from '@pages/vaults/components/widget/shared/PriceImpactWarning'
@@ -50,6 +51,7 @@ import { isSwapChainId, MAJOR_SWAP_TOKENS } from './constants'
 import { SwapVaultAnnualReturnRow, SwapVaultWorthRow } from './SwapVaultDetails'
 import { SwapWalletPanel } from './SwapWalletPanel'
 import { buildSwapSearchParams, parseSwapSelection, type TSwapSelection } from './swapParams'
+import { buildSwapVaultPolicyEntries, getSwapSelectionPolicy } from './swapPolicy'
 import { resolveSwapTokenPrice } from './swapTokenPrice'
 import { getSwapVaultEstimate } from './swapVaultEstimate'
 
@@ -239,12 +241,13 @@ export default function SwapPage(): ReactElement {
   const [selectorTarget, setSelectorTarget] = useState<TSelectorTarget>(null)
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const [isApprovalOpen, setIsApprovalOpen] = useState(false)
+  const [selectionPolicyNotice, setSelectionPolicyNotice] = useState<string | undefined>()
   const [customRecipient, setCustomRecipient] = useState<Address | undefined>()
   const [requestedSlippage, setRequestedSlippage] = useState(0)
   const { address: account, openLoginModal } = useWeb3()
   const wagmiConfig = useConfig()
   const { onRefresh } = useWalletActions()
-  const { allVaults, zapSlippage } = useYearn()
+  const { allVaults, isLoadingVaultList, zapSlippage } = useYearn()
   const ensoEnabled = useEnsoEnabled()
   const { token: fromToken, price: fromTokenPrice } = useResolvedSwapToken(selection.fromToken, selection.fromChainId)
   const { token: toToken, price: toTokenPrice } = useResolvedSwapToken(selection.toToken, selection.toChainId)
@@ -288,12 +291,33 @@ export default function SwapPage(): ReactElement {
     receiver,
     inputValue.debouncedBn
   ].join(':')
+  const vaultPolicyEntries = useMemo(() => buildSwapVaultPolicyEntries(allVaults), [allVaults])
+  const selectionPolicy = useMemo(
+    () =>
+      getSwapSelectionPolicy({
+        entries: vaultPolicyEntries,
+        isLoading: isLoadingVaultList,
+        selection
+      }),
+    [isLoadingVaultList, selection, vaultPolicyEntries]
+  )
 
   const updateSelection = useCallback(
     (nextSelection: TSwapSelection): void => {
+      const nextPolicy = getSwapSelectionPolicy({
+        entries: vaultPolicyEntries,
+        isLoading: isLoadingVaultList,
+        selection: nextSelection
+      })
+      if (!nextPolicy.isAllowed) {
+        setSelectionPolicyNotice(nextPolicy.message ?? 'Vault data is still loading. Try again shortly.')
+        return
+      }
+
+      setSelectionPolicyNotice(undefined)
       router.replace(`${pathname}?${buildSwapSearchParams(nextSelection).toString()}`, { scroll: false })
     },
-    [pathname, router]
+    [isLoadingVaultList, pathname, router, vaultPolicyEntries]
   )
 
   const resolveCustomToken = useCallback(
@@ -327,6 +351,7 @@ export default function SwapPage(): ReactElement {
   useEffect(() => {
     setRequestedSlippage(0)
     setIsApprovalOpen(false)
+    setSelectionPolicyNotice(undefined)
   }, [routeKey])
 
   const solver = useSolverEnso({
@@ -340,11 +365,19 @@ export default function SwapPage(): ReactElement {
     slippage: toBasisPoints(requestedSlippage),
     requestKey: `${routeKey}:${requestedSlippage}`,
     decimalsOut: toToken.decimals,
-    enabled: ensoEnabled && !isSameToken && fromToken.symbol !== '???' && toToken.symbol !== '???'
+    enabled:
+      ensoEnabled && selectionPolicy.isAllowed && !isSameToken && fromToken.symbol !== '???' && toToken.symbol !== '???'
   })
 
   useEffect(() => {
-    if (!account || !receiver || inputValue.debouncedBn <= 0n || isSameToken || !ensoEnabled) {
+    if (
+      !account ||
+      !receiver ||
+      inputValue.debouncedBn <= 0n ||
+      isSameToken ||
+      !ensoEnabled ||
+      !selectionPolicy.isAllowed
+    ) {
       solver.methods.resetRoute()
       return
     }
@@ -358,6 +391,7 @@ export default function SwapPage(): ReactElement {
     receiver,
     routeKey,
     requestedSlippage,
+    selectionPolicy.isAllowed,
     solver.methods.getRoute,
     solver.methods.resetRoute
   ])
@@ -430,6 +464,10 @@ export default function SwapPage(): ReactElement {
   })
   const isCrossChain = selection.fromChainId !== selection.toChainId
   const needsApproval = !solver.periphery.isAllowanceSufficient
+  const inputExceedsBalance = inputValue.bn > fromToken.balance.raw
+  const hasSyncedInput = !inputValue.isDebouncing && inputValue.bn === inputValue.debouncedBn
+  const shouldBlockApprovalForAllowanceReset =
+    hasSyncedInput && !inputExceedsBalance && needsApproval && solver.periphery.needsAllowanceResetBeforeApproval
   const isNativeInput = isAddressEqual(fromToken.address, ETH_TOKEN_ADDRESS)
   const approvalSpenderAddress = solver.periphery.approvalWarning
     ? undefined
@@ -532,16 +570,22 @@ export default function SwapPage(): ReactElement {
   ])
 
   const [isTransactionOpen, setIsTransactionOpen] = useState(false)
-  const inputExceedsBalance = inputValue.bn > fromToken.balance.raw
+  const selectionPolicyError = selectionPolicy.message ?? selectionPolicyNotice
   const isQuoteBlocked =
     protectedQuote.priceImpactInfo.isBlocking ||
     protectedQuote.priceImpactInfo.isAboveTolerance ||
     protectedQuote.hasUnpricedQuoteError
-  const isPreparing = inputValue.isDebouncing || protectedQuote.isPreparing || solver.periphery.isLoadingAllowance
+  const isPreparing =
+    !selectionPolicy.isReady ||
+    inputValue.isDebouncing ||
+    protectedQuote.isPreparing ||
+    solver.periphery.isLoadingAllowance
   const isActionDisabled =
     inputValue.bn <= 0n ||
     inputExceedsBalance ||
     isSameToken ||
+    !selectionPolicy.isAllowed ||
+    shouldBlockApprovalForAllowanceReset ||
     isQuoteBlocked ||
     isPreparing ||
     Boolean(solver.periphery.error) ||
@@ -580,17 +624,23 @@ export default function SwapPage(): ReactElement {
 
   const actionLabel = !account
     ? 'Connect Wallet'
-    : inputValue.bn <= 0n
-      ? 'Enter an amount'
-      : inputExceedsBalance
-        ? `Insufficient ${fromToken.symbol} balance`
-        : isSameToken
-          ? 'Choose different assets'
-          : isPreparing
-            ? 'Finding best route'
-            : needsApproval
-              ? `Approve ${fromToken.symbol}`
-              : 'Swap'
+    : !selectionPolicy.isReady
+      ? 'Loading vault data'
+      : selectionPolicyError
+        ? 'Choose different assets'
+        : inputValue.bn <= 0n
+          ? 'Enter an amount'
+          : inputExceedsBalance
+            ? `Insufficient ${fromToken.symbol} balance`
+            : isSameToken
+              ? 'Choose different assets'
+              : isPreparing
+                ? 'Finding best route'
+                : shouldBlockApprovalForAllowanceReset
+                  ? `Reset ${fromToken.symbol} approval`
+                  : needsApproval
+                    ? `Approve ${fromToken.symbol}`
+                    : 'Swap'
 
   const selectedToken = selectorTarget === 'from' ? selection.fromToken : selection.toToken
   const selectedChainId = selectorTarget === 'from' ? selection.fromChainId : selection.toChainId
@@ -770,6 +820,17 @@ export default function SwapPage(): ReactElement {
               </div>
 
               <div className="max-h-60 shrink-0 space-y-3 overflow-y-auto empty:hidden" aria-live="polite">
+                {selectionPolicyError ? (
+                  <p className="break-words rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
+                    {selectionPolicyError}
+                  </p>
+                ) : null}
+                {shouldBlockApprovalForAllowanceReset ? (
+                  <ApprovalResetWarning
+                    tokenSymbol={fromToken.symbol}
+                    onManageApproval={() => setIsApprovalOpen(true)}
+                  />
+                ) : null}
                 <PriceImpactWarning
                   percentage={protectedQuote.worstCaseRouteImpactPercentage}
                   userTolerancePercentage={zapSlippage}

--- a/src/components/pages/swap/index.tsx
+++ b/src/components/pages/swap/index.tsx
@@ -641,7 +641,7 @@ export default function SwapPage(): ReactElement {
             id="swap-swap-panel"
             role="tabpanel"
             aria-labelledby="swap-swap-tab"
-            className="relative flex h-[600px] flex-col overflow-y-auto"
+            className="relative flex h-[600px] flex-col overflow-hidden"
           >
             <div className="flex shrink-0 items-center justify-between px-6 pt-4">
               <p className="text-xs text-text-secondary">Best available route, powered by Enso.</p>
@@ -650,144 +650,148 @@ export default function SwapPage(): ReactElement {
               ) : null}
             </div>
             <div className="flex min-h-0 flex-1 flex-col gap-3 p-6 pt-3">
-              <InputTokenAmount
-                input={input}
-                title="You pay"
-                placeholder="0.00"
-                balance={fromToken.balance.raw}
-                decimals={fromToken.decimals}
-                symbol={fromToken.symbol}
-                onMaxClick={handleMax}
-                errorMessage={inputExceedsBalance ? `Insufficient ${fromToken.symbol} balance` : undefined}
-                showTokenSelector
-                inputTokenUsdPrice={fromTokenPrice}
-                tokenAddress={fromToken.address}
-                tokenChainId={fromToken.chainID}
-                tokenLogoURI={fromToken.logoURI}
-                onTokenSelectorClick={() => setSelectorTarget('from')}
-              />
-
-              <div className="relative h-0">
-                <button
-                  type="button"
-                  onClick={reversePair}
-                  aria-label="Reverse swap direction"
-                  className="absolute left-1/2 top-1/2 z-10 flex size-9 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-surface text-text-secondary shadow-sm transition-colors hover:text-text-primary"
-                >
-                  <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
-                    <path
-                      d="M8 4v14m0 0-3-3m3 3 3-3M16 20V6m0 0-3 3m3-3 3 3"
-                      strokeWidth="1.8"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </button>
-              </div>
-
-              <SwapOutputField
-                amount={protectedQuote.display.expectedOut}
-                isLoading={protectedQuote.isDisplayLoading}
-                onSelect={() => setSelectorTarget('to')}
-                token={toToken}
-                tokenPrice={toTokenPrice}
-              />
-
-              <div className="min-h-[201px] space-y-2 pt-3">
-                <DetailRow
-                  label="Minimum received"
-                  value={
-                    minExpectedOut > 0n
-                      ? `${formatWidgetPreciseValue(minExpectedOut, toToken.decimals)} ${toToken.symbol}`
-                      : 'Unavailable'
-                  }
+              <div className="min-h-0 flex-1 space-y-3 overflow-y-auto">
+                <InputTokenAmount
+                  input={input}
+                  title="You pay"
+                  placeholder="0.00"
+                  balance={fromToken.balance.raw}
+                  decimals={fromToken.decimals}
+                  symbol={fromToken.symbol}
+                  onMaxClick={handleMax}
+                  errorMessage={inputExceedsBalance ? `Insufficient ${fromToken.symbol} balance` : undefined}
+                  showTokenSelector
+                  inputTokenUsdPrice={fromTokenPrice}
+                  tokenAddress={fromToken.address}
+                  tokenChainId={fromToken.chainID}
+                  tokenLogoURI={fromToken.logoURI}
+                  onTokenSelectorClick={() => setSelectorTarget('from')}
                 />
-                {destinationVaultEstimate && destinationVaultMetadata ? (
-                  <SwapVaultWorthRow
-                    estimate={destinationVaultEstimate}
-                    underlyingSymbol={destinationVaultMetadata.underlyingSymbol}
-                    isLoading={protectedQuote.isDisplayLoading}
-                  />
-                ) : null}
-                <DetailRow
-                  label="Est. / Worst price impact"
-                  value={
-                    expectedOut > 0n
-                      ? `${protectedQuote.estimatedPriceImpactPercentage.toFixed(2)}% | ${protectedQuote.worstCaseRouteImpactPercentage.toFixed(2)}%`
-                      : 'Unavailable'
-                  }
+
+                <div className="relative h-0">
+                  <button
+                    type="button"
+                    onClick={reversePair}
+                    aria-label="Reverse swap direction"
+                    className="absolute left-1/2 top-1/2 z-10 flex size-9 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-surface text-text-secondary shadow-sm transition-colors hover:text-text-primary"
+                  >
+                    <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+                      <path
+                        d="M8 4v14m0 0-3-3m3 3 3-3M16 20V6m0 0-3 3m3-3 3 3"
+                        strokeWidth="1.8"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </button>
+                </div>
+
+                <SwapOutputField
+                  amount={protectedQuote.display.expectedOut}
+                  isLoading={protectedQuote.isDisplayLoading}
+                  onSelect={() => setSelectorTarget('to')}
+                  token={toToken}
+                  tokenPrice={toTokenPrice}
                 />
-                {destinationVaultEstimate && destinationVaultMetadata ? (
-                  <SwapVaultAnnualReturnRow
-                    estimate={destinationVaultEstimate}
-                    underlyingSymbol={destinationVaultMetadata.underlyingSymbol}
-                    annualRate={destinationVaultMetadata.annualRate}
-                    isLoading={protectedQuote.isDisplayLoading}
-                  />
-                ) : null}
-                <DetailRow label="Routing" value="Enso" />
-                {customRecipient ? (
+
+                <div className="min-h-[201px] space-y-2 pt-3">
                   <DetailRow
-                    label="Recipient"
-                    value={`${customRecipient.slice(0, 6)}...${customRecipient.slice(-4)}`}
+                    label="Minimum received"
+                    value={
+                      minExpectedOut > 0n
+                        ? `${formatWidgetPreciseValue(minExpectedOut, toToken.decimals)} ${toToken.symbol}`
+                        : 'Unavailable'
+                    }
                   />
-                ) : null}
-                {account && !isNativeInput && approvalSpenderAddress ? (
-                  <div className="flex items-start justify-between gap-4 text-sm">
-                    <button
-                      type="button"
-                      onClick={() => setIsApprovalOpen(true)}
-                      className="yearn--link-dots text-left text-text-secondary transition-colors hover:text-text-primary"
-                    >
-                      Existing Approval (Enso Router)
-                    </button>
-                    {solver.periphery.isLoadingAllowance ? (
-                      <span className="inline-block h-4 w-20 animate-pulse rounded bg-surface-secondary" />
-                    ) : solver.periphery.allowance > 0n && allowanceDisplay !== 'Unlimited' ? (
+                  {destinationVaultEstimate && destinationVaultMetadata ? (
+                    <SwapVaultWorthRow
+                      estimate={destinationVaultEstimate}
+                      underlyingSymbol={destinationVaultMetadata.underlyingSymbol}
+                      isLoading={protectedQuote.isDisplayLoading}
+                    />
+                  ) : null}
+                  <DetailRow
+                    label="Est. / Worst price impact"
+                    value={
+                      expectedOut > 0n
+                        ? `${protectedQuote.estimatedPriceImpactPercentage.toFixed(2)}% | ${protectedQuote.worstCaseRouteImpactPercentage.toFixed(2)}%`
+                        : 'Unavailable'
+                    }
+                  />
+                  {destinationVaultEstimate && destinationVaultMetadata ? (
+                    <SwapVaultAnnualReturnRow
+                      estimate={destinationVaultEstimate}
+                      underlyingSymbol={destinationVaultMetadata.underlyingSymbol}
+                      annualRate={destinationVaultMetadata.annualRate}
+                      isLoading={protectedQuote.isDisplayLoading}
+                    />
+                  ) : null}
+                  <DetailRow label="Routing" value="Enso" />
+                  {customRecipient ? (
+                    <DetailRow
+                      label="Recipient"
+                      value={`${customRecipient.slice(0, 6)}...${customRecipient.slice(-4)}`}
+                    />
+                  ) : null}
+                  {account && !isNativeInput && approvalSpenderAddress ? (
+                    <div className="flex items-start justify-between gap-4 text-sm">
                       <button
                         type="button"
-                        onClick={() => setInputValue(formatUnits(solver.periphery.allowance, fromToken.decimals))}
-                        className="text-right font-semibold text-text-primary transition-colors hover:text-primary"
+                        onClick={() => setIsApprovalOpen(true)}
+                        className="yearn--link-dots text-left text-text-secondary transition-colors hover:text-text-primary"
                       >
-                        {allowanceDisplay} {fromToken.symbol}
+                        Existing Approval (Enso Router)
                       </button>
-                    ) : (
-                      <span className="text-right font-semibold text-text-primary">
-                        {allowanceDisplay === 'Unlimited'
-                          ? allowanceDisplay
-                          : `${allowanceDisplay} ${fromToken.symbol}`}
-                      </span>
-                    )}
-                  </div>
+                      {solver.periphery.isLoadingAllowance ? (
+                        <span className="inline-block h-4 w-20 animate-pulse rounded bg-surface-secondary" />
+                      ) : solver.periphery.allowance > 0n && allowanceDisplay !== 'Unlimited' ? (
+                        <button
+                          type="button"
+                          onClick={() => setInputValue(formatUnits(solver.periphery.allowance, fromToken.decimals))}
+                          className="text-right font-semibold text-text-primary transition-colors hover:text-primary"
+                        >
+                          {allowanceDisplay} {fromToken.symbol}
+                        </button>
+                      ) : (
+                        <span className="text-right font-semibold text-text-primary">
+                          {allowanceDisplay === 'Unlimited'
+                            ? allowanceDisplay
+                            : `${allowanceDisplay} ${fromToken.symbol}`}
+                        </span>
+                      )}
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="max-h-60 shrink-0 space-y-3 overflow-y-auto empty:hidden" aria-live="polite">
+                <PriceImpactWarning
+                  percentage={protectedQuote.worstCaseRouteImpactPercentage}
+                  userTolerancePercentage={zapSlippage}
+                  isBlocking={protectedQuote.priceImpactInfo.isBlocking}
+                  isLoading={protectedQuote.isPreparing}
+                  isDebouncing={inputValue.isDebouncing}
+                  isAmountSynced={inputValue.bn === inputValue.debouncedBn}
+                  hasAmount={inputValue.bn > 0n}
+                />
+                {protectedQuote.hasUnpricedQuoteError ? (
+                  <p className="break-words rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
+                    Price impact cannot be verified for this pair, so execution is blocked.
+                  </p>
+                ) : null}
+                {routeError ? (
+                  <p className="break-words rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
+                    {routeError}
+                  </p>
+                ) : null}
+                {!ensoEnabled ? (
+                  <p className="break-words rounded-md border border-border bg-surface-secondary px-3 py-2 text-xs text-text-secondary">
+                    Enso routing is temporarily unavailable.
+                  </p>
                 ) : null}
               </div>
 
-              <PriceImpactWarning
-                percentage={protectedQuote.worstCaseRouteImpactPercentage}
-                userTolerancePercentage={zapSlippage}
-                isBlocking={protectedQuote.priceImpactInfo.isBlocking}
-                isLoading={protectedQuote.isPreparing}
-                isDebouncing={inputValue.isDebouncing}
-                isAmountSynced={inputValue.bn === inputValue.debouncedBn}
-                hasAmount={inputValue.bn > 0n}
-              />
-              {protectedQuote.hasUnpricedQuoteError ? (
-                <p className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
-                  Price impact cannot be verified for this pair, so execution is blocked.
-                </p>
-              ) : null}
-              {routeError ? (
-                <p className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
-                  {routeError}
-                </p>
-              ) : null}
-              {!ensoEnabled ? (
-                <p className="rounded-md border border-border bg-surface-secondary px-3 py-2 text-xs text-text-secondary">
-                  Enso routing is temporarily unavailable.
-                </p>
-              ) : null}
-
-              <div className="mt-auto flex items-center gap-2">
+              <div className="mt-auto flex shrink-0 items-center gap-2">
                 <div className="flex-1">
                   {!account ? (
                     <Button

--- a/src/components/pages/swap/index.tsx
+++ b/src/components/pages/swap/index.tsx
@@ -627,7 +627,7 @@ export default function SwapPage(): ReactElement {
         </div>
 
         {activeTab === 'wallet' ? (
-          <div id="swap-wallet-panel" role="tabpanel" aria-labelledby="swap-wallet-tab" className="h-[600px]">
+          <div id="swap-wallet-panel" role="tabpanel" aria-labelledby="swap-wallet-tab" className="h-[640px]">
             <SwapWalletPanel
               onSelectToken={(address, chainId) => {
                 if (!isSwapChainId(chainId)) return
@@ -641,7 +641,7 @@ export default function SwapPage(): ReactElement {
             id="swap-swap-panel"
             role="tabpanel"
             aria-labelledby="swap-swap-tab"
-            className="relative flex h-[600px] flex-col overflow-hidden"
+            className="relative flex h-[640px] flex-col overflow-hidden"
           >
             <div className="flex shrink-0 items-center justify-between px-6 pt-4">
               <p className="text-xs text-text-secondary">Best available route, powered by Enso.</p>

--- a/src/components/pages/swap/index.tsx
+++ b/src/components/pages/swap/index.tsx
@@ -644,10 +644,7 @@ export default function SwapPage(): ReactElement {
             className="relative flex h-[600px] flex-col overflow-y-auto"
           >
             <div className="flex shrink-0 items-center justify-between px-6 pt-4">
-              <div>
-                <h1 className="text-base font-semibold text-text-primary">Swap</h1>
-                <p className="text-xs text-text-secondary">Best available route, powered by Enso.</p>
-              </div>
+              <p className="text-xs text-text-secondary">Best available route, powered by Enso.</p>
               {isCrossChain ? (
                 <span className="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">Cross-chain</span>
               ) : null}
@@ -696,7 +693,7 @@ export default function SwapPage(): ReactElement {
                 tokenPrice={toTokenPrice}
               />
 
-              <div className="min-h-[201px] space-y-2 border-t border-border pt-3">
+              <div className="min-h-[201px] space-y-2 pt-3">
                 <DetailRow
                   label="Minimum received"
                   value={

--- a/src/components/pages/swap/index.tsx
+++ b/src/components/pages/swap/index.tsx
@@ -1,0 +1,758 @@
+'use client'
+
+import { InputTokenAmount } from '@pages/vaults/components/widget/InputTokenAmount'
+import { SettingsPanel } from '@pages/vaults/components/widget/SettingsPanel'
+import { PriceImpactWarning } from '@pages/vaults/components/widget/shared/PriceImpactWarning'
+import { TokenSelectorOverlay } from '@pages/vaults/components/widget/shared/TokenSelectorOverlay'
+import { TransactionOverlay, type TransactionStep } from '@pages/vaults/components/widget/shared/TransactionOverlay'
+import { useProtectedEnsoQuoteState } from '@pages/vaults/components/widget/shared/useProtectedEnsoQuoteState'
+import { formatWidgetPreciseValue } from '@pages/vaults/components/widget/shared/valueDisplay'
+import { getTokenLogoSources } from '@pages/vaults/components/widget/tokenLogo.utils'
+import {
+  getVaultAddress,
+  getVaultChainID,
+  getVaultDecimals,
+  getVaultInfo,
+  getVaultName,
+  getVaultSymbol
+} from '@pages/vaults/domain/kongVaultSelectors'
+import { useSolverEnso } from '@pages/vaults/hooks/solvers/useSolverEnso'
+import { useDebouncedInput } from '@pages/vaults/hooks/useDebouncedInput'
+import { useEnsoEnabled } from '@pages/vaults/hooks/useEnsoEnabled'
+import { useEnsoOrder } from '@pages/vaults/hooks/useEnsoOrder'
+import { fetchTokenData, useTokens } from '@pages/vaults/hooks/useTokens'
+import { Button } from '@shared/components/Button'
+import { TokenLogoV2 } from '@shared/components/TokenLogoV2'
+import { useWalletActions, useWalletTokens } from '@shared/contexts/useWallet'
+import { useWeb3 } from '@shared/contexts/useWeb3'
+import { useYearn } from '@shared/contexts/useYearn'
+import { useTokenList } from '@shared/contexts/WithTokenList'
+import { IconSettings } from '@shared/icons/IconSettings'
+import type { TToken } from '@shared/types'
+import type { TCreateNotificationParams } from '@shared/types/notifications'
+import { cl, ETH_TOKEN_ADDRESS, formatTAmount, toAddress, toNormalizedBN } from '@shared/utils'
+import { formatUSD } from '@shared/utils/format'
+import { toBasisPoints } from '@shared/utils/slippage'
+import { getNetwork } from '@shared/utils/wagmi'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { type ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
+import { type Address, formatUnits, isAddressEqual } from 'viem'
+import { useConfig } from 'wagmi'
+import { resolveExecutionChainId } from '@/config/tenderly'
+import { isSwapChainId, MAJOR_SWAP_TOKENS } from './constants'
+import { SwapWalletPanel } from './SwapWalletPanel'
+import { buildSwapSearchParams, parseSwapSelection, type TSwapSelection } from './swapParams'
+
+type TSwapTab = 'swap' | 'wallet'
+type TSelectorTarget = 'from' | 'to' | null
+
+function useResolvedSwapToken(address: Address, chainId: number): { token: TToken; price: number } {
+  const { address: account } = useWeb3()
+  const { balances, getToken: getWalletToken } = useWalletTokens()
+  const { getToken: getListedToken } = useTokenList()
+  const { allVaults, getPrice } = useYearn()
+  const isNative = isAddressEqual(address, ETH_TOKEN_ADDRESS)
+  const { tokens } = useTokens([isNative ? undefined : address], chainId, account)
+  const rpcToken = tokens[0]
+  const normalizedAddress = toAddress(address)
+  const walletToken = balances[chainId]?.[normalizedAddress] ?? getWalletToken({ address, chainID: chainId })
+  const listedToken = getListedToken({ address, chainID: chainId })
+  const vault = Object.values(allVaults).find(
+    (candidate) =>
+      getVaultChainID(candidate) === chainId &&
+      !getVaultInfo(candidate).isHidden &&
+      isAddressEqual(toAddress(getVaultAddress(candidate)), normalizedAddress)
+  )
+  const network = getNetwork(chainId)
+  const price = getPrice({ address: normalizedAddress, chainID: chainId }).normalized
+  const balance =
+    walletToken.address && isAddressEqual(walletToken.address, normalizedAddress)
+      ? walletToken.balance
+      : toNormalizedBN(0n, rpcToken?.decimals ?? (isNative ? network.nativeCurrency.decimals : 18))
+  const nativeToken: TToken | undefined = isNative
+    ? {
+        address: ETH_TOKEN_ADDRESS,
+        name: network.nativeCurrency.name,
+        symbol: network.nativeCurrency.symbol,
+        decimals: network.nativeCurrency.decimals,
+        chainID: chainId,
+        value: balance.normalized * price,
+        balance
+      }
+    : undefined
+  const vaultToken: TToken | undefined = vault
+    ? {
+        address: normalizedAddress,
+        name: getVaultName(vault),
+        symbol: getVaultSymbol(vault) || 'Vault',
+        decimals: getVaultDecimals(vault),
+        chainID: chainId,
+        value: walletToken.value || balance.normalized * price,
+        balance
+      }
+    : undefined
+  const rpcResolvedToken: TToken | undefined = rpcToken?.address
+    ? {
+        address: normalizedAddress,
+        name: rpcToken.name || rpcToken.symbol || 'Token',
+        symbol: rpcToken.symbol || '???',
+        decimals: rpcToken.decimals ?? 18,
+        chainID: chainId,
+        value: balance.normalized * price,
+        balance
+      }
+    : undefined
+  const metadataToken = [nativeToken, walletToken, listedToken, vaultToken, rpcResolvedToken].find(
+    (candidate) =>
+      candidate?.address &&
+      isAddressEqual(candidate.address, normalizedAddress) &&
+      candidate.symbol &&
+      candidate.symbol !== '???'
+  )
+
+  return {
+    token: metadataToken
+      ? {
+          ...metadataToken,
+          address: normalizedAddress,
+          chainID: chainId,
+          balance,
+          value: walletToken.value || balance.normalized * price
+        }
+      : {
+          address: normalizedAddress,
+          name: 'Unknown token',
+          symbol: '???',
+          decimals: 18,
+          chainID: chainId,
+          value: 0,
+          balance
+        },
+    price
+  }
+}
+
+function SwapOutputField({
+  amount,
+  isLoading,
+  onSelect,
+  token,
+  tokenPrice
+}: {
+  amount: bigint
+  isLoading: boolean
+  onSelect: () => void
+  token: TToken
+  tokenPrice: number
+}): ReactElement {
+  const network = getNetwork(token.chainID)
+  const logo = getTokenLogoSources({
+    address: token.address,
+    chainId: token.chainID,
+    logoURI: token.logoURI,
+    size: 32
+  })
+  const normalizedAmount = Number(formatUnits(amount, token.decimals))
+
+  return (
+    <div className="rounded-md border border-border px-3 py-2">
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-sm font-medium text-text-primary">You receive</span>
+        <span className="text-xs text-text-secondary">{network.name}</span>
+      </div>
+      <div className="flex min-h-12 items-center gap-2">
+        <span className={cl('min-w-0 flex-1 text-2xl font-medium text-text-primary', isLoading ? 'animate-pulse' : '')}>
+          {isLoading ? 'Finding route...' : formatWidgetPreciseValue(amount, token.decimals)}
+        </span>
+        <button
+          type="button"
+          onClick={onSelect}
+          className="flex min-h-11 items-center gap-2 rounded-lg px-2 py-1 text-xl font-medium text-text-primary transition-colors hover:bg-surface-secondary"
+        >
+          <TokenLogoV2
+            src={logo.src}
+            altSrc={logo.altSrc}
+            tokenSymbol={token.symbol}
+            tokenName={token.name}
+            chainId={token.chainID}
+            width={32}
+            height={32}
+            className="rounded-full"
+          />
+          <span>{token.symbol}</span>
+          <svg className="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m19 9-7 7-7-7" />
+          </svg>
+        </button>
+      </div>
+      <div className="flex items-center justify-between text-sm text-text-secondary">
+        <span>{tokenPrice > 0 && amount > 0n ? formatUSD(normalizedAmount * tokenPrice) : 'Unavailable'}</span>
+        <span>Balance: {formatTAmount({ value: token.balance.raw, decimals: token.decimals })}</span>
+      </div>
+    </div>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: string }): ReactElement {
+  return (
+    <div className="flex items-start justify-between gap-4 text-sm">
+      <span className="text-text-secondary">{label}</span>
+      <span className="text-right font-semibold text-text-primary">{value}</span>
+    </div>
+  )
+}
+
+export default function SwapPage(): ReactElement {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const selection = useMemo(() => parseSwapSelection(new URLSearchParams(searchParams.toString())), [searchParams])
+  const [activeTab, setActiveTab] = useState<TSwapTab>('swap')
+  const [selectorTarget, setSelectorTarget] = useState<TSelectorTarget>(null)
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [customRecipient, setCustomRecipient] = useState<Address | undefined>()
+  const [requestedSlippage, setRequestedSlippage] = useState(0)
+  const { address: account, openLoginModal } = useWeb3()
+  const wagmiConfig = useConfig()
+  const { onRefresh } = useWalletActions()
+  const { zapSlippage } = useYearn()
+  const ensoEnabled = useEnsoEnabled()
+  const { token: fromToken, price: fromTokenPrice } = useResolvedSwapToken(selection.fromToken, selection.fromChainId)
+  const { token: toToken, price: toTokenPrice } = useResolvedSwapToken(selection.toToken, selection.toChainId)
+  const input = useDebouncedInput(fromToken.decimals)
+  const [inputValue, , setInputValue] = input
+  const receiver = customRecipient ?? account
+  const isSameToken =
+    selection.fromChainId === selection.toChainId && isAddressEqual(selection.fromToken, selection.toToken)
+  const routeKey = [
+    selection.fromChainId,
+    selection.fromToken,
+    selection.toChainId,
+    selection.toToken,
+    receiver,
+    inputValue.debouncedBn
+  ].join(':')
+
+  const updateSelection = useCallback(
+    (nextSelection: TSwapSelection): void => {
+      router.replace(`${pathname}?${buildSwapSearchParams(nextSelection).toString()}`, { scroll: false })
+    },
+    [pathname, router]
+  )
+
+  const resolveCustomToken = useCallback(
+    async (address: Address, chainId: number): Promise<TToken | undefined> => {
+      const executionChainId = resolveExecutionChainId(chainId)
+      if (!executionChainId) return undefined
+      const [token] = await fetchTokenData(wagmiConfig, [address], chainId, executionChainId, account)
+      if (!token?.address || !token.symbol || token.symbol === '???') return undefined
+
+      return {
+        address: token.address,
+        name: token.name || token.symbol,
+        symbol: token.symbol,
+        decimals: token.decimals ?? 18,
+        chainID: chainId,
+        value: 0,
+        balance: token.balance
+      }
+    },
+    [account, wagmiConfig]
+  )
+
+  // Keep the shareable route explicit even when the user lands on the default pair.
+  useEffect(() => {
+    const canonical = buildSwapSearchParams(selection).toString()
+    if (searchParams.toString() !== canonical) {
+      router.replace(`${pathname}?${canonical}`, { scroll: false })
+    }
+  }, [pathname, router, searchParams, selection])
+
+  useEffect(() => {
+    setRequestedSlippage(0)
+  }, [routeKey])
+
+  const solver = useSolverEnso({
+    tokenIn: selection.fromToken,
+    tokenOut: selection.toToken,
+    amountIn: inputValue.debouncedBn,
+    fromAddress: account,
+    receiver,
+    chainId: selection.fromChainId,
+    destinationChainId: selection.toChainId === selection.fromChainId ? undefined : selection.toChainId,
+    slippage: toBasisPoints(requestedSlippage),
+    requestKey: `${routeKey}:${requestedSlippage}`,
+    decimalsOut: toToken.decimals,
+    enabled: ensoEnabled && !isSameToken && fromToken.symbol !== '???' && toToken.symbol !== '???'
+  })
+
+  useEffect(() => {
+    if (!account || !receiver || inputValue.debouncedBn <= 0n || isSameToken || !ensoEnabled) {
+      solver.methods.resetRoute()
+      return
+    }
+
+    void solver.methods.getRoute()
+  }, [
+    account,
+    ensoEnabled,
+    inputValue.debouncedBn,
+    isSameToken,
+    receiver,
+    routeKey,
+    requestedSlippage,
+    solver.methods.getRoute,
+    solver.methods.resetRoute
+  ])
+
+  const expectedOut = solver.periphery.expectedOut.raw
+  const minExpectedOut = solver.periphery.minExpectedOut.raw
+  const inputUsd = inputValue.debouncedSimple * fromTokenPrice
+  const expectedOutUsd = Number(formatUnits(expectedOut, toToken.decimals)) * toTokenPrice
+  const minExpectedOutUsd = Number(formatUnits(minExpectedOut, toToken.decimals)) * toTokenPrice
+  const localPriceImpact =
+    inputUsd > 0 && expectedOutUsd > 0 ? Math.max(0, ((inputUsd - expectedOutUsd) / inputUsd) * 100) : 0
+  const localWorstCaseImpact =
+    inputUsd > 0 && minExpectedOutUsd > 0 ? Math.max(0, ((inputUsd - minExpectedOutUsd) / inputUsd) * 100) : 0
+  const protectedQuote = useProtectedEnsoQuoteState({
+    stateKey: routeKey,
+    isEnsoRoute: true,
+    amount: inputValue.debouncedBn,
+    requestedSlippage,
+    setRequestedSlippage,
+    isLoadingQuote: solver.periphery.isLoadingRoute,
+    userTolerancePercentage: zapSlippage,
+    localPriceImpactPercentage: localPriceImpact,
+    localWorstCasePriceImpactPercentage: localWorstCaseImpact,
+    hasIncompleteUsdValuation: fromTokenPrice <= 0 || toTokenPrice <= 0,
+    ensoPriceImpact: solver.periphery.priceImpact,
+    expectedOut,
+    minExpectedOut,
+    tx: solver.periphery.route?.tx,
+    display: { expectedOut, minExpectedOut }
+  })
+  const getProtectedTransaction = useCallback(
+    () =>
+      protectedQuote.executableTx
+        ? {
+            ...protectedQuote.executableTx,
+            chainId: solver.periphery.route?.tx.chainId ?? selection.fromChainId
+          }
+        : undefined,
+    [protectedQuote.executableTx, selection.fromChainId, solver.periphery.route?.tx.chainId]
+  )
+  const { prepareEnsoOrder } = useEnsoOrder({
+    getEnsoTransaction: getProtectedTransaction,
+    enabled: Boolean(protectedQuote.executableTx && solver.periphery.isAllowanceSufficient),
+    chainId: selection.fromChainId
+  })
+
+  const formattedInput = formatTAmount({
+    value: inputValue.debouncedBn,
+    decimals: fromToken.decimals,
+    options: { maximumFractionDigits: 8 }
+  })
+  const formattedOutput = formatTAmount({
+    value: minExpectedOut,
+    decimals: toToken.decimals,
+    options: { maximumFractionDigits: 8 }
+  })
+  const isCrossChain = selection.fromChainId !== selection.toChainId
+  const needsApproval = !solver.periphery.isAllowanceSufficient
+
+  const approveNotification = useMemo<TCreateNotificationParams | undefined>(
+    () =>
+      account && solver.periphery.routerAddress
+        ? {
+            type: 'approve',
+            amount: formattedInput,
+            fromAddress: selection.fromToken,
+            fromSymbol: fromToken.symbol,
+            fromChainId: selection.fromChainId,
+            toAddress: solver.periphery.routerAddress,
+            toSymbol: 'Enso Router'
+          }
+        : undefined,
+    [
+      account,
+      formattedInput,
+      fromToken.symbol,
+      selection.fromChainId,
+      selection.fromToken,
+      solver.periphery.routerAddress
+    ]
+  )
+  const swapNotification = useMemo<TCreateNotificationParams | undefined>(
+    () =>
+      account && expectedOut > 0n
+        ? {
+            type: isCrossChain ? 'crosschain swap' : 'swap',
+            amount: formattedInput,
+            fromAddress: selection.fromToken,
+            fromSymbol: fromToken.symbol,
+            fromChainId: selection.fromChainId,
+            toAddress: selection.toToken,
+            toSymbol: toToken.symbol,
+            toAmount: formattedOutput,
+            toChainId: isCrossChain ? selection.toChainId : undefined
+          }
+        : undefined,
+    [
+      account,
+      expectedOut,
+      formattedInput,
+      formattedOutput,
+      fromToken.symbol,
+      isCrossChain,
+      selection.fromChainId,
+      selection.fromToken,
+      selection.toChainId,
+      selection.toToken,
+      toToken.symbol
+    ]
+  )
+
+  const currentStep = useMemo<TransactionStep | undefined>(() => {
+    if (needsApproval) {
+      return {
+        prepare: solver.actions.prepareApprove,
+        label: 'Approve',
+        confirmMessage: `Approving ${formattedInput} ${fromToken.symbol}`,
+        successTitle: 'Approval successful',
+        successMessage: `${fromToken.symbol} is approved for this swap.`,
+        isEnabled: solver.periphery.prepareApproveEnabled && !protectedQuote.isPreparing,
+        completesFlow: false,
+        notification: approveNotification
+      }
+    }
+
+    return {
+      prepare: prepareEnsoOrder,
+      label: 'Swap',
+      confirmMessage: `Swapping ${formattedInput} ${fromToken.symbol}`,
+      successTitle: isCrossChain ? 'Swap submitted' : 'Swap successful',
+      successMessage: isCrossChain
+        ? `Your cross-chain swap to ${toToken.symbol} has been submitted. It may take a few minutes to arrive.`
+        : `Swapped ${formattedInput} ${fromToken.symbol} for ${formattedOutput} ${toToken.symbol}.`,
+      isEnabled: Boolean(protectedQuote.executableTx && prepareEnsoOrder.isSuccess),
+      completesFlow: true,
+      showConfetti: true,
+      notification: swapNotification
+    }
+  }, [
+    approveNotification,
+    formattedInput,
+    formattedOutput,
+    fromToken.symbol,
+    isCrossChain,
+    needsApproval,
+    prepareEnsoOrder,
+    protectedQuote.executableTx,
+    protectedQuote.isPreparing,
+    solver.actions.prepareApprove,
+    solver.periphery.prepareApproveEnabled,
+    swapNotification,
+    toToken.symbol
+  ])
+
+  const [isTransactionOpen, setIsTransactionOpen] = useState(false)
+  const inputExceedsBalance = inputValue.bn > fromToken.balance.raw
+  const isQuoteBlocked =
+    protectedQuote.priceImpactInfo.isBlocking ||
+    protectedQuote.priceImpactInfo.isAboveTolerance ||
+    protectedQuote.hasUnpricedQuoteError
+  const isPreparing = inputValue.isDebouncing || protectedQuote.isPreparing || solver.periphery.isLoadingAllowance
+  const isActionDisabled =
+    inputValue.bn <= 0n ||
+    inputExceedsBalance ||
+    isSameToken ||
+    isQuoteBlocked ||
+    isPreparing ||
+    Boolean(solver.periphery.error) ||
+    !currentStep?.isEnabled
+
+  const handleMax = useCallback((): void => {
+    const balance = fromToken.balance.raw
+    const isNative = isAddressEqual(fromToken.address, ETH_TOKEN_ADDRESS)
+    const nativeReserve = 3_000_000_000_000_000n
+    const maxAmount = isNative ? (balance > nativeReserve ? balance - nativeReserve : (balance * 9n) / 10n) : balance
+    setInputValue(formatUnits(maxAmount, fromToken.decimals))
+  }, [fromToken.address, fromToken.balance.raw, fromToken.decimals, setInputValue])
+
+  const handlePairTokenChange = useCallback(
+    (target: Exclude<TSelectorTarget, null>, address: Address, chainId?: number): void => {
+      if (!chainId || !isSwapChainId(chainId)) return
+      updateSelection(
+        target === 'from'
+          ? { ...selection, fromToken: toAddress(address), fromChainId: chainId }
+          : { ...selection, toToken: toAddress(address), toChainId: chainId }
+      )
+      setSelectorTarget(null)
+    },
+    [selection, updateSelection]
+  )
+
+  const reversePair = useCallback((): void => {
+    updateSelection({
+      fromChainId: selection.toChainId,
+      fromToken: selection.toToken,
+      toChainId: selection.fromChainId,
+      toToken: selection.fromToken
+    })
+    setInputValue('')
+  }, [selection, setInputValue, updateSelection])
+
+  const actionLabel = !account
+    ? 'Connect Wallet'
+    : inputValue.bn <= 0n
+      ? 'Enter an amount'
+      : inputExceedsBalance
+        ? `Insufficient ${fromToken.symbol} balance`
+        : isSameToken
+          ? 'Choose different assets'
+          : isPreparing
+            ? 'Finding best route'
+            : needsApproval
+              ? `Approve ${fromToken.symbol}`
+              : 'Swap'
+
+  const selectedToken = selectorTarget === 'from' ? selection.fromToken : selection.toToken
+  const selectedChainId = selectorTarget === 'from' ? selection.fromChainId : selection.toChainId
+  const routeError = solver.periphery.error?.message
+
+  return (
+    <div className="mx-auto flex w-full max-w-[480px] flex-col px-4 pb-16 pt-8 md:pt-16">
+      <div className="relative overflow-hidden rounded-lg border border-border bg-surface shadow-sm">
+        <div
+          className="flex gap-2 border-b border-border bg-surface-secondary p-1"
+          role="tablist"
+          aria-label="Swap views"
+        >
+          {(['swap', 'wallet'] as const).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab}
+              aria-controls={`swap-${tab}-panel`}
+              id={`swap-${tab}-tab`}
+              onClick={() => {
+                setSelectorTarget(null)
+                setIsSettingsOpen(false)
+                setActiveTab(tab)
+              }}
+              className={cl(
+                'min-h-10 flex-1 rounded-md border px-3 py-2 text-xs font-semibold capitalize transition-colors',
+                activeTab === tab
+                  ? 'border-border bg-surface text-text-primary'
+                  : 'border-transparent text-text-secondary hover:text-text-primary'
+              )}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+
+        {activeTab === 'wallet' ? (
+          <div id="swap-wallet-panel" role="tabpanel" aria-labelledby="swap-wallet-tab">
+            <SwapWalletPanel
+              onSelectToken={(address, chainId) => {
+                if (!isSwapChainId(chainId)) return
+                updateSelection({ ...selection, fromToken: address, fromChainId: chainId })
+                setActiveTab('swap')
+              }}
+            />
+          </div>
+        ) : (
+          <div id="swap-swap-panel" role="tabpanel" aria-labelledby="swap-swap-tab" className="relative">
+            <div className="flex items-center justify-between px-6 pt-4">
+              <div>
+                <h1 className="text-base font-semibold text-text-primary">Swap</h1>
+                <p className="text-xs text-text-secondary">Best available route, powered by Enso.</p>
+              </div>
+              {isCrossChain ? (
+                <span className="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">Cross-chain</span>
+              ) : null}
+            </div>
+            <div className="flex flex-col gap-3 p-6 pt-3">
+              <InputTokenAmount
+                input={input}
+                title="You pay"
+                placeholder="0.00"
+                balance={fromToken.balance.raw}
+                decimals={fromToken.decimals}
+                symbol={fromToken.symbol}
+                onMaxClick={handleMax}
+                errorMessage={inputExceedsBalance ? `Insufficient ${fromToken.symbol} balance` : undefined}
+                showTokenSelector
+                inputTokenUsdPrice={fromTokenPrice}
+                tokenAddress={fromToken.address}
+                tokenChainId={fromToken.chainID}
+                tokenLogoURI={fromToken.logoURI}
+                onTokenSelectorClick={() => setSelectorTarget('from')}
+              />
+
+              <div className="relative h-0">
+                <button
+                  type="button"
+                  onClick={reversePair}
+                  aria-label="Reverse swap direction"
+                  className="absolute left-1/2 top-1/2 z-10 flex size-9 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full border border-border bg-surface text-text-secondary shadow-sm transition-colors hover:text-text-primary"
+                >
+                  <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+                    <path
+                      d="M8 4v14m0 0-3-3m3 3 3-3M16 20V6m0 0-3 3m3-3 3 3"
+                      strokeWidth="1.8"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+
+              <SwapOutputField
+                amount={protectedQuote.display.expectedOut}
+                isLoading={protectedQuote.isDisplayLoading}
+                onSelect={() => setSelectorTarget('to')}
+                token={toToken}
+                tokenPrice={toTokenPrice}
+              />
+
+              <div className="space-y-2 border-t border-border pt-3">
+                <DetailRow
+                  label="Minimum received"
+                  value={
+                    minExpectedOut > 0n
+                      ? `${formatWidgetPreciseValue(minExpectedOut, toToken.decimals)} ${toToken.symbol}`
+                      : 'Unavailable'
+                  }
+                />
+                <DetailRow
+                  label="Est. / Worst price impact"
+                  value={
+                    expectedOut > 0n
+                      ? `${protectedQuote.estimatedPriceImpactPercentage.toFixed(2)}% | ${protectedQuote.worstCaseRouteImpactPercentage.toFixed(2)}%`
+                      : 'Unavailable'
+                  }
+                />
+                <DetailRow label="Routing" value="Enso" />
+                {customRecipient ? (
+                  <DetailRow
+                    label="Recipient"
+                    value={`${customRecipient.slice(0, 6)}...${customRecipient.slice(-4)}`}
+                  />
+                ) : null}
+              </div>
+
+              <PriceImpactWarning
+                percentage={protectedQuote.worstCaseRouteImpactPercentage}
+                userTolerancePercentage={zapSlippage}
+                isBlocking={protectedQuote.priceImpactInfo.isBlocking}
+                isLoading={protectedQuote.isPreparing}
+                isDebouncing={inputValue.isDebouncing}
+                isAmountSynced={inputValue.bn === inputValue.debouncedBn}
+                hasAmount={inputValue.bn > 0n}
+              />
+              {protectedQuote.hasUnpricedQuoteError ? (
+                <p className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
+                  Price impact cannot be verified for this pair, so execution is blocked.
+                </p>
+              ) : null}
+              {routeError ? (
+                <p className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-500">
+                  {routeError}
+                </p>
+              ) : null}
+              {!ensoEnabled ? (
+                <p className="rounded-md border border-border bg-surface-secondary px-3 py-2 text-xs text-text-secondary">
+                  Enso routing is temporarily unavailable.
+                </p>
+              ) : null}
+
+              <div className="flex items-center gap-2">
+                <div className="flex-1">
+                  {!account ? (
+                    <Button
+                      onClick={openLoginModal}
+                      variant="filled"
+                      className="w-full"
+                      classNameOverride="yearn--button--nextgen w-full"
+                    >
+                      {actionLabel}
+                    </Button>
+                  ) : (
+                    <Button
+                      onClick={() => setIsTransactionOpen(true)}
+                      variant={isPreparing ? 'busy' : 'filled'}
+                      isBusy={isPreparing}
+                      disabled={isActionDisabled}
+                      className="w-full"
+                      classNameOverride="yearn--button--nextgen w-full"
+                    >
+                      {actionLabel}
+                    </Button>
+                  )}
+                </div>
+                {account ? (
+                  <button
+                    type="button"
+                    onClick={() => setIsSettingsOpen(true)}
+                    aria-label="Open transaction settings"
+                    aria-pressed={isSettingsOpen}
+                    className="flex min-h-11 items-center justify-center rounded-md bg-surface-secondary px-3 py-2 text-text-secondary transition-colors hover:bg-surface-tertiary hover:text-text-primary"
+                  >
+                    <IconSettings className="size-4" />
+                  </button>
+                ) : null}
+              </div>
+            </div>
+
+            <SettingsPanel
+              isActive={isSettingsOpen}
+              onClose={() => setIsSettingsOpen(false)}
+              variant="overlay"
+              description="Route impact consumes part of this tolerance. You can also send the output to another address."
+              showAutoStaking={false}
+              defaultRecipient={account}
+              recipient={customRecipient}
+              onRecipientChange={setCustomRecipient}
+            />
+          </div>
+        )}
+
+        {selectorTarget ? (
+          <TokenSelectorOverlay
+            onClose={() => setSelectorTarget(null)}
+            onChange={(address, chainId) => handlePairTokenChange(selectorTarget, address, chainId)}
+            chainId={selectedChainId}
+            value={selectedToken}
+            priorityTokens={MAJOR_SWAP_TOKENS}
+            topTokens={MAJOR_SWAP_TOKENS}
+            mode="swap"
+            excludeRetiredVaults={selectorTarget === 'to'}
+            balanceOnly={selectorTarget === 'from'}
+            resolveCustomToken={resolveCustomToken}
+          />
+        ) : null}
+      </div>
+
+      <TransactionOverlay
+        isOpen={isTransactionOpen}
+        onClose={() => setIsTransactionOpen(false)}
+        step={currentStep}
+        isLastStep={!needsApproval}
+        autoContinueToNextStep
+        autoContinueStepLabels={['Approve']}
+        onStepSuccess={(label) => {
+          if (label === 'Approve') void solver.periphery.refetchAllowance()
+        }}
+        onBeforeSuccess={async () => {
+          await onRefresh()
+        }}
+        onAllComplete={() => {
+          setInputValue('')
+        }}
+      />
+    </div>
+  )
+}

--- a/src/components/pages/swap/index.tsx
+++ b/src/components/pages/swap/index.tsx
@@ -178,6 +178,7 @@ function SwapOutputField({
     size: 32
   })
   const normalizedAmount = Number(formatUnits(amount, token.decimals))
+  const tokenSelectorTitle = token.name !== token.symbol ? `${token.name} (${token.symbol})` : token.symbol
 
   return (
     <div className="rounded-md border border-border px-3 py-2">
@@ -192,7 +193,9 @@ function SwapOutputField({
         <button
           type="button"
           onClick={onSelect}
-          className="flex min-h-11 items-center gap-2 rounded-lg px-2 py-1 text-xl font-medium text-text-primary transition-colors hover:bg-surface-secondary"
+          data-token-selector-button
+          title={tokenSelectorTitle}
+          className="flex min-h-11 max-w-[50%] shrink-0 items-center gap-2 overflow-hidden rounded-lg px-2 py-1 text-xl font-medium text-text-primary transition-colors hover:bg-surface-secondary"
         >
           <TokenLogoV2
             src={logo.src}
@@ -202,10 +205,10 @@ function SwapOutputField({
             chainId={token.chainID}
             width={32}
             height={32}
-            className="rounded-full"
+            className="shrink-0 rounded-full"
           />
-          <span>{token.symbol}</span>
-          <svg className="size-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+          <span className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap scrollbar-none">{token.symbol}</span>
+          <svg className="size-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m19 9-7 7-7-7" />
           </svg>
         </button>
@@ -658,9 +661,11 @@ export default function SwapPage(): ReactElement {
                   balance={fromToken.balance.raw}
                   decimals={fromToken.decimals}
                   symbol={fromToken.symbol}
+                  tokenName={fromToken.name}
                   onMaxClick={handleMax}
                   errorMessage={inputExceedsBalance ? `Insufficient ${fromToken.symbol} balance` : undefined}
                   showTokenSelector
+                  limitTokenSelectorWidth
                   inputTokenUsdPrice={fromTokenPrice}
                   tokenAddress={fromToken.address}
                   tokenChainId={fromToken.chainID}

--- a/src/components/pages/swap/swapParams.test.ts
+++ b/src/components/pages/swap/swapParams.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { buildSwapSearchParams, DEFAULT_SWAP_SELECTION, parseSwapSelection } from './swapParams'
+
+describe('swap URL parameters', () => {
+  it('defaults to mainnet USDC to ETH', () => {
+    expect(parseSwapSelection(new URLSearchParams())).toEqual(DEFAULT_SWAP_SELECTION)
+  })
+
+  it('round-trips supported cross-chain selections', () => {
+    const selection = {
+      fromChainId: 10 as const,
+      fromToken: '0x4200000000000000000000000000000000000006' as const,
+      toChainId: 8453 as const,
+      toToken: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as const
+    }
+
+    expect(parseSwapSelection(buildSwapSearchParams(selection))).toEqual(selection)
+  })
+
+  it('rejects unsupported chains and malformed addresses', () => {
+    expect(parseSwapSelection(new URLSearchParams('fromChain=250&from=nope&toChain=146&to=also-nope'))).toEqual(
+      DEFAULT_SWAP_SELECTION
+    )
+  })
+})

--- a/src/components/pages/swap/swapParams.ts
+++ b/src/components/pages/swap/swapParams.ts
@@ -1,0 +1,51 @@
+import { toAddress } from '@shared/utils'
+import { type Address, isAddress } from 'viem'
+import {
+  DEFAULT_SWAP_FROM_CHAIN_ID,
+  DEFAULT_SWAP_FROM_TOKEN,
+  DEFAULT_SWAP_TO_CHAIN_ID,
+  DEFAULT_SWAP_TO_TOKEN,
+  isSwapChainId,
+  type TSwapChainId
+} from './constants'
+
+export type TSwapSelection = {
+  fromChainId: TSwapChainId
+  fromToken: Address
+  toChainId: TSwapChainId
+  toToken: Address
+}
+
+export const DEFAULT_SWAP_SELECTION: TSwapSelection = {
+  fromChainId: DEFAULT_SWAP_FROM_CHAIN_ID,
+  fromToken: DEFAULT_SWAP_FROM_TOKEN,
+  toChainId: DEFAULT_SWAP_TO_CHAIN_ID,
+  toToken: DEFAULT_SWAP_TO_TOKEN
+}
+
+function parseChain(value: string | null, fallback: TSwapChainId): TSwapChainId {
+  const parsed = Number(value)
+  return isSwapChainId(parsed) ? parsed : fallback
+}
+
+function parseToken(value: string | null, fallback: Address): Address {
+  return value && isAddress(value) ? toAddress(value) : fallback
+}
+
+export function parseSwapSelection(params: URLSearchParams): TSwapSelection {
+  return {
+    fromChainId: parseChain(params.get('fromChain'), DEFAULT_SWAP_SELECTION.fromChainId),
+    fromToken: parseToken(params.get('from'), DEFAULT_SWAP_SELECTION.fromToken),
+    toChainId: parseChain(params.get('toChain'), DEFAULT_SWAP_SELECTION.toChainId),
+    toToken: parseToken(params.get('to'), DEFAULT_SWAP_SELECTION.toToken)
+  }
+}
+
+export function buildSwapSearchParams(selection: TSwapSelection): URLSearchParams {
+  return new URLSearchParams({
+    fromChain: String(selection.fromChainId),
+    from: selection.fromToken,
+    toChain: String(selection.toChainId),
+    to: selection.toToken
+  })
+}

--- a/src/components/pages/swap/swapPolicy.test.ts
+++ b/src/components/pages/swap/swapPolicy.test.ts
@@ -1,0 +1,93 @@
+import type { TKongVaultListItem } from '@shared/utils/schemas/kongVaultListSchema'
+import type { Address } from 'viem'
+import { describe, expect, it } from 'vitest'
+import type { TSwapSelection } from './swapParams'
+import { buildSwapVaultPolicyEntries, getSwapSelectionPolicy } from './swapPolicy'
+
+const TOKEN_A = '0x0000000000000000000000000000000000000001' as Address
+const TOKEN_B = '0x0000000000000000000000000000000000000002' as Address
+const VAULT = '0x0000000000000000000000000000000000000003' as Address
+const STAKING = '0x0000000000000000000000000000000000000004' as Address
+
+const selection: TSwapSelection = {
+  fromChainId: 1,
+  fromToken: TOKEN_A,
+  toChainId: 1,
+  toToken: TOKEN_B
+}
+
+describe('getSwapSelectionPolicy', () => {
+  it('builds policy entries for both vault shares and staking aliases', () => {
+    const entries = buildSwapVaultPolicyEntries({
+      [VAULT]: {
+        address: VAULT,
+        chainId: 1,
+        isHidden: true,
+        isRetired: false,
+        staking: { address: STAKING, available: true, source: '', rewards: [] }
+      } as unknown as TKongVaultListItem
+    })
+
+    expect(entries).toEqual([
+      {
+        address: VAULT,
+        chainId: 1,
+        isHidden: true,
+        isRetired: false,
+        stakingAddress: STAKING
+      }
+    ])
+  })
+
+  it('blocks hidden vault shares and staking aliases on either side', () => {
+    const entries = [
+      {
+        address: VAULT,
+        stakingAddress: STAKING,
+        chainId: 1,
+        isHidden: true,
+        isRetired: false
+      }
+    ]
+
+    expect(
+      getSwapSelectionPolicy({ entries, isLoading: false, selection: { ...selection, fromToken: VAULT } })
+    ).toMatchObject({ isAllowed: false, message: 'Hidden vault tokens cannot be swapped.' })
+    expect(
+      getSwapSelectionPolicy({ entries, isLoading: false, selection: { ...selection, toToken: STAKING } })
+    ).toMatchObject({ isAllowed: false, message: 'Hidden vault tokens cannot be swapped.' })
+  })
+
+  it('allows retired vault sources but blocks retired destinations and staking aliases', () => {
+    const entries = [
+      {
+        address: VAULT,
+        stakingAddress: STAKING,
+        chainId: 1,
+        isHidden: false,
+        isRetired: true
+      }
+    ]
+
+    expect(
+      getSwapSelectionPolicy({ entries, isLoading: false, selection: { ...selection, fromToken: VAULT } })
+    ).toEqual({ isAllowed: true, isReady: true })
+    expect(
+      getSwapSelectionPolicy({ entries, isLoading: false, selection: { ...selection, toToken: STAKING } })
+    ).toMatchObject({ isAllowed: false, message: expect.stringContaining('Retired vault tokens') })
+  })
+
+  it('allows arbitrary non-vault tokens after the registry is ready', () => {
+    expect(getSwapSelectionPolicy({ entries: [], isLoading: false, selection })).toEqual({
+      isAllowed: true,
+      isReady: true
+    })
+  })
+
+  it('blocks quote preparation while the registry is loading', () => {
+    expect(getSwapSelectionPolicy({ entries: [], isLoading: true, selection })).toEqual({
+      isAllowed: false,
+      isReady: false
+    })
+  })
+})

--- a/src/components/pages/swap/swapPolicy.ts
+++ b/src/components/pages/swap/swapPolicy.ts
@@ -1,0 +1,74 @@
+import type { TDict } from '@shared/types'
+import { toAddress } from '@shared/utils'
+import type { TKongVaultListItem } from '@shared/utils/schemas/kongVaultListSchema'
+import { type Address, isAddressEqual, zeroAddress } from 'viem'
+import type { TSwapSelection } from './swapParams'
+
+type TSwapVaultPolicyEntry = {
+  address: Address
+  chainId: number
+  isHidden: boolean
+  isRetired: boolean
+  stakingAddress?: Address
+}
+
+export type TSwapSelectionPolicy = {
+  isAllowed: boolean
+  isReady: boolean
+  message?: string
+}
+
+export function buildSwapVaultPolicyEntries(allVaults: TDict<TKongVaultListItem>): TSwapVaultPolicyEntry[] {
+  return Object.values(allVaults).map((vault) => ({
+    address: toAddress(vault.address),
+    chainId: vault.chainId,
+    isHidden: vault.isHidden,
+    isRetired: vault.isRetired,
+    stakingAddress:
+      vault.staking?.address && !isAddressEqual(vault.staking.address, zeroAddress)
+        ? toAddress(vault.staking.address)
+        : undefined
+  }))
+}
+
+export function getSwapSelectionPolicy({
+  entries,
+  isLoading,
+  selection
+}: {
+  entries: TSwapVaultPolicyEntry[]
+  isLoading: boolean
+  selection: TSwapSelection
+}): TSwapSelectionPolicy {
+  if (isLoading) {
+    return { isAllowed: false, isReady: false }
+  }
+
+  const findEntry = (chainId: number, address: Address): TSwapVaultPolicyEntry | undefined =>
+    entries.find(
+      (entry) =>
+        entry.chainId === chainId &&
+        (isAddressEqual(entry.address, address) ||
+          Boolean(entry.stakingAddress && isAddressEqual(entry.stakingAddress, address)))
+    )
+  const fromEntry = findEntry(selection.fromChainId, selection.fromToken)
+  const toEntry = findEntry(selection.toChainId, selection.toToken)
+
+  if (fromEntry?.isHidden || toEntry?.isHidden) {
+    return {
+      isAllowed: false,
+      isReady: true,
+      message: 'Hidden vault tokens cannot be swapped.'
+    }
+  }
+
+  if (toEntry?.isRetired) {
+    return {
+      isAllowed: false,
+      isReady: true,
+      message: 'Retired vault tokens can only be selected as the asset you pay.'
+    }
+  }
+
+  return { isAllowed: true, isReady: true }
+}

--- a/src/components/pages/swap/swapTokenPrice.test.ts
+++ b/src/components/pages/swap/swapTokenPrice.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSwapTokenPrice } from './swapTokenPrice'
+
+describe('resolveSwapTokenPrice', () => {
+  it('prefers a valid context price', () => {
+    expect(
+      resolveSwapTokenPrice({
+        contextPrice: 2,
+        walletValue: 30,
+        walletBalance: 10,
+        vaultUnderlyingPrice: 4,
+        vaultPricePerShare: 1.2
+      })
+    ).toBe(2)
+  })
+
+  it('derives a price from wallet value when the context price is unavailable', () => {
+    expect(resolveSwapTokenPrice({ contextPrice: 0, walletValue: 9_513.34, walletBalance: 4.99 })).toBeCloseTo(
+      1_906.48,
+      2
+    )
+  })
+
+  it('derives a vault-share price from underlying price and PPS', () => {
+    expect(
+      resolveSwapTokenPrice({
+        contextPrice: 0,
+        walletValue: 0,
+        walletBalance: 0,
+        vaultUnderlyingPrice: 1,
+        vaultPricePerShare: 1.08
+      })
+    ).toBe(1.08)
+  })
+
+  it('returns zero rather than inventing a price', () => {
+    expect(resolveSwapTokenPrice({ contextPrice: 0, walletValue: 0, walletBalance: 0 })).toBe(0)
+  })
+})

--- a/src/components/pages/swap/swapTokenPrice.ts
+++ b/src/components/pages/swap/swapTokenPrice.ts
@@ -1,0 +1,25 @@
+export function resolveSwapTokenPrice({
+  contextPrice,
+  walletValue,
+  walletBalance,
+  vaultUnderlyingPrice,
+  vaultPricePerShare
+}: {
+  contextPrice: number
+  walletValue: number
+  walletBalance: number
+  vaultUnderlyingPrice?: number
+  vaultPricePerShare?: number
+}): number {
+  if (Number.isFinite(contextPrice) && contextPrice > 0) {
+    return contextPrice
+  }
+
+  const walletPrice = walletBalance > 0 ? walletValue / walletBalance : 0
+  if (Number.isFinite(walletPrice) && walletPrice > 0) {
+    return walletPrice
+  }
+
+  const vaultSharePrice = (vaultUnderlyingPrice ?? 0) * (vaultPricePerShare ?? 0)
+  return Number.isFinite(vaultSharePrice) && vaultSharePrice > 0 ? vaultSharePrice : 0
+}

--- a/src/components/pages/swap/swapTransaction.test.ts
+++ b/src/components/pages/swap/swapTransaction.test.ts
@@ -1,0 +1,63 @@
+import { toNormalizedBN } from '@shared/utils'
+import { describe, expect, it } from 'vitest'
+import {
+  getSwapSuccessMessage,
+  getSwapWorstCaseImpact,
+  hasExecutableSwapMinimum,
+  resolveSwapTokenBalance
+} from './swapTransaction'
+
+const TOKEN = '0x0000000000000000000000000000000000000001' as const
+
+describe('swap transaction helpers', () => {
+  it('uses the RPC balance when the selected custom token is absent from wallet balances', () => {
+    const rpcBalance = toNormalizedBN(12_500_000n, 6)
+
+    expect(
+      resolveSwapTokenBalance({
+        address: TOKEN,
+        rpcToken: { address: TOKEN, balance: rpcBalance, decimals: 6 },
+        fallbackWalletToken: {
+          address: TOKEN,
+          balance: toNormalizedBN(0n, 6)
+        },
+        fallbackDecimals: 6
+      })
+    ).toEqual(rpcBalance)
+  })
+
+  it('keeps an exact wallet balance authoritative when present', () => {
+    const walletBalance = toNormalizedBN(2_000_000n, 6)
+
+    expect(
+      resolveSwapTokenBalance({
+        address: TOKEN,
+        walletBalanceToken: { address: TOKEN, balance: walletBalance },
+        rpcToken: { address: TOKEN, balance: toNormalizedBN(3_000_000n, 6), decimals: 6 },
+        fallbackDecimals: 6
+      })
+    ).toEqual(walletBalance)
+  })
+
+  it('blocks positive quotes without an enforceable minimum output', () => {
+    expect(hasExecutableSwapMinimum(100n, 0n)).toBe(false)
+    expect(getSwapWorstCaseImpact({ inputUsd: 100, expectedOutUsd: 99, minExpectedOutUsd: 0 })).toBe(100)
+  })
+
+  it('retains ordinary worst-case impact calculations for valid quotes', () => {
+    expect(hasExecutableSwapMinimum(100n, 98n)).toBe(true)
+    expect(getSwapWorstCaseImpact({ inputUsd: 100, expectedOutUsd: 99, minExpectedOutUsd: 98 })).toBe(2)
+  })
+
+  it('labels same-chain output as expected instead of realized', () => {
+    expect(
+      getSwapSuccessMessage({
+        formattedInput: '10',
+        fromSymbol: 'USDC',
+        formattedExpectedOutput: '0.004',
+        toSymbol: 'ETH',
+        isCrossChain: false
+      })
+    ).toBe('Swap confirmed for 10 USDC. Expected output: 0.004 ETH.')
+  })
+})

--- a/src/components/pages/swap/swapTransaction.ts
+++ b/src/components/pages/swap/swapTransaction.ts
@@ -1,0 +1,82 @@
+import type { Token as TRpcToken } from '@pages/vaults/hooks/useTokens'
+import type { TNormalizedBN, TToken } from '@shared/types'
+import { toNormalizedBN } from '@shared/utils'
+import { type Address, isAddressEqual } from 'viem'
+
+type TBalanceToken = Pick<TToken, 'address' | 'balance'>
+
+function isMatchingToken(token: TBalanceToken | TRpcToken | undefined, address: Address): boolean {
+  return Boolean(token?.address && isAddressEqual(token.address, address))
+}
+
+export function resolveSwapTokenBalance({
+  address,
+  walletBalanceToken,
+  rpcToken,
+  fallbackWalletToken,
+  fallbackDecimals
+}: {
+  address: Address
+  walletBalanceToken?: TBalanceToken
+  rpcToken?: TRpcToken
+  fallbackWalletToken?: TBalanceToken
+  fallbackDecimals: number
+}): TNormalizedBN {
+  if (isMatchingToken(walletBalanceToken, address)) {
+    return walletBalanceToken!.balance
+  }
+
+  if (isMatchingToken(rpcToken, address)) {
+    return rpcToken!.balance
+  }
+
+  if (isMatchingToken(fallbackWalletToken, address)) {
+    return fallbackWalletToken!.balance
+  }
+
+  return toNormalizedBN(0n, rpcToken?.decimals ?? fallbackDecimals)
+}
+
+export function getSwapWorstCaseImpact({
+  inputUsd,
+  expectedOutUsd,
+  minExpectedOutUsd
+}: {
+  inputUsd: number
+  expectedOutUsd: number
+  minExpectedOutUsd: number
+}): number {
+  if (inputUsd <= 0 || expectedOutUsd <= 0) {
+    return 0
+  }
+
+  if (minExpectedOutUsd <= 0) {
+    return 100
+  }
+
+  return Math.max(0, ((inputUsd - minExpectedOutUsd) / inputUsd) * 100)
+}
+
+export function hasExecutableSwapMinimum(expectedOut: bigint, minExpectedOut: bigint): boolean {
+  return expectedOut > 0n && minExpectedOut > 0n
+}
+
+export function getSwapSuccessMessage({
+  formattedInput,
+  fromSymbol,
+  formattedExpectedOutput,
+  toSymbol,
+  isCrossChain
+}: {
+  formattedInput: string
+  fromSymbol: string
+  formattedExpectedOutput: string
+  toSymbol: string
+  isCrossChain: boolean
+}): string {
+  if (isCrossChain) {
+    return `Your cross-chain swap to ${toSymbol} has been submitted. It may take a few minutes to arrive.`
+  }
+
+  return `Swap confirmed for ${formattedInput} ${fromSymbol}. Expected output: ${formattedExpectedOutput} ${toSymbol}.`
+}

--- a/src/components/pages/swap/swapVaultEstimate.test.ts
+++ b/src/components/pages/swap/swapVaultEstimate.test.ts
@@ -1,0 +1,56 @@
+import { parseUnits } from 'viem'
+import { describe, expect, it } from 'vitest'
+import { getSwapVaultEstimate } from './swapVaultEstimate'
+
+describe('getSwapVaultEstimate', () => {
+  it('converts quoted vault shares into underlying value and annual return', () => {
+    expect(
+      getSwapVaultEstimate({
+        expectedShares: parseUnits('10', 18),
+        minimumShares: parseUnits('9.9', 18),
+        shareDecimals: 18,
+        pricePerShare: 1.25,
+        underlyingPrice: 2,
+        annualRate: 0.1
+      })
+    ).toEqual({
+      expectedUnderlying: 12.5,
+      minimumUnderlying: 12.375,
+      expectedUnderlyingUsd: 25,
+      minimumUnderlyingUsd: 24.75,
+      estimatedAnnualReturn: 1.2375,
+      estimatedAnnualReturnUsd: 2.475
+    })
+  })
+
+  it('keeps unavailable price and APR data distinct from zero', () => {
+    expect(
+      getSwapVaultEstimate({
+        expectedShares: parseUnits('10', 18),
+        minimumShares: parseUnits('9.9', 18),
+        shareDecimals: 18,
+        pricePerShare: 1.25
+      })
+    ).toEqual({
+      expectedUnderlying: 12.5,
+      minimumUnderlying: 12.375,
+      expectedUnderlyingUsd: null,
+      minimumUnderlyingUsd: null,
+      estimatedAnnualReturn: null,
+      estimatedAnnualReturnUsd: null
+    })
+  })
+
+  it('does not synthesize underlying values without a price per share', () => {
+    expect(
+      getSwapVaultEstimate({
+        expectedShares: parseUnits('10', 18),
+        minimumShares: parseUnits('9.9', 18),
+        shareDecimals: 18,
+        pricePerShare: 0,
+        underlyingPrice: 2,
+        annualRate: 0.1
+      }).minimumUnderlying
+    ).toBeNull()
+  })
+})

--- a/src/components/pages/swap/swapVaultEstimate.ts
+++ b/src/components/pages/swap/swapVaultEstimate.ts
@@ -1,0 +1,53 @@
+import { formatUnits } from 'viem'
+
+export type TSwapVaultEstimate = {
+  expectedUnderlying: number | null
+  minimumUnderlying: number | null
+  expectedUnderlyingUsd: number | null
+  minimumUnderlyingUsd: number | null
+  estimatedAnnualReturn: number | null
+  estimatedAnnualReturnUsd: number | null
+}
+
+export function getSwapVaultEstimate({
+  expectedShares,
+  minimumShares,
+  shareDecimals,
+  pricePerShare,
+  underlyingPrice,
+  annualRate
+}: {
+  expectedShares: bigint
+  minimumShares: bigint
+  shareDecimals: number
+  pricePerShare: number
+  underlyingPrice?: number
+  annualRate?: number
+}): TSwapVaultEstimate {
+  if (!Number.isFinite(pricePerShare) || pricePerShare <= 0) {
+    return {
+      expectedUnderlying: null,
+      minimumUnderlying: null,
+      expectedUnderlyingUsd: null,
+      minimumUnderlyingUsd: null,
+      estimatedAnnualReturn: null,
+      estimatedAnnualReturnUsd: null
+    }
+  }
+
+  const expectedUnderlying = Number(formatUnits(expectedShares, shareDecimals)) * pricePerShare
+  const minimumUnderlying = Number(formatUnits(minimumShares, shareDecimals)) * pricePerShare
+  const hasUnderlyingPrice = Number.isFinite(underlyingPrice) && (underlyingPrice ?? 0) > 0
+  const hasAnnualRate = Number.isFinite(annualRate) && annualRate !== undefined && annualRate >= 0
+  const estimatedAnnualReturn = hasAnnualRate ? minimumUnderlying * annualRate : null
+
+  return {
+    expectedUnderlying,
+    minimumUnderlying,
+    expectedUnderlyingUsd: hasUnderlyingPrice ? expectedUnderlying * (underlyingPrice ?? 0) : null,
+    minimumUnderlyingUsd: hasUnderlyingPrice ? minimumUnderlying * (underlyingPrice ?? 0) : null,
+    estimatedAnnualReturn,
+    estimatedAnnualReturnUsd:
+      estimatedAnnualReturn !== null && hasUnderlyingPrice ? estimatedAnnualReturn * (underlyingPrice ?? 0) : null
+  }
+}

--- a/src/components/pages/swap/walletAssets.test.ts
+++ b/src/components/pages/swap/walletAssets.test.ts
@@ -1,0 +1,67 @@
+import { toNormalizedBN } from '@shared/utils'
+import { describe, expect, it } from 'vitest'
+import { getSwapWalletAssets } from './walletAssets'
+
+const token = (address: `0x${string}`, symbol: string, value: number) => ({
+  address,
+  name: symbol,
+  symbol,
+  decimals: 18,
+  chainID: 1,
+  value,
+  balance: toNormalizedBN(value > 0 ? 1n : 0n, 18)
+})
+
+describe('getSwapWalletAssets', () => {
+  it('hides unverified balances by default and reveals them on request', () => {
+    const verified = token('0x0000000000000000000000000000000000000001', 'USDC', 10)
+    const unverified = token('0x0000000000000000000000000000000000000002', 'Claim', 100)
+    const params = {
+      tokens: [verified, unverified],
+      knownAddresses: new Set([verified.address.toLowerCase()]),
+      majorAddresses: new Set<string>(),
+      yearnAddresses: new Set<string>(),
+      excludedAddresses: new Set<string>()
+    }
+
+    expect(getSwapWalletAssets({ ...params, showUnverified: false }).map((asset) => asset.token.symbol)).toEqual([
+      'USDC'
+    ])
+    expect(getSwapWalletAssets({ ...params, showUnverified: true }).map((asset) => asset.token.symbol)).toEqual([
+      'USDC',
+      'Claim'
+    ])
+  })
+
+  it('prioritizes major assets, then Yearn vaults, then other verified assets', () => {
+    const major = token('0x0000000000000000000000000000000000000001', 'USDC', 1)
+    const vault = token('0x0000000000000000000000000000000000000002', 'yvUSDC', 20)
+    const listed = token('0x0000000000000000000000000000000000000003', 'LIST', 100)
+
+    expect(
+      getSwapWalletAssets({
+        tokens: [listed, vault, major],
+        knownAddresses: new Set([listed.address.toLowerCase()]),
+        majorAddresses: new Set([major.address.toLowerCase()]),
+        yearnAddresses: new Set([vault.address.toLowerCase()]),
+        excludedAddresses: new Set<string>(),
+        showUnverified: false
+      }).map((asset) => asset.token.symbol)
+    ).toEqual(['USDC', 'yvUSDC', 'LIST'])
+  })
+
+  it('never exposes balances for excluded hidden vault addresses', () => {
+    const hiddenVault = token('0x0000000000000000000000000000000000000004', 'yvHidden', 100)
+
+    expect(
+      getSwapWalletAssets({
+        tokens: [hiddenVault],
+        knownAddresses: new Set([hiddenVault.address.toLowerCase()]),
+        majorAddresses: new Set<string>(),
+        yearnAddresses: new Set<string>(),
+        excludedAddresses: new Set([hiddenVault.address.toLowerCase()]),
+        showUnverified: true
+      })
+    ).toEqual([])
+  })
+})

--- a/src/components/pages/swap/walletAssets.ts
+++ b/src/components/pages/swap/walletAssets.ts
@@ -1,0 +1,48 @@
+import type { TToken } from '@shared/types'
+import { toAddress } from '@shared/utils'
+
+export type TSwapWalletAsset = {
+  token: TToken
+  isMajor: boolean
+  isYearn: boolean
+  isVerified: boolean
+}
+
+export function getSwapWalletAssets({
+  tokens,
+  knownAddresses,
+  majorAddresses,
+  yearnAddresses,
+  excludedAddresses,
+  showUnverified
+}: {
+  tokens: TToken[]
+  knownAddresses: ReadonlySet<string>
+  majorAddresses: ReadonlySet<string>
+  yearnAddresses: ReadonlySet<string>
+  excludedAddresses: ReadonlySet<string>
+  showUnverified: boolean
+}): TSwapWalletAsset[] {
+  return tokens
+    .filter((token) => token.balance.raw > 0n && !excludedAddresses.has(toAddress(token.address).toLowerCase()))
+    .map((token): TSwapWalletAsset => {
+      const address = toAddress(token.address).toLowerCase()
+      const isMajor = majorAddresses.has(address)
+      const isYearn = yearnAddresses.has(address)
+
+      return {
+        token,
+        isMajor,
+        isYearn,
+        isVerified: isMajor || isYearn || knownAddresses.has(address)
+      }
+    })
+    .filter((asset) => showUnverified || asset.isVerified)
+    .sort((a, b) => {
+      const rankA = a.isMajor ? 0 : a.isYearn ? 1 : a.isVerified ? 2 : 3
+      const rankB = b.isMajor ? 0 : b.isYearn ? 1 : b.isVerified ? 2 : 3
+      if (rankA !== rankB) return rankA - rankB
+      if (a.token.value !== b.token.value) return b.token.value - a.token.value
+      return a.token.symbol.localeCompare(b.token.symbol)
+    })
+}

--- a/src/components/pages/vaults/components/notifications/Notification.tsx
+++ b/src/components/pages/vaults/components/notifications/Notification.tsx
@@ -13,6 +13,7 @@ import Link from 'next/link'
 import type { ReactElement } from 'react'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { env } from '@/env'
+import { getNotificationReceiveLabel } from './notificationAmount'
 
 const NETWORK_BY_CHAIN_ID = new Map(SUPPORTED_NETWORKS.map((network) => [network.id, network] as const)) as ReadonlyMap<
   number,
@@ -257,7 +258,9 @@ function DepositNotificationContent({ notification }: { notification: TNotificat
           {notification.toTokenName && notification.toAddress && (
             <>
               <p>
-                {notification.type === 'swap' || notification.type === 'crosschain swap' ? 'Receive:' : 'To vault:'}
+                {notification.type === 'swap' || notification.type === 'crosschain swap'
+                  ? getNotificationReceiveLabel(notification)
+                  : 'To vault:'}
               </p>
               <p className={'text-right font-bold'}>
                 <Link

--- a/src/components/pages/vaults/components/notifications/Notification.tsx
+++ b/src/components/pages/vaults/components/notifications/Notification.tsx
@@ -256,16 +256,22 @@ function DepositNotificationContent({ notification }: { notification: TNotificat
           </p>
           {notification.toTokenName && notification.toAddress && (
             <>
-              <p>{'To vault:'}</p>
+              <p>
+                {notification.type === 'swap' || notification.type === 'crosschain swap' ? 'Receive:' : 'To vault:'}
+              </p>
               <p className={'text-right font-bold'}>
                 <Link
                   href={`${toChainExplorerBaseURI}/address/${notification.toAddress}`}
                   target={'_blank'}
                   rel={'noopener noreferrer'}
-                  aria-label={`View vault ${notification.toTokenName} on explorer`}
+                  aria-label={`View token ${notification.toTokenName} on explorer`}
                   className={'text-text-primary hover:text-text-secondary'}
                 >
-                  <button className={'text-xs font-medium underline'}>{notification.toTokenName}</button>
+                  <button className={'text-xs font-medium underline'}>
+                    {notification.toAmount
+                      ? `${notification.toAmount} ${notification.toTokenName}`
+                      : notification.toTokenName}
+                  </button>
                 </Link>
               </p>
             </>
@@ -505,7 +511,11 @@ function NotificationContent({ notification }: { notification: TNotification }):
     return <CooldownNotificationContent notification={notification} />
   }
 
-  if (['deposit', 'stake', 'zap', 'crosschain zap', 'deposit and stake'].includes(notification.type)) {
+  if (
+    ['deposit', 'stake', 'zap', 'crosschain zap', 'swap', 'crosschain swap', 'deposit and stake'].includes(
+      notification.type
+    )
+  ) {
     return <DepositNotificationContent notification={notification} />
   }
 
@@ -571,6 +581,10 @@ export const Notification = memo(function Notification({
         return 'Zap'
       case 'crosschain zap':
         return 'Cross-chain Zap'
+      case 'swap':
+        return 'Swap'
+      case 'crosschain swap':
+        return 'Cross-chain Swap'
       case 'withdraw zap':
         return 'Withdraw Zap'
       case 'crosschain withdraw zap':

--- a/src/components/pages/vaults/components/notifications/notificationAmount.test.ts
+++ b/src/components/pages/vaults/components/notifications/notificationAmount.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+import { getNotificationReceiveLabel } from './notificationAmount'
+
+describe('getNotificationReceiveLabel', () => {
+  it('labels swap quotes by their amount semantics', () => {
+    expect(getNotificationReceiveLabel({ type: 'swap', toAmountType: 'expected' })).toBe('Expected receive:')
+    expect(getNotificationReceiveLabel({ type: 'crosschain swap', toAmountType: 'minimum' })).toBe('Minimum receive:')
+  })
+
+  it('preserves the existing receive label for other notification types', () => {
+    expect(getNotificationReceiveLabel({ type: 'withdraw', toAmountType: undefined })).toBe('Receive:')
+  })
+})

--- a/src/components/pages/vaults/components/notifications/notificationAmount.ts
+++ b/src/components/pages/vaults/components/notifications/notificationAmount.ts
@@ -1,0 +1,14 @@
+import type { TNotification } from '@shared/types/notifications'
+
+export function getNotificationReceiveLabel(notification: Pick<TNotification, 'type' | 'toAmountType'>): string {
+  if (notification.type === 'swap' || notification.type === 'crosschain swap') {
+    if (notification.toAmountType === 'minimum') {
+      return 'Minimum receive:'
+    }
+    if (notification.toAmountType === 'expected') {
+      return 'Expected receive:'
+    }
+  }
+
+  return 'Receive:'
+}

--- a/src/components/pages/vaults/components/widget/InputTokenAmount.test.tsx
+++ b/src/components/pages/vaults/components/widget/InputTokenAmount.test.tsx
@@ -113,8 +113,8 @@ describe('InputTokenAmount', () => {
       />
     )
 
-    expect(html).toContain('max-w-[50%]')
-    expect(html).toContain('overflow-x-auto')
+    expect(html).toContain('max-w-[60%]')
+    expect(html).toContain('overflow-hidden')
     expect(html).toContain('title="Curve RSUP-WETH Factory yVault (yvCurve-RSUP-WETH-f)"')
   })
 

--- a/src/components/pages/vaults/components/widget/InputTokenAmount.test.tsx
+++ b/src/components/pages/vaults/components/widget/InputTokenAmount.test.tsx
@@ -91,6 +91,33 @@ describe('InputTokenAmount', () => {
     expect(html).toContain('Balance: 4 yvUSD')
   })
 
+  it('caps an opted-in token selector and exposes its full name', async () => {
+    const InputTokenAmount = await loadInputTokenAmount()
+    const html = renderToStaticMarkup(
+      <InputTokenAmount
+        input={
+          [
+            {
+              formValue: '1',
+              activity: [false, vi.fn()],
+              decimals: 18
+            },
+            vi.fn(),
+            vi.fn()
+          ] as never
+        }
+        symbol={'yvCurve-RSUP-WETH-f'}
+        tokenName={'Curve RSUP-WETH Factory yVault'}
+        showTokenSelector
+        limitTokenSelectorWidth
+      />
+    )
+
+    expect(html).toContain('max-w-[50%]')
+    expect(html).toContain('overflow-x-auto')
+    expect(html).toContain('title="Curve RSUP-WETH Factory yVault (yvCurve-RSUP-WETH-f)"')
+  })
+
   it('renders zap output USD from raw quote amounts instead of compact display text', async () => {
     const InputTokenAmount = await loadInputTokenAmount()
     const html = renderToStaticMarkup(

--- a/src/components/pages/vaults/components/widget/InputTokenAmount.tsx
+++ b/src/components/pages/vaults/components/widget/InputTokenAmount.tsx
@@ -17,6 +17,7 @@ interface Props {
   displayBalance?: bigint
   decimals?: number
   symbol?: string
+  tokenName?: string
   placeholder?: string
   title?: string
   disabled?: boolean
@@ -25,6 +26,7 @@ interface Props {
   onInputChange?: (value: bigint) => void
   onMaxClick?: () => Promise<void> | void // Optional callback when MAX is clicked
   showTokenSelector?: boolean
+  limitTokenSelectorWidth?: boolean
   onTokenSelectorClick?: () => void
   // USD prices
   inputTokenUsdPrice?: number
@@ -54,6 +56,7 @@ export const InputTokenAmount: FC<Props> = ({
   displayBalance,
   decimals,
   symbol,
+  tokenName,
   placeholder,
   disabled: _disabled,
   isMaxButtonLoading = false,
@@ -62,6 +65,7 @@ export const InputTokenAmount: FC<Props> = ({
   onMaxClick,
   title = 'Amount',
   showTokenSelector = false,
+  limitTokenSelectorWidth = false,
   onTokenSelectorClick,
   inputTokenUsdPrice = 0,
   outputTokenUsdPrice = 0,
@@ -118,6 +122,8 @@ export const InputTokenAmount: FC<Props> = ({
     () => getTokenLogoSources({ address: tokenAddress, chainId: tokenChainId, logoURI: tokenLogoURI, size: 32 }),
     [tokenAddress, tokenChainId, tokenLogoURI]
   )
+  const tokenSelectorTitle =
+    tokenName && tokenName !== symbol ? `${tokenName} (${symbol ?? 'Select Token'})` : (symbol ?? 'Select Token')
 
   // Calculate percentage amounts
   const handlePercentageClick = async (percentage: number) => {
@@ -240,11 +246,13 @@ export const InputTokenAmount: FC<Props> = ({
               type="button"
               onClick={handleTokenButtonClick}
               data-token-selector-button
+              title={tokenSelectorTitle}
               disabled={!showTokenSelector && disabled}
               className={cl(
-                'px-2 py-1.5 md:py-1 rounded-lg flex items-center gap-1.5 md:gap-2',
+                'px-2 py-1.5 md:py-1 rounded-lg flex items-center gap-1.5 md:gap-2 overflow-hidden',
                 'text-text-primary text-base md:text-xl font-medium',
                 'min-h-[44px]',
+                limitTokenSelectorWidth ? 'max-w-[50%] shrink-0' : undefined,
                 showTokenSelector
                   ? 'bg-transparent hover:bg-surface-secondary active:bg-surface-secondary'
                   : disabled
@@ -261,12 +269,20 @@ export const InputTokenAmount: FC<Props> = ({
                   chainId={tokenChainId}
                   width={32}
                   height={32}
-                  className="rounded-full"
+                  className="shrink-0 rounded-full"
                 />
               )}
-              <span>{symbol ?? 'Select Token'}</span>
+              <span
+                className={cl(
+                  limitTokenSelectorWidth
+                    ? 'min-w-0 flex-1 overflow-x-auto whitespace-nowrap scrollbar-none'
+                    : undefined
+                )}
+              >
+                {symbol ?? 'Select Token'}
+              </span>
               {showTokenSelector && (
-                <svg className="w-5 h-5 ml-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg className="ml-1 size-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                 </svg>
               )}

--- a/src/components/pages/vaults/components/widget/InputTokenAmount.tsx
+++ b/src/components/pages/vaults/components/widget/InputTokenAmount.tsx
@@ -1,5 +1,6 @@
 import type { useDebouncedInput } from '@pages/vaults/hooks/useDebouncedInput'
 import type { useInput } from '@pages/vaults/hooks/useInput'
+import { OverflowMarqueeText } from '@shared/components/OverflowMarqueeText'
 import { TokenLogoV2 } from '@shared/components/TokenLogoV2'
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { cl, formatTAmount, simpleToExact } from '@shared/utils'
@@ -252,7 +253,7 @@ export const InputTokenAmount: FC<Props> = ({
                 'px-2 py-1.5 md:py-1 rounded-lg flex items-center gap-1.5 md:gap-2 overflow-hidden',
                 'text-text-primary text-base md:text-xl font-medium',
                 'min-h-[44px]',
-                limitTokenSelectorWidth ? 'max-w-[50%] shrink-0' : undefined,
+                limitTokenSelectorWidth ? 'max-w-[60%] shrink-0' : undefined,
                 showTokenSelector
                   ? 'bg-transparent hover:bg-surface-secondary active:bg-surface-secondary'
                   : disabled
@@ -272,15 +273,11 @@ export const InputTokenAmount: FC<Props> = ({
                   className="shrink-0 rounded-full"
                 />
               )}
-              <span
-                className={cl(
-                  limitTokenSelectorWidth
-                    ? 'min-w-0 flex-1 overflow-x-auto whitespace-nowrap scrollbar-none'
-                    : undefined
-                )}
-              >
-                {symbol ?? 'Select Token'}
-              </span>
+              {limitTokenSelectorWidth ? (
+                <OverflowMarqueeText>{symbol ?? 'Select Token'}</OverflowMarqueeText>
+              ) : (
+                <span>{symbol ?? 'Select Token'}</span>
+              )}
               {showTokenSelector && (
                 <svg className="ml-1 size-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />

--- a/src/components/pages/vaults/components/widget/SettingsPanel.tsx
+++ b/src/components/pages/vaults/components/widget/SettingsPanel.tsx
@@ -8,7 +8,8 @@ import {
   ZAP_SLIPPAGE_RISK_ACKNOWLEDGEMENT_TEXT
 } from '@shared/utils/slippage'
 import { type FC, useCallback, useEffect, useId, useState } from 'react'
-import { type Address, getAddress, isAddress } from 'viem'
+import type { Address } from 'viem'
+import { getSettingsRecipientState } from './settingsRecipient'
 
 type SettingsPanelProps = {
   isActive: boolean
@@ -49,8 +50,8 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({
   }, [isActive, recipient, zapSlippage])
 
   const handleClose = useCallback(() => {
-    const normalizedRecipient = localRecipient.trim()
-    if (onRecipientChange && normalizedRecipient && !isAddress(normalizedRecipient)) {
+    const recipientState = getSettingsRecipientState(localRecipient, defaultRecipient)
+    if (onRecipientChange && recipientState.error) {
       return
     }
 
@@ -68,8 +69,7 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({
     }
 
     if (onRecipientChange) {
-      const nextRecipient = normalizedRecipient ? getAddress(normalizedRecipient) : undefined
-      onRecipientChange(nextRecipient === defaultRecipient ? undefined : nextRecipient)
+      onRecipientChange(recipientState.recipient)
     }
 
     onClose?.()
@@ -95,8 +95,7 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({
   })
   const riskAcknowledgementMessage =
     needsRiskAcknowledgement && !hasValidRiskAcknowledgement ? 'Sentence does not match exactly.' : null
-  const recipientError =
-    localRecipient.trim() && !isAddress(localRecipient.trim()) ? 'Enter a valid EVM address.' : null
+  const recipientError = getSettingsRecipientState(localRecipient, defaultRecipient).error
 
   const panelClass =
     variant === 'overlay'

--- a/src/components/pages/vaults/components/widget/SettingsPanel.tsx
+++ b/src/components/pages/vaults/components/widget/SettingsPanel.tsx
@@ -8,29 +8,52 @@ import {
   ZAP_SLIPPAGE_RISK_ACKNOWLEDGEMENT_TEXT
 } from '@shared/utils/slippage'
 import { type FC, useCallback, useEffect, useId, useState } from 'react'
+import { type Address, getAddress, isAddress } from 'viem'
 
 type SettingsPanelProps = {
   isActive: boolean
   onClose?: () => void
   variant?: 'panel' | 'overlay'
+  description?: string
+  showAutoStaking?: boolean
+  defaultRecipient?: Address
+  recipient?: Address
+  onRecipientChange?: (recipient: Address | undefined) => void
 }
 
-export const SettingsPanel: FC<SettingsPanelProps> = ({ isActive, onClose, variant = 'panel' }) => {
+export const SettingsPanel: FC<SettingsPanelProps> = ({
+  isActive,
+  onClose,
+  variant = 'panel',
+  description = 'Applies site-wide across all vaults. Route impact consumes part of this tolerance; the remainder is used as execution buffer.',
+  showAutoStaking = true,
+  defaultRecipient,
+  recipient,
+  onRecipientChange
+}) => {
   const { zapSlippage, setZapSlippage, isAutoStakingEnabled, setIsAutoStakingEnabled } = useYearn()
   const [localSlippage, setLocalSlippage] = useState(zapSlippage)
   const [riskAcknowledgement, setRiskAcknowledgement] = useState('')
+  const [localRecipient, setLocalRecipient] = useState(recipient ?? '')
   const slippageId = useId()
   const riskAcknowledgementId = useId()
   const maximizeYieldId = useId()
+  const recipientId = useId()
 
   useEffect(() => {
     if (!isActive) {
       setLocalSlippage(zapSlippage)
       setRiskAcknowledgement('')
+      setLocalRecipient(recipient ?? '')
     }
-  }, [isActive, zapSlippage])
+  }, [isActive, recipient, zapSlippage])
 
   const handleClose = useCallback(() => {
+    const normalizedRecipient = localRecipient.trim()
+    if (onRecipientChange && normalizedRecipient && !isAddress(normalizedRecipient)) {
+      return
+    }
+
     const { sanitizedSlippage, isSlippageDirty, hasValidRiskAcknowledgement } = getZapSlippageSaveState({
       localSlippage,
       currentSlippage: zapSlippage,
@@ -44,8 +67,22 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({ isActive, onClose, varia
       setRiskAcknowledgement('')
     }
 
+    if (onRecipientChange) {
+      const nextRecipient = normalizedRecipient ? getAddress(normalizedRecipient) : undefined
+      onRecipientChange(nextRecipient === defaultRecipient ? undefined : nextRecipient)
+    }
+
     onClose?.()
-  }, [localSlippage, onClose, riskAcknowledgement, setZapSlippage, zapSlippage])
+  }, [
+    defaultRecipient,
+    localRecipient,
+    localSlippage,
+    onClose,
+    onRecipientChange,
+    riskAcknowledgement,
+    setZapSlippage,
+    zapSlippage
+  ])
 
   if (!isActive) {
     return null
@@ -58,6 +95,8 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({ isActive, onClose, varia
   })
   const riskAcknowledgementMessage =
     needsRiskAcknowledgement && !hasValidRiskAcknowledgement ? 'Sentence does not match exactly.' : null
+  const recipientError =
+    localRecipient.trim() && !isAddress(localRecipient.trim()) ? 'Enter a valid EVM address.' : null
 
   const panelClass =
     variant === 'overlay'
@@ -76,10 +115,7 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({ isActive, onClose, varia
         <div className="flex items-start justify-between gap-4 px-6 py-4 border-b border-border">
           <div className="flex flex-col gap-1">
             <h3 className="text-base font-semibold text-text-primary">Transaction Settings</h3>
-            <p className="text-xs text-text-secondary">
-              Applies site-wide across all vaults. Route impact consumes part of this tolerance; the remainder is used
-              as execution buffer.
-            </p>
+            <p className="text-xs text-text-secondary">{description}</p>
           </div>
           {onClose ? (
             <button
@@ -175,32 +211,68 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({ isActive, onClose, varia
                 ) : null}
               </div>
 
-              <div className="flex items-center justify-between pt-2 border-t border-border">
-                <div className="space-y-0.5">
-                  <label htmlFor={maximizeYieldId} className="text-sm text-text-primary">
-                    Stake Automatically
-                  </label>
-                  <p className="text-xs text-text-secondary">Automatically stake to maximize APY.</p>
-                  <p className="text-xs text-text-secondary">No assets will be locked.</p>
-                </div>
-                <button
-                  id={maximizeYieldId}
-                  role="switch"
-                  aria-checked={isAutoStakingEnabled}
-                  onClick={() => setIsAutoStakingEnabled(!isAutoStakingEnabled)}
-                  className={cl(
-                    'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
-                    isAutoStakingEnabled ? 'bg-blue-600' : 'bg-surface-tertiary'
-                  )}
-                >
-                  <span
-                    className={cl(
-                      'inline-block h-4 w-4 transform rounded-full bg-surface border border-border shadow-sm transition-transform',
-                      isAutoStakingEnabled ? 'translate-x-6' : 'translate-x-1'
-                    )}
+              {onRecipientChange ? (
+                <div className="space-y-2 border-t border-border pt-4">
+                  <div className="space-y-0.5">
+                    <label htmlFor={recipientId} className="text-sm text-text-primary">
+                      Recipient (advanced)
+                    </label>
+                    <p className="text-xs text-text-secondary">
+                      Leave blank to receive in the connected wallet. Only change this if you control the destination.
+                    </p>
+                  </div>
+                  <input
+                    id={recipientId}
+                    type="text"
+                    value={localRecipient}
+                    onChange={(event) => setLocalRecipient(event.target.value)}
+                    className="w-full rounded-md border border-border bg-surface px-3 py-2 text-xs text-text-primary"
+                    placeholder={defaultRecipient ?? '0x...'}
+                    spellCheck={false}
+                    autoComplete="off"
+                    aria-invalid={Boolean(recipientError)}
                   />
-                </button>
-              </div>
+                  {recipientError ? <p className="text-xs text-red-500">{recipientError}</p> : null}
+                  {localRecipient ? (
+                    <button
+                      type="button"
+                      onClick={() => setLocalRecipient('')}
+                      className="text-xs font-medium text-text-secondary underline transition-colors hover:text-text-primary"
+                    >
+                      Use connected wallet
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {showAutoStaking ? (
+                <div className="flex items-center justify-between pt-2 border-t border-border">
+                  <div className="space-y-0.5">
+                    <label htmlFor={maximizeYieldId} className="text-sm text-text-primary">
+                      Stake Automatically
+                    </label>
+                    <p className="text-xs text-text-secondary">Automatically stake to maximize APY.</p>
+                    <p className="text-xs text-text-secondary">No assets will be locked.</p>
+                  </div>
+                  <button
+                    id={maximizeYieldId}
+                    role="switch"
+                    aria-checked={isAutoStakingEnabled}
+                    onClick={() => setIsAutoStakingEnabled(!isAutoStakingEnabled)}
+                    className={cl(
+                      'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
+                      isAutoStakingEnabled ? 'bg-blue-600' : 'bg-surface-tertiary'
+                    )}
+                  >
+                    <span
+                      className={cl(
+                        'inline-block h-4 w-4 transform rounded-full bg-surface border border-border shadow-sm transition-transform',
+                        isAutoStakingEnabled ? 'translate-x-6' : 'translate-x-1'
+                      )}
+                    />
+                  </button>
+                </div>
+              ) : null}
             </div>
           </div>
         </div>

--- a/src/components/pages/vaults/components/widget/TokenSelector.test.tsx
+++ b/src/components/pages/vaults/components/widget/TokenSelector.test.tsx
@@ -8,9 +8,10 @@ const VAULT_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000002' as cons
 const STAKING_TOKEN_ADDRESS = '0x0000000000000000000000000000000000000003' as const
 const LEGACY_USDAF_ADDRESS = '0x85E30b8b263bC64d94b827ed450F2EdFEE8579dA' as const
 
-const { mockUseWallet, mockUseYearn } = vi.hoisted(() => ({
+const { mockUseWallet, mockUseYearn, mockUseTokenList } = vi.hoisted(() => ({
   mockUseWallet: vi.fn(),
-  mockUseYearn: vi.fn()
+  mockUseYearn: vi.fn(),
+  mockUseTokenList: vi.fn()
 }))
 
 vi.mock('@shared/contexts/useWallet', () => ({
@@ -33,9 +34,7 @@ vi.mock('@shared/contexts/useWallet', () => ({
 }))
 
 vi.mock('@shared/contexts/WithTokenList', () => ({
-  useTokenList: () => ({
-    tokenLists: {}
-  })
+  useTokenList: mockUseTokenList
 }))
 
 vi.mock('@shared/contexts/useYearn', () => ({
@@ -61,6 +60,7 @@ function buildToken(overrides: Partial<TToken> = {}): TToken {
 }
 
 describe('TokenSelector', () => {
+  mockUseTokenList.mockReturnValue({ tokenLists: {}, addCustomToken: vi.fn() })
   mockUseYearn.mockReturnValue({
     allVaults: {},
     getPrice: () => ({ normalized: 0 })
@@ -464,6 +464,132 @@ describe('TokenSelector', () => {
     expect(html).toContain('Base Token')
     expect(html).not.toContain('kpdWETH')
     expect(html).not.toContain('stkWETH')
+  })
+
+  it('excludes retired vaults only when selecting a swap destination', () => {
+    const retiredVault = {
+      chainID: 1,
+      version: '3.0.0',
+      address: VAULT_TOKEN_ADDRESS,
+      name: 'Retired Vault',
+      symbol: 'yvOLD',
+      decimals: 18,
+      token: {
+        address: BASE_TOKEN_ADDRESS,
+        symbol: 'BASE',
+        name: 'Base Token',
+        description: '',
+        decimals: 18
+      },
+      staking: {
+        address: STAKING_TOKEN_ADDRESS,
+        available: true,
+        source: '',
+        rewards: null
+      },
+      info: {
+        sourceURL: '',
+        riskLevel: 0,
+        riskScore: [],
+        riskScoreComment: '',
+        uiNotice: '',
+        isRetired: true,
+        isBoosted: false,
+        isHighlighted: false,
+        isHidden: false
+      }
+    }
+    mockUseWallet.mockReturnValue({
+      isLoading: false,
+      balances: {
+        1: {
+          [VAULT_TOKEN_ADDRESS]: buildToken({
+            address: VAULT_TOKEN_ADDRESS,
+            name: 'Retired Vault',
+            symbol: 'yvOLD'
+          })
+        }
+      },
+      getToken: ({ address }: { address: string }) =>
+        address === VAULT_TOKEN_ADDRESS
+          ? buildToken({ address: VAULT_TOKEN_ADDRESS, name: 'Retired Vault', symbol: 'yvOLD' })
+          : buildToken()
+    })
+    mockUseYearn.mockReturnValue({
+      allVaults: { [VAULT_TOKEN_ADDRESS]: retiredVault },
+      getPrice: () => ({ normalized: 0 })
+    })
+
+    const sourceHtml = renderToStaticMarkup(
+      <TokenSelector value={VAULT_TOKEN_ADDRESS} onChange={() => undefined} chainId={1} mode="swap" />
+    )
+    const destinationHtml = renderToStaticMarkup(
+      <TokenSelector
+        value={BASE_TOKEN_ADDRESS}
+        onChange={() => undefined}
+        chainId={1}
+        mode="swap"
+        excludeRetiredVaults
+      />
+    )
+
+    expect(sourceHtml).toContain('yvOLD')
+    expect(destinationHtml).not.toContain('yvOLD')
+  })
+
+  it('shows only positive wallet balances when balance-only selection is enabled', () => {
+    const heldToken = buildToken({ name: 'Held Token', symbol: 'HELD' })
+    const emptyToken = buildToken({
+      address: VAULT_TOKEN_ADDRESS,
+      name: 'Empty Token',
+      symbol: 'EMPTY',
+      balance: { raw: 0n, normalized: 0, display: '0', decimals: 18 }
+    })
+    mockUseWallet.mockReturnValue({
+      isLoading: false,
+      balances: { 1: { [BASE_TOKEN_ADDRESS]: heldToken, [VAULT_TOKEN_ADDRESS]: emptyToken } },
+      getToken: ({ address }: { address: string }) => (address === VAULT_TOKEN_ADDRESS ? emptyToken : heldToken)
+    })
+    mockUseYearn.mockReturnValue({
+      allVaults: {},
+      getPrice: () => ({ normalized: 0 })
+    })
+
+    const html = renderToStaticMarkup(
+      <TokenSelector value={BASE_TOKEN_ADDRESS} onChange={() => undefined} chainId={1} mode="swap" balanceOnly />
+    )
+
+    expect(html).toContain('Held Token')
+    expect(html).not.toContain('Empty Token')
+  })
+
+  it('does not render the full application token registry for swaps', () => {
+    const registryToken = buildToken({
+      address: VAULT_TOKEN_ADDRESS,
+      name: 'Registry Only Token',
+      symbol: 'REGISTRY',
+      balance: { raw: 0n, normalized: 0, display: '0', decimals: 18 }
+    })
+    mockUseTokenList.mockReturnValue({
+      tokenLists: { 1: { [VAULT_TOKEN_ADDRESS]: registryToken } },
+      addCustomToken: vi.fn()
+    })
+    mockUseWallet.mockReturnValue({
+      isLoading: false,
+      balances: { 1: {} },
+      getToken: () => buildToken()
+    })
+    mockUseYearn.mockReturnValue({
+      allVaults: {},
+      getPrice: () => ({ normalized: 0 })
+    })
+
+    const html = renderToStaticMarkup(
+      <TokenSelector value={BASE_TOKEN_ADDRESS} onChange={() => undefined} chainId={1} mode="swap" />
+    )
+
+    expect(html).not.toContain('Registry Only Token')
+    mockUseTokenList.mockReturnValue({ tokenLists: {}, addCustomToken: vi.fn() })
   })
 
   it('keeps the hidden vault share token available only for explicit unstake selection', () => {

--- a/src/components/pages/vaults/components/widget/TokenSelector.tsx
+++ b/src/components/pages/vaults/components/widget/TokenSelector.tsx
@@ -1,8 +1,11 @@
 import {
   getVaultAddress,
   getVaultChainID,
+  getVaultDecimals,
   getVaultInfo,
-  getVaultStakingAddress
+  getVaultName,
+  getVaultStakingAddress,
+  getVaultSymbol
 } from '@pages/vaults/domain/kongVaultSelectors'
 import { ImageWithFallback } from '@shared/components/ImageWithFallback'
 import { TokenLogoV2 } from '@shared/components/TokenLogoV2'
@@ -10,8 +13,8 @@ import { useWalletStatus, useWalletTokens } from '@shared/contexts/useWallet'
 import { useYearn } from '@shared/contexts/useYearn'
 import { useTokenList } from '@shared/contexts/WithTokenList'
 import type { TToken } from '@shared/types'
-import { cl, formatTAmount, toAddress } from '@shared/utils'
-import { type FC, useCallback, useMemo, useState } from 'react'
+import { cl, formatTAmount, toAddress, toNormalizedBN } from '@shared/utils'
+import { type FC, useCallback, useEffect, useMemo, useState } from 'react'
 import { isAddress, zeroAddress } from 'viem'
 import { env } from '@/env'
 import { CloseIcon } from './shared/Icons'
@@ -55,7 +58,10 @@ interface TokenSelectorProps {
   vaultAddress?: `0x${string}`
   stakingAddress?: `0x${string}`
   allowHiddenVaultTokenSelection?: boolean
+  excludeRetiredVaults?: boolean
+  balanceOnly?: boolean
   mode?: TTokenSelectorMode
+  resolveCustomToken?: (address: `0x${string}`, chainId: number) => Promise<TToken | undefined>
 }
 
 const TokenTypeChip: FC<{ type: TTokenType }> = ({ type }) => {
@@ -101,6 +107,7 @@ const TokenItem: FC<{
           tokenName={token.name}
           width={24}
           height={24}
+          loading="lazy"
           className="rounded-full"
         />
         <div className="text-left">
@@ -137,18 +144,37 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
   vaultAddress,
   stakingAddress,
   allowHiddenVaultTokenSelection,
-  mode = 'default'
+  excludeRetiredVaults,
+  balanceOnly,
+  mode = 'default',
+  resolveCustomToken
 }) => {
   const [searchText, setSearchText] = useState('')
   const [selectedChainId, setSelectedChainId] = useState(chainId)
   const { getToken, balances } = useWalletTokens()
   const { isLoading } = useWalletStatus()
-  const { tokenLists } = useTokenList()
-  const { allVaults, getPrice } = useYearn()
+  const { addCustomToken, tokenLists } = useTokenList()
+  const { allVaults, getPrice, isLoadingVaultList } = useYearn()
   const customAddress = useMemo(
     () => (searchText && isAddress(searchText) ? (searchText as `0x${string}`) : undefined),
     [searchText]
   )
+  const [customAddressToken, setCustomAddressToken] = useState<TToken | undefined>()
+
+  useEffect(() => {
+    if (!customAddress || !resolveCustomToken) {
+      setCustomAddressToken(undefined)
+      return
+    }
+
+    let isCurrent = true
+    void resolveCustomToken(customAddress, selectedChainId).then((token) => {
+      if (isCurrent) setCustomAddressToken(token)
+    })
+    return () => {
+      isCurrent = false
+    }
+  }, [customAddress, resolveCustomToken, selectedChainId])
 
   const priorityTokenAddresses = useMemo(
     () => (priorityTokens?.[selectedChainId] || []).map((address) => toAddress(address) as `0x${string}`),
@@ -182,6 +208,25 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
 
     return [...hiddenAddresses]
   }, [allVaults, selectedChainId])
+  const retiredVaultTokenAddresses = useMemo(() => {
+    if (!excludeRetiredVaults) {
+      return []
+    }
+
+    return Object.values(allVaults).flatMap((vault) => {
+      const info = getVaultInfo(vault)
+      if (getVaultChainID(vault) !== selectedChainId || !info.isRetired) {
+        return []
+      }
+
+      const addresses = [toAddress(getVaultAddress(vault)) as `0x${string}`]
+      const retiredStakingAddress = getVaultStakingAddress(vault)
+      if (retiredStakingAddress !== zeroAddress) {
+        addresses.push(retiredStakingAddress as `0x${string}`)
+      }
+      return addresses
+    })
+  }, [allVaults, excludeRetiredVaults, selectedChainId])
   const hiddenVaultExemptAddresses = useMemo(
     () =>
       mode === 'withdraw' && allowHiddenVaultTokenSelection && selectedChainId === chainId && vaultAddress
@@ -197,11 +242,12 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
           ...hiddenVaultTokenAddresses.filter(
             (address) => !hiddenVaultExemptAddresses.includes(toAddress(address) as `0x${string}`)
           ),
+          ...retiredVaultTokenAddresses,
           ...(LEGACY_SELECTOR_TOKEN_ADDRESSES_BY_CHAIN[selectedChainId] || [])
         ].map((address) => toAddress(address))
       )
     ],
-    [excludeTokens, hiddenVaultExemptAddresses, hiddenVaultTokenAddresses, selectedChainId]
+    [excludeTokens, hiddenVaultExemptAddresses, hiddenVaultTokenAddresses, retiredVaultTokenAddresses, selectedChainId]
   )
   const assetLogoToken = useMemo<TTokenLogoSourceToken | undefined>(() => {
     if (selectedChainId !== assetChainId || !assetAddress) {
@@ -265,6 +311,27 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
       })
     }
 
+    if (mode === 'swap') {
+      Object.values(allVaults)
+        .filter((vault) => getVaultChainID(vault) === selectedChainId && !getVaultInfo(vault).isHidden)
+        .map((vault): TToken => {
+          const address = toAddress(getVaultAddress(vault))
+          const decimals = getVaultDecimals(vault)
+          const walletToken = chainBalances[address]
+
+          return {
+            address,
+            name: getVaultName(vault),
+            symbol: getVaultSymbol(vault) || 'Vault',
+            decimals,
+            chainID: selectedChainId,
+            value: walletToken?.value ?? 0,
+            balance: walletToken?.balance ?? toNormalizedBN(0n, decimals)
+          }
+        })
+        .forEach(setOverride)
+    }
+
     // Add all tokens from wallet balances
     Object.entries(chainBalances).forEach(([address, token]) => {
       if (token.chainID === 137 && toAddress(address) === '0x0000000000000000000000000000000000001010') {
@@ -299,6 +366,16 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
       const customToken = getToken({ address: toAddress(customAddress), chainID: selectedChainId })
       if (customToken.symbol) {
         setIfMissing(customToken)
+      } else if (customAddressToken?.address && customAddressToken.symbol && customAddressToken.symbol !== '???') {
+        setIfMissing({
+          address: toAddress(customAddressToken.address),
+          name: customAddressToken.name || customAddressToken.symbol,
+          symbol: customAddressToken.symbol,
+          decimals: customAddressToken.decimals ?? 18,
+          chainID: selectedChainId,
+          value: 0,
+          balance: customAddressToken.balance
+        })
       }
     }
 
@@ -308,8 +385,22 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
       setOverride(extraToken)
     }
 
-    return [...tokenMap.values()]
-  }, [balances, selectedChainId, value, customAddress, getToken, priorityTokenAddresses, chainExtraTokens])
+    const availableTokens = [...tokenMap.values()]
+    return balanceOnly ? availableTokens.filter((token) => token.balance.raw > 0n) : availableTokens
+  }, [
+    allVaults,
+    balanceOnly,
+    balances,
+    chainExtraTokens,
+    customAddress,
+    customAddressToken,
+    getToken,
+    mode,
+    priorityTokenAddresses,
+    selectedChainId,
+    tokenLists,
+    value
+  ])
 
   const yearnKnownTokenAddresses = useMemo(
     () =>
@@ -397,12 +488,18 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
 
   const handleSelect = useCallback(
     (address: `0x${string}`) => {
+      const selectedCustomToken = customAddressToken?.address
+        ? tokens.find((token) => toAddress(token.address) === toAddress(customAddressToken.address))
+        : undefined
+      if (selectedCustomToken && toAddress(address) === toAddress(selectedCustomToken.address)) {
+        addCustomToken(selectedCustomToken)
+      }
       onChange(address, selectedChainId)
       if (onClose) {
         onClose()
       }
     },
-    [onChange, onClose, selectedChainId]
+    [addCustomToken, customAddressToken?.address, onChange, onClose, selectedChainId, tokens]
   )
 
   const getTokenType = useCallback(
@@ -428,6 +525,8 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
             <button
               key={chain.id}
               onClick={() => setSelectedChainId(chain.id)}
+              aria-label={`Select ${chain.name}`}
+              title={chain.name}
               className={cl(
                 'size-9 flex items-center justify-center rounded-md',
                 selectedChainId === chain.id ? 'bg-surface shadow-sm' : 'bg-transparent hover:bg-surface/50'
@@ -462,7 +561,7 @@ export const TokenSelector: FC<TokenSelectorProps> = ({
 
       {/* Token list */}
       <div className="flex-1 overflow-y-auto px-4 pb-4 overscroll-contain">
-        {isLoading ? (
+        {isLoading || (mode === 'swap' && isLoadingVaultList) ? (
           <div className="flex items-center justify-center py-8">
             <div className="w-5 h-5 border-2 border-border border-t-primary rounded-full animate-spin" />
           </div>

--- a/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/ApprovalOverlay.tsx
@@ -31,6 +31,7 @@ interface ApprovalOverlayProps {
   chainId: number
   currentAllowance: string
   approvalWarning?: string
+  actionLabel?: string
 }
 
 export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
@@ -44,7 +45,8 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
   spenderName,
   chainId,
   currentAllowance,
-  approvalWarning
+  approvalWarning,
+  actionLabel = 'depositing'
 }) => {
   const [txState, setTxState] = useState<TxState>('idle')
   const [errorMessage, setErrorMessage] = useState('')
@@ -247,7 +249,7 @@ export const ApprovalOverlay: FC<ApprovalOverlayProps> = ({
                 <p className="text-sm text-text-secondary">
                   Token approval allows a smart contract to transfer your{' '}
                   <span className="font-semibold text-text-primary">{tokenSymbol}</span> up to a set limit. This is
-                  required before depositing.
+                  required before {actionLabel}.
                 </p>
                 {disableSetUnlimited && (
                   <p className="text-sm text-text-secondary">

--- a/src/components/pages/vaults/components/widget/settingsRecipient.test.ts
+++ b/src/components/pages/vaults/components/widget/settingsRecipient.test.ts
@@ -1,0 +1,30 @@
+import type { Address } from 'viem'
+import { describe, expect, it } from 'vitest'
+import { getSettingsRecipientState } from './settingsRecipient'
+
+const ACCOUNT = '0x0000000000000000000000000000000000000001' as Address
+const RECIPIENT = '0x0000000000000000000000000000000000000002' as Address
+
+describe('getSettingsRecipientState', () => {
+  it('uses the connected wallet for blank input or the default address', () => {
+    expect(getSettingsRecipientState('  ', ACCOUNT)).toEqual({ error: null, recipient: undefined })
+    expect(getSettingsRecipientState(ACCOUNT.toLowerCase(), ACCOUNT)).toEqual({
+      error: null,
+      recipient: undefined
+    })
+  })
+
+  it('normalizes a valid custom recipient', () => {
+    expect(getSettingsRecipientState(RECIPIENT.toLowerCase(), ACCOUNT)).toEqual({
+      error: null,
+      recipient: RECIPIENT
+    })
+  })
+
+  it('rejects invalid and zero addresses', () => {
+    expect(getSettingsRecipientState('not-an-address', ACCOUNT).error).toBe('Enter a valid nonzero EVM address.')
+    expect(getSettingsRecipientState('0x0000000000000000000000000000000000000000', ACCOUNT).error).toBe(
+      'Enter a valid nonzero EVM address.'
+    )
+  })
+})

--- a/src/components/pages/vaults/components/widget/settingsRecipient.ts
+++ b/src/components/pages/vaults/components/widget/settingsRecipient.ts
@@ -1,0 +1,27 @@
+import { type Address, getAddress, isAddress, isAddressEqual, zeroAddress } from 'viem'
+
+export type TSettingsRecipientState = {
+  error: string | null
+  recipient: Address | undefined
+}
+
+export function getSettingsRecipientState(value: string, defaultRecipient?: Address): TSettingsRecipientState {
+  const normalizedValue = value.trim()
+  if (!normalizedValue) {
+    return { error: null, recipient: undefined }
+  }
+
+  if (!isAddress(normalizedValue)) {
+    return { error: 'Enter a valid nonzero EVM address.', recipient: undefined }
+  }
+
+  const recipient = getAddress(normalizedValue)
+  if (isAddressEqual(recipient, zeroAddress)) {
+    return { error: 'Enter a valid nonzero EVM address.', recipient: undefined }
+  }
+
+  return {
+    error: null,
+    recipient: defaultRecipient && isAddressEqual(recipient, defaultRecipient) ? undefined : recipient
+  }
+}

--- a/src/components/pages/vaults/components/widget/shared/TokenSelectorOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TokenSelectorOverlay.tsx
@@ -18,7 +18,10 @@ interface TokenSelectorOverlayProps {
   vaultAddress?: Address
   stakingAddress?: Address
   allowHiddenVaultTokenSelection?: boolean
+  excludeRetiredVaults?: boolean
+  balanceOnly?: boolean
   mode?: TTokenSelectorMode
+  resolveCustomToken?: (address: Address, chainId: number) => Promise<TToken | undefined>
 }
 
 export const TokenSelectorOverlay: FC<TokenSelectorOverlayProps> = ({
@@ -35,7 +38,10 @@ export const TokenSelectorOverlay: FC<TokenSelectorOverlayProps> = ({
   vaultAddress,
   stakingAddress,
   allowHiddenVaultTokenSelection,
-  mode
+  excludeRetiredVaults,
+  balanceOnly,
+  mode,
+  resolveCustomToken
 }) => {
   return (
     <div
@@ -65,7 +71,10 @@ export const TokenSelectorOverlay: FC<TokenSelectorOverlayProps> = ({
           vaultAddress={vaultAddress}
           stakingAddress={stakingAddress}
           allowHiddenVaultTokenSelection={allowHiddenVaultTokenSelection}
+          excludeRetiredVaults={excludeRetiredVaults}
+          balanceOnly={balanceOnly}
           mode={mode}
+          resolveCustomToken={resolveCustomToken}
         />
       </div>
     </div>

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   resolveCompletionDeferral,
+  runBeforeSuccessSafely,
   shouldAutoContinuePermitSuccess,
   shouldRunDeferredCompletion
 } from './transactionOverlay.helpers'
@@ -127,5 +128,31 @@ describe('shouldRunDeferredCompletion', () => {
         trigger: 'close'
       })
     ).toBe(true)
+  })
+})
+
+describe('runBeforeSuccessSafely', () => {
+  it('absorbs refresh failures so confirmed transactions can still finalize', async () => {
+    const error = new Error('RPC unavailable')
+    const onError = vi.fn()
+
+    await expect(
+      runBeforeSuccessSafely({
+        onBeforeSuccess: async () => await Promise.reject(error),
+        label: 'Swap',
+        onError
+      })
+    ).resolves.toBeUndefined()
+    expect(onError).toHaveBeenCalledWith(error)
+  })
+
+  it('awaits a successful refresh without reporting an error', async () => {
+    const onBeforeSuccess = vi.fn(async () => undefined)
+    const onError = vi.fn()
+
+    await runBeforeSuccessSafely({ onBeforeSuccess, label: 'Swap', onError })
+
+    expect(onBeforeSuccess).toHaveBeenCalledWith('Swap')
+    expect(onError).not.toHaveBeenCalled()
   })
 })

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -152,6 +152,10 @@ function isUserRejectionError(error: any): boolean {
   )
 }
 
+function isCrossChainNotification(type: TCreateNotificationParams['type'] | undefined): boolean {
+  return type === 'crosschain zap' || type === 'crosschain swap'
+}
+
 function getTransactionErrorMessage(error: any): string {
   const errorMsg = error?.shortMessage || error?.message || 'Transaction failed. Please try again.'
   return errorMsg.length > 100 ? 'Transaction failed. Please try again.' : errorMsg
@@ -657,7 +661,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       }
 
       const isEnsoOrder = Boolean(request.__isEnsoOrder)
-      const isCrossChain = currentStep.notification?.type === 'crosschain zap'
+      const isCrossChain = isCrossChainNotification(currentStep.notification?.type)
 
       try {
         if (isEnsoOrder) {
@@ -825,7 +829,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     overlayState === 'pending' && receiptOutcome === 'success' && !wasLastStepRef.current && executedStepAutoContinues
   const isSuccessButtonBusy = !isTerminalSuccess && (!isStepReady || isAutoContinuing)
   const successButtonLabel = getSuccessButtonLabel({
-    isCrossChainNotification: successStep?.notification?.type === 'crosschain zap',
+    isCrossChainNotification: isCrossChainNotification(successStep?.notification?.type),
     isTerminalSuccess,
     isAutoContinuing,
     executedStepAutoContinues,
@@ -992,7 +996,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       const completedAllSteps = executedStepRef.current?.completesFlow ?? wasLastStepRef.current
       const capturedStep = executedStepRef.current
       const capturedReceipt = receipt.data
-      const capturedStatus = capturedStep?.notification?.type === 'crosschain zap' ? 'submitted' : 'success'
+      const capturedStatus = isCrossChainNotification(capturedStep?.notification?.type) ? 'submitted' : 'success'
       autoContinueNonceRef.current += 1
       setIsAutoContinuing(false)
       setIsWaitingForNextStep(false)

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -30,6 +30,7 @@ import {
   resolveOverlayConnectedChainId,
   resolvePendingSafeOverlayState,
   resolveTransactionReceiptOutcome,
+  runBeforeSuccessSafely,
   shouldAutoContinueFromSuccessState,
   shouldAutoContinuePermitSuccess,
   shouldRefetchNextStepAfterReceipt,
@@ -1009,7 +1010,13 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       if (completedAllSteps && onBeforeSuccess) {
         setOverlayState('refreshing')
         void (async () => {
-          await onBeforeSuccess(capturedStep?.label ?? '')
+          await runBeforeSuccessSafely({
+            onBeforeSuccess,
+            label: capturedStep?.label ?? '',
+            onError: (error) => {
+              console.error('[TransactionOverlay] Post-confirmation refresh failed', error)
+            }
+          })
           await new Promise((resolve) => setTimeout(resolve, 500))
           finalizeSuccessState(completedAllSteps, capturedStep)
           if (capturedStep?.showConfetti) {

--- a/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
+++ b/src/components/pages/vaults/components/widget/shared/transactionOverlay.helpers.ts
@@ -233,3 +233,19 @@ export function shouldRunDeferredCompletion(params: {
 
   return false
 }
+
+export async function runBeforeSuccessSafely({
+  onBeforeSuccess,
+  label,
+  onError
+}: {
+  onBeforeSuccess: (label: string) => Promise<void>
+  label: string
+  onError: (error: unknown) => void
+}): Promise<void> {
+  try {
+    await onBeforeSuccess(label)
+  } catch (error) {
+    onError(error)
+  }
+}

--- a/src/components/pages/vaults/components/widget/tokenSelectorList.utils.test.ts
+++ b/src/components/pages/vaults/components/widget/tokenSelectorList.utils.test.ts
@@ -148,6 +148,31 @@ describe('filterAndSortTokenSelectorTokens', () => {
     expect(filtered.map((token) => token.address)).toEqual([TOKEN_A])
   })
 
+  it('keeps positive wallet balances available for swaps even when they are not curated', () => {
+    const filtered = filterAndSortTokenSelectorTokens({
+      tokens: [
+        buildToken({
+          address: TOKEN_A,
+          name: 'Wallet Token',
+          symbol: 'WALLET',
+          normalizedBalance: 10,
+          rawBalance: 10n
+        }),
+        buildToken({
+          address: TOKEN_B,
+          name: 'Unknown Empty Token',
+          symbol: 'EMPTY'
+        })
+      ],
+      mode: 'swap',
+      yearnKnownTokenAddresses: new Set<string>(),
+      explicitTokenAddresses: new Set<string>(),
+      getTokenUsdValue: () => 0
+    })
+
+    expect(filtered.map((token) => token.address)).toEqual([TOKEN_A])
+  })
+
   it('still hides known deposit-token dust when a valid price puts it below the minimum threshold', () => {
     const filtered = filterAndSortTokenSelectorTokens({
       tokens: [

--- a/src/components/pages/vaults/components/widget/tokenSelectorList.utils.ts
+++ b/src/components/pages/vaults/components/widget/tokenSelectorList.utils.ts
@@ -10,7 +10,7 @@ import type { TDict, TToken } from '@shared/types'
 import { toAddress } from '@shared/utils'
 import { type Address, zeroAddress } from 'viem'
 
-export type TTokenSelectorMode = 'default' | 'deposit' | 'withdraw'
+export type TTokenSelectorMode = 'default' | 'deposit' | 'withdraw' | 'swap'
 
 type TGetPrice = (props: { address: Address; chainID: number }) => { normalized: number }
 const MIN_SELECTOR_USD_VALUE = 0.01
@@ -190,6 +190,15 @@ export function filterAndSortTokenSelectorTokens({
       }
 
       if (mode === 'deposit' && usdValue <= 0 && !knownAddresses.has(address) && !explicitAddresses.has(address)) {
+        return false
+      }
+
+      if (
+        mode === 'swap' &&
+        token.balance.raw <= 0n &&
+        !knownAddresses.has(address) &&
+        !explicitAddresses.has(address)
+      ) {
         return false
       }
 

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
@@ -1,7 +1,7 @@
 import { type AppUseSimulateContractReturnType, useSimulateContract } from '@shared/hooks/useAppWagmi'
 import type { TNormalizedBN } from '@shared/types'
 import { ETH_TOKEN_ADDRESS, isZeroAddress, toAddress, toNormalizedBN } from '@shared/utils'
-import { getApproveAbi } from '@shared/utils/approve'
+import { getApproveAbi, requiresAllowanceResetForApproval } from '@shared/utils/approve'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Address } from 'viem'
 import { env } from '@/env'
@@ -42,6 +42,7 @@ interface UseSolverEnsoReturn {
     priceImpact: number | null | undefined
     allowance: bigint
     isAllowanceSufficient: boolean
+    needsAllowanceResetBeforeApproval: boolean
     route: EnsoRouteResponse | undefined
     routeHasSwap: boolean
     error: EnsoError | undefined
@@ -262,7 +263,18 @@ export const useSolverEnso = ({
   const hasCurrentError = errorRequestKey === requestKey
   const isLoadingCurrentRequest = isLoadingRoute || (canRequestRoute && !hasCurrentRoute && !hasCurrentError)
   const isAllowanceSufficient = isNativeToken || !allowanceSpender || allowance >= amountIn
-  const prepareApproveEnabled = !isNativeToken && routerAddress && !isAllowanceSufficient && isValidInput && enabled
+  const needsAllowanceResetBeforeApproval = requiresAllowanceResetForApproval({
+    tokenAddress: tokenIn,
+    currentAllowance: allowance,
+    requiredAmount: amountIn
+  })
+  const prepareApproveEnabled =
+    !isNativeToken &&
+    routerAddress &&
+    !isAllowanceSufficient &&
+    !needsAllowanceResetBeforeApproval &&
+    isValidInput &&
+    enabled
   const prepareApprove: AppUseSimulateContractReturnType = useSimulateContract({
     abi: getApproveAbi(tokenIn),
     functionName: 'approve',
@@ -289,6 +301,7 @@ export const useSolverEnso = ({
       priceImpact: visibleRoute?.priceImpact,
       allowance,
       isAllowanceSufficient,
+      needsAllowanceResetBeforeApproval,
       route: visibleRoute,
       routeHasSwap: visibleRouteHasSwap,
       error: visibleError,

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
@@ -1,6 +1,6 @@
 import { type AppUseSimulateContractReturnType, useSimulateContract } from '@shared/hooks/useAppWagmi'
 import type { TNormalizedBN } from '@shared/types'
-import { isZeroAddress, toNormalizedBN } from '@shared/utils'
+import { ETH_TOKEN_ADDRESS, isZeroAddress, toAddress, toNormalizedBN } from '@shared/utils'
 import { getApproveAbi } from '@shared/utils/approve'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Address } from 'viem'
@@ -83,6 +83,7 @@ export const useSolverEnso = ({
   const routeAbortControllerRef = useRef<AbortController | null>(null)
 
   const isCrossChain = destinationChainId !== undefined && destinationChainId !== chainId
+  const isNativeToken = toAddress(tokenIn) === ETH_TOKEN_ADDRESS
   const requestedRoute = resolvedRequestKey === requestKey ? route : undefined
   const requestedRouterAddress = requestedRoute?.tx?.to
   const routerAddress = getValidatedEnsoRouterAddress({
@@ -118,7 +119,7 @@ export const useSolverEnso = ({
     spender: allowanceSpender,
     watch: true,
     chainId,
-    enabled: !!allowanceSpender
+    enabled: !!allowanceSpender && !isNativeToken
   })
 
   const getRoute = useCallback(async () => {
@@ -260,8 +261,8 @@ export const useSolverEnso = ({
   const hasCurrentRoute = resolvedRequestKey === requestKey
   const hasCurrentError = errorRequestKey === requestKey
   const isLoadingCurrentRequest = isLoadingRoute || (canRequestRoute && !hasCurrentRoute && !hasCurrentError)
-  const isAllowanceSufficient = !allowanceSpender || allowance >= amountIn
-  const prepareApproveEnabled = routerAddress && !isAllowanceSufficient && isValidInput && enabled
+  const isAllowanceSufficient = isNativeToken || !allowanceSpender || allowance >= amountIn
+  const prepareApproveEnabled = !isNativeToken && routerAddress && !isAllowanceSufficient && isValidInput && enabled
   const prepareApprove: AppUseSimulateContractReturnType = useSimulateContract({
     abi: getApproveAbi(tokenIn),
     functionName: 'approve',

--- a/src/components/pages/vaults/hooks/useEnsoOrder.ts
+++ b/src/components/pages/vaults/hooks/useEnsoOrder.ts
@@ -144,7 +144,7 @@ export const useEnsoOrder = ({
 
   return {
     prepareEnsoOrder,
-    receiptSuccess,
+    receiptSuccess: receiptSuccess && receipt?.status === 'success',
     txHash
   }
 }

--- a/src/components/pages/vaults/hooks/useTokens.ts
+++ b/src/components/pages/vaults/hooks/useTokens.ts
@@ -15,7 +15,7 @@ export interface Token {
   balance: TNormalizedBN
 }
 
-async function fetchTokenData(
+export async function fetchTokenData(
   config: any,
   addresses: Address[],
   canonicalChainId: number,

--- a/src/components/shared/components/Header.tsx
+++ b/src/components/shared/components/Header.tsx
@@ -287,6 +287,16 @@ function AppHeader(): ReactElement {
                         {'Portfolio'}
                       </span>
                     </Link>
+
+                    <Link href={'/swap'} prefetch={false}>
+                      <span
+                        className={
+                          'text-base font-medium text-text-secondary transition-colors hover:text-text-primary'
+                        }
+                      >
+                        {'Swap'}
+                      </span>
+                    </Link>
                   </div>
                   <button
                     className={

--- a/src/components/shared/components/MobileNavMenu.tsx
+++ b/src/components/shared/components/MobileNavMenu.tsx
@@ -512,6 +512,14 @@ export function MobileNavMenu({
                     >
                       <span>{'Portfolio'}</span>
                     </Link>
+                    <Link
+                      href={'/swap'}
+                      prefetch={false}
+                      onClick={onClose}
+                      className={navItemClass(pathname.startsWith('/swap'), false)}
+                    >
+                      <span>{'Swap'}</span>
+                    </Link>
                   </div>
 
                   <div className={'h-px w-full bg-border'} />

--- a/src/components/shared/components/OverflowMarqueeText.tsx
+++ b/src/components/shared/components/OverflowMarqueeText.tsx
@@ -1,0 +1,62 @@
+import { cl } from '@shared/utils'
+import type { CSSProperties, ReactElement, ReactNode } from 'react'
+import { useEffect, useRef, useState } from 'react'
+
+type TOverflowMarqueeTextProps = {
+  children: ReactNode
+  className?: string
+}
+
+type TMarqueeStyle = CSSProperties & {
+  '--token-marquee-distance': string
+  '--token-marquee-duration': string
+}
+
+function getMarqueeDuration(distance: number): string {
+  return `${Math.min(14, Math.max(8, 6 + distance / 24))}s`
+}
+
+export function OverflowMarqueeText({ children, className }: TOverflowMarqueeTextProps): ReactElement {
+  const viewportRef = useRef<HTMLSpanElement>(null)
+  const contentRef = useRef<HTMLSpanElement>(null)
+  const [overflowDistance, setOverflowDistance] = useState(0)
+
+  // ResizeObserver is the only reliable way to animate exactly the clipped text distance.
+  useEffect(() => {
+    const viewport = viewportRef.current
+    const content = contentRef.current
+    if (!viewport || !content) return
+
+    const measureOverflow = (): void => {
+      setOverflowDistance(Math.max(0, content.scrollWidth - viewport.clientWidth))
+    }
+
+    measureOverflow()
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', measureOverflow)
+      return () => window.removeEventListener('resize', measureOverflow)
+    }
+
+    const observer = new ResizeObserver(measureOverflow)
+    observer.observe(viewport)
+    observer.observe(content)
+    return () => observer.disconnect()
+  }, [])
+
+  const marqueeStyle: TMarqueeStyle = {
+    '--token-marquee-distance': `${overflowDistance}px`,
+    '--token-marquee-duration': getMarqueeDuration(overflowDistance)
+  }
+
+  return (
+    <span ref={viewportRef} className={cl('min-w-0 flex-1 overflow-hidden whitespace-nowrap', className)}>
+      <span
+        ref={contentRef}
+        className={cl('inline-block min-w-max', overflowDistance > 0 ? 'token-selector-marquee' : undefined)}
+        style={marqueeStyle}
+      >
+        {children}
+      </span>
+    </span>
+  )
+}

--- a/src/components/shared/contexts/useNotificationsActions.tsx
+++ b/src/components/shared/contexts/useNotificationsActions.tsx
@@ -34,6 +34,7 @@ export const WithNotificationsActions = ({ children }: { children: React.ReactEl
         toAddress: params.toAddress ? toAddress(params.toAddress) : undefined,
         toTokenName: params.toSymbol,
         toAmount: params.toAmount,
+        toAmountType: params.toAmountType,
         toChainId: params.toChainId !== params.fromChainId ? params.toChainId : undefined,
         // For approve notifications, use toAddress/toSymbol as spender
         spenderAddress: params.type === 'approve' ? toAddress(params.toAddress) : undefined,

--- a/src/components/shared/contexts/useYearn.tsx
+++ b/src/components/shared/contexts/useYearn.tsx
@@ -12,6 +12,7 @@ import { usePathname } from 'next/navigation'
 import type { ReactElement } from 'react'
 import { createContext, memo, useCallback, useContext, useEffect, useState } from 'react'
 import { deserialize, serialize } from 'wagmi'
+import { shouldLoadAppVaultList } from '@/appRouteDataLoading'
 import { env } from '@/env'
 
 export const DEFAULT_SLIPPAGE = 0.5
@@ -87,8 +88,7 @@ export const YearnContextApp = memo(function YearnContextApp({ children }: { chi
     }
   )
 
-  const isPortfolioRoute = pathname.startsWith('/portfolio')
-  const shouldEnableVaultList = isPortfolioRoute
+  const shouldEnableVaultList = shouldLoadAppVaultList(pathname)
   const [isManuallyEnabled, setIsManuallyEnabled] = useState(false)
   const isVaultListEnabled = shouldEnableVaultList || isManuallyEnabled
   const sanitizedZapSlippage = clampZapSlippage(zapSlippage ?? DEFAULT_SLIPPAGE)

--- a/src/components/shared/types/notifications.ts
+++ b/src/components/shared/types/notifications.ts
@@ -2,6 +2,7 @@ import type { Hash, TransactionReceipt } from 'viem'
 import type { TAddress } from './address'
 
 export type TNotificationStatus = 'pending' | 'submitted' | 'success' | 'error'
+export type TNotificationAmountType = 'actual' | 'expected' | 'minimum'
 
 export type TNotificationType =
   | 'approve'
@@ -38,7 +39,8 @@ export type TNotification = {
   fromAmount?: string
   toAddress?: TAddress // Vault token to receive
   toTokenName?: string
-  toAmount?: string // Expected output amount for deposits/withdrawals
+  toAmount?: string // Output amount; semantics are explicit in toAmountType when needed
+  toAmountType?: TNotificationAmountType
   txHash?: Hash
   timeFinished?: number
   blockNumber?: bigint
@@ -67,7 +69,8 @@ export type TCreateNotificationParams = {
   executionChainId?: number
   toAddress?: TAddress // optional for approve/claim
   toSymbol?: string
-  toAmount?: string // expected output amount for deposits/withdrawals
+  toAmount?: string // output amount; set toAmountType when it is not an observed amount
+  toAmountType?: TNotificationAmountType
   toChainId?: number // only when cross-chain
 }
 

--- a/src/components/shared/types/notifications.ts
+++ b/src/components/shared/types/notifications.ts
@@ -13,6 +13,8 @@ export type TNotificationType =
   | 'crosschain zap'
   | 'withdraw zap'
   | 'crosschain withdraw zap'
+  | 'swap'
+  | 'crosschain swap'
   | 'deposit and stake'
   | 'stake'
   | 'unstake'

--- a/src/components/shared/utils/approve.test.ts
+++ b/src/components/shared/utils/approve.test.ts
@@ -1,0 +1,29 @@
+import type { Address } from 'viem'
+import { describe, expect, it } from 'vitest'
+import { requiresAllowanceResetForApproval } from './approve'
+
+const USDT = '0xdAC17F958D2ee523a2206206994597C13D831ec7' as Address
+const DAI = '0x6B175474E89094C44Da98b954EedeAC495271d0F' as Address
+
+describe('requiresAllowanceResetForApproval', () => {
+  it('requires a reset for nonzero insufficient mainnet USDT allowance', () => {
+    expect(requiresAllowanceResetForApproval({ tokenAddress: USDT, currentAllowance: 1n, requiredAmount: 2n })).toBe(
+      true
+    )
+  })
+
+  it('does not require a reset for zero or sufficient allowance', () => {
+    expect(requiresAllowanceResetForApproval({ tokenAddress: USDT, currentAllowance: 0n, requiredAmount: 2n })).toBe(
+      false
+    )
+    expect(requiresAllowanceResetForApproval({ tokenAddress: USDT, currentAllowance: 2n, requiredAmount: 2n })).toBe(
+      false
+    )
+  })
+
+  it('does not require a reset for standard approval tokens', () => {
+    expect(requiresAllowanceResetForApproval({ tokenAddress: DAI, currentAllowance: 1n, requiredAmount: 2n })).toBe(
+      false
+    )
+  })
+})

--- a/src/components/shared/utils/approve.ts
+++ b/src/components/shared/utils/approve.ts
@@ -21,3 +21,17 @@ export function requiresAllowanceResetBeforeApproval(tokenAddress?: Address): bo
 
   return TOKENS_REQUIRING_ALLOWANCE_RESET_BEFORE_APPROVAL.has(getAddress(tokenAddress))
 }
+
+export function requiresAllowanceResetForApproval({
+  tokenAddress,
+  currentAllowance,
+  requiredAmount
+}: {
+  tokenAddress?: Address
+  currentAllowance: bigint
+  requiredAmount: bigint
+}): boolean {
+  return (
+    requiresAllowanceResetBeforeApproval(tokenAddress) && currentAllowance > 0n && requiredAmount > currentAllowance
+  )
+}

--- a/style.css
+++ b/style.css
@@ -759,6 +759,36 @@ input[type='number'] {
     transform: translateX(-50%);
   }
 }
+.token-selector-marquee {
+  animation: tokenSelectorMarquee var(--token-marquee-duration, 8s) infinite;
+  will-change: transform;
+}
+@keyframes tokenSelectorMarquee {
+  0%,
+  18% {
+    transform: translateX(0);
+  }
+  18% {
+    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  45%,
+  55% {
+    transform: translateX(calc(-1 * var(--token-marquee-distance, 0px)));
+  }
+  55% {
+    animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  82%,
+  100% {
+    transform: translateX(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .token-selector-marquee {
+    animation: none;
+    transform: none;
+  }
+}
 .wordWrapper {
   display: inline-block;
   vertical-align: top;


### PR DESCRIPTION
### Summary

Adds a new Enso-powered swap page with URL-synchronized same-chain and cross-chain asset selection. The interface reuses the vault widget transaction plumbing while adding wallet balances, curated tokens, Yearn vault support, approval management, vault return estimates, and stable widget geometry.

Hidden vaults are excluded throughout, and retired vaults cannot be selected as swap destinations.

### How to review

Start with `src/components/pages/swap/index.tsx` for quote, approval, execution, and layout behavior. Then review the wallet and token-selector filtering, followed by the shared widget changes for overlays, settings, and notifications.

Smoke test:

1. Connect a wallet and switch between Swap and Wallet.
2. Select wallet-held inputs and curated, custom-address, or Yearn vault outputs.
3. Compare asset-to-vault and vault-to-asset routes.
4. Confirm USD values, minimum received, vault estimates, approval status, and action-button positioning.
5. Exercise same-chain and cross-chain quotes plus the advanced recipient setting.

### Test plan

- [x] Automated: `bun run lint:fix`
- [x] Automated: `bun run tslint`
- [x] Automated: focused Vitest suite, 72 tests passed
- [x] Automated: `bun run build`
- [x] Manual: measured identical panel and action-button positions across route directions
- [x] Manual: production preview route returned HTTP 200

### Risk / impact

This introduces a new funds and token-approval flow backed by Enso, so routing, allowance handling, recipient selection, price-impact protection, and hidden or retired vault filtering deserve close review. Enso availability remains guarded by the existing enablement check. There are no migrations or production configuration changes; reverting the two branch commits removes the feature.
