### PR TITLE
Force Enso vault zaps through router

### DIFF
--- a/packages/vault-widget/src/components/widget/deposit/index.tsx
+++ b/packages/vault-widget/src/components/widget/deposit/index.tsx
@@ -385,7 +385,6 @@ export function WidgetDeposit({
     slippage: ensoQuoteSlippage,
     ensoQuotePurpose: ensoQuoteRequest.purpose,
     ensoEnabled,
-    ensoRoutingStrategy: isWalletSafe ? 'router' : undefined,
     routeRefreshKey: approvalRouteRefreshKey,
     stakingSource
   })

--- a/packages/vault-widget/src/components/widget/deposit/useDepositFlow.ts
+++ b/packages/vault-widget/src/components/widget/deposit/useDepositFlow.ts
@@ -4,7 +4,7 @@ import { useDirectStake } from '@yearn/vault-widget/internal/hooks/actions/useDi
 import { useEnsoDeposit } from '@yearn/vault-widget/internal/hooks/actions/useEnsoDeposit'
 import { useYBoldZapperDeposit } from '@yearn/vault-widget/internal/hooks/actions/useYBoldZapperDeposit'
 import { useYvUsdLockedZapDeposit } from '@yearn/vault-widget/internal/hooks/actions/useYvUsdLockedZapDeposit'
-import type { EnsoQuotePurpose, EnsoRoutingStrategy } from '@yearn/vault-widget/internal/hooks/solvers/useSolverEnso'
+import type { EnsoQuotePurpose } from '@yearn/vault-widget/internal/hooks/solvers/useSolverEnso'
 import { toAddress } from '@yearn/vault-widget/internal/utils'
 import { toBasisPoints } from '@yearn/vault-widget/internal/utils/slippage'
 import { YVUSD_LOCKED_ADDRESS } from '@yearn/vault-widget/internal/utils/yvUsd'
@@ -38,7 +38,6 @@ interface UseDepositFlowProps {
   slippage: number
   ensoQuotePurpose: EnsoQuotePurpose
   ensoEnabled: boolean
-  ensoRoutingStrategy?: EnsoRoutingStrategy
   routeRefreshKey?: number
   stakingSource?: string
 }
@@ -99,7 +98,6 @@ export const useDepositFlow = ({
   slippage,
   ensoQuotePurpose,
   ensoEnabled,
-  ensoRoutingStrategy,
   routeRefreshKey,
   stakingSource
 }: UseDepositFlowProps): DepositFlowResult => {
@@ -173,7 +171,6 @@ export const useDepositFlow = ({
     enabled: routeType === 'ENSO' && !!depositToken && amount > 0n && currentAmount > 0n,
     slippage: toBasisPoints(slippage),
     quotePurpose: ensoQuotePurpose,
-    routingStrategy: ensoRoutingStrategy,
     routeRefreshKey
   })
 

--- a/packages/vault-widget/src/components/widget/deposit/useFetchMaxQuote.test.ts
+++ b/packages/vault-widget/src/components/widget/deposit/useFetchMaxQuote.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { resolveMaxQuoteSlippage } from './useFetchMaxQuote'
+import { buildMaxQuoteRequestParams, resolveMaxQuoteSlippage } from './useFetchMaxQuote'
+
+const ACCOUNT = '0x0000000000000000000000000000000000000001'
+const DEPOSIT_TOKEN = '0x0000000000000000000000000000000000000002'
+const DESTINATION_TOKEN = '0x0000000000000000000000000000000000000003'
 
 describe('resolveMaxQuoteSlippage', () => {
   it('falls back to the user tolerance when the bootstrap quote is unavailable', () => {
@@ -21,4 +25,29 @@ describe('resolveMaxQuoteSlippage', () => {
       })
     ).toBe(2.02)
   })
+})
+
+describe('buildMaxQuoteRequestParams', () => {
+  it.each([
+    { destinationChainId: 1, expectedDestinationChainId: null, route: 'same-chain' },
+    { destinationChainId: 10, expectedDestinationChainId: '10', route: 'cross-chain' }
+  ])(
+    'serializes the router-only policy for $route MAX quotes',
+    ({ destinationChainId, expectedDestinationChainId }) => {
+      const params = buildMaxQuoteRequestParams({
+        account: ACCOUNT,
+        balance: 100n,
+        depositToken: DEPOSIT_TOKEN,
+        destinationToken: DESTINATION_TOKEN,
+        sourceChainId: 1,
+        destinationChainId,
+        routeSlippage: 1
+      })
+
+      expect(params.get('routingStrategy')).toBe('router')
+      expect(params.get('destinationChainId')).toBe(expectedDestinationChainId)
+      expect(params.get('receiver')).toBe(ACCOUNT)
+      expect(params.get('slippage')).toBe('100')
+    }
+  )
 })

