### PR TITLE
Add site status indicator

### DIFF
--- a/apps/yearn/app/api/status/route.ts
+++ b/apps/yearn/app/api/status/route.ts
@@ -1,0 +1,4 @@
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+export { GET, OPTIONS } from '@/server/status'

--- a/apps/yearn/next.config.ts
+++ b/apps/yearn/next.config.ts
@@ -4,6 +4,7 @@ import type { NextConfig } from 'next'
 
 const WORKSPACE_ROOT = fileURLToPath(new URL('../..', import.meta.url))
 loadEnvConfig(WORKSPACE_ROOT, process.env.NODE_ENV !== 'production', console, true)
+const siteUpdatedAt = process.env.NEXT_PUBLIC_SITE_UPDATED_AT || new Date().toISOString()
 
 const CSP_REPORT_URI =
   'https://o4510960324837376.ingest.us.sentry.io/api/4510960614375424/security/?sentry_key=6b1b2932f1532eff2227d01a122adbb4'
@@ -51,6 +52,9 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
   transpilePackages: ['@yearn/vault-widget'],
+  env: {
+    NEXT_PUBLIC_SITE_UPDATED_AT: siteUpdatedAt
+  },
   turbopack: {
     resolveAlias: {
       '@safe-global/safe-apps-sdk': '../../node_modules/@safe-global/safe-apps-sdk/dist/esm'

--- a/apps/yearn/src/AppFrame.tsx
+++ b/apps/yearn/src/AppFrame.tsx
@@ -1,4 +1,5 @@
 import { ScrollToTopButton } from '@pages/vaults/components/detail/ScrollToTopButton'
+import { SiteStatus } from '@shared/components/SiteStatus'
 import { cl } from '@shared/utils/cl'
 import type { ReactElement, ReactNode } from 'react'
 
@@ -14,7 +15,8 @@ export function AppFrame({ children, header }: TAppFrameProps): ReactElement {
       <div id={'app'} className={cl('mx-auto mb-0 flex', 'max-md:pt-[var(--header-height)]')}>
         <div className={'block size-full min-h-max'}>{children}</div>
       </div>
-      <ScrollToTopButton className="bottom-20 right-4 md:bottom-6 md:right-6" />
+      <SiteStatus />
+      <ScrollToTopButton className="bottom-20 right-4 md:bottom-6 md:right-6 min-[1700px]:bottom-24" />
     </>
   )
 }

--- a/apps/yearn/src/components/pages/vaults/components/tour/VaultDetailsWelcomeTour.tsx
+++ b/apps/yearn/src/components/pages/vaults/components/tour/VaultDetailsWelcomeTour.tsx
@@ -177,7 +177,7 @@ export function VaultDetailsWelcomeTour({ onTourStateChange }: VaultDetailsWelco
   return (
     <>
       {!isDismissed && !isTourOpen ? (
-        <div className="fixed bottom-4 right-4 z-60 w-[calc(100%-2rem)] max-w-[360px]">
+        <div className="fixed bottom-4 right-4 z-60 w-[calc(100%-2rem)] max-w-[360px] min-[1700px]:bottom-24">
           <div className="rounded-2xl border border-border bg-surface p-4 shadow-xl">
             <div className="flex items-start gap-3">
               <div className="flex-1">
@@ -224,7 +224,7 @@ export function VaultDetailsWelcomeTour({ onTourStateChange }: VaultDetailsWelco
             role="dialog"
             aria-modal="true"
             className={cl(
-              'absolute bottom-4 right-4 w-[min(360px,calc(100%-2rem))] rounded-2xl border border-border bg-surface p-5 text-text-primary shadow-2xl'
+              'absolute bottom-4 right-4 w-[min(360px,calc(100%-2rem))] rounded-2xl border border-border bg-surface p-5 text-text-primary shadow-2xl min-[1700px]:bottom-24'
             )}
           >
             <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-secondary">

--- a/apps/yearn/src/components/pages/vaults/components/tour/VaultDetailsWelcomeTour.tsx
+++ b/apps/yearn/src/components/pages/vaults/components/tour/VaultDetailsWelcomeTour.tsx
@@ -177,7 +177,7 @@ export function VaultDetailsWelcomeTour({ onTourStateChange }: VaultDetailsWelco
   return (
     <>
       {!isDismissed && !isTourOpen ? (
-        <div className="fixed bottom-4 right-4 z-60 w-[calc(100%-2rem)] max-w-[360px] min-[1700px]:bottom-24">
+        <div data-site-tour-notification className="fixed right-4 bottom-4 z-60 w-[calc(100%-2rem)] max-w-[360px]">
           <div className="rounded-2xl border border-border bg-surface p-4 shadow-xl">
             <div className="flex items-start gap-3">
               <div className="flex-1">

--- a/apps/yearn/src/components/pages/vaults/components/tour/VaultsWelcomeTour.tsx
+++ b/apps/yearn/src/components/pages/vaults/components/tour/VaultsWelcomeTour.tsx
@@ -172,7 +172,7 @@ export function VaultsWelcomeTour({ onTourStateChange }: VaultsWelcomeTourProps)
   return (
     <>
       {!isDismissed && !isTourOpen ? (
-        <div className="fixed bottom-4 right-4 z-60 max-w-[360px]">
+        <div className="fixed bottom-4 right-4 z-60 max-w-[360px] min-[1700px]:bottom-24">
           <div className="rounded-2xl border border-border bg-surface p-4 shadow-xl">
             <div className="flex items-start gap-3">
               <div className="flex-1">
@@ -219,7 +219,7 @@ export function VaultsWelcomeTour({ onTourStateChange }: VaultsWelcomeTourProps)
             role="dialog"
             aria-modal="true"
             className={cl(
-              'absolute bottom-4 right-4 w-[min(360px,calc(100%-2rem))] rounded-2xl border border-border bg-surface p-5 text-text-primary shadow-2xl'
+              'absolute bottom-4 right-4 w-[min(360px,calc(100%-2rem))] rounded-2xl border border-border bg-surface p-5 text-text-primary shadow-2xl min-[1700px]:bottom-24'
             )}
           >
             <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-text-secondary">

--- a/apps/yearn/src/components/pages/vaults/components/tour/VaultsWelcomeTour.tsx
+++ b/apps/yearn/src/components/pages/vaults/components/tour/VaultsWelcomeTour.tsx
@@ -172,7 +172,7 @@ export function VaultsWelcomeTour({ onTourStateChange }: VaultsWelcomeTourProps)
   return (
     <>
       {!isDismissed && !isTourOpen ? (
-        <div className="fixed bottom-4 right-4 z-60 max-w-[360px] min-[1700px]:bottom-24">
+        <div data-site-tour-notification className="fixed right-4 bottom-4 z-60 max-w-[360px]">
           <div className="rounded-2xl border border-border bg-surface p-4 shadow-xl">
             <div className="flex items-start gap-3">
               <div className="flex-1">

--- a/apps/yearn/src/components/shared/components/MobileNavMenu.tsx
+++ b/apps/yearn/src/components/shared/components/MobileNavMenu.tsx
@@ -2,6 +2,7 @@ import { Dialog, Transition, TransitionChild } from '@headlessui/react'
 import { setThemePreference, useThemePreference } from '@hooks/useThemePreference'
 import { BottomDrawer } from '@pages/vaults/components/detail/BottomDrawer'
 import { useAppSettings } from '@pages/vaults/contexts/useAppSettings'
+import { MobileSiteStatus } from '@shared/components/SiteStatus'
 import { useWalletStatus } from '@shared/contexts/useWallet'
 import { useWalletVaultTotals } from '@shared/contexts/useWalletVaultTotals'
 import { useWeb3 } from '@shared/contexts/useWeb3'
@@ -655,6 +656,9 @@ export function MobileNavMenu({
                     >
                       <IconTwitter className={cl('size-6', isDarkTheme ? 'text-white' : 'text-text-primary')} />
                     </Link>
+                  </div>
+                  <div className={'mt-1.5'}>
+                    <MobileSiteStatus />
                   </div>
                 </div>
               </div>

--- a/apps/yearn/src/components/shared/components/SiteStatus.tsx
+++ b/apps/yearn/src/components/shared/components/SiteStatus.tsx
@@ -107,6 +107,7 @@ export function SiteStatus(): ReactElement {
 
   return (
     <aside
+      data-site-status
       aria-label={'Site status'}
       aria-busy={statusQuery.isPending}
       className={

--- a/apps/yearn/src/components/shared/components/SiteStatus.tsx
+++ b/apps/yearn/src/components/shared/components/SiteStatus.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { cl } from '@shared/utils/cl'
+import { useQuery } from '@tanstack/react-query'
+import type { ReactElement } from 'react'
+import type { TSiteHealth, TSiteHealthState } from '@/types/siteStatus'
+
+const siteUpdatedAt = process.env.NEXT_PUBLIC_SITE_UPDATED_AT || ''
+
+type TServiceLabelProps = {
+  label: string
+  state?: TSiteHealthState
+  status: string
+  title: string
+}
+
+function formatUpdatedAt(value: string): string {
+  const date = new Date(value)
+  if (!value || Number.isNaN(date.getTime())) {
+    return 'unknown'
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+    timeZone: 'UTC',
+    timeZoneName: 'short'
+  }).format(date)
+}
+
+function getStateClassName(state?: TSiteHealthState): string {
+  if (state === 'operational') {
+    return 'bg-success'
+  }
+  if (state === 'degraded') {
+    return 'bg-warning'
+  }
+  if (state === 'unavailable') {
+    return 'bg-error'
+  }
+  return 'bg-text-tertiary'
+}
+
+function getOverallState(health?: TSiteHealth): TSiteHealthState | undefined {
+  if (!health) {
+    return undefined
+  }
+  if (health.services.kong.state === 'operational' && health.services.rpc.state === 'operational') {
+    return 'operational'
+  }
+  if (health.services.kong.state === 'unavailable' && health.services.rpc.state === 'unavailable') {
+    return 'unavailable'
+  }
+  return 'degraded'
+}
+
+async function fetchSiteHealth(): Promise<TSiteHealth> {
+  const response = await fetch('/api/status', { headers: { Accept: 'application/json' } })
+  if (!response.ok) {
+    throw new Error(`Site status request failed (${response.status})`)
+  }
+  return (await response.json()) as TSiteHealth
+}
+
+function useSiteHealth() {
+  return useQuery({
+    queryKey: ['site-status'],
+    queryFn: fetchSiteHealth,
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+    retry: 1
+  })
+}
+
+function ServiceLabel({ label, state, status, title }: TServiceLabelProps): ReactElement {
+  return (
+    <span className={'inline-flex items-center gap-1.5 whitespace-nowrap'} title={title}>
+      <span className={cl('size-1.5 rounded-full', getStateClassName(state))} aria-hidden={'true'} />
+      <span>{label}</span>
+      <span className={'text-text-primary'}>{status}</span>
+    </span>
+  )
+}
+
+export function SiteStatus(): ReactElement {
+  const statusQuery = useSiteHealth()
+  const health = statusQuery.data
+  const overallState = getOverallState(health)
+  const overallStatus = statusQuery.isError ? 'unknown' : overallState || 'checking'
+  const kongStatus =
+    health?.services.kong.state === 'operational' ? 'online' : health?.services.kong.state || 'checking'
+  const rpcStatus = health
+    ? `${health.services.rpc.operational}/${health.services.rpc.total} online`
+    : statusQuery.isError
+      ? 'unknown'
+      : 'checking'
+  const kongTitle = health
+    ? `Kong ${health.services.kong.state}, ${health.services.kong.latencyMs}ms response`
+    : 'Checking Kong status'
+  const rpcTitle = health
+    ? health.services.rpc.chains.map((chain) => `${chain.name}: ${chain.state}`).join(', ')
+    : 'Checking supported chain RPCs'
+
+  return (
+    <aside
+      aria-label={'Site status'}
+      aria-busy={statusQuery.isPending}
+      className={
+        'group fixed top-[calc(var(--header-height)+0.125rem)] right-[max(1rem,calc(50vw_-_600px))] z-50 hidden cursor-default items-center gap-3 font-aeonik-mono text-[10px] uppercase tracking-[0.08em] text-text-secondary md:flex min-[1700px]:top-auto min-[1700px]:right-6 min-[1700px]:bottom-6 min-[1700px]:flex-col min-[1700px]:items-end min-[1700px]:gap-1'
+      }
+    >
+      <time className={'whitespace-nowrap'} dateTime={siteUpdatedAt || undefined} title={siteUpdatedAt || undefined}>
+        {`Updated ${formatUpdatedAt(siteUpdatedAt)}`}
+      </time>
+      <span className={'min-[1700px]:hidden'} aria-hidden={'true'}>
+        {'·'}
+      </span>
+      <span className={'grid items-center'}>
+        <span
+          className={
+            'col-start-1 row-start-1 inline-flex items-center gap-1.5 whitespace-nowrap group-hover:hidden min-[1700px]:hidden'
+          }
+        >
+          <span className={cl('size-1.5 rounded-full', getStateClassName(overallState))} aria-hidden={'true'} />
+          <span className={'text-text-primary'}>{overallStatus}</span>
+        </span>
+        <span
+          className={
+            'col-start-1 row-start-1 hidden items-center gap-3 whitespace-nowrap group-hover:flex min-[1700px]:flex min-[1700px]:flex-col min-[1700px]:items-end min-[1700px]:gap-1'
+          }
+        >
+          <ServiceLabel
+            label={'Kong'}
+            state={health?.services.kong.state}
+            status={statusQuery.isError ? 'unknown' : kongStatus}
+            title={statusQuery.isError ? 'Kong status unavailable' : kongTitle}
+          />
+          <span className={'min-[1700px]:hidden'} aria-hidden={'true'}>
+            {'·'}
+          </span>
+          <ServiceLabel
+            label={'RPCs'}
+            state={health?.services.rpc.state}
+            status={rpcStatus}
+            title={statusQuery.isError ? 'RPC status unavailable' : rpcTitle}
+          />
+        </span>
+      </span>
+    </aside>
+  )
+}
+
+export function MobileSiteStatus(): ReactElement {
+  const statusQuery = useSiteHealth()
+  const health = statusQuery.data
+  const kongStatus =
+    health?.services.kong.state === 'operational' ? 'online' : health?.services.kong.state || 'checking'
+  const rpcStatus = health
+    ? `${health.services.rpc.operational}/${health.services.rpc.total}`
+    : statusQuery.isError
+      ? 'unknown'
+      : 'checking'
+
+  return (
+    <aside
+      aria-label={'Site status'}
+      aria-busy={statusQuery.isPending}
+      className={'font-aeonik-mono text-[10px] uppercase tracking-[0.08em] text-text-secondary'}
+    >
+      <div className={'flex flex-col items-center gap-1 whitespace-nowrap text-center'}>
+        <time className={'whitespace-nowrap'} dateTime={siteUpdatedAt || undefined} title={siteUpdatedAt || undefined}>
+          {`Updated ${formatUpdatedAt(siteUpdatedAt)}`}
+        </time>
+        <span className={'flex items-center justify-center gap-3'}>
+          <ServiceLabel
+            label={'Kong'}
+            state={health?.services.kong.state}
+            status={statusQuery.isError ? 'unknown' : kongStatus}
+            title={'Kong status'}
+          />
+          <span aria-hidden={'true'}>{'·'}</span>
+          <ServiceLabel
+            label={'RPCs'}
+            state={health?.services.rpc.state}
+            status={rpcStatus}
+            title={'Supported chain RPC status'}
+          />
+        </span>
+      </div>
+    </aside>
+  )
+}

--- a/apps/yearn/src/server/status.test.ts
+++ b/apps/yearn/src/server/status.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { canonicalChains } from '@/config/chainDefinitions'
+import { GET } from './status'
+
+function rpcResponse(chainId: number): Response {
+  return Response.json({ jsonrpc: '2.0', id: 1, result: `0x${chainId.toString(16)}` })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('site status', () => {
+  it('reports Kong and every supported RPC as operational', async () => {
+    const rpcResponses = canonicalChains.map((chain) => rpcResponse(chain.id))
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+      .mockImplementation(() => Promise.resolve(rpcResponses.shift() as Response))
+
+    const response = await GET()
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Cache-Control')).toBe('public, max-age=0, must-revalidate')
+    expect(response.headers.get('Vercel-CDN-Cache-Control')).toBe('public, s-maxage=30, stale-while-revalidate=30')
+    expect(payload.services.kong.state).toBe('operational')
+    expect(payload.services.rpc).toMatchObject({
+      state: 'operational',
+      operational: canonicalChains.length,
+      total: canonicalChains.length
+    })
+    expect(JSON.stringify(payload)).not.toContain('http')
+  })
+
+  it('reports degraded RPC health when one supported chain fails', async () => {
+    const rpcResponses = canonicalChains.map((chain, index) =>
+      index === 0 ? Response.json({ error: 'unavailable' }, { status: 503 }) : rpcResponse(chain.id)
+    )
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockImplementation(() => Promise.resolve(rpcResponses.shift() as Response))
+
+    const response = await GET()
+    const payload = await response.json()
+
+    expect(payload.services.kong.state).toBe('unavailable')
+    expect(payload.services.rpc).toMatchObject({
+      state: 'degraded',
+      operational: canonicalChains.length - 1,
+      total: canonicalChains.length
+    })
+    expect(payload.services.rpc.chains[0]).toMatchObject({ chainId: 1, state: 'unavailable' })
+  })
+})

--- a/apps/yearn/src/server/status.ts
+++ b/apps/yearn/src/server/status.ts
@@ -1,0 +1,103 @@
+import { canonicalChains } from '@/config/chainDefinitions'
+import { GET_CORS_HEADERS, json, noContent } from '@/server/http'
+import { KONG_VAULT_LIST_URL } from '@/server/lib/aio'
+import { getVercelCdnCacheHeaders } from '@/server/lib/cacheHeaders'
+import type { TSiteHealth, TSiteHealthChain, TSiteHealthState } from '@/types/siteStatus'
+
+const HEALTH_CHECK_TIMEOUT_MS = 4_000
+const STATUS_CACHE_HEADERS = {
+  ...GET_CORS_HEADERS,
+  ...getVercelCdnCacheHeaders('public, s-maxage=30, stale-while-revalidate=30')
+} as const
+
+function getRpcUrl(chain: (typeof canonicalChains)[number]): string {
+  return process.env[`NEXT_PUBLIC_RPC_URI_FOR_${chain.id}`]?.trim() || chain.rpcUrls.default.http[0] || ''
+}
+
+async function checkKong(): Promise<TSiteHealth['services']['kong']> {
+  const startedAt = performance.now()
+  try {
+    const response = await fetch(KONG_VAULT_LIST_URL, {
+      method: 'HEAD',
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+      cache: 'no-store'
+    })
+    return {
+      state: response.ok ? 'operational' : 'unavailable',
+      latencyMs: Math.round(performance.now() - startedAt)
+    }
+  } catch {
+    return { state: 'unavailable', latencyMs: Math.round(performance.now() - startedAt) }
+  }
+}
+
+async function checkRpc(chain: (typeof canonicalChains)[number]): Promise<TSiteHealthChain> {
+  const startedAt = performance.now()
+  const rpcUrl = getRpcUrl(chain)
+  if (!rpcUrl) {
+    return { chainId: chain.id, name: chain.name, state: 'unavailable', latencyMs: 0 }
+  }
+
+  try {
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_chainId', params: [] }),
+      signal: AbortSignal.timeout(HEALTH_CHECK_TIMEOUT_MS),
+      cache: 'no-store'
+    })
+    const payload = (await response.json()) as { result?: string }
+    const expectedChainId = `0x${chain.id.toString(16)}`
+    return {
+      chainId: chain.id,
+      name: chain.name,
+      state: response.ok && payload.result?.toLowerCase() === expectedChainId ? 'operational' : 'unavailable',
+      latencyMs: Math.round(performance.now() - startedAt)
+    }
+  } catch {
+    return {
+      chainId: chain.id,
+      name: chain.name,
+      state: 'unavailable',
+      latencyMs: Math.round(performance.now() - startedAt)
+    }
+  }
+}
+
+function getRpcState(operational: number, total: number): TSiteHealthState {
+  if (operational === total) {
+    return 'operational'
+  }
+  if (operational > 0) {
+    return 'degraded'
+  }
+  return 'unavailable'
+}
+
+export function OPTIONS(): Response {
+  return noContent(GET_CORS_HEADERS)
+}
+
+export async function GET(): Promise<Response> {
+  const [kong, chains] = await Promise.all([checkKong(), Promise.all(canonicalChains.map(checkRpc))])
+  const operational = chains.filter((chain) => chain.state === 'operational').length
+
+  return json(
+    {
+      checkedAt: new Date().toISOString(),
+      services: {
+        kong,
+        rpc: {
+          state: getRpcState(operational, chains.length),
+          operational,
+          total: chains.length,
+          chains
+        }
+      }
+    } satisfies TSiteHealth,
+    { headers: STATUS_CACHE_HEADERS }
+  )
+}
+
+export default GET

--- a/apps/yearn/src/types/siteStatus.ts
+++ b/apps/yearn/src/types/siteStatus.ts
@@ -1,0 +1,24 @@
+export type TSiteHealthState = 'operational' | 'degraded' | 'unavailable'
+
+export type TSiteHealthChain = {
+  chainId: number
+  name: string
+  state: Exclude<TSiteHealthState, 'degraded'>
+  latencyMs: number
+}
+
+export type TSiteHealth = {
+  checkedAt: string
+  services: {
+    kong: {
+      state: Exclude<TSiteHealthState, 'degraded'>
+      latencyMs: number
+    }
+    rpc: {
+      state: TSiteHealthState
+      operational: number
+      total: number
+      chains: TSiteHealthChain[]
+    }
+  }
+}

--- a/apps/yearn/style.css
+++ b/apps/yearn/style.css
@@ -158,6 +158,12 @@ html {
   text-size-adjust: 100%;
 }
 
+@media (min-width: 1700px) {
+  body:has([data-site-tour-notification]) [data-site-status] {
+    bottom: 11.5rem;
+  }
+}
+
 html {
   background-color: var(--color-app);
 }


### PR DESCRIPTION
### Summary
Per request for Engn33r, AIO guidelines recommend a visible last updated element on the site. This adds a responsive status indicator with the build time, Kong health, and supported RPC availability. The status element lives in the bottom right of the screen when in desktop mode with space on the side, and below the wallet button if there is not available space beside the content. On mobile it is in the hamburger menu

### How to review
Start with `src/server/status.ts` and `app/api/status/route.ts` to review the health checks and cache policy. Then review `src/components/shared/components/SiteStatus.tsx` for the responsive display.

Check these layouts:
- Standard desktop: the summary appears below the header and expands on hover.
- Wide desktop at 1700px or more: the full status appears vertically in the bottom-right corner.
- Mobile: the full date and service details appear on two centered lines at the bottom of the navigation menu.
- Vault welcome prompts remain above the wide desktop status.

### Test plan
- [x] Manual: verified standard desktop, hover expansion, wide desktop, mobile navigation, and welcome prompt positioning with Playwright.
- [x] Manual: verified the live status route reports Kong and all 8 supported RPCs without exposing endpoint URLs.
- [x] Automated: `bun run lint:fix`
- [x] Automated: `bun run tslint`
- [x] Automated: `bun run test` (923 tests)
- [x] Automated: production build

### Risk / impact
This does not affect funds, wallet connections, authentication, or database state. The public route makes read-only checks to Kong and 8 configured RPC endpoints in parallel, uses a 4-second timeout, and is cached at the Vercel CDN for 30 seconds. The client refreshes once per minute.

The change can be rolled back by reverting the feature commit.