### PR TITLE
Update Wagmi to latest build-compatible version

### DIFF
--- a/apps/ybold/package.json
+++ b/apps/ybold/package.json
@@ -21,7 +21,7 @@
     "react-dom": "19.2.8",
     "react-rewards": "2.1.0",
     "viem": "2.55.11",
-    "wagmi": "2.18.2"
+    "wagmi": "2.19.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",

--- a/apps/yearn/package.json
+++ b/apps/yearn/package.json
@@ -34,7 +34,7 @@
     "recharts": "2.15.4",
     "use-indexeddb": "2.0.2",
     "viem": "2.55.11",
-    "wagmi": "2.18.2",
+    "wagmi": "2.19.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "react-dom": "19.2.8",
         "react-rewards": "2.1.0",
         "viem": "2.55.11",
-        "wagmi": "2.18.2",
+        "wagmi": "2.19.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.16",
@@ -69,7 +69,7 @@
         "recharts": "2.15.4",
         "use-indexeddb": "2.0.2",
         "viem": "2.55.11",
-        "wagmi": "2.18.2",
+        "wagmi": "2.19.0",
         "zod": "4.4.3",
       },
       "devDependencies": {
@@ -100,7 +100,7 @@
         "typescript": "5.9.3",
         "viem": "2.55.11",
         "vitest": "4.1.10",
-        "wagmi": "2.18.2",
+        "wagmi": "2.19.0",
       },
       "peerDependencies": {
         "@tanstack/react-query": "5.101.4",
@@ -109,7 +109,7 @@
         "react-dom": "19.2.8",
         "react-rewards": "2.1.0",
         "viem": "2.55.11",
-        "wagmi": "2.18.2",
+        "wagmi": "2.19.0",
       },
     },
   },
@@ -527,7 +527,7 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
-    "@wagmi/connectors": ["@wagmi/connectors@6.1.0", "", { "dependencies": { "@base-org/account": "1.1.1", "@coinbase/wallet-sdk": "4.3.6", "@gemini-wallet/core": "0.2.0", "@metamask/sdk": "0.33.1", "@safe-global/safe-apps-provider": "0.18.6", "@safe-global/safe-apps-sdk": "9.1.0", "@walletconnect/ethereum-provider": "2.21.1", "cbw-sdk": "npm:@coinbase/wallet-sdk@3.9.3", "porto": "0.2.19" }, "peerDependencies": { "@wagmi/core": "2.22.1", "typescript": ">=5.0.4", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-MnpJHEABUIsajNxLc6br0LiqJvoFZbavQ6yG+mQb7Xlb3Hmm3IRjH5NU1g2zw5PCTRd3BFQLjwniLdwDnUPYNw=="],
+    "@wagmi/connectors": ["@wagmi/connectors@6.1.1", "", { "dependencies": { "@base-org/account": "1.1.1", "@coinbase/wallet-sdk": "4.3.6", "@gemini-wallet/core": "0.2.0", "@metamask/sdk": "0.33.1", "@safe-global/safe-apps-provider": "0.18.6", "@safe-global/safe-apps-sdk": "9.1.0", "@walletconnect/ethereum-provider": "2.21.1", "cbw-sdk": "npm:@coinbase/wallet-sdk@3.9.3", "porto": "0.2.34" }, "peerDependencies": { "@wagmi/core": "2.22.1", "typescript": ">=5.0.4", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-T5orLdX6Kz+UnJxy88aRnlSohnNCkP3KqWI3Hadho2uhFUqA87VWkE6+fD0TI4XA/pDA5wjI2EjCaGTmAxqDtQ=="],
 
     "@wagmi/core": ["@wagmi/core@2.22.1", "", { "dependencies": { "eventemitter3": "5.0.1", "mipd": "0.0.7", "zustand": "5.0.0" }, "peerDependencies": { "@tanstack/query-core": ">=5.0.0", "typescript": ">=5.0.4", "viem": "2.x" }, "optionalPeers": ["@tanstack/query-core", "typescript"] }, "sha512-cG/xwQWsBEcKgRTkQVhH29cbpbs/TdcUJVFXCyri3ZknxhMyGv0YEjTcrNpRgt2SaswL1KrvslSNYKKo+5YEAg=="],
 
@@ -1151,7 +1151,7 @@
 
     "pony-cause": ["pony-cause@2.1.11", "", {}, "sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg=="],
 
-    "porto": ["porto@0.2.19", "", { "dependencies": { "hono": "^4.9.6", "idb-keyval": "^6.2.1", "mipd": "^0.0.7", "ox": "^0.9.6", "zod": "^4.1.5", "zustand": "^5.0.1" }, "peerDependencies": { "@tanstack/react-query": ">=5.59.0", "@wagmi/core": ">=2.16.3", "react": ">=18", "typescript": ">=5.4.0", "viem": ">=2.37.0", "wagmi": ">=2.0.0" }, "optionalPeers": ["@tanstack/react-query", "react", "typescript", "wagmi"], "bin": { "porto": "_dist/cli/bin/index.js" } }, "sha512-q1vEJgdtlEOf6byWgD31GHiMwpfLuxFSfx9f7Sw4RGdvpQs2ANBGfnzzardADZegr87ZXsebSp+3vaaznEUzPQ=="],
+    "porto": ["porto@0.2.34", "", { "dependencies": { "hono": "^4.10.3", "idb-keyval": "^6.2.1", "mipd": "^0.0.7", "ox": "^0.9.6", "zod": "^4.1.5", "zustand": "^5.0.1" }, "peerDependencies": { "@tanstack/react-query": ">=5.59.0", "@wagmi/core": ">=2.16.3", "expo-auth-session": ">=7.0.8", "expo-crypto": ">=15.0.7", "expo-web-browser": ">=15.0.8", "react": ">=18", "react-native": ">=0.81.4", "typescript": ">=5.4.0", "viem": ">=2.37.0", "wagmi": ">=2.0.0" }, "optionalPeers": ["@tanstack/react-query", "expo-auth-session", "expo-crypto", "expo-web-browser", "react", "react-native", "typescript", "wagmi"], "bin": { "porto": "dist/cli/bin/index.js" } }, "sha512-o+hK9r6a4j3EAFOkgNXtcwYc4vAMsmbVhRJHrBXXV/tGVLb2V2sVGLcCFFH3CLevRAyyUUKoT0KIaoQaro4saA=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1405,7 +1405,7 @@
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
-    "wagmi": ["wagmi@2.18.2", "", { "dependencies": { "@wagmi/connectors": "6.1.0", "@wagmi/core": "2.22.1", "use-sync-external-store": "1.4.0" }, "peerDependencies": { "@tanstack/react-query": ">=5.0.0", "react": ">=18", "typescript": ">=5.0.4", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-9jFip+0ZfjMBxT72m02MZD2+VmQQ/UmqZhHl+98N9HEqXLn765fIu45QPV85DAnQqIHD81gvY3vTvfWt16A5yQ=="],
+    "wagmi": ["wagmi@2.19.0", "", { "dependencies": { "@wagmi/connectors": "6.1.1", "@wagmi/core": "2.22.1", "use-sync-external-store": "1.4.0" }, "peerDependencies": { "@tanstack/react-query": ">=5.0.0", "react": ">=18", "typescript": ">=5.0.4", "viem": "2.x" }, "optionalPeers": ["typescript"] }, "sha512-0Ypzs5rkj1d6uBcz2PBGqAfk+r2TfsmPh4cMxoCJyFy5P1IL3FHY9lQLCu77NJZ8DlVl+dd9mdPZrQADb8sLcw=="],
 
     "webextension-polyfill": ["webextension-polyfill@0.10.0", "", {}, "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="],
 

--- a/packages/vault-widget/package.json
+++ b/packages/vault-widget/package.json
@@ -45,7 +45,7 @@
     "react-dom": "19.2.8",
     "react-rewards": "2.1.0",
     "viem": "2.55.11",
-    "wagmi": "2.18.2"
+    "wagmi": "2.19.0"
   },
   "devDependencies": {
     "@tanstack/react-query": "5.101.4",
@@ -59,6 +59,6 @@
     "typescript": "5.9.3",
     "viem": "2.55.11",
     "vitest": "4.1.10",
-    "wagmi": "2.18.2"
+    "wagmi": "2.19.0"
   }
 }


### PR DESCRIPTION
### Summary
Update Wagmi from 2.18.2 to 2.19.0 in both applications and the shared vault widget. This is the newest Wagmi release that supports the current RainbowKit setup and passes both production builds.

This PR replaces the incompatible Wagmi 3 update in #1361. Wagmi 2.19.1 and newer pull Base Account 2.4, whose optional x402 imports fail in the current Next.js Turbopack build.

### How to review
Review the version changes in `apps/yearn/package.json`, `apps/ybold/package.json`, and `packages/vault-widget/package.json`, followed by the matching workspace resolutions in `bun.lock`. No application code changes are included.

### Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run lint:fix`
- [x] Vault widget boundary and type checks
- [x] Vault widget tests — 304 tests passed
- [x] yBOLD type check, tests, and production build — 5 tests passed
- [x] Yearn type check, tests, and production build — 820 tests passed

### Risk / impact
Low application-code risk because this only updates Wagmi within RainbowKit 2.2.11's supported Wagmi 2 peer range. All monorepo consumers use the same Wagmi version. The lockfile also updates the matching Wagmi connector and wallet transport dependencies. Roll back by reverting the dependency commit.