--- a/packages/vault-widget/src/components/widget/deposit/useFetchMaxQuote.ts
+++ b/packages/vault-widget/src/components/widget/deposit/useFetchMaxQuote.ts
@@ -4,6 +4,10 @@ import {
   normalizeEnsoRouteResponse
 } from '@yearn/vault-widget/internal/hooks/solvers/ensoRoute'
 import {
+  buildEnsoRouteRequestParams,
+  VAULT_ENSO_ROUTING_STRATEGY
+} from '@yearn/vault-widget/internal/hooks/solvers/ensoRouteRequest'
+import {
   calculateRemainingEnsoSlippagePercentage,
   clampZapSlippage,
   toBasisPoints
@@ -64,6 +68,36 @@ interface FetchMaxQuoteResult {
   isFetching: boolean
 }
 
+export function buildMaxQuoteRequestParams({
+  account,
+  balance,
+  depositToken,
+  destinationToken,
+  sourceChainId,
+  destinationChainId,
+  routeSlippage
+}: {
+  account: Address
+  balance: bigint
+  depositToken: Address
+  destinationToken: Address
+  sourceChainId: number
+  destinationChainId: number
+  routeSlippage: number
+}): URLSearchParams {
+  return buildEnsoRouteRequestParams({
+    fromAddress: account,
+    chainId: sourceChainId,
+    tokenIn: depositToken,
+    tokenOut: destinationToken,
+    amountIn: balance,
+    slippage: toBasisPoints(routeSlippage),
+    routingStrategy: VAULT_ENSO_ROUTING_STRATEGY,
+    destinationChainId,
+    receiver: account
+  })
+}
+
 export const useFetchMaxQuote = ({
   isNativeToken,
   account,
@@ -92,15 +126,14 @@ export const useFetchMaxQuote = ({
   const fetchRoute = useCallback(
     async (routeSlippage: number): Promise<EnsoRouteResponse | undefined> => {
       const isCrossChain = sourceChainId !== chainId
-      const params = new URLSearchParams({
-        fromAddress: account!,
-        chainId: sourceChainId.toString(),
-        tokenIn: depositToken,
-        tokenOut: destinationToken,
-        amountIn: balance!.toString(),
-        slippage: toBasisPoints(routeSlippage).toString(),
-        ...(isCrossChain && { destinationChainId: chainId.toString() }),
-        receiver: account!
+      const params = buildMaxQuoteRequestParams({
+        account: account!,
+        balance: balance!,
+        depositToken,
+        destinationToken,
+        sourceChainId,
+        destinationChainId: chainId,
+        routeSlippage
       })
 
       const response = await fetch(`${ensoRouteEndpoint}?${params}`)

--- a/packages/vault-widget/src/components/widget/withdraw/index.tsx
+++ b/packages/vault-widget/src/components/widget/withdraw/index.tsx
@@ -388,8 +388,7 @@ export function WidgetWithdraw({
     withdrawalSource,
     isUnstake,
     isDebouncing: disableFlow ? false : withdrawAmount.isDebouncing,
-    useErc4626: usesErc4626,
-    ensoRoutingStrategy: isWalletSafe ? 'router' : undefined
+    useErc4626: usesErc4626
   })
   const effectiveDirectWithdrawPrepare = blockDirectWithdrawStep
     ? undefined

--- a/packages/vault-widget/src/components/widget/withdraw/useWithdrawFlow.ts
+++ b/packages/vault-widget/src/components/widget/withdraw/useWithdrawFlow.ts
@@ -3,7 +3,7 @@ import { useDirectWithdraw } from '@yearn/vault-widget/internal/hooks/actions/us
 import { useEnsoWithdraw } from '@yearn/vault-widget/internal/hooks/actions/useEnsoWithdraw'
 import { useYBoldZapperWithdraw } from '@yearn/vault-widget/internal/hooks/actions/useYBoldZapperWithdraw'
 import { useYvUsdLockedZapWithdraw } from '@yearn/vault-widget/internal/hooks/actions/useYvUsdLockedZapWithdraw'
-import type { EnsoQuotePurpose, EnsoRoutingStrategy } from '@yearn/vault-widget/internal/hooks/solvers/useSolverEnso'
+import type { EnsoQuotePurpose } from '@yearn/vault-widget/internal/hooks/solvers/useSolverEnso'
 import { toAddress } from '@yearn/vault-widget/internal/utils'
 import { toBasisPoints } from '@yearn/vault-widget/internal/utils/slippage'
 import { YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@yearn/vault-widget/internal/utils/yvUsd'
@@ -48,7 +48,6 @@ interface UseWithdrawFlowProps {
   isUnstake: boolean
   isDebouncing: boolean
   useErc4626: boolean
-  ensoRoutingStrategy?: EnsoRoutingStrategy
 }
 
 export interface WithdrawFlowResult {
@@ -87,8 +86,7 @@ export function useWithdrawFlow({
   withdrawalSource,
   isUnstake,
   isDebouncing,
-  useErc4626,
-  ensoRoutingStrategy
+  useErc4626
 }: UseWithdrawFlowProps): WithdrawFlowResult {
   const routeType = useWithdrawRoute({
     vaultAddress,
@@ -184,8 +182,7 @@ export function useWithdrawFlow({
     decimalsOut: outputDecimals,
     enabled: ensoFlowEnabled,
     slippage: toBasisPoints(slippage),
-    quotePurpose: ensoQuotePurpose,
-    routingStrategy: ensoRoutingStrategy
+    quotePurpose: ensoQuotePurpose
   })
 
   const activeFlow = useMemo((): UseWidgetWithdrawFlowReturn => {

--- a/packages/vault-widget/src/hooks/actions/ensoRouting.test.ts
+++ b/packages/vault-widget/src/hooks/actions/ensoRouting.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useEnsoDeposit } from './useEnsoDeposit'
+import { useEnsoWithdraw } from './useEnsoWithdraw'
+
+const { useSolverEnsoMock } = vi.hoisted(() => ({ useSolverEnsoMock: vi.fn() }))
+
+vi.mock('../solvers/useSolverEnso', () => ({
+  useSolverEnso: useSolverEnsoMock
+}))
+
+vi.mock('../useEnsoOrder', () => ({
+  useEnsoOrder: vi.fn(() => ({ prepareEnsoOrder: {} }))
+}))
+
+const VAULT = '0x0000000000000000000000000000000000000001'
+const TOKEN = '0x0000000000000000000000000000000000000002'
+const ACCOUNT = '0x0000000000000000000000000000000000000003'
+
+beforeEach(() => {
+  useSolverEnsoMock.mockReturnValue({
+    actions: { prepareApprove: {} },
+    periphery: {
+      prepareApproveEnabled: false,
+      expectedOut: { raw: 0n },
+      minExpectedOut: { raw: 0n },
+      priceImpact: undefined,
+      allowance: 0n,
+      route: undefined,
+      routeHasSwap: false,
+      bridgeProtocol: undefined,
+      error: undefined,
+      isLoadingRoute: false,
+      isCrossChain: false,
+      routerAddress: undefined,
+      approvalSpenderAddress: undefined,
+      approvalWarning: undefined,
+      refetchAllowance: vi.fn()
+    },
+    methods: {
+      getRoute: vi.fn(),
+      getEnsoTransaction: vi.fn(),
+      resetRoute: vi.fn()
+    }
+  })
+})
+
+describe('vault Enso routing', () => {
+  it('always requests router execution for deposits', () => {
+    renderHook(() =>
+      useEnsoDeposit({
+        vaultAddress: VAULT,
+        depositToken: TOKEN,
+        amount: 1n,
+        account: ACCOUNT,
+        chainId: 1,
+        decimalsOut: 18,
+        enabled: true
+      })
+    )
+
+    expect(useSolverEnsoMock).toHaveBeenCalledWith(expect.objectContaining({ routingStrategy: 'router' }))
+  })
+
+  it('always requests router execution for withdrawals', () => {
+    renderHook(() =>
+      useEnsoWithdraw({
+        vaultAddress: VAULT,
+        withdrawToken: TOKEN,
+        amount: 1n,
+        account: ACCOUNT,
+        chainId: 1,
+        decimalsOut: 6,
+        enabled: true
+      })
+    )
+
+    expect(useSolverEnsoMock).toHaveBeenCalledWith(expect.objectContaining({ routingStrategy: 'router' }))
+  })
+})

--- a/packages/vault-widget/src/hooks/actions/useEnsoDeposit.ts
+++ b/packages/vault-widget/src/hooks/actions/useEnsoDeposit.ts
@@ -1,7 +1,8 @@
 import type { UseWidgetDepositFlowReturn } from '@yearn/vault-widget/types'
 import { useCallback, useMemo } from 'react'
 import type { Address } from 'viem'
-import type { EnsoQuotePurpose, EnsoRoutingStrategy } from '../solvers/useSolverEnso'
+import { VAULT_ENSO_ROUTING_STRATEGY } from '../solvers/ensoRouteRequest'
+import type { EnsoQuotePurpose } from '../solvers/useSolverEnso'
 import { useSolverEnso } from '../solvers/useSolverEnso'
 import { useEnsoOrder } from '../useEnsoOrder'
 import { refreshEnsoReadiness } from './ensoReadiness'
@@ -17,7 +18,6 @@ interface UseEnsoDepositParams {
   enabled: boolean
   slippage?: number
   quotePurpose?: EnsoQuotePurpose
-  routingStrategy?: EnsoRoutingStrategy
   routeRefreshKey?: number
 }
 
@@ -31,7 +31,7 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
         params.vaultAddress,
         params.account ?? 'no-account',
         params.slippage ?? 'default',
-        params.routingStrategy ?? 'default-strategy',
+        VAULT_ENSO_ROUTING_STRATEGY,
         params.routeRefreshKey ?? 0
       ].join(':'),
     [
@@ -41,7 +41,6 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
       params.vaultAddress,
       params.account,
       params.slippage,
-      params.routingStrategy,
       params.routeRefreshKey
     ]
   )
@@ -58,7 +57,7 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
     decimalsOut: params.decimalsOut,
     slippage: params.slippage,
     quotePurpose: params.quotePurpose,
-    routingStrategy: params.routingStrategy,
+    routingStrategy: VAULT_ENSO_ROUTING_STRATEGY,
     requestKey: routeQueryKey,
     enabled: params.enabled
   })

--- a/packages/vault-widget/src/hooks/actions/useEnsoWithdraw.ts
+++ b/packages/vault-widget/src/hooks/actions/useEnsoWithdraw.ts
@@ -1,7 +1,8 @@
 import type { UseWidgetWithdrawFlowReturn } from '@yearn/vault-widget/types'
 import { useCallback, useMemo } from 'react'
 import type { Address } from 'viem'
-import type { EnsoQuotePurpose, EnsoRoutingStrategy } from '../solvers/useSolverEnso'
+import { VAULT_ENSO_ROUTING_STRATEGY } from '../solvers/ensoRouteRequest'
+import type { EnsoQuotePurpose } from '../solvers/useSolverEnso'
 import { useSolverEnso } from '../solvers/useSolverEnso'
 import { useEnsoOrder } from '../useEnsoOrder'
 import { refreshEnsoReadiness } from './ensoReadiness'
@@ -18,7 +19,6 @@ interface UseEnsoWithdrawParams {
   enabled: boolean
   slippage?: number
   quotePurpose?: EnsoQuotePurpose
-  routingStrategy?: EnsoRoutingStrategy
 }
 
 export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdrawFlowReturn {
@@ -32,7 +32,7 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
         params.account ?? 'no-account',
         params.receiver ?? 'no-receiver',
         params.slippage ?? 'default',
-        params.routingStrategy ?? 'default-strategy'
+        VAULT_ENSO_ROUTING_STRATEGY
       ].join(':'),
     [
       params.chainId,
@@ -41,8 +41,7 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
       params.withdrawToken,
       params.account,
       params.receiver,
-      params.slippage,
-      params.routingStrategy
+      params.slippage
     ]
   )
 
@@ -58,7 +57,7 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
     decimalsOut: params.decimalsOut,
     slippage: params.slippage,
     quotePurpose: params.quotePurpose,
-    routingStrategy: params.routingStrategy,
+    routingStrategy: VAULT_ENSO_ROUTING_STRATEGY,
     requestKey: routeQueryKey,
     enabled: params.enabled
   })

--- a/packages/vault-widget/src/hooks/solvers/ensoRoute.test.ts
+++ b/packages/vault-widget/src/hooks/solvers/ensoRoute.test.ts
@@ -39,3 +39,54 @@ describe('getEnsoBridgeProtocol', () => {
     ).toBeUndefined()
   })
 })
+
+describe('normalizeEnsoRouteResponse', () => {
+  it('accepts a normal Enso router call', () => {
+    const normalized = normalizeEnsoRouteResponse(
+      {
+        ...routePayload,
+        tx: { ...routePayload.tx, operationType: 0 },
+        route: []
+      },
+      200
+    )
+
+    expect(normalized.error).toBeUndefined()
+    expect(normalized.route?.tx.operationType).toBe(0)
+  })
+
+  it('rejects a delegate route before exposing its transaction', () => {
+    const normalized = normalizeEnsoRouteResponse(
+      {
+        ...routePayload,
+        tx: {
+          ...routePayload.tx,
+          to: '0xA2F4F9c6Ec598ca8C633024F8851C79CA5f43E48',
+          operationType: 1
+        },
+        route: []
+      },
+      200
+    )
+
+    expect(normalized.route).toBeUndefined()
+    expect(normalized.error).toMatchObject({
+      error: 'UnsupportedEnsoDelegateRoute',
+      message: 'Enso returned an unsupported wallet route. Please retry the quote.'
+    })
+  })
+
+  it('rejects unknown operation types', () => {
+    const normalized = normalizeEnsoRouteResponse(
+      {
+        ...routePayload,
+        tx: { ...routePayload.tx, operationType: 2 },
+        route: []
+      },
+      200
+    )
+
+    expect(normalized.route).toBeUndefined()
+    expect(normalized.error?.error).toBe('UnsupportedEnsoDelegateRoute')
+  })
+})

--- a/packages/vault-widget/src/hooks/solvers/ensoRoute.ts
+++ b/packages/vault-widget/src/hooks/solvers/ensoRoute.ts
@@ -14,6 +14,7 @@ export interface EnsoRouteResponse {
     value: string
     from: Address
     chainId: number
+    operationType?: 0 | 1
   }
   amountOut: string
   minAmountOut: string
@@ -40,8 +41,9 @@ type EnsoRouteErrorPayload = {
 
 type EnsoRouteCandidate = Omit<EnsoRouteResponse, 'tx' | 'priceImpact'> & {
   priceImpact?: unknown
-  tx: Omit<EnsoRouteResponse['tx'], 'chainId'> & {
+  tx: Omit<EnsoRouteResponse['tx'], 'chainId' | 'operationType'> & {
     chainId?: number
+    operationType?: unknown
   }
 }
 
@@ -113,6 +115,19 @@ export function normalizeEnsoRouteResponse(
     const resolvedChainId = typeof data.tx.chainId === 'number' ? data.tx.chainId : fallbackChainId
     const priceImpact = normalizeEnsoPriceImpact(data.priceImpact)
     const { priceImpact: _rawPriceImpact, tx, ...routeData } = data
+    const { operationType, ...transaction } = tx
+
+    if (operationType !== undefined && operationType !== 0) {
+      return {
+        error: buildEnsoError(
+          {
+            error: 'UnsupportedEnsoDelegateRoute',
+            message: 'Enso returned an unsupported wallet route. Please retry the quote.'
+          },
+          statusCode
+        )
+      }
+    }
 
     if (typeof resolvedChainId !== 'number') {
       return { error: buildEnsoError({ message: 'Enso route payload missing tx.chainId' }, statusCode) }
@@ -123,7 +138,8 @@ export function normalizeEnsoRouteResponse(
         ...routeData,
         ...(priceImpact !== undefined ? { priceImpact } : {}),
         tx: {
-          ...tx,
+          ...transaction,
+          ...(operationType === 0 ? { operationType: 0 as const } : {}),
           chainId: resolvedChainId
         }
       }

--- a/packages/vault-widget/src/hooks/solvers/ensoRouteRequest.test.ts
+++ b/packages/vault-widget/src/hooks/solvers/ensoRouteRequest.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { buildEnsoRouteRequestParams, VAULT_ENSO_ROUTING_STRATEGY } from './ensoRouteRequest'
+
+const TOKEN_IN = '0x0000000000000000000000000000000000000001'
+const TOKEN_OUT = '0x0000000000000000000000000000000000000002'
+const ACCOUNT = '0x0000000000000000000000000000000000000003'
+
+describe('buildEnsoRouteRequestParams', () => {
+  it.each([
+    { label: 'same-chain', destinationChainId: 1 },
+    { label: 'cross-chain', destinationChainId: 8453 }
+  ])('serializes router execution for a $label vault zap', ({ destinationChainId }) => {
+    const params = buildEnsoRouteRequestParams({
+      fromAddress: ACCOUNT,
+      chainId: 1,
+      tokenIn: TOKEN_IN,
+      tokenOut: TOKEN_OUT,
+      amountIn: 10n,
+      slippage: 100,
+      routingStrategy: VAULT_ENSO_ROUTING_STRATEGY,
+      destinationChainId,
+      receiver: ACCOUNT
+    })
+
+    expect(params.get('routingStrategy')).toBe('router')
+    expect(params.get('destinationChainId')).toBe(destinationChainId === 1 ? null : '8453')
+  })
+})

--- a/packages/vault-widget/src/hooks/solvers/ensoRouteRequest.ts
+++ b/packages/vault-widget/src/hooks/solvers/ensoRouteRequest.ts
@@ -1,0 +1,41 @@
+import type { Address } from 'viem'
+
+export type EnsoRoutingStrategy = 'router' | 'delegate' | 'router-legacy' | 'delegate-legacy' | 'ensowallet'
+
+export const VAULT_ENSO_ROUTING_STRATEGY = 'router' as const satisfies EnsoRoutingStrategy
+
+export function buildEnsoRouteRequestParams({
+  fromAddress,
+  chainId,
+  tokenIn,
+  tokenOut,
+  amountIn,
+  slippage,
+  routingStrategy,
+  destinationChainId,
+  receiver
+}: {
+  fromAddress: Address
+  chainId: number
+  tokenIn: Address
+  tokenOut: Address
+  amountIn: bigint
+  slippage: number
+  routingStrategy?: EnsoRoutingStrategy
+  destinationChainId?: number
+  receiver?: Address
+}): URLSearchParams {
+  const isCrossChain = destinationChainId !== undefined && destinationChainId !== chainId
+
+  return new URLSearchParams({
+    fromAddress,
+    chainId: chainId.toString(),
+    tokenIn,
+    tokenOut,
+    amountIn: amountIn.toString(),
+    slippage: slippage.toString(),
+    ...(routingStrategy && { routingStrategy }),
+    ...(isCrossChain && { destinationChainId: destinationChainId.toString() }),
+    ...(receiver && { receiver })
+  })
+}

--- a/packages/vault-widget/src/hooks/solvers/useSolverEnso.ts
+++ b/packages/vault-widget/src/hooks/solvers/useSolverEnso.ts
@@ -23,9 +23,11 @@ import {
   normalizeEnsoRouteResponse,
   routeHasSwapStep
 } from './ensoRoute'
+import { buildEnsoRouteRequestParams, type EnsoRoutingStrategy } from './ensoRouteRequest'
 
 const ENSO_ROUTE_PROXY = '/api/enso/route'
-export type EnsoRoutingStrategy = 'router' | 'delegate' | 'router-legacy' | 'delegate-legacy' | 'ensowallet'
+
+export type { EnsoRoutingStrategy } from './ensoRouteRequest'
 export type EnsoQuotePurpose = 'calibration' | 'execution'
 
 export function getEffectiveEnsoRequestSlippage(requestedSlippage: number, isCrossChain: boolean): number {
@@ -141,16 +143,16 @@ export const useSolverEnso = ({
     staleTime: 0,
     queryFn: async ({ signal }) => {
       if (!fromAddress) return undefined
-      const params = new URLSearchParams({
+      const params = buildEnsoRouteRequestParams({
         fromAddress,
-        chainId: chainId.toString(),
+        chainId,
         tokenIn,
         tokenOut,
-        amountIn: amountIn.toString(),
-        slippage: effectiveSlippage.toString(),
-        ...(routingStrategy && { routingStrategy }),
-        ...(isCrossChain && { destinationChainId: destinationChainId!.toString() }),
-        ...(receiver && { receiver })
+        amountIn,
+        slippage: effectiveSlippage,
+        routingStrategy,
+        destinationChainId,
+        receiver
       })
       const response = await fetch(`${routeEndpoint}?${params}`, { signal })
       const data = await response.json()


### PR DESCRIPTION
### Summary
Vault zaps could receive an Enso delegate-call route when a smart account was connected outside the Safe app. The widget cannot execute delegate calls, so the quote was blocked by the router safety check.

This change makes router execution an invariant inside the vault deposit and withdrawal hooks. It also rejects delegate-call responses before they enter widget state.

Stacked on #1351.

### How to review
Review the route boundary first:

1. Check useEnsoDeposit and useEnsoWithdraw. Both always pass routingStrategy=router.
2. Check ensoRoute. Any non-zero or unknown operationType is rejected before the route is exposed.
3. Check the removed widget and flow props. Safe detection still controls Safe batching and tracking, but no longer controls Enso routing.
4. Check the pure request serializer and focused regression tests.

### Test plan
- [x] Automated: bun run test:all (1,071 tests passed)
- [x] Automated: bun run tslint:all
- [x] Automated: bun run check:vault-widget-boundary
- [x] Automated: Biome check on all 12 changed files
- [x] Automated: bun run build
- [x] Manual: reproduced the reported smart-account USDS vault to USDC route with routingStrategy=router; Enso returned the documented router and no delegate operation

### Risk / impact
This affects transaction preparation for all Enso vault deposits and withdrawals. It reduces the supported route set to the normal router execution mode that the widget already approves, simulates, batches, and validates.

The existing router allowlist remains active. Delegate transactions never reach approval or execution. Reverting commit 23a078d7 restores the previous strategy selection.

### Note
A version of this fix is also in #1355 for the main branch