### PR TITLE
Fix Biome linting in Codex worktrees

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -69,7 +69,7 @@
       "!**/build",
       "!**/node_modules",
       "!**/.next",
-      "!**/.codex",
+      "!.codex",
       "!**/.git",
       "!**/generated",
       "!**/wagmi.ts",


### PR DESCRIPTION
### Summary
Biome checked zero files when the repository was inside a Codex worktree because the broad .codex exclusion also matched the parent directory. Scope that exclusion to the repository root so both lint commands traverse the checkout normally.

### How to review
Review the single pattern change in biome.jsonc. To reproduce the original failure, run the lint command from a checkout located below a .codex directory.

### Test plan
- [x] Automated: bun run lint (867 files checked)
- [x] Automated: bun run lint:fix (867 files checked)
- [x] Automated: bun run tslint
- [x] Automated: bun run build

### Risk / impact
Low risk. This only narrows the .codex ignore pattern to the repository-local directory. Application behavior is unchanged, and reverting the one-line configuration change restores the previous behavior.