### PR TITLE
Make vault Enso routes router-only

### DIFF
--- a/src/components/pages/vaults/components/widget/deposit/index.tsx
+++ b/src/components/pages/vaults/components/widget/deposit/index.tsx
@@ -367,7 +367,6 @@ export function WidgetDeposit({
     inputDecimals: inputToken?.decimals ?? 18,
     vaultDecimals: vault?.decimals ?? 18,
     slippage: ensoQuoteSlippage,
-    ensoRoutingStrategy: isWalletSafe ? 'router' : undefined,
     routeRefreshKey: approvalRouteRefreshKey,
     stakingSource
   })

--- a/src/components/pages/vaults/components/widget/deposit/useDepositError.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositError.ts
@@ -1,3 +1,4 @@
+import { UNSUPPORTED_ENSO_DELEGATE_ROUTE_MESSAGE } from '@pages/vaults/hooks/solvers/ensoRoute'
 import { UNKNOWN_ENSO_APPROVAL_ROUTER_MESSAGE } from '@pages/vaults/utils/ensoRouters'
 import { useMemo } from 'react'
 import type { Address } from 'viem'
@@ -54,6 +55,10 @@ export const useDepositError = ({
     if (routeType === 'ENSO' && flowError && !isLoadingRoute && debouncedAmount > 0n && !isDebouncing) {
       if (flowError === UNKNOWN_ENSO_APPROVAL_ROUTER_MESSAGE) {
         return UNKNOWN_ENSO_APPROVAL_ROUTER_MESSAGE
+      }
+
+      if (flowError === UNSUPPORTED_ENSO_DELEGATE_ROUTE_MESSAGE) {
+        return UNSUPPORTED_ENSO_DELEGATE_ROUTE_MESSAGE
       }
 
       return 'Unable to find route'

--- a/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useDepositFlow.ts
@@ -4,7 +4,6 @@ import { useDirectStake } from '@pages/vaults/hooks/actions/useDirectStake'
 import { useEnsoDeposit } from '@pages/vaults/hooks/actions/useEnsoDeposit'
 import { useYBoldZapperDeposit } from '@pages/vaults/hooks/actions/useYBoldZapperDeposit'
 import { useYvUsdLockedZapDeposit } from '@pages/vaults/hooks/actions/useYvUsdLockedZapDeposit'
-import type { EnsoRoutingStrategy } from '@pages/vaults/hooks/solvers/useSolverEnso'
 import { YVUSD_LOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { toAddress } from '@shared/utils'
 import { toBasisPoints } from '@shared/utils/slippage'
@@ -36,7 +35,6 @@ interface UseDepositFlowProps {
   vaultDecimals: number
   // Settings
   slippage: number
-  ensoRoutingStrategy?: EnsoRoutingStrategy
   routeRefreshKey?: number
   stakingSource?: string
 }
@@ -94,7 +92,6 @@ export const useDepositFlow = ({
   inputDecimals,
   vaultDecimals,
   slippage,
-  ensoRoutingStrategy,
   routeRefreshKey,
   stakingSource
 }: UseDepositFlowProps): DepositFlowResult => {
@@ -168,7 +165,6 @@ export const useDepositFlow = ({
     decimalsOut: vaultDecimals,
     enabled: routeType === 'ENSO' && !!depositToken && amount > 0n && currentAmount > 0n,
     slippage: toBasisPoints(slippage),
-    routingStrategy: ensoRoutingStrategy,
     routeRefreshKey
   })
 

--- a/src/components/pages/vaults/components/widget/deposit/useFetchMaxQuote.test.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useFetchMaxQuote.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { resolveMaxQuoteSlippage } from './useFetchMaxQuote'
+import { buildMaxQuoteRequestParams, resolveMaxQuoteSlippage } from './useFetchMaxQuote'
+
+const ACCOUNT = '0x0000000000000000000000000000000000000001'
+const DEPOSIT_TOKEN = '0x0000000000000000000000000000000000000002'
+const DESTINATION_TOKEN = '0x0000000000000000000000000000000000000003'
 
 describe('resolveMaxQuoteSlippage', () => {
   it('falls back to the user tolerance when the bootstrap quote is unavailable', () => {
@@ -20,5 +24,30 @@ describe('resolveMaxQuoteSlippage', () => {
         quoteImpactPercentage: 1
       })
     ).toBe(2.02)
+  })
+})
+
+describe('buildMaxQuoteRequestParams', () => {
+  it.each([
+    { destinationChainId: 1, expectedDestinationChainId: null, route: 'same-chain' },
+    { destinationChainId: 10, expectedDestinationChainId: '10', route: 'cross-chain' }
+  ])('serializes the router-only policy for $route MAX quotes', ({
+    destinationChainId,
+    expectedDestinationChainId
+  }) => {
+    const params = buildMaxQuoteRequestParams({
+      account: ACCOUNT,
+      balance: 100n,
+      depositToken: DEPOSIT_TOKEN,
+      destinationToken: DESTINATION_TOKEN,
+      sourceChainId: 1,
+      destinationChainId,
+      routeSlippage: 1
+    })
+
+    expect(params.get('routingStrategy')).toBe('router')
+    expect(params.get('destinationChainId')).toBe(expectedDestinationChainId)
+    expect(params.get('receiver')).toBe(ACCOUNT)
+    expect(params.get('slippage')).toBe('100')
   })
 })

--- a/src/components/pages/vaults/components/widget/deposit/useFetchMaxQuote.ts
+++ b/src/components/pages/vaults/components/widget/deposit/useFetchMaxQuote.ts
@@ -1,5 +1,6 @@
 import { getRedeemPreviewCall } from '@pages/vaults/hooks/actions/stakingAdapter'
 import { type EnsoRouteResponse, normalizeEnsoRouteResponse } from '@pages/vaults/hooks/solvers/ensoRoute'
+import { buildEnsoRouteRequestParams, VAULT_ENSO_ROUTING_STRATEGY } from '@pages/vaults/hooks/solvers/ensoRouteRequest'
 import { calculateRemainingEnsoSlippagePercentage, clampZapSlippage, toBasisPoints } from '@shared/utils/slippage'
 import { useCallback, useState } from 'react'
 import { type Address, formatUnits, isAddressEqual } from 'viem'
@@ -57,6 +58,36 @@ interface FetchMaxQuoteResult {
   isFetching: boolean
 }
 
+export function buildMaxQuoteRequestParams({
+  account,
+  balance,
+  depositToken,
+  destinationToken,
+  sourceChainId,
+  destinationChainId,
+  routeSlippage
+}: {
+  account: Address
+  balance: bigint
+  depositToken: Address
+  destinationToken: Address
+  sourceChainId: number
+  destinationChainId: number
+  routeSlippage: number
+}): URLSearchParams {
+  return buildEnsoRouteRequestParams({
+    fromAddress: account,
+    chainId: sourceChainId,
+    tokenIn: depositToken,
+    tokenOut: destinationToken,
+    amountIn: balance,
+    slippage: toBasisPoints(routeSlippage),
+    routingStrategy: VAULT_ENSO_ROUTING_STRATEGY,
+    destinationChainId,
+    receiver: account
+  })
+}
+
 export const useFetchMaxQuote = ({
   isNativeToken,
   account,
@@ -83,15 +114,14 @@ export const useFetchMaxQuote = ({
   const fetchRoute = useCallback(
     async (routeSlippage: number): Promise<EnsoRouteResponse | undefined> => {
       const isCrossChain = sourceChainId !== chainId
-      const params = new URLSearchParams({
-        fromAddress: account!,
-        chainId: sourceChainId.toString(),
-        tokenIn: depositToken,
-        tokenOut: destinationToken,
-        amountIn: balance!.toString(),
-        slippage: toBasisPoints(routeSlippage).toString(),
-        ...(isCrossChain && { destinationChainId: chainId.toString() }),
-        receiver: account!
+      const params = buildMaxQuoteRequestParams({
+        account: account!,
+        balance: balance!,
+        depositToken,
+        destinationToken,
+        sourceChainId,
+        destinationChainId: chainId,
+        routeSlippage
       })
 
       const response = await fetch(`${ENSO_ROUTE_PROXY}?${params}`)

--- a/src/components/pages/vaults/components/widget/withdraw/index.tsx
+++ b/src/components/pages/vaults/components/widget/withdraw/index.tsx
@@ -372,8 +372,7 @@ export function WidgetWithdraw({
     withdrawalSource,
     isUnstake,
     isDebouncing: disableFlow ? false : withdrawAmount.isDebouncing,
-    useErc4626: usesErc4626,
-    ensoRoutingStrategy: isWalletSafe ? 'router' : undefined
+    useErc4626: usesErc4626
   })
   const effectiveDirectWithdrawPrepare = blockDirectWithdrawStep
     ? undefined

--- a/src/components/pages/vaults/components/widget/withdraw/useWithdrawError.ts
+++ b/src/components/pages/vaults/components/widget/withdraw/useWithdrawError.ts
@@ -1,3 +1,4 @@
+import { UNSUPPORTED_ENSO_DELEGATE_ROUTE_MESSAGE } from '@pages/vaults/hooks/solvers/ensoRoute'
 import { useMemo } from 'react'
 import type { Address } from 'viem'
 import type { WithdrawalSource, WithdrawRouteType } from './types'
@@ -49,6 +50,10 @@ export const useWithdrawError = ({
     // Route-dependent validation - wait for debounce and route fetch
     if (routeType === 'ENSO') {
       if (flowError && !isLoadingRoute && debouncedAmount > 0n && !isDebouncing) {
+        if (flowError === UNSUPPORTED_ENSO_DELEGATE_ROUTE_MESSAGE) {
+          return UNSUPPORTED_ENSO_DELEGATE_ROUTE_MESSAGE
+        }
+
         return 'Unable to find route'
       }
     }

--- a/src/components/pages/vaults/components/widget/withdraw/useWithdrawFlow.ts
+++ b/src/components/pages/vaults/components/widget/withdraw/useWithdrawFlow.ts
@@ -3,7 +3,6 @@ import { useDirectWithdraw } from '@pages/vaults/hooks/actions/useDirectWithdraw
 import { useEnsoWithdraw } from '@pages/vaults/hooks/actions/useEnsoWithdraw'
 import { useYBoldZapperWithdraw } from '@pages/vaults/hooks/actions/useYBoldZapperWithdraw'
 import { useYvUsdLockedZapWithdraw } from '@pages/vaults/hooks/actions/useYvUsdLockedZapWithdraw'
-import type { EnsoRoutingStrategy } from '@pages/vaults/hooks/solvers/useSolverEnso'
 import type { UseWidgetWithdrawFlowReturn } from '@pages/vaults/types'
 import { YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@pages/vaults/utils/yvUsd'
 import { toAddress } from '@shared/utils'
@@ -46,7 +45,6 @@ interface UseWithdrawFlowProps {
   isUnstake: boolean
   isDebouncing: boolean
   useErc4626: boolean
-  ensoRoutingStrategy?: EnsoRoutingStrategy
 }
 
 export interface WithdrawFlowResult {
@@ -83,8 +81,7 @@ export function useWithdrawFlow({
   withdrawalSource,
   isUnstake,
   isDebouncing,
-  useErc4626,
-  ensoRoutingStrategy
+  useErc4626
 }: UseWithdrawFlowProps): WithdrawFlowResult {
   const routeType = useWithdrawRoute({
     vaultAddress,
@@ -179,8 +176,7 @@ export function useWithdrawFlow({
     destinationChainId,
     decimalsOut: outputDecimals,
     enabled: ensoEnabled,
-    slippage: toBasisPoints(slippage),
-    routingStrategy: ensoRoutingStrategy
+    slippage: toBasisPoints(slippage)
   })
 
   const activeFlow = useMemo((): UseWidgetWithdrawFlowReturn => {

--- a/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
+++ b/src/components/pages/vaults/hooks/actions/useEnsoDeposit.ts
@@ -1,7 +1,7 @@
 import type { UseWidgetDepositFlowReturn } from '@pages/vaults/types'
 import { useEffect, useMemo } from 'react'
 import type { Address } from 'viem'
-import type { EnsoRoutingStrategy } from '../solvers/useSolverEnso'
+import { VAULT_ENSO_ROUTING_STRATEGY } from '../solvers/ensoRouteRequest'
 import { useSolverEnso } from '../solvers/useSolverEnso'
 import { useEnsoOrder } from '../useEnsoOrder'
 
@@ -16,7 +16,6 @@ interface UseEnsoDepositParams {
   decimalsOut: number
   enabled: boolean
   slippage?: number
-  routingStrategy?: EnsoRoutingStrategy
   routeRefreshKey?: number
 }
 
@@ -30,7 +29,7 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
         params.vaultAddress,
         params.account ?? 'no-account',
         params.slippage ?? 'default',
-        params.routingStrategy ?? 'default-strategy',
+        VAULT_ENSO_ROUTING_STRATEGY,
         params.routeRefreshKey ?? 0
       ].join(':'),
     [
@@ -40,7 +39,6 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
       params.vaultAddress,
       params.account,
       params.slippage,
-      params.routingStrategy,
       params.routeRefreshKey
     ]
   )
@@ -56,7 +54,7 @@ export function useEnsoDeposit(params: UseEnsoDepositParams): UseWidgetDepositFl
     receiver: params.account,
     decimalsOut: params.decimalsOut,
     slippage: params.slippage,
-    routingStrategy: params.routingStrategy,
+    routingStrategy: VAULT_ENSO_ROUTING_STRATEGY,
     requestKey: routeQueryKey,
     enabled: params.enabled
   })

--- a/src/components/pages/vaults/hooks/actions/useEnsoWithdraw.ts
+++ b/src/components/pages/vaults/hooks/actions/useEnsoWithdraw.ts
@@ -1,7 +1,7 @@
 import type { UseWidgetWithdrawFlowReturn } from '@pages/vaults/types'
 import { useEffect, useMemo } from 'react'
 import type { Address } from 'viem'
-import type { EnsoRoutingStrategy } from '../solvers/useSolverEnso'
+import { VAULT_ENSO_ROUTING_STRATEGY } from '../solvers/ensoRouteRequest'
 import { useSolverEnso } from '../solvers/useSolverEnso'
 import { useEnsoOrder } from '../useEnsoOrder'
 
@@ -17,7 +17,6 @@ interface UseEnsoWithdrawParams {
   decimalsOut: number
   enabled: boolean
   slippage?: number
-  routingStrategy?: EnsoRoutingStrategy
 }
 
 export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdrawFlowReturn {
@@ -31,7 +30,7 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
         params.account ?? 'no-account',
         params.receiver ?? 'no-receiver',
         params.slippage ?? 'default',
-        params.routingStrategy ?? 'default-strategy'
+        VAULT_ENSO_ROUTING_STRATEGY
       ].join(':'),
     [
       params.chainId,
@@ -40,8 +39,7 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
       params.withdrawToken,
       params.account,
       params.receiver,
-      params.slippage,
-      params.routingStrategy
+      params.slippage
     ]
   )
 
@@ -56,7 +54,7 @@ export function useEnsoWithdraw(params: UseEnsoWithdrawParams): UseWidgetWithdra
     destinationChainId: params.destinationChainId,
     decimalsOut: params.decimalsOut,
     slippage: params.slippage,
-    routingStrategy: params.routingStrategy,
+    routingStrategy: VAULT_ENSO_ROUTING_STRATEGY,
     requestKey: routeQueryKey,
     enabled: params.enabled
   })

--- a/src/components/pages/vaults/hooks/actions/vaultEnsoRouting.test.tsx
+++ b/src/components/pages/vaults/hooks/actions/vaultEnsoRouting.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useSolverEnso } from '../solvers/useSolverEnso'
+import { useEnsoOrder } from '../useEnsoOrder'
+import { useEnsoDeposit } from './useEnsoDeposit'
+import { useEnsoWithdraw } from './useEnsoWithdraw'
+
+vi.mock('../solvers/useSolverEnso', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../solvers/useSolverEnso')>()),
+  useSolverEnso: vi.fn()
+}))
+
+vi.mock('../useEnsoOrder', () => ({
+  useEnsoOrder: vi.fn()
+}))
+
+const useSolverEnsoMock = vi.mocked(useSolverEnso)
+const useEnsoOrderMock = vi.mocked(useEnsoOrder)
+const ACCOUNT = '0x0000000000000000000000000000000000000001'
+const VAULT = '0x0000000000000000000000000000000000000002'
+const TOKEN = '0x0000000000000000000000000000000000000003'
+
+function createEnsoFlow(): ReturnType<typeof useSolverEnso> {
+  return {
+    actions: { prepareApprove: {} },
+    periphery: {
+      prepareApproveEnabled: false,
+      expectedOut: { raw: 0n },
+      minExpectedOut: { raw: 0n },
+      priceImpact: undefined,
+      allowance: 0n,
+      isAllowanceSufficient: true,
+      route: undefined,
+      routeHasSwap: false,
+      error: undefined,
+      isLoadingRoute: false,
+      isLoadingAllowance: false,
+      isCrossChain: false,
+      routerAddress: undefined,
+      approvalSpenderAddress: undefined,
+      approvalWarning: undefined,
+      refetchAllowance: vi.fn()
+    },
+    methods: {
+      getRoute: vi.fn(),
+      getEnsoTransaction: vi.fn(),
+      resetRoute: vi.fn()
+    }
+  } as unknown as ReturnType<typeof useSolverEnso>
+}
+
+describe('vault Enso routing policy', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useSolverEnsoMock.mockReturnValue(createEnsoFlow())
+    useEnsoOrderMock.mockReturnValue({ prepareEnsoOrder: {} } as ReturnType<typeof useEnsoOrder>)
+  })
+
+  it.each([
+    { destinationChainId: undefined, route: 'same-chain' },
+    { destinationChainId: 10, route: 'cross-chain' }
+  ])('always configures deposit vault $route routes with the router strategy', ({ destinationChainId }) => {
+    renderHook(() =>
+      useEnsoDeposit({
+        vaultAddress: VAULT,
+        depositToken: TOKEN,
+        amount: 100n,
+        account: ACCOUNT,
+        chainId: 1,
+        destinationChainId,
+        decimalsOut: 18,
+        enabled: true
+      })
+    )
+
+    expect(useSolverEnsoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routingStrategy: 'router',
+        destinationChainId
+      })
+    )
+    expect(useSolverEnsoMock.mock.calls.at(-1)?.[0]).not.toHaveProperty('isWalletSafe')
+  })
+
+  it.each([
+    { destinationChainId: undefined, route: 'same-chain' },
+    { destinationChainId: 10, route: 'cross-chain' }
+  ])('always configures withdraw vault $route routes with the router strategy', ({ destinationChainId }) => {
+    renderHook(() =>
+      useEnsoWithdraw({
+        vaultAddress: VAULT,
+        withdrawToken: TOKEN,
+        amount: 100n,
+        account: ACCOUNT,
+        receiver: ACCOUNT,
+        chainId: 1,
+        destinationChainId,
+        decimalsOut: 18,
+        enabled: true
+      })
+    )
+
+    expect(useSolverEnsoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routingStrategy: 'router',
+        destinationChainId
+      })
+    )
+    expect(useSolverEnsoMock.mock.calls.at(-1)?.[0]).not.toHaveProperty('isWalletSafe')
+  })
+})

--- a/src/components/pages/vaults/hooks/solvers/ensoRoute.test.ts
+++ b/src/components/pages/vaults/hooks/solvers/ensoRoute.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { normalizeEnsoRouteResponse, routeHasSwapStep } from './ensoRoute'
 
 describe('normalizeEnsoRouteResponse', () => {
-  it('keeps valid Enso route payloads as routes', () => {
+  it('accepts routes without tx.operationType', () => {
     const routePayload = {
       tx: {
         to: '0x0000000000000000000000000000000000000001',
@@ -24,13 +24,13 @@ describe('normalizeEnsoRouteResponse', () => {
 
   it('accepts normal call routes with operationType 0', () => {
     const routePayload = {
-      operationType: 0 as const,
       tx: {
         to: '0x0000000000000000000000000000000000000001',
         data: '0x1234',
         value: '0',
         from: '0x0000000000000000000000000000000000000002',
-        chainId: 1
+        chainId: 1,
+        operationType: 0 as const
       },
       amountOut: '100',
       minAmountOut: '95',
@@ -41,16 +41,18 @@ describe('normalizeEnsoRouteResponse', () => {
     expect(normalizeEnsoRouteResponse(routePayload, 200)).toEqual({ route: routePayload })
   })
 
-  it.each([1, 2])('rejects unsupported operationType %i before exposing its transaction', (operationType) => {
+  it.each([
+    1, 2
+  ])('rejects unsupported numeric tx.operationType %i before exposing its transaction', (operationType) => {
     const normalized = normalizeEnsoRouteResponse(
       {
-        operationType,
         tx: {
           to: '0x00000000000000000000000000000000000000de',
           data: '0x1234',
           value: '0',
           from: '0x0000000000000000000000000000000000000002',
-          chainId: 1
+          chainId: 1,
+          operationType
         },
         amountOut: '100',
         minAmountOut: '95',
@@ -68,6 +70,37 @@ describe('normalizeEnsoRouteResponse', () => {
       }
     })
     expect(normalized.route).toBeUndefined()
+    expect(normalized.route?.tx).toBeUndefined()
+  })
+
+  it.each(['0', null])('rejects malformed tx.operationType %j before exposing its transaction', (operationType) => {
+    const normalized = normalizeEnsoRouteResponse(
+      {
+        tx: {
+          to: '0x00000000000000000000000000000000000000de',
+          data: '0x1234',
+          value: '0',
+          from: '0x0000000000000000000000000000000000000002',
+          chainId: 1,
+          operationType
+        },
+        amountOut: '100',
+        minAmountOut: '95',
+        gas: '123456',
+        route: []
+      },
+      200
+    )
+
+    expect(normalized).toEqual({
+      error: {
+        error: 'UnsupportedEnsoDelegateRoute',
+        message: 'Enso returned an unsupported wallet route. Please retry the quote.',
+        statusCode: 200
+      }
+    })
+    expect(normalized.route).toBeUndefined()
+    expect(normalized.route?.tx).toBeUndefined()
   })
 
   it('fills tx.chainId from the request context when Enso omits it in a 200 response', () => {

--- a/src/components/pages/vaults/hooks/solvers/ensoRoute.test.ts
+++ b/src/components/pages/vaults/hooks/solvers/ensoRoute.test.ts
@@ -22,6 +22,54 @@ describe('normalizeEnsoRouteResponse', () => {
     })
   })
 
+  it('accepts normal call routes with operationType 0', () => {
+    const routePayload = {
+      operationType: 0 as const,
+      tx: {
+        to: '0x0000000000000000000000000000000000000001',
+        data: '0x1234',
+        value: '0',
+        from: '0x0000000000000000000000000000000000000002',
+        chainId: 1
+      },
+      amountOut: '100',
+      minAmountOut: '95',
+      gas: '123456',
+      route: []
+    }
+
+    expect(normalizeEnsoRouteResponse(routePayload, 200)).toEqual({ route: routePayload })
+  })
+
+  it.each([1, 2])('rejects unsupported operationType %i before exposing its transaction', (operationType) => {
+    const normalized = normalizeEnsoRouteResponse(
+      {
+        operationType,
+        tx: {
+          to: '0x00000000000000000000000000000000000000de',
+          data: '0x1234',
+          value: '0',
+          from: '0x0000000000000000000000000000000000000002',
+          chainId: 1
+        },
+        amountOut: '100',
+        minAmountOut: '95',
+        gas: '123456',
+        route: []
+      },
+      200
+    )
+
+    expect(normalized).toEqual({
+      error: {
+        error: 'UnsupportedEnsoDelegateRoute',
+        message: 'Enso returned an unsupported wallet route. Please retry the quote.',
+        statusCode: 200
+      }
+    })
+    expect(normalized.route).toBeUndefined()
+  })
+
   it('fills tx.chainId from the request context when Enso omits it in a 200 response', () => {
     expect(
       normalizeEnsoRouteResponse(

--- a/src/components/pages/vaults/hooks/solvers/ensoRoute.ts
+++ b/src/components/pages/vaults/hooks/solvers/ensoRoute.ts
@@ -8,13 +8,13 @@ export interface EnsoError {
 }
 
 export interface EnsoRouteResponse {
-  operationType?: 0 | 1
   tx: {
     to: Address
     data: Hex
     value: string
     from: Address
     chainId: number
+    operationType?: 0 | 1
   }
   amountOut: string
   minAmountOut: string
@@ -37,11 +37,11 @@ type EnsoRouteErrorPayload = {
   statusCode?: number
 }
 
-type EnsoRouteCandidate = Omit<EnsoRouteResponse, 'operationType' | 'tx' | 'priceImpact'> & {
-  operationType?: unknown
+type EnsoRouteCandidate = Omit<EnsoRouteResponse, 'tx' | 'priceImpact'> & {
   priceImpact?: unknown
-  tx: Omit<EnsoRouteResponse['tx'], 'chainId'> & {
+  tx: Omit<EnsoRouteResponse['tx'], 'chainId' | 'operationType'> & {
     chainId?: number
+    operationType?: unknown
   }
 }
 
@@ -113,7 +113,7 @@ export function normalizeEnsoRouteResponse(
   route?: EnsoRouteResponse
 } {
   if (isEnsoRouteCandidate(data)) {
-    if (data.operationType !== undefined && data.operationType !== 0) {
+    if (data.tx.operationType !== undefined && data.tx.operationType !== 0) {
       return {
         error: {
           error: 'UnsupportedEnsoDelegateRoute',
@@ -125,7 +125,8 @@ export function normalizeEnsoRouteResponse(
 
     const resolvedChainId = typeof data.tx.chainId === 'number' ? data.tx.chainId : fallbackChainId
     const priceImpact = normalizeEnsoPriceImpact(data.priceImpact)
-    const { operationType, priceImpact: _rawPriceImpact, tx, ...routeData } = data
+    const { priceImpact: _rawPriceImpact, tx, ...routeData } = data
+    const { operationType, ...transaction } = tx
 
     if (typeof resolvedChainId !== 'number') {
       return { error: buildEnsoError({ message: 'Enso route payload missing tx.chainId' }, statusCode) }
@@ -134,11 +135,11 @@ export function normalizeEnsoRouteResponse(
     return {
       route: {
         ...routeData,
-        ...(operationType === 0 ? { operationType } : {}),
         ...(priceImpact !== undefined ? { priceImpact } : {}),
         tx: {
-          ...tx,
-          chainId: resolvedChainId
+          ...transaction,
+          chainId: resolvedChainId,
+          ...(operationType === 0 ? { operationType } : {})
         }
       }
     }

--- a/src/components/pages/vaults/hooks/solvers/ensoRoute.ts
+++ b/src/components/pages/vaults/hooks/solvers/ensoRoute.ts
@@ -8,6 +8,7 @@ export interface EnsoError {
 }
 
 export interface EnsoRouteResponse {
+  operationType?: 0 | 1
   tx: {
     to: Address
     data: Hex
@@ -36,12 +37,16 @@ type EnsoRouteErrorPayload = {
   statusCode?: number
 }
 
-type EnsoRouteCandidate = Omit<EnsoRouteResponse, 'tx' | 'priceImpact'> & {
+type EnsoRouteCandidate = Omit<EnsoRouteResponse, 'operationType' | 'tx' | 'priceImpact'> & {
+  operationType?: unknown
   priceImpact?: unknown
   tx: Omit<EnsoRouteResponse['tx'], 'chainId'> & {
     chainId?: number
   }
 }
+
+export const UNSUPPORTED_ENSO_DELEGATE_ROUTE_MESSAGE =
+  'Enso returned an unsupported wallet route. Please retry the quote.'
 
 function isEnsoRouteCandidate(data: unknown): data is EnsoRouteCandidate {
   if (!data || typeof data !== 'object') {
@@ -108,9 +113,19 @@ export function normalizeEnsoRouteResponse(
   route?: EnsoRouteResponse
 } {
   if (isEnsoRouteCandidate(data)) {
+    if (data.operationType !== undefined && data.operationType !== 0) {
+      return {
+        error: {
+          error: 'UnsupportedEnsoDelegateRoute',
+          message: UNSUPPORTED_ENSO_DELEGATE_ROUTE_MESSAGE,
+          statusCode
+        }
+      }
+    }
+
     const resolvedChainId = typeof data.tx.chainId === 'number' ? data.tx.chainId : fallbackChainId
     const priceImpact = normalizeEnsoPriceImpact(data.priceImpact)
-    const { priceImpact: _rawPriceImpact, tx, ...routeData } = data
+    const { operationType, priceImpact: _rawPriceImpact, tx, ...routeData } = data
 
     if (typeof resolvedChainId !== 'number') {
       return { error: buildEnsoError({ message: 'Enso route payload missing tx.chainId' }, statusCode) }
@@ -119,6 +134,7 @@ export function normalizeEnsoRouteResponse(
     return {
       route: {
         ...routeData,
+        ...(operationType === 0 ? { operationType } : {}),
         ...(priceImpact !== undefined ? { priceImpact } : {}),
         tx: {
           ...tx,

--- a/src/components/pages/vaults/hooks/solvers/ensoRouteRequest.test.ts
+++ b/src/components/pages/vaults/hooks/solvers/ensoRouteRequest.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { buildEnsoRouteRequestParams } from './ensoRouteRequest'
+
+const FROM_ADDRESS = '0x0000000000000000000000000000000000000001'
+const TOKEN_IN = '0x0000000000000000000000000000000000000002'
+const TOKEN_OUT = '0x0000000000000000000000000000000000000003'
+
+describe('buildEnsoRouteRequestParams', () => {
+  it.each([
+    { destinationChainId: undefined, route: 'same-chain' },
+    { destinationChainId: 10, route: 'cross-chain' }
+  ])('serializes routingStrategy=router for $route routes', ({ destinationChainId }) => {
+    const params = buildEnsoRouteRequestParams({
+      fromAddress: FROM_ADDRESS,
+      chainId: 1,
+      tokenIn: TOKEN_IN,
+      tokenOut: TOKEN_OUT,
+      amountIn: 100n,
+      slippage: 100,
+      routingStrategy: 'router',
+      destinationChainId,
+      receiver: FROM_ADDRESS
+    })
+
+    expect(params.get('routingStrategy')).toBe('router')
+    expect(params.toString()).toContain('routingStrategy=router')
+    expect(params.get('destinationChainId')).toBe(destinationChainId?.toString() ?? null)
+  })
+})

--- a/src/components/pages/vaults/hooks/solvers/ensoRouteRequest.ts
+++ b/src/components/pages/vaults/hooks/solvers/ensoRouteRequest.ts
@@ -1,0 +1,42 @@
+import type { Address } from 'viem'
+
+export type EnsoRoutingStrategy = 'router' | 'delegate' | 'router-legacy' | 'delegate-legacy' | 'ensowallet'
+export const VAULT_ENSO_ROUTING_STRATEGY = 'router' as const
+
+interface BuildEnsoRouteRequestParams {
+  fromAddress: Address
+  chainId: number
+  tokenIn: Address
+  tokenOut: Address
+  amountIn: bigint
+  slippage: number
+  routingStrategy?: EnsoRoutingStrategy
+  destinationChainId?: number
+  receiver?: Address
+}
+
+export function buildEnsoRouteRequestParams({
+  fromAddress,
+  chainId,
+  tokenIn,
+  tokenOut,
+  amountIn,
+  slippage,
+  routingStrategy,
+  destinationChainId,
+  receiver
+}: BuildEnsoRouteRequestParams): URLSearchParams {
+  return new URLSearchParams({
+    fromAddress,
+    chainId: chainId.toString(),
+    tokenIn,
+    tokenOut,
+    amountIn: amountIn.toString(),
+    slippage: slippage.toString(),
+    ...(routingStrategy && { routingStrategy }),
+    ...(destinationChainId !== undefined && destinationChainId !== chainId
+      ? { destinationChainId: destinationChainId.toString() }
+      : {}),
+    ...(receiver && { receiver })
+  })
+}

--- a/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
+++ b/src/components/pages/vaults/hooks/solvers/useSolverEnso.ts
@@ -12,9 +12,9 @@ import {
 } from '../../utils/ensoRouters'
 import { useTokenAllowance } from '../useTokenAllowance'
 import { type EnsoError, type EnsoRouteResponse, normalizeEnsoRouteResponse, routeHasSwapStep } from './ensoRoute'
+import { buildEnsoRouteRequestParams, type EnsoRoutingStrategy } from './ensoRouteRequest'
 
 const ENSO_ROUTE_PROXY = '/api/enso/route'
-export type EnsoRoutingStrategy = 'router' | 'delegate' | 'router-legacy' | 'delegate-legacy' | 'ensowallet'
 
 interface UseSolverEnsoProps {
   tokenIn: Address
@@ -134,16 +134,16 @@ export const useSolverEnso = ({
 
     setIsLoadingRoute(true)
     try {
-      const params = new URLSearchParams({
+      const params = buildEnsoRouteRequestParams({
         fromAddress,
-        chainId: chainId.toString(),
+        chainId,
         tokenIn,
         tokenOut,
-        amountIn: amountIn.toString(),
-        slippage: normalizedSlippage.toString(),
-        ...(routingStrategy && { routingStrategy }),
-        ...(isCrossChain && { destinationChainId: destinationChainId!.toString() }),
-        ...(receiver && { receiver })
+        amountIn,
+        slippage: normalizedSlippage,
+        routingStrategy,
+        destinationChainId,
+        receiver
       })
 
       const response = await fetch(`${ENSO_ROUTE_PROXY}?${params}`, { signal: abortController.signal })


### PR DESCRIPTION
### Summary
Vault zaps could request an Enso delegate route when a Safe or smart account was connected outside the Safe app. The widget cannot execute delegate routes, so deposits and withdrawals could fail.

This change makes every vault Enso request use the router strategy. It also rejects unsupported operation types before their transactions reach approval or execution paths.

Closes #1353

### How to review
Start with the vault policy in useEnsoDeposit and useEnsoWithdraw. Then review request serialization and response normalization in the Enso solver hooks.

Confirm that native-token MAX quotes use the same router policy. Safe batching, notifications, approval behavior, slippage handling, router allowlisting, and chain validation should remain unchanged.

### Test plan
- [x] Automated: focused Enso routing and router validation tests, 23 tests passed
- [x] Automated: bun run tslint
- [x] Automated: explicit Biome checks on all 16 changed files
- [x] Automated: production build with the public service values documented in .env.example
- [ ] Manual: verify deposit and withdrawal quotes with an EOA, an externally connected Safe, and the Safe app
- [ ] Manual: verify same-chain and cross-chain requests contain routingStrategy=router

### Risk / impact
This change affects funds-sensitive transaction routing and approval preparation. It narrows supported Enso execution to known router calls and keeps the existing router and chain checks.

Rollback by reverting commit ee3f7753 if router-only requests cause an unexpected quote regression.

### Note
A version of this fix is included in https://github.com/yearn/yearn.fi/pull/1354 for the monorepo branch