### PR TITLE
Fix Enso cross-chain calibration

### DIFF
--- a/src/components/pages/vaults/components/widget/deposit/depositStepSuccess.test.ts
+++ b/src/components/pages/vaults/components/widget/deposit/depositStepSuccess.test.ts
@@ -1,0 +1,71 @@
+import { handleDepositStepSuccess } from '@pages/vaults/components/widget/deposit/depositStepSuccess'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('handleDepositStepSuccess', () => {
+  it('refreshes the confirmed allowance before completing an approval flow', async () => {
+    const events: string[] = []
+    const refetchAllowance = vi.fn(async () => {
+      events.push('allowance-refreshed')
+    })
+    const completeApprovalFlow = vi.fn(() => {
+      events.push('approval-completed')
+    })
+
+    await handleDepositStepSuccess({
+      label: 'Approve',
+      approvalFlowKey: 'enso-cross-chain-deposit',
+      refetchAllowance,
+      completeApprovalFlow
+    })
+
+    expect(events).toEqual(['allowance-refreshed', 'approval-completed'])
+    expect(completeApprovalFlow).toHaveBeenCalledWith('enso-cross-chain-deposit')
+  })
+
+  it('does not advance when the confirmed allowance cannot be refreshed', async () => {
+    const error = new Error('allowance RPC failed')
+    const completeApprovalFlow = vi.fn()
+
+    await expect(
+      handleDepositStepSuccess({
+        label: 'Approve',
+        approvalFlowKey: 'enso-cross-chain-deposit',
+        refetchAllowance: vi.fn().mockRejectedValue(error),
+        completeApprovalFlow
+      })
+    ).rejects.toThrow(error)
+
+    expect(completeApprovalFlow).not.toHaveBeenCalled()
+  })
+
+  it('does not advance when the allowance refresh resolves with a query error', async () => {
+    const error = new Error('allowance read failed')
+    const completeApprovalFlow = vi.fn()
+
+    await expect(
+      handleDepositStepSuccess({
+        label: 'Approve',
+        approvalFlowKey: 'enso-cross-chain-deposit',
+        refetchAllowance: vi.fn().mockResolvedValue({ error }),
+        completeApprovalFlow
+      })
+    ).rejects.toThrow(error)
+
+    expect(completeApprovalFlow).not.toHaveBeenCalled()
+  })
+
+  it('completes permit flows without refetching an on-chain allowance', async () => {
+    const refetchAllowance = vi.fn()
+    const completeApprovalFlow = vi.fn()
+
+    await handleDepositStepSuccess({
+      label: 'Sign Permit',
+      approvalFlowKey: 'permit-deposit',
+      refetchAllowance,
+      completeApprovalFlow
+    })
+
+    expect(refetchAllowance).not.toHaveBeenCalled()
+    expect(completeApprovalFlow).toHaveBeenCalledWith('permit-deposit')
+  })
+})

--- a/src/components/pages/vaults/components/widget/deposit/depositStepSuccess.ts
+++ b/src/components/pages/vaults/components/widget/deposit/depositStepSuccess.ts
@@ -1,0 +1,26 @@
+type HandleDepositStepSuccessParams = {
+  label: string
+  approvalFlowKey: string
+  refetchAllowance?: () => Promise<unknown>
+  completeApprovalFlow: (approvalFlowKey: string) => void
+}
+
+type AllowanceRefetchResult = {
+  error?: unknown
+}
+
+export async function handleDepositStepSuccess({
+  label,
+  approvalFlowKey,
+  refetchAllowance,
+  completeApprovalFlow
+}: HandleDepositStepSuccessParams): Promise<void> {
+  if (label !== 'Approve' && label !== 'Sign Permit') return
+
+  if (label === 'Approve') {
+    const result = (await refetchAllowance?.()) as AllowanceRefetchResult | undefined
+    if (result?.error) throw result.error
+  }
+
+  completeApprovalFlow(approvalFlowKey)
+}

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -1,3 +1,4 @@
+import { handleDepositStepSuccess } from '@pages/vaults/components/widget/deposit/depositStepSuccess'
 import { buildSafeDepositBatch } from '@pages/vaults/components/widget/deposit/safeDepositBatch'
 import { InputTokenAmount } from '@pages/vaults/components/widget/InputTokenAmount'
 import { YBOLD_STAKING_ADDRESS, YBOLD_VAULT_ADDRESS } from '@pages/vaults/domain/normalizeVault'
@@ -880,16 +881,18 @@ export function WidgetDeposit({
     [isCrossChain, depositRefreshTargets, refreshWalletBalances, refetchVaultUserData]
   )
 
-  const handleDepositStepSuccess = useCallback(
-    (label: string) => {
-      if (label === 'Approve' || label === 'Sign Permit') {
-        setCompletedApprovalFlowKey(approvalFlowKey)
-      }
-    },
-    [approvalFlowKey]
+  const refetchActiveAllowance = activeFlow.periphery.refetchAllowance
+  const handleTransactionStepSuccess = useCallback(
+    (label: string) =>
+      handleDepositStepSuccess({
+        label,
+        approvalFlowKey,
+        refetchAllowance: refetchActiveAllowance,
+        completeApprovalFlow: setCompletedApprovalFlowKey
+      }),
+    [approvalFlowKey, refetchActiveAllowance]
   )
 
-  const refetchActiveAllowance = activeFlow.periphery.refetchAllowance
   const handleApprovalOverlayDone = useCallback(async () => {
     try {
       await refetchActiveAllowance?.()
@@ -1368,7 +1371,7 @@ export function WidgetDeposit({
         deferOnAllCompleteUntilConfettiEnd={deferSuccessEffectsUntilConfettiEnd}
         autoContinueToNextStep
         autoContinueStepLabels={['Approve', 'Sign Permit']}
-        onStepSuccess={handleDepositStepSuccess}
+        onStepSuccess={handleTransactionStepSuccess}
         onBeforeSuccess={handleDepositTransactionSuccess}
         onAllComplete={handleDepositSuccess}
       />

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -541,6 +541,7 @@ export function WidgetDeposit({
   const protectedEnsoQuote = useProtectedEnsoQuoteState({
     stateKey: ensoSlippageCalibrationKey,
     isEnsoRoute,
+    isCrossChain,
     amount: depositAmount.debouncedBn,
     requestedSlippage: ensoQuoteSlippage,
     setRequestedSlippage: setEnsoQuoteSlippage,
@@ -658,11 +659,16 @@ export function WidgetDeposit({
     zapSlippage
   ])
 
-  const unpricedEnsoDepositError =
-    protectedEnsoQuote.hasUnpricedQuoteError && !depositAmount.isDebouncing
-      ? 'Unable to estimate zap price impact for the selected token. Use the base asset flow or swap elsewhere.'
-      : null
-  const effectiveDepositError = depositError || unpricedEnsoDepositError
+  const protectedEnsoDepositError = !depositAmount.isDebouncing
+    ? protectedEnsoQuote.blockedReason === 'cross-chain-minimum-slippage'
+      ? 'Cross-chain routes require at least 0.01% slippage.'
+      : protectedEnsoQuote.blockedReason === 'no-protected-tolerance'
+        ? 'No protected slippage remains after estimated price impact. Increase your tolerance or use the base asset flow.'
+        : protectedEnsoQuote.hasUnpricedQuoteError
+          ? 'Unable to estimate zap price impact for the selected token. Use the base asset flow or swap elsewhere.'
+          : null
+    : null
+  const effectiveDepositError = depositError || protectedEnsoDepositError
 
   const {
     spenderAddress: approvalSpenderAddress,

--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -21,6 +21,8 @@ import { formatUnits, isAddressEqual } from 'viem'
 import { env } from '@/env'
 import { SettingsPanel } from '../SettingsPanel'
 import { PriceImpactWarning } from '../shared/PriceImpactWarning'
+import { getProtectedEnsoQuoteError } from '../shared/protectedEnsoQuoteError'
+import { isProtectedEnsoTransactionStepEnabled } from '../shared/protectedEnsoTransaction'
 import { TokenSelectorOverlay } from '../shared/TokenSelectorOverlay'
 import { TransactionOverlay, type TransactionStep } from '../shared/TransactionOverlay'
 import { useProtectedEnsoQuoteState } from '../shared/useProtectedEnsoQuoteState'
@@ -565,6 +567,7 @@ export function WidgetDeposit({
     isPreparing: isPreparingEnsoQuote,
     isDisplayLoading: isDisplayLoadingEnsoQuote,
     isWaitingForProtectedQuote: isWaitingForProtectedEnsoQuote,
+    canExecute: canExecuteProtectedEnsoQuote,
     executableTx: executableEnsoTx
   } = protectedEnsoQuote
 
@@ -659,15 +662,12 @@ export function WidgetDeposit({
     zapSlippage
   ])
 
-  const protectedEnsoDepositError = !depositAmount.isDebouncing
-    ? protectedEnsoQuote.blockedReason === 'cross-chain-minimum-slippage'
-      ? 'Cross-chain routes require at least 0.01% slippage.'
-      : protectedEnsoQuote.blockedReason === 'no-protected-tolerance'
-        ? 'No protected slippage remains after estimated price impact. Increase your tolerance or use the base asset flow.'
-        : protectedEnsoQuote.hasUnpricedQuoteError
-          ? 'Unable to estimate zap price impact for the selected token. Use the base asset flow or swap elsewhere.'
-          : null
-    : null
+  const protectedEnsoDepositError = getProtectedEnsoQuoteError({
+    blockedReason: protectedEnsoQuote.blockedReason,
+    hasUnpricedQuoteError: protectedEnsoQuote.hasUnpricedQuoteError,
+    isDebouncing: depositAmount.isDebouncing,
+    flow: 'deposit'
+  })
   const effectiveDepositError = depositError || protectedEnsoDepositError
 
   const {
@@ -794,7 +794,10 @@ export function WidgetDeposit({
         confirmMessage: `${progressLabel} ${formattedDepositAmount} ${inputToken?.symbol || ''}`,
         successTitle: 'Transaction Submitted',
         successMessage: `Your cross-chain ${actionLabel.toLowerCase()} has been submitted.\nIt may take a few minutes to complete on the destination chain.`,
-        isEnabled: !isWaitingForProtectedEnsoQuote && activeFlow.periphery.prepareDepositEnabled,
+        isEnabled: isProtectedEnsoTransactionStepEnabled({
+          canExecute: canExecuteProtectedEnsoQuote,
+          prepareEnabled: activeFlow.periphery.prepareDepositEnabled
+        }),
         completesFlow: true,
         showConfetti: true,
         notification: depositNotificationParams
@@ -807,7 +810,10 @@ export function WidgetDeposit({
       confirmMessage: `${progressLabel} ${formattedDepositAmount} ${inputToken?.symbol || ''}`,
       successTitle: `${actionLabel} successful!`,
       successMessage: `You have ${pastTenseLabel} ${formattedDepositAmount} ${inputToken?.symbol || ''} into ${vaultSymbol}.`,
-      isEnabled: !isWaitingForProtectedEnsoQuote && activeFlow.periphery.prepareDepositEnabled,
+      isEnabled: isProtectedEnsoTransactionStepEnabled({
+        canExecute: canExecuteProtectedEnsoQuote,
+        prepareEnabled: activeFlow.periphery.prepareDepositEnabled
+      }),
       completesFlow: true,
       showConfetti: true,
       notification: depositNotificationParams
@@ -826,7 +832,8 @@ export function WidgetDeposit({
     approveNotificationParams,
     depositNotificationParams,
     isCrossChain,
-    isWaitingForProtectedEnsoQuote
+    isWaitingForProtectedEnsoQuote,
+    canExecuteProtectedEnsoQuote
   ])
 
   const { fetchMaxQuote, isFetching: isFetchingMaxQuote } = useFetchMaxQuote({

--- a/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
+++ b/src/components/pages/vaults/components/widget/shared/TransactionOverlay.tsx
@@ -165,7 +165,7 @@ type TransactionOverlayProps = {
   onAllComplete?: () => void
   deferOnAllCompleteUntilClose?: boolean
   deferOnAllCompleteUntilConfettiEnd?: boolean
-  onStepSuccess?: (label: string) => void
+  onStepSuccess?: (label: string) => void | Promise<void>
   /**
    * Called after the final transaction is confirmed, before the success screen
    * is shown. The overlay stays in a "refreshing" state while this resolves.
@@ -296,6 +296,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   const [isAutoContinuing, setIsAutoContinuing] = useState(false)
   const [confettiRequestNonce, setConfettiRequestNonce] = useState(0)
   const [isWaitingForNextStep, setIsWaitingForNextStep] = useState(false)
+  const [failedStepSuccessLabel, setFailedStepSuccessLabel] = useState<string | null>(null)
 
   useEffect(() => {
     writeContractResetRef.current = writeContract.reset
@@ -332,6 +333,26 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     colors: ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899'],
     onAnimationComplete: () => runAllCompleteIfPending('confetti')
   })
+
+  const reportStepSuccess = useCallback(
+    async (label: string): Promise<boolean> => {
+      try {
+        await onStepSuccess?.(label)
+        setFailedStepSuccessLabel(null)
+        return true
+      } catch (error) {
+        console.error('[TransactionOverlay] Failed to prepare the next transaction step', {
+          step: label,
+          error: (error as Error)?.message || error
+        })
+        setFailedStepSuccessLabel(label)
+        setOverlayState('error')
+        setErrorMessage('Transaction confirmed, but the next step could not be prepared. Please try again.')
+        return false
+      }
+    },
+    [onStepSuccess]
+  )
 
   const requestConfetti = useCallback(() => {
     setConfettiRequestNonce((nonce) => nonce + 1)
@@ -447,6 +468,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       autoContinueNonceRef.current += 1
       setIsAutoContinuing(false)
       setIsWaitingForNextStep(false)
+      setFailedStepSuccessLabel(null)
       handledConfettiRequestRef.current = 0
       setConfettiRequestNonce(0)
     }
@@ -529,7 +551,8 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
         const completedAllSteps = currentStep.completesFlow ?? isLastStep
         if (!hasReportedStepSuccessRef.current && currentStep.label) {
           hasReportedStepSuccessRef.current = true
-          onStepSuccess?.(currentStep.label)
+          const didReportSuccess = await reportStepSuccess(currentStep.label)
+          if (!didReportSuccess) return
         }
         finalizeSuccessState(completedAllSteps, currentStep)
 
@@ -550,7 +573,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       finalizeSuccessState,
       isLastStep,
       onClose,
-      onStepSuccess,
+      reportStepSuccess,
       requestConfetti,
       setStepExecutionContext,
       signTypedDataAsync
@@ -843,9 +866,16 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
   }, [isAutoContinuing, isTerminalSuccess, onClose, advanceToNextStep])
 
   const handleRetry = useCallback(() => {
+    if (failedStepSuccessLabel) {
+      setOverlayState('pending')
+      setErrorMessage('')
+      void reportStepSuccess(failedStepSuccessLabel)
+      return
+    }
+
     resetTxState()
     executeStep()
-  }, [resetTxState, executeStep])
+  }, [executeStep, failedStepSuccessLabel, reportStepSuccess, resetTxState])
 
   const handleClose = useCallback(() => {
     onClose()
@@ -922,7 +952,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
       const executedStepLabel = executedStepRef.current?.label
       if (!hasReportedStepSuccessRef.current && executedStepLabel) {
         hasReportedStepSuccessRef.current = true
-        onStepSuccess?.(executedStepLabel)
+        void reportStepSuccess(executedStepLabel)
       }
     }
 
@@ -1025,7 +1055,7 @@ export const TransactionOverlay: FC<TransactionOverlayProps> = ({
     overlayState,
     requestConfetti,
     handleUpdateNotification,
-    onStepSuccess,
+    reportStepSuccess,
     onBeforeSuccess,
     isStepReady,
     step?.label,
@@ -1256,7 +1286,9 @@ Execution may happen separately after the required confirmations are collected.`
           {overlayState === 'error' && (
             <>
               <ErrorIcon />
-              <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">Transaction failed</h3>
+              <h3 className="text-lg font-semibold text-text-primary mt-6 mb-2">
+                {failedStepSuccessLabel ? 'Next step unavailable' : 'Transaction failed'}
+              </h3>
               <p className="text-sm text-text-secondary mb-6">{errorMessage}</p>
               <Button
                 onClick={handleRetry}
@@ -1264,7 +1296,7 @@ Execution may happen separately after the required confirmations are collected.`
                 className="w-full max-w-xs"
                 classNameOverride="yearn--button--nextgen w-full"
               >
-                Try Again
+                {failedStepSuccessLabel ? 'Retry next step' : 'Try Again'}
               </Button>
             </>
           )}

--- a/src/components/pages/vaults/components/widget/shared/protectedEnsoQuoteError.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/protectedEnsoQuoteError.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { getProtectedEnsoQuoteError } from './protectedEnsoQuoteError'
+
+describe('getProtectedEnsoQuoteError', () => {
+  it('shows the cross-chain minimum for both transaction flows', () => {
+    const params = {
+      blockedReason: 'cross-chain-minimum-slippage' as const,
+      hasUnpricedQuoteError: false,
+      isDebouncing: false
+    }
+
+    expect(getProtectedEnsoQuoteError({ ...params, flow: 'deposit' })).toBe(
+      'Cross-chain routes require at least 0.01% slippage.'
+    )
+    expect(getProtectedEnsoQuoteError({ ...params, flow: 'withdraw' })).toBe(
+      'Cross-chain routes require at least 0.01% slippage.'
+    )
+  })
+
+  it('uses actionable flow-specific copy when positive tolerance is exhausted', () => {
+    const params = {
+      blockedReason: 'no-protected-tolerance' as const,
+      hasUnpricedQuoteError: false,
+      isDebouncing: false
+    }
+
+    expect(getProtectedEnsoQuoteError({ ...params, flow: 'deposit' })).toContain('use the base asset flow')
+    expect(getProtectedEnsoQuoteError({ ...params, flow: 'withdraw' })).toContain('withdraw the base asset')
+  })
+
+  it('does not show a stale quote error while the amount is debouncing', () => {
+    expect(
+      getProtectedEnsoQuoteError({
+        blockedReason: 'cross-chain-minimum-slippage',
+        hasUnpricedQuoteError: true,
+        isDebouncing: true,
+        flow: 'deposit'
+      })
+    ).toBeNull()
+  })
+})

--- a/src/components/pages/vaults/components/widget/shared/protectedEnsoQuoteError.ts
+++ b/src/components/pages/vaults/components/widget/shared/protectedEnsoQuoteError.ts
@@ -1,0 +1,35 @@
+import type { ProtectedEnsoBlockedReason } from './useProtectedEnsoQuoteState'
+
+export function getProtectedEnsoQuoteError({
+  blockedReason,
+  hasUnpricedQuoteError,
+  isDebouncing,
+  flow
+}: {
+  blockedReason?: ProtectedEnsoBlockedReason
+  hasUnpricedQuoteError: boolean
+  isDebouncing: boolean
+  flow: 'deposit' | 'withdraw'
+}): string | null {
+  if (isDebouncing) {
+    return null
+  }
+
+  if (blockedReason === 'cross-chain-minimum-slippage') {
+    return 'Cross-chain routes require at least 0.01% slippage.'
+  }
+
+  if (blockedReason === 'no-protected-tolerance') {
+    return flow === 'deposit'
+      ? 'No protected slippage remains after estimated price impact. Increase your tolerance or use the base asset flow.'
+      : 'No protected slippage remains after estimated price impact. Increase your tolerance or withdraw the base asset.'
+  }
+
+  if (hasUnpricedQuoteError) {
+    return flow === 'deposit'
+      ? 'Unable to estimate zap price impact for the selected token. Use the base asset flow or swap elsewhere.'
+      : 'Unable to estimate zap price impact for the selected token. Withdraw the base asset or swap elsewhere.'
+  }
+
+  return null
+}

--- a/src/components/pages/vaults/components/widget/shared/protectedEnsoTransaction.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/protectedEnsoTransaction.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { isProtectedEnsoTransactionStepEnabled } from './protectedEnsoTransaction'
+
+describe.each(['deposit', 'withdraw'])('%s protected Enso transaction step', () => {
+  it('does not enable the raw prepare while the protected quote is not executable', () => {
+    expect(
+      isProtectedEnsoTransactionStepEnabled({
+        canExecute: false,
+        prepareEnabled: true
+      })
+    ).toBe(false)
+  })
+
+  it('enables only a prepared transaction from a ready protected quote', () => {
+    expect(
+      isProtectedEnsoTransactionStepEnabled({
+        canExecute: true,
+        prepareEnabled: true
+      })
+    ).toBe(true)
+  })
+})

--- a/src/components/pages/vaults/components/widget/shared/protectedEnsoTransaction.ts
+++ b/src/components/pages/vaults/components/widget/shared/protectedEnsoTransaction.ts
@@ -1,0 +1,9 @@
+export function isProtectedEnsoTransactionStepEnabled({
+  canExecute,
+  prepareEnabled
+}: {
+  canExecute: boolean
+  prepareEnabled: boolean
+}): boolean {
+  return canExecute && prepareEnabled
+}

--- a/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.test.ts
@@ -51,6 +51,7 @@ describe('resolveProtectedEnsoQuoteView', () => {
 
     expect(view.routeState).toBe('protecting')
     expect(view.isPreparing).toBe(true)
+    expect(view.canExecute).toBe(false)
     expect(view.isDisplayLoading).toBe(true)
     expect(view.display.amount).toBe(0n)
     expect(view.display.routeHasSwap).toBe(false)
@@ -106,6 +107,33 @@ describe('resolveProtectedEnsoQuoteView', () => {
     expect(view.executableTx).toBeUndefined()
   })
 
+  it('blocks a calibration when positive configured tolerance is exhausted', () => {
+    const view = resolveProtectedEnsoQuoteView({
+      isEnsoRoute: true,
+      isCrossChain: true,
+      amount: 1000n,
+      requestedSlippage: 0,
+      isLoadingQuote: false,
+      hasCurrentQuote: true,
+      currentSnapshot: {
+        ...snapshot(990n, true),
+        estimatedPriceImpactPercentage: 1,
+        worstCaseRouteImpactPercentage: 1
+      },
+      desiredSlippage: 0,
+      userTolerancePercentage: 1,
+      fallbackDisplay: { amount: 0n, routeHasSwap: false },
+      fallbackEstimatedPriceImpactPercentage: 1,
+      fallbackWorstCaseRouteImpactPercentage: 1,
+      tx: TX
+    })
+
+    expect(view.routeState).toBe('blocked')
+    expect(view.blockedReason).toBe('no-protected-tolerance')
+    expect(view.canExecute).toBe(false)
+    expect(view.executableTx).toBeUndefined()
+  })
+
   it('preserves existing price-impact and hard-cap blocking', () => {
     const view = resolveProtectedEnsoQuoteView({
       isEnsoRoute: true,
@@ -135,6 +163,37 @@ describe('resolveProtectedEnsoQuoteView', () => {
 })
 
 describe('useProtectedEnsoQuoteState', () => {
+  it('does not request pass two when positive tolerance is exhausted by calibration impact', () => {
+    const setRequestedSlippage = vi.fn()
+    const { result } = renderHook(() =>
+      useProtectedEnsoQuoteState({
+        stateKey: 'exhausted-cross-chain-deposit',
+        isEnsoRoute: true,
+        isCrossChain: true,
+        amount: 1000n,
+        requestedSlippage: 0,
+        setRequestedSlippage,
+        isLoadingQuote: false,
+        userTolerancePercentage: 1,
+        localPriceImpactPercentage: 1,
+        localWorstCasePriceImpactPercentage: 1,
+        hasIncompleteUsdValuation: false,
+        ensoPriceImpact: 100,
+        expectedOut: 990n,
+        minExpectedOut: 990n,
+        tx: TX,
+        display: { amount: 990n, routeHasSwap: true }
+      })
+    )
+
+    expect(result.current.desiredSlippage).toBe(0)
+    expect(result.current.routeState).toBe('blocked')
+    expect(result.current.blockedReason).toBe('no-protected-tolerance')
+    expect(result.current.canExecute).toBe(false)
+    expect(result.current.executableTx).toBeUndefined()
+    expect(setRequestedSlippage).not.toHaveBeenCalled()
+  })
+
   it('requests a second protected quote and only exposes its transaction', async () => {
     const setRequestedSlippage = vi.fn()
     const initialProps = {
@@ -160,6 +219,7 @@ describe('useProtectedEnsoQuoteState', () => {
     })
 
     expect(result.current.executableTx).toBeUndefined()
+    expect(result.current.canExecute).toBe(false)
     await waitFor(() => expect(setRequestedSlippage).toHaveBeenCalledWith(0.5))
 
     const protectedTx: ProtectedEnsoTx = { ...TX, data: '0x1234' }
@@ -173,6 +233,7 @@ describe('useProtectedEnsoQuoteState', () => {
     })
 
     expect(result.current.routeState).toBe('ready')
+    expect(result.current.canExecute).toBe(true)
     expect(result.current.executableTx).toEqual(protectedTx)
     expect(result.current.desiredSlippage).toBeLessThanOrEqual(initialProps.userTolerancePercentage)
   })

--- a/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.test.ts
+++ b/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest'
-import { type ProtectedQuoteSnapshot, resolveProtectedEnsoQuoteView } from './useProtectedEnsoQuoteState'
+// @vitest-environment jsdom
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  type ProtectedEnsoTx,
+  type ProtectedQuoteSnapshot,
+  resolveProtectedEnsoQuoteView,
+  useProtectedEnsoQuoteState
+} from './useProtectedEnsoQuoteState'
 
 const TX = {
   to: '0x0000000000000000000000000000000000000001',
@@ -27,6 +35,7 @@ describe('resolveProtectedEnsoQuoteView', () => {
   it('keeps bootstrap quotes out of display and execution state while protecting', () => {
     const view = resolveProtectedEnsoQuoteView({
       isEnsoRoute: true,
+      isCrossChain: true,
       amount: 1000n,
       requestedSlippage: 0,
       isLoadingQuote: false,
@@ -51,6 +60,7 @@ describe('resolveProtectedEnsoQuoteView', () => {
   it('keeps the quote view loading while a protected quote refetches, even with a cached display', () => {
     const view = resolveProtectedEnsoQuoteView({
       isEnsoRoute: true,
+      isCrossChain: true,
       amount: 1000n,
       requestedSlippage: 0.2,
       isLoadingQuote: true,
@@ -71,5 +81,99 @@ describe('resolveProtectedEnsoQuoteView', () => {
     expect(view.display.amount).toBe(995n)
     expect(view.display.routeHasSwap).toBe(true)
     expect(view.executableTx).toBeUndefined()
+  })
+
+  it('blocks a completed calibration with no remaining protected tolerance', () => {
+    const view = resolveProtectedEnsoQuoteView({
+      isEnsoRoute: true,
+      isCrossChain: true,
+      amount: 1000n,
+      requestedSlippage: 0,
+      isLoadingQuote: false,
+      hasCurrentQuote: true,
+      currentSnapshot: snapshot(1000n, true),
+      desiredSlippage: 0,
+      userTolerancePercentage: 0,
+      fallbackDisplay: { amount: 0n, routeHasSwap: false },
+      fallbackEstimatedPriceImpactPercentage: 0,
+      fallbackWorstCaseRouteImpactPercentage: 0,
+      tx: TX
+    })
+
+    expect(view.routeState).toBe('blocked')
+    expect(view.blockedReason).toBe('cross-chain-minimum-slippage')
+    expect(view.isPreparing).toBe(false)
+    expect(view.executableTx).toBeUndefined()
+  })
+
+  it('preserves existing price-impact and hard-cap blocking', () => {
+    const view = resolveProtectedEnsoQuoteView({
+      isEnsoRoute: true,
+      isCrossChain: true,
+      amount: 1000n,
+      requestedSlippage: 0.5,
+      isLoadingQuote: false,
+      hasCurrentQuote: true,
+      currentSnapshot: {
+        ...snapshot(900n, true),
+        estimatedPriceImpactPercentage: 5,
+        worstCaseRouteImpactPercentage: 5
+      },
+      desiredSlippage: 0.5,
+      userTolerancePercentage: 5,
+      fallbackDisplay: { amount: 0n, routeHasSwap: false },
+      fallbackEstimatedPriceImpactPercentage: 0,
+      fallbackWorstCaseRouteImpactPercentage: 0,
+      tx: TX
+    })
+
+    expect(view.routeState).toBe('blocked')
+    expect(view.blockedReason).toBe('price-impact')
+    expect(view.priceImpactInfo.isBlocking).toBe(true)
+    expect(view.executableTx).toBeUndefined()
+  })
+})
+
+describe('useProtectedEnsoQuoteState', () => {
+  it('requests a second protected quote and only exposes its transaction', async () => {
+    const setRequestedSlippage = vi.fn()
+    const initialProps = {
+      stateKey: 'cross-chain-deposit',
+      isEnsoRoute: true,
+      isCrossChain: true,
+      amount: 1000n,
+      requestedSlippage: 0,
+      setRequestedSlippage,
+      isLoadingQuote: false,
+      userTolerancePercentage: 1,
+      localPriceImpactPercentage: 0.5,
+      localWorstCasePriceImpactPercentage: 0.5,
+      hasIncompleteUsdValuation: false,
+      ensoPriceImpact: 50,
+      expectedOut: 995n,
+      minExpectedOut: 990n,
+      tx: TX as ProtectedEnsoTx,
+      display: { amount: 990n, routeHasSwap: true }
+    }
+    const { result, rerender } = renderHook((props) => useProtectedEnsoQuoteState(props), {
+      initialProps
+    })
+
+    expect(result.current.executableTx).toBeUndefined()
+    await waitFor(() => expect(setRequestedSlippage).toHaveBeenCalledWith(0.5))
+
+    const protectedTx: ProtectedEnsoTx = { ...TX, data: '0x1234' }
+    rerender({
+      ...initialProps,
+      requestedSlippage: 0.5,
+      expectedOut: 994n,
+      minExpectedOut: 989n,
+      tx: protectedTx,
+      display: { amount: 989n, routeHasSwap: true }
+    })
+
+    expect(result.current.routeState).toBe('ready')
+    expect(result.current.executableTx).toEqual(protectedTx)
+    expect(result.current.desiredSlippage).toBeLessThanOrEqual(initialProps.userTolerancePercentage)
   })
 })

--- a/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.ts
+++ b/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.ts
@@ -129,10 +129,12 @@ export function resolveProtectedEnsoQuoteView<TDisplay>({
     : priceImpactInfo.isBlocking || priceImpactInfo.isAboveTolerance
       ? 'price-impact'
       : undefined
+  const canExecute = !isEnsoRoute || routeState === 'ready'
 
   return {
     routeState,
     blockedReason,
+    canExecute,
     display: snapshot?.display ?? fallbackDisplay,
     isPreparing,
     isDisplayLoading,
@@ -141,7 +143,7 @@ export function resolveProtectedEnsoQuoteView<TDisplay>({
     estimatedPriceImpactPercentage: displayedEstimatedPriceImpactPercentage,
     worstCaseRouteImpactPercentage: displayedWorstCaseRouteImpactPercentage,
     priceImpactInfo,
-    executableTx: isEnsoRoute && routeState !== 'ready' ? undefined : tx
+    executableTx: canExecute ? tx : undefined
   }
 }
 

--- a/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.ts
+++ b/src/components/pages/vaults/components/widget/shared/useProtectedEnsoQuoteState.ts
@@ -1,13 +1,16 @@
 import type { TAddress } from '@shared/types'
 import {
   calculateRemainingEnsoSlippagePercentage,
+  MIN_CROSS_CHAIN_ENSO_SLIPPAGE_BPS,
   optionalBasisPointsToPercentage,
+  toBasisPoints,
   ZAP_SLIPPAGE_HARD_CAP
 } from '@shared/utils/slippage'
 import { useEffect, useMemo, useRef } from 'react'
 import type { Hex } from 'viem'
 
 export type ProtectedEnsoRouteState = 'idle' | 'loading' | 'protecting' | 'ready' | 'blocked'
+export type ProtectedEnsoBlockedReason = 'cross-chain-minimum-slippage' | 'no-protected-tolerance' | 'price-impact'
 
 export type ProtectedEnsoTx = {
   to: TAddress
@@ -27,6 +30,7 @@ export type ProtectedQuoteSnapshot<TDisplay> = {
 type UseProtectedEnsoQuoteStateParams<TDisplay> = {
   stateKey: string
   isEnsoRoute: boolean
+  isCrossChain: boolean
   amount: bigint
   requestedSlippage: number
   setRequestedSlippage: (value: number) => void
@@ -44,6 +48,7 @@ type UseProtectedEnsoQuoteStateParams<TDisplay> = {
 
 export function resolveProtectedEnsoQuoteView<TDisplay>({
   isEnsoRoute,
+  isCrossChain,
   amount,
   requestedSlippage,
   isLoadingQuote,
@@ -58,6 +63,7 @@ export function resolveProtectedEnsoQuoteView<TDisplay>({
   tx
 }: {
   isEnsoRoute: boolean
+  isCrossChain: boolean
   amount: bigint
   requestedSlippage: number
   isLoadingQuote: boolean
@@ -71,11 +77,17 @@ export function resolveProtectedEnsoQuoteView<TDisplay>({
   fallbackWorstCaseRouteImpactPercentage: number
   tx?: ProtectedEnsoTx
 }) {
+  const isCalibrationQuote = isEnsoRoute && requestedSlippage === 0
+  const hasCompletedCalibration = isCalibrationQuote && hasCurrentQuote && !isLoadingQuote
+  const hasNoProtectedTolerance = hasCompletedCalibration && desiredSlippage === 0
+  const hasInsufficientCrossChainTolerance =
+    isCrossChain && toBasisPoints(userTolerancePercentage) < MIN_CROSS_CHAIN_ENSO_SLIPPAGE_BPS
   const isWaitingForProtectedQuote =
     isEnsoRoute &&
     amount > 0n &&
     ((requestedSlippage === 0 && hasCurrentQuote && desiredSlippage > 0) || (requestedSlippage > 0 && isLoadingQuote))
-  const canDisplayCurrentQuote = hasCurrentQuote && !isWaitingForProtectedQuote && !isLoadingQuote
+  const canDisplayCurrentQuote =
+    hasCurrentQuote && !isCalibrationQuote && !isWaitingForProtectedQuote && !isLoadingQuote
   const snapshot = canDisplayCurrentQuote ? currentSnapshot : cachedSnapshot
   const isPreparing = isLoadingQuote || isWaitingForProtectedQuote
   const isDisplayLoading = isEnsoRoute && amount > 0n && isPreparing
@@ -99,18 +111,28 @@ export function resolveProtectedEnsoQuoteView<TDisplay>({
   const routeState: ProtectedEnsoRouteState =
     !isEnsoRoute || amount === 0n
       ? 'idle'
-      : isWaitingForProtectedQuote
-        ? 'protecting'
-        : isDisplayLoading
-          ? 'loading'
-          : priceImpactInfo.isBlocking || priceImpactInfo.isAboveTolerance
-            ? 'blocked'
-            : hasCurrentQuote
-              ? 'ready'
-              : 'loading'
+      : hasNoProtectedTolerance
+        ? 'blocked'
+        : isWaitingForProtectedQuote
+          ? 'protecting'
+          : isDisplayLoading
+            ? 'loading'
+            : priceImpactInfo.isBlocking || priceImpactInfo.isAboveTolerance
+              ? 'blocked'
+              : hasCurrentQuote
+                ? 'ready'
+                : 'loading'
+  const blockedReason: ProtectedEnsoBlockedReason | undefined = hasNoProtectedTolerance
+    ? hasInsufficientCrossChainTolerance
+      ? 'cross-chain-minimum-slippage'
+      : 'no-protected-tolerance'
+    : priceImpactInfo.isBlocking || priceImpactInfo.isAboveTolerance
+      ? 'price-impact'
+      : undefined
 
   return {
     routeState,
+    blockedReason,
     display: snapshot?.display ?? fallbackDisplay,
     isPreparing,
     isDisplayLoading,
@@ -119,13 +141,14 @@ export function resolveProtectedEnsoQuoteView<TDisplay>({
     estimatedPriceImpactPercentage: displayedEstimatedPriceImpactPercentage,
     worstCaseRouteImpactPercentage: displayedWorstCaseRouteImpactPercentage,
     priceImpactInfo,
-    executableTx: isEnsoRoute && isPreparing ? undefined : tx
+    executableTx: isEnsoRoute && routeState !== 'ready' ? undefined : tx
   }
 }
 
 export function useProtectedEnsoQuoteState<TDisplay>({
   stateKey,
   isEnsoRoute,
+  isCrossChain,
   amount,
   requestedSlippage,
   setRequestedSlippage,
@@ -202,6 +225,7 @@ export function useProtectedEnsoQuoteState<TDisplay>({
 
   const view = resolveProtectedEnsoQuoteView({
     isEnsoRoute,
+    isCrossChain,
     amount,
     requestedSlippage,
     isLoadingQuote,

--- a/src/components/pages/vaults/components/widget/withdraw/index.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/index.tsx
@@ -16,6 +16,8 @@ import { ApprovalOverlay } from '../deposit/ApprovalOverlay'
 import { InputTokenAmount } from '../InputTokenAmount'
 import { SettingsPanel } from '../SettingsPanel'
 import { PriceImpactWarning } from '../shared/PriceImpactWarning'
+import { getProtectedEnsoQuoteError } from '../shared/protectedEnsoQuoteError'
+import { isProtectedEnsoTransactionStepEnabled } from '../shared/protectedEnsoTransaction'
 import { TokenSelectorOverlay } from '../shared/TokenSelectorOverlay'
 import { TransactionOverlay, type TransactionStep } from '../shared/TransactionOverlay'
 import { useProtectedEnsoQuoteState } from '../shared/useProtectedEnsoQuoteState'
@@ -588,6 +590,7 @@ export function WidgetWithdraw({
     isPreparing: isPreparingEnsoQuote,
     isDisplayLoading: isDisplayLoadingEnsoQuote,
     isWaitingForProtectedQuote: isWaitingForProtectedEnsoQuote,
+    canExecute: canExecuteProtectedEnsoQuote,
     executableTx: executableEnsoTx
   } = protectedEnsoQuote
 
@@ -675,15 +678,12 @@ export function WidgetWithdraw({
     zapSlippage
   ])
 
-  const protectedEnsoWithdrawError = !withdrawAmount.isDebouncing
-    ? protectedEnsoQuote.blockedReason === 'cross-chain-minimum-slippage'
-      ? 'Cross-chain routes require at least 0.01% slippage.'
-      : protectedEnsoQuote.blockedReason === 'no-protected-tolerance'
-        ? 'No protected slippage remains after estimated price impact. Increase your tolerance or withdraw the base asset.'
-        : protectedEnsoQuote.hasUnpricedQuoteError
-          ? 'Unable to estimate zap price impact for the selected token. Withdraw the base asset or swap elsewhere.'
-          : null
-    : null
+  const protectedEnsoWithdrawError = getProtectedEnsoQuoteError({
+    blockedReason: protectedEnsoQuote.blockedReason,
+    hasUnpricedQuoteError: protectedEnsoQuote.hasUnpricedQuoteError,
+    isDebouncing: withdrawAmount.isDebouncing,
+    flow: 'withdraw'
+  })
   const effectiveWithdrawError = baseWithdrawError || protectedEnsoWithdrawError
 
   const canOpenTokenSelector = ensoEnabled && !disableTokenSelector
@@ -808,7 +808,10 @@ export function WidgetWithdraw({
         withdrawNotificationParams,
         safeWithdrawBatch,
         prepareApproveEnabled: !isWaitingForProtectedEnsoQuote && Boolean(activeFlow.periphery.prepareApproveEnabled),
-        prepareWithdrawEnabled: !isWaitingForProtectedEnsoQuote && Boolean(activeFlow.periphery.prepareWithdrawEnabled),
+        prepareWithdrawEnabled: isProtectedEnsoTransactionStepEnabled({
+          canExecute: canExecuteProtectedEnsoQuote,
+          prepareEnabled: Boolean(activeFlow.periphery.prepareWithdrawEnabled)
+        }),
         directUnstakePrepareEnabled: Boolean(directUnstakeFlow.periphery.prepareWithdrawEnabled),
         directWithdrawPrepareEnabled: Boolean(directWithdrawFlow.periphery.prepareWithdrawEnabled)
       }),
@@ -836,7 +839,8 @@ export function WidgetWithdraw({
       safeWithdrawBatch,
       activeFlow.periphery.prepareApproveEnabled,
       activeFlow.periphery.prepareWithdrawEnabled,
-      isWaitingForProtectedEnsoQuote
+      isWaitingForProtectedEnsoQuote,
+      canExecuteProtectedEnsoQuote
     ]
   )
 

--- a/src/components/pages/vaults/components/widget/withdraw/index.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/index.tsx
@@ -564,6 +564,7 @@ export function WidgetWithdraw({
   const protectedEnsoQuote = useProtectedEnsoQuoteState({
     stateKey: ensoSlippageCalibrationKey,
     isEnsoRoute,
+    isCrossChain,
     amount: flowRequiredShares,
     requestedSlippage: ensoQuoteSlippage,
     setRequestedSlippage: setEnsoQuoteSlippage,
@@ -674,11 +675,16 @@ export function WidgetWithdraw({
     zapSlippage
   ])
 
-  const unpricedEnsoWithdrawError =
-    protectedEnsoQuote.hasUnpricedQuoteError && !withdrawAmount.isDebouncing
-      ? 'Unable to estimate zap price impact for the selected token. Withdraw the base asset or swap elsewhere.'
-      : null
-  const effectiveWithdrawError = baseWithdrawError || unpricedEnsoWithdrawError
+  const protectedEnsoWithdrawError = !withdrawAmount.isDebouncing
+    ? protectedEnsoQuote.blockedReason === 'cross-chain-minimum-slippage'
+      ? 'Cross-chain routes require at least 0.01% slippage.'
+      : protectedEnsoQuote.blockedReason === 'no-protected-tolerance'
+        ? 'No protected slippage remains after estimated price impact. Increase your tolerance or withdraw the base asset.'
+        : protectedEnsoQuote.hasUnpricedQuoteError
+          ? 'Unable to estimate zap price impact for the selected token. Withdraw the base asset or swap elsewhere.'
+          : null
+    : null
+  const effectiveWithdrawError = baseWithdrawError || protectedEnsoWithdrawError
 
   const canOpenTokenSelector = ensoEnabled && !disableTokenSelector
   const shouldShowZapUi = !isBaseWithdrawToken

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.test.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.test.ts
@@ -1,5 +1,41 @@
-import { describe, expect, it } from 'vitest'
-import { getEffectiveEnsoRequestSlippage } from './useSolverEnso'
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getEffectiveEnsoRequestSlippage, useSolverEnso } from './useSolverEnso'
+
+const fetchMock = vi.fn()
+
+vi.mock('@shared/hooks/useAppWagmi', () => ({
+  useSimulateContract: vi.fn(() => ({}))
+}))
+
+vi.mock('../useTokenAllowance', () => ({
+  useTokenAllowance: vi.fn(() => ({
+    allowance: 0n,
+    isLoading: false,
+    refetch: vi.fn(async () => undefined)
+  }))
+}))
+
+const TOKEN_IN = '0x0000000000000000000000000000000000000001'
+const TOKEN_OUT = '0x0000000000000000000000000000000000000002'
+const ACCOUNT = '0x0000000000000000000000000000000000000003'
+
+beforeEach(() => {
+  fetchMock.mockResolvedValue({
+    status: 400,
+    json: vi.fn(async () => ({ message: 'No route in request serialization test' }))
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  fetchMock.mockReset()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
 
 describe('getEffectiveEnsoRequestSlippage', () => {
   it('uses one basis point for a zero-slippage cross-chain request', () => {
@@ -13,5 +49,36 @@ describe('getEffectiveEnsoRequestSlippage', () => {
   it('keeps positive requested slippage unchanged', () => {
     expect(getEffectiveEnsoRequestSlippage(37, true)).toBe(37)
     expect(getEffectiveEnsoRequestSlippage(37, false)).toBe(37)
+  })
+})
+
+describe('useSolverEnso request slippage', () => {
+  it.each([
+    { label: 'cross-chain calibration', destinationChainId: 8453, requestedSlippage: 0, expectedSlippage: '1' },
+    { label: 'same-chain calibration', destinationChainId: 1, requestedSlippage: 0, expectedSlippage: '0' },
+    { label: 'protected cross-chain quote', destinationChainId: 8453, requestedSlippage: 37, expectedSlippage: '37' }
+  ])('sends $expectedSlippage bps for a $label', async ({
+    destinationChainId,
+    requestedSlippage,
+    expectedSlippage
+  }) => {
+    const { result } = renderHook(() =>
+      useSolverEnso({
+        tokenIn: TOKEN_IN,
+        tokenOut: TOKEN_OUT,
+        amountIn: 1n,
+        fromAddress: ACCOUNT,
+        chainId: 1,
+        destinationChainId,
+        slippage: requestedSlippage
+      })
+    )
+
+    await act(async () => {
+      await result.current.methods.getRoute()
+    })
+
+    const requestUrl = new URL(String(fetchMock.mock.calls[0]?.[0]), 'http://localhost')
+    expect(requestUrl.searchParams.get('slippage')).toBe(expectedSlippage)
   })
 })

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.test.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { getEffectiveEnsoRequestSlippage } from './useSolverEnso'
+
+describe('getEffectiveEnsoRequestSlippage', () => {
+  it('uses one basis point for a zero-slippage cross-chain request', () => {
+    expect(getEffectiveEnsoRequestSlippage(0, true)).toBe(1)
+  })
+
+  it('keeps zero slippage for a same-chain request', () => {
+    expect(getEffectiveEnsoRequestSlippage(0, false)).toBe(0)
+  })
+
+  it('keeps positive requested slippage unchanged', () => {
+    expect(getEffectiveEnsoRequestSlippage(37, true)).toBe(37)
+    expect(getEffectiveEnsoRequestSlippage(37, false)).toBe(37)
+  })
+})

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
@@ -2,6 +2,7 @@ import { type AppUseSimulateContractReturnType, useSimulateContract } from '@sha
 import type { TNormalizedBN } from '@shared/types'
 import { isZeroAddress, toNormalizedBN } from '@shared/utils'
 import { getApproveAbi } from '@shared/utils/approve'
+import { MIN_CROSS_CHAIN_ENSO_SLIPPAGE_BPS } from '@shared/utils/slippage'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Address } from 'viem'
 import { env } from '@/env'
@@ -15,6 +16,11 @@ import { type EnsoError, type EnsoRouteResponse, normalizeEnsoRouteResponse, rou
 
 const ENSO_ROUTE_PROXY = '/api/enso/route'
 export type EnsoRoutingStrategy = 'router' | 'delegate' | 'router-legacy' | 'delegate-legacy' | 'ensowallet'
+
+export function getEffectiveEnsoRequestSlippage(requestedSlippage: number, isCrossChain: boolean): number {
+  const normalizedSlippage = Number.isFinite(requestedSlippage) ? Math.max(0, Math.floor(requestedSlippage)) : 0
+  return isCrossChain && normalizedSlippage === 0 ? MIN_CROSS_CHAIN_ENSO_SLIPPAGE_BPS : normalizedSlippage
+}
 
 interface UseSolverEnsoProps {
   tokenIn: Address
@@ -125,6 +131,7 @@ export const useSolverEnso = ({
     if (!enabled || !fromAddress || amountIn <= 0n) return
     if (isZeroAddress(tokenIn) || isZeroAddress(tokenOut)) return
     const normalizedSlippage = Number.isFinite(slippage) ? Math.max(0, Math.floor(slippage)) : 0
+    const effectiveSlippage = getEffectiveEnsoRequestSlippage(normalizedSlippage, isCrossChain)
 
     const requestId = routeRequestIdRef.current + 1
     routeRequestIdRef.current = requestId
@@ -140,7 +147,7 @@ export const useSolverEnso = ({
         tokenIn,
         tokenOut,
         amountIn: amountIn.toString(),
-        slippage: normalizedSlippage.toString(),
+        slippage: effectiveSlippage.toString(),
         ...(routingStrategy && { routingStrategy }),
         ...(isCrossChain && { destinationChainId: destinationChainId!.toString() }),
         ...(receiver && { receiver })

--- a/src/components/shared/utils/slippage.test.ts
+++ b/src/components/shared/utils/slippage.test.ts
@@ -69,4 +69,19 @@ describe('slippage utils', () => {
       })
     ).toBe(0)
   })
+
+  it('never rounds final Enso slippage above sub-basis-point user tolerance', () => {
+    expect(
+      calculateRemainingEnsoSlippagePercentage({
+        userTolerancePercentage: 0.009,
+        quoteImpactPercentage: 0
+      })
+    ).toBe(0)
+    expect(
+      calculateRemainingEnsoSlippagePercentage({
+        userTolerancePercentage: 0.01,
+        quoteImpactPercentage: 0
+      })
+    ).toBe(0.01)
+  })
 })

--- a/src/components/shared/utils/slippage.ts
+++ b/src/components/shared/utils/slippage.ts
@@ -1,5 +1,6 @@
 export const ZAP_SLIPPAGE_RISK_ACKNOWLEDGEMENT_THRESHOLD = 1
 export const ZAP_SLIPPAGE_HARD_CAP = 5
+export const MIN_CROSS_CHAIN_ENSO_SLIPPAGE_BPS = 1
 export const ZAP_SLIPPAGE_RISK_ACKNOWLEDGEMENT_TEXT = 'I accept the risk that I may lose money doing this'
 
 function sanitizeNumber(value: number): number {


### PR DESCRIPTION
### Summary
Some Enso cross-chain deposits and withdrawals failed before the user could submit a transaction. This PR fixes the first quote that yearn.fi sends to Enso.

For a cross-chain route, yearn.fi now uses 0.01% slippage for the first quote. This first quote is used only to check the route. The app never lets the user execute it. The app then asks for a second quote using the user's slippage setting. Only the second quote can be executed.

Slippage is the maximum price change that the user is willing to accept.

### What was wrong
Users saw this error in both production and local builds:

> All cross-chain bridge routes failed. No valid route found.

This message made the problem look like a bridge outage. It was not a bridge outage.

Yearn.fi sends two quotes for an Enso transaction:

1. The first quote checks the route and measures its price impact.
2. The second quote uses the user's slippage setting and is the quote that can be executed.

Before this PR, the first quote used 0% slippage. Enso could not build some complex cross-chain routes with 0% slippage. Enso returned an error, so yearn.fi never asked for the second quote.

This problem was in the shared deposit and withdrawal code on `main`. It was not caused by the new swap page, and it was not limited to one chain.

We reproduced the problem with routes to both Base and Katana:

| Route | First quote setting | Result |
| --- | ---: | --- |
| Ethereum WETH to Katana Yearn vault | 0% | Failed with HTTP 400 |
| Ethereum WETH to Katana Yearn vault | 0.01% | Worked |
| Ethereum USDC to Base Yearn vault | 0% | Failed with HTTP 400 |
| Ethereum USDC to Base Yearn vault | 0.01% | Worked |

Some simple cross-chain token transfers worked with 0%. This is why the problem looked random at first.

### What this PR changes
For cross-chain routes:

1. The first quote now uses 0.01% slippage instead of 0%.
2. Yearn.fi uses the first quote to measure the route.
3. Yearn.fi calculates the allowed slippage from the user's setting.
4. Yearn.fi asks Enso for a second quote.
5. Only the second quote can be executed.

This PR does not increase the user's final slippage setting. The 0.01% value is only used for the first, non-executable quote.

If there is no safe slippage value left for the second quote, the app blocks the transaction and shows an error. Same-chain quotes continue to work as before.

### How to review
Start with `src/components/pages/vaults/hooks/solvers/useSolverEnso.ts`. Check that only the first cross-chain quote gets the 0.01% minimum.

Then review `useProtectedEnsoQuoteState.ts`. Check these safety rules:

- The first quote can never be executed.
- A loading or blocked quote can never be executed.
- Only the second quote can provide a transaction.
- The second quote never uses more slippage than the user allowed.

The deposit and withdrawal files only show the new error messages in the existing UI.

### Test plan
- [x] Automated: `bun run tslint`
- [x] Automated: protected quote state, route request, and slippage tests (15 tests)
- [x] Automated: touched-file Biome check
- [x] Automated: `bun run build`
- [x] Manual: Ethereum USDC to Base Yearn vault returned complete quotes at 1 bps and 100 bps
- [x] Manual: Ethereum WETH to Katana Yearn vault returned complete quotes at 1 bps and 100 bps
- [x] Manual: submit transaction

Note: `bun run lint:fix` does not scan this Codex worktree because its full path contains `.codex`. All seven changed files were checked directly with Biome.

### Risk / impact
This changes how yearn.fi asks Enso for cross-chain deposit and withdrawal quotes. It does not change contracts or move funds by itself.

The most important safety rule is that the first quote must never be executable. Tests cover this rule. The final quote still follows the user's slippage setting and the existing 5% safety limit.

Rollback is a single commit revert.
