### PR TITLE
remove USDT spectra pool

### DIFF
--- a/src/components/pages/vaults/constants/addresses.ts
+++ b/src/components/pages/vaults/constants/addresses.ts
@@ -4,8 +4,7 @@ export const KATANA_CHAIN_ID = 747474
  ** Vault addresses eligible for Spectra boost on Katana chain
  *************************************************************************************************/
 export const SPECTRA_MARKET_VAULT_ADDRESSES = [
-  '0x80c34BD3A3569E126e7055831036aa7b212cB159', //vbUSDC
-  '0x9A6bd7B6Fd5C4F87eb66356441502fc7dCdd185B' //vbUSDT
+  '0x80c34BD3A3569E126e7055831036aa7b212cB159' //vbUSDC
 ].map((addr) => addr.toLowerCase())
 
 export const VAULT_ADDRESSES = {


### PR DESCRIPTION
## Description

Removes the Spectra Market information from the vbUSDT vault as there is no longer a spectra market for this vault.

- Icon next to APY value on vault list is removed
- Spectra info on hover over APY value on vault list no longer mentions Spectra.
- Icon next to APY value on vbUSDT vault page is removed
- Spectra info on hover over APY values on vault page no longer mentions Spectra.

## Related Issue

none

## Motivation and Context

Clean up stale info

## How Has This Been Tested?

locally. To test, open the preview and assume the above elements are true.

## Screenshots (if appropriate):

Before:
<img width="1212" height="101" alt="image" src="https://github.com/user-attachments/assets/5c2f4392-cba8-46d4-a38d-2ff3f2384bb6" />

After:
<img width="1223" height="108" alt="image" src="https://github.com/user-attachments/assets/8a40349d-7658-4fe9-8d04-bcdf5957b1ca" />

Before:
<img width="839" height="269" alt="image" src="https://github.com/user-attachments/assets/7bf4049e-8456-44fc-85fe-c409c2d9d975" />

After:
<img width="794" height="233" alt="image" src="https://github.com/user-attachments/assets/4563f0ae-ff3e-43f5-9fe5-15af76d90eda" />
