### PR TITLE
test: add regression test for portfolio double-counting (#1013)

### DIFF
--- a/src/components/shared/contexts/useWalletVaultTotals.test.tsx
+++ b/src/components/shared/contexts/useWalletVaultTotals.test.tsx
@@ -8,6 +8,8 @@ const VISIBLE_VAULT_ADDRESS = '0x0000000000000000000000000000000000000001' as co
 const HIDDEN_VAULT_ADDRESS = '0x0000000000000000000000000000000000000002' as const
 const HIDDEN_STAKING_ADDRESS = '0x0000000000000000000000000000000000000003' as const
 const ASSET_ADDRESS = '0x0000000000000000000000000000000000000004' as const
+const STAKED_VISIBLE_VAULT_ADDRESS = '0x0000000000000000000000000000000000000005' as const
+const STAKED_VISIBLE_STAKING_ADDRESS = '0x0000000000000000000000000000000000000006' as const
 
 const { mockGetVaultHoldingsUsd, mockUseWalletTokens, mockUseYearn } = vi.hoisted(() => ({
   mockGetVaultHoldingsUsd: vi.fn(),
@@ -136,6 +138,7 @@ describe('useWalletVaultTotals', () => {
     )
   })
 
+
   it('excludes direct hidden vault balances from wallet totals', () => {
     mockUseWalletTokens.mockReturnValue({
       balances: {
@@ -153,6 +156,7 @@ describe('useWalletVaultTotals', () => {
     })
   })
 
+
   it('excludes balances mapped through a hidden vault staking token', () => {
     mockUseWalletTokens.mockReturnValue({
       balances: {
@@ -165,4 +169,36 @@ describe('useWalletVaultTotals', () => {
 
     expect(renderTotals().totalValue).toBe(19.31)
   })
+
+  // Regression test for #1013 ("Bug: Incorrect Portfolio total balance"): when a wallet
+  // holds both the raw vault-share token AND the staking token for the SAME visible
+  // vault, the vault's holdings value must be counted exactly once, not twice.
+  it('counts a visible vault only once when both its vault token and staking token are held', () => {
+    const stakedVisibleVault = makeVault({
+      address: STAKED_VISIBLE_VAULT_ADDRESS,
+      isHidden: false,
+      stakingAddress: STAKED_VISIBLE_STAKING_ADDRESS
+    })
+
+    mockUseYearn.mockReturnValue({
+      allVaults: {
+        [VISIBLE_VAULT_ADDRESS]: makeVault({ address: VISIBLE_VAULT_ADDRESS, isHidden: false }),
+        [STAKED_VISIBLE_VAULT_ADDRESS]: stakedVisibleVault
+      }
+    })
+    mockGetVaultHoldingsUsd.mockImplementation((vault: TKongVault) =>
+      vault.address === STAKED_VISIBLE_VAULT_ADDRESS ? 500 : 0
+    )
+    mockUseWalletTokens.mockReturnValue({
+      balances: {
+        1: {
+          [STAKED_VISIBLE_VAULT_ADDRESS]: makeToken(STAKED_VISIBLE_VAULT_ADDRESS, 500),
+          [STAKED_VISIBLE_STAKING_ADDRESS]: makeToken(STAKED_VISIBLE_STAKING_ADDRESS, 500)
+        }
+      }
+    })
+
+    expect(renderTotals().totalValue).toBe(500)
+  })
+
 })


### PR DESCRIPTION
Closes #1013

## What happened

After #978 merged, portfolio total balance was reported as calculated
incorrectly (#1013). A fix was attempted in #1016 (a targeted guard in
the old `apps/lib/contexts/useWallet.tsx`), but it was closed unmerged.

@rossgalloway asked in #1013: *"this is the staked asset balance
issue?"*  that question was never answered.

## What I found

Since #1013 was filed, the wallet/portfolio logic was rewritten
(`useWalletVaultTotals.ts`), and it now includes a `countedVaults` Set
that dedupes by vault identity  this correctly prevents the exact
double-count scenario described in #1013 (a vault counted once via its
raw share token, once via its staking token).

Confirmed rossgalloway's suspicion was correct, and the fix is already
in place  but **no test covers this exact scenario**. Only the
"hidden vault" exclusion paths are tested.

## What this PR does

Adds one regression test that encodes the original #1013 scenario: a
**visible** vault held via both its vault-share token and staking
token simultaneously should be counted once, not twice.

**Verified with a negative control**  temporarily removing the
`countedVaults` dedup guard makes this exact test fail with the
precise reported symptom (total `1000` instead of `500` for a single
$500 position). Restoring the guard passes it again.

Full suite: 911/911 passing locally (2 pre-existing unrelated failures
from a missing `@testing-library/dom` module, present before this
change too).