### PR TITLE
Fix vault strategy allocation display issue

### DIFF
--- a/src/components/pages/vaults/components/list/VaultsListRowExpandedContent.test.tsx
+++ b/src/components/pages/vaults/components/list/VaultsListRowExpandedContent.test.tsx
@@ -1,0 +1,105 @@
+import type { TKongVaultInput } from '@pages/vaults/domain/kongVaultSelectors'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import VaultsListRowExpandedContent from './VaultsListRowExpandedContent'
+
+const { snapshot } = vi.hoisted(() => ({
+  snapshot: {
+    address: '0x1111111111111111111111111111111111111111',
+    chainId: 1,
+    totalAssets: '100000000',
+    tvl: { close: 250 },
+    composition: [
+      {
+        address: '0x2222222222222222222222222222222222222222',
+        name: 'Snapshot Strategy',
+        status: 'active',
+        totalDebt: '75000000'
+      }
+    ]
+  }
+}))
+
+vi.mock('@hooks/usePlausible', () => ({
+  usePlausible: () => vi.fn()
+}))
+
+vi.mock('@pages/vaults/hooks/useVaultSnapshot', () => ({
+  useVaultSnapshot: () => ({ data: snapshot })
+}))
+
+vi.mock('@pages/vaults/hooks/useVaultApyData', () => ({
+  useVaultApyData: () => undefined
+}))
+
+vi.mock('@pages/vaults/components/table/apyDisplayConfig', () => ({
+  resolveForwardApyDisplayConfig: () => ({ displayConfig: {} })
+}))
+
+vi.mock('@pages/vaults/components/detail/VaultAboutSection', () => ({
+  VaultAboutSection: () => <div>{'About'}</div>
+}))
+
+vi.mock('@shared/contexts/useYearn', () => ({
+  useYearn: () => ({ vaults: {} })
+}))
+
+vi.mock('@shared/components/AllocationChart', () => ({
+  AllocationChart: ({ allocationChartData }: { allocationChartData: unknown }) => (
+    <div>{JSON.stringify(allocationChartData)}</div>
+  ),
+  DARK_MODE_COLORS: ['#000'],
+  LIGHT_MODE_COLORS: ['#fff'],
+  useDarkMode: () => false
+}))
+
+const COMPACT_SSR_VAULT = {
+  address: '0x1111111111111111111111111111111111111111',
+  version: '3.0.0',
+  type: 'Standard',
+  kind: 'Multi Strategy',
+  symbol: 'yvTEST',
+  name: 'Test Vault',
+  description: '',
+  category: 'Stablecoin',
+  decimals: 6,
+  chainID: 1,
+  token: {
+    address: '0x3333333333333333333333333333333333333333',
+    name: 'Test Token',
+    symbol: 'TEST',
+    description: '',
+    decimals: 6
+  },
+  tvl: {
+    totalAssets: 0n,
+    tvl: 200,
+    price: 0
+  },
+  strategies: [],
+  staking: {
+    address: '0x0000000000000000000000000000000000000000',
+    available: false,
+    source: '',
+    rewards: null
+  }
+} as unknown as TKongVaultInput
+
+describe('VaultsListRowExpandedContent', () => {
+  it('renders snapshot allocation and unallocated TVL for an anonymous compact SSR row', () => {
+    const html = renderToStaticMarkup(
+      <VaultsListRowExpandedContent
+        currentVault={COMPACT_SSR_VAULT}
+        expandedView={'strategies'}
+        onExpandedViewChange={vi.fn()}
+        onNavigateToVault={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('Snapshot Strategy')
+    expect(html).toContain('&quot;value&quot;:75')
+    expect(html).toContain('&quot;name&quot;:&quot;Unallocated&quot;')
+    expect(html).toContain('&quot;value&quot;:25')
+    expect(html).not.toContain('No strategy allocation data available.')
+  })
+})

--- a/src/components/pages/vaults/domain/kongVaultSelectors.test.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.test.ts
@@ -132,6 +132,56 @@ describe('getVaultTVL', () => {
     expect(tvl.tvl).toBe(0)
     expect(tvl.price).toBe(0)
   })
+
+  it('fills compact SSR TVL fields from the snapshot', () => {
+    const tvl = getVaultTVL(
+      {
+        version: '3.0.0',
+        chainID: 1,
+        token: { decimals: 6 },
+        tvl: {
+          totalAssets: 0n,
+          tvl: 200,
+          price: 0
+        }
+      } as any,
+      {
+        totalAssets: '100000000',
+        tvl: {
+          close: 250
+        }
+      } as any
+    )
+
+    expect(tvl.totalAssets).toBe(100_000_000n)
+    expect(tvl.tvl).toBe(200)
+    expect(tvl.price).toBe(2)
+  })
+
+  it('preserves a genuine zero TVL in the compact SSR model', () => {
+    const tvl = getVaultTVL(
+      {
+        version: '3.0.0',
+        chainID: 1,
+        token: { decimals: 6 },
+        tvl: {
+          totalAssets: 0n,
+          tvl: 0,
+          price: 0
+        }
+      } as any,
+      {
+        totalAssets: '100000000',
+        tvl: {
+          close: 250
+        }
+      } as any
+    )
+
+    expect(tvl.totalAssets).toBe(100_000_000n)
+    expect(tvl.tvl).toBe(0)
+    expect(tvl.price).toBe(0)
+  })
 })
 
 describe('getVaultStaking', () => {
@@ -409,6 +459,36 @@ describe('getVaultStrategies', () => {
     chainId: 1,
     address: '0x1111111111111111111111111111111111111111'
   } as any
+
+  it('fills an empty compact SSR strategy list from snapshot composition', () => {
+    const strategies = getVaultStrategies(
+      {
+        version: '3.0.0',
+        chainID: 1,
+        strategies: []
+      } as any,
+      {
+        totalAssets: '1000000',
+        composition: [
+          {
+            address: '0x5555555555555555555555555555555555555555',
+            name: 'Snapshot Strategy',
+            status: 'active',
+            totalDebt: '750000'
+          }
+        ]
+      } as any
+    )
+
+    expect(strategies).toHaveLength(1)
+    expect(strategies[0]).toMatchObject({
+      name: 'Snapshot Strategy',
+      details: {
+        totalDebt: '750000',
+        debtRatio: 7500
+      }
+    })
+  })
 
   it('prefers composition estimated apy over oracle apy', () => {
     const strategies = getVaultStrategies(vault, {

--- a/src/components/pages/vaults/domain/kongVaultSelectors.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.ts
@@ -525,7 +525,17 @@ export const getVaultCategory = (vault: TKongVaultInput, snapshot?: TKongVaultSn
 
 export const getVaultTVL = (vault: TKongVaultInput, snapshot?: TKongVaultSnapshot): TKongVaultTvl => {
   if (isVaultView(vault)) {
-    return vault.tvl
+    const snapshotTotalAssets = toBigIntValue(snapshot?.totalAssets)
+    const totalAssets = vault.tvl.totalAssets > 0n ? vault.tvl.totalAssets : snapshotTotalAssets
+    const tvl = vault.tvl.tvl
+    const normalizedAssets = toNormalizedBN(totalAssets, vault.token.decimals).normalized
+    const price = vault.tvl.price || (tvl > 0 && normalizedAssets > 0 ? tvl / normalizedAssets : 0)
+
+    return {
+      totalAssets,
+      tvl,
+      price
+    }
   }
   const token = getVaultToken(vault, snapshot)
   const totalAssetsRaw = snapshot?.totalAssets ?? '0'
@@ -900,11 +910,11 @@ const resolveTotalDebtForRatios = (snapshot?: TKongVaultSnapshot): string => {
 }
 
 export const getVaultStrategies = (vault: TKongVaultInput, snapshot?: TKongVaultSnapshot): TKongVaultStrategy[] => {
-  if (isVaultView(vault)) {
-    return vault.strategies ?? []
+  if (isVaultView(vault) && vault.strategies?.length) {
+    return vault.strategies
   }
   if (!snapshot) {
-    return []
+    return isVaultView(vault) ? (vault.strategies ?? []) : []
   }
 
   const totalAssetsForRatios = resolveTotalAssetsForRatios(snapshot)
@@ -921,7 +931,15 @@ export const getVaultFeaturingScore = (vault: TKongVaultInput): number =>
 
 export const getVaultView = (vault: TKongVaultInput, snapshot?: TKongVaultSnapshot): TKongVaultView => {
   if (isVaultView(vault)) {
-    return vault
+    if (!snapshot) {
+      return vault
+    }
+
+    return {
+      ...vault,
+      tvl: getVaultTVL(vault, snapshot),
+      strategies: getVaultStrategies(vault, snapshot)
+    }
   }
 
   return {


### PR DESCRIPTION
### Summary
Anonymous users (users who do not have a wallet connected) receive a compact server-rendered vault list. This list did not have enough data to populate the vault strategy allocation chart in the expanded vault list sections, so they were left blank.

Before: <img width="1224" height="1129" alt="image" src="https://github.com/user-attachments/assets/1310150c-31ab-44c8-999c-c37f7f8601f5" />

This change fills the missing strategy composition and total assets from the snapshot.

After: 
<img width="1228" height="1126" alt="image" src="https://github.com/user-attachments/assets/4f1fa696-ffce-4c92-867e-e4ee51d95e2d" />

### How to review
Start with `kongVaultSelectors.ts` and confirm that compact vault views use snapshot strategies only when their strategy list is empty.

Then review the selector tests and the anonymous expanded-row regression. To test manually, open `/vaults` without connecting a wallet, expand yvUSD, and confirm that the strategy allocation is visible.

### Test plan
- [x] Manual: Expanded yvUSD from the anonymous vault list and confirmed that allocated strategies render without console errors or failed requests.
- [x] Automated: `bun run lint`
- [x] Automated: `bun run tslint`
- [x] Automated: `bun run test` (925 tests)
- [x] Automated: Focused selector and expanded-row tests (25 tests)

### Risk / impact
Low risk. This changes read-only vault display data and does not change deposits, withdrawals, transactions, or wallet behavior. Existing non-empty strategy lists remain unchanged, and explicit zero TVL values stay zero.

Rollback is a revert of this commit.
