### PR TITLE
Use staked net APY for yBOLD estimates

### DIFF
--- a/app/metadata.test.ts
+++ b/app/metadata.test.ts
@@ -1,0 +1,92 @@
+import { YBOLD_STAKING_ADDRESS, YBOLD_VAULT_ADDRESS } from '@pages/vaults/domain/yBoldProduct'
+import { buildVaultSnapshotEndpoint } from '@shared/data/publicQueryEndpoints'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildVaultMetadataFromInput, buildVaultStructuredDataFromInput, fetchVaultMetadataSnapshot } from './metadata'
+
+const { fetchWithSchemaMock } = vi.hoisted(() => ({
+  fetchWithSchemaMock: vi.fn()
+}))
+
+vi.mock('@shared/utils/fetchQuery', () => ({
+  fetchWithSchema: fetchWithSchemaMock
+}))
+
+const BASE_SNAPSHOT = {
+  meta: {
+    displayName: 'yBOLD',
+    displaySymbol: 'yBOLD',
+    token: { symbol: 'BOLD' }
+  },
+  apy: {
+    net: 0.0552,
+    weeklyNet: 0.0552
+  },
+  performance: {
+    estimated: { apy: 0.2 },
+    oracle: { netAPY: 0.0552 }
+  },
+  tvl: { close: 5_890_000 }
+} as any
+
+const STAKED_SNAPSHOT = {
+  apy: {
+    net: 0.0495,
+    weeklyNet: 0.046
+  },
+  performance: {
+    estimated: { apy: 0.2 },
+    oracle: { netAPY: 0.0495 }
+  }
+} as any
+
+describe('yBOLD vault metadata', () => {
+  beforeEach(() => {
+    fetchWithSchemaMock.mockReset()
+  })
+
+  it('fetches and merges the staked snapshot for the vanilla yBOLD route', async () => {
+    fetchWithSchemaMock.mockResolvedValueOnce(BASE_SNAPSHOT).mockResolvedValueOnce(STAKED_SNAPSHOT)
+
+    const snapshot = await fetchVaultMetadataSnapshot('1', YBOLD_VAULT_ADDRESS)
+
+    expect(fetchWithSchemaMock).toHaveBeenNthCalledWith(
+      1,
+      buildVaultSnapshotEndpoint(1, YBOLD_VAULT_ADDRESS),
+      expect.anything(),
+      { timeout: 7000 }
+    )
+    expect(fetchWithSchemaMock).toHaveBeenNthCalledWith(
+      2,
+      buildVaultSnapshotEndpoint(1, YBOLD_STAKING_ADDRESS),
+      expect.anything(),
+      { timeout: 7000 }
+    )
+    expect(snapshot?.apy?.weeklyNet).toBe(0.046)
+    expect(snapshot?.performance?.oracle?.netAPY).toBe(0.0495)
+  })
+
+  it('publishes the higher of staked weeklyNet and oracle.netAPY', () => {
+    const metadata = buildVaultMetadataFromInput({
+      chainID: '1',
+      address: YBOLD_VAULT_ADDRESS,
+      snapshot: {
+        ...BASE_SNAPSHOT,
+        apy: { ...BASE_SNAPSHOT.apy, weeklyNet: 0.046 },
+        performance: { ...BASE_SNAPSHOT.performance, oracle: { netAPY: 0.0495 } }
+      }
+    })
+    const structuredData = buildVaultStructuredDataFromInput({
+      chainID: '1',
+      address: YBOLD_VAULT_ADDRESS,
+      snapshot: {
+        ...BASE_SNAPSHOT,
+        apy: { ...BASE_SNAPSHOT.apy, weeklyNet: 0.051 },
+        performance: { ...BASE_SNAPSHOT.performance, oracle: { netAPY: 0.0495 } }
+      }
+    }) as { annualPercentageRate: { value: number } }
+
+    expect(metadata.description).toContain('Est. APY 4.95%')
+    expect(metadata.description).not.toContain('20.00%')
+    expect(structuredData.annualPercentageRate.value).toBe(5.1)
+  })
+})

--- a/app/metadata.test.ts
+++ b/app/metadata.test.ts
@@ -1,6 +1,6 @@
 import { YBOLD_STAKING_ADDRESS, YBOLD_VAULT_ADDRESS } from '@pages/vaults/domain/yBoldProduct'
 import { buildVaultSnapshotEndpoint } from '@shared/data/publicQueryEndpoints'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { buildVaultMetadataFromInput, buildVaultStructuredDataFromInput, fetchVaultMetadataSnapshot } from './metadata'
 
 const { fetchWithSchemaMock } = vi.hoisted(() => ({
@@ -42,6 +42,11 @@ const STAKED_SNAPSHOT = {
 describe('yBOLD vault metadata', () => {
   beforeEach(() => {
     fetchWithSchemaMock.mockReset()
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
   it('fetches and merges the staked snapshot for the vanilla yBOLD route', async () => {
@@ -88,5 +93,25 @@ describe('yBOLD vault metadata', () => {
     expect(metadata.description).toContain('Est. APY 4.95%')
     expect(metadata.description).not.toContain('20.00%')
     expect(structuredData.annualPercentageRate.value).toBe(5.1)
+  })
+
+  it('keeps base metadata without APY when the staked snapshot fails', async () => {
+    fetchWithSchemaMock.mockResolvedValueOnce(BASE_SNAPSHOT).mockRejectedValueOnce(new Error('timeout'))
+
+    const snapshot = await fetchVaultMetadataSnapshot('1', YBOLD_VAULT_ADDRESS)
+    const metadata = buildVaultMetadataFromInput({ chainID: '1', address: YBOLD_VAULT_ADDRESS, snapshot })
+    const structuredData = buildVaultStructuredDataFromInput({
+      chainID: '1',
+      address: YBOLD_VAULT_ADDRESS,
+      snapshot
+    }) as { annualPercentageRate?: unknown; name: string }
+
+    expect(snapshot?.meta).toEqual(BASE_SNAPSHOT.meta)
+    expect(snapshot?.tvl).toEqual(BASE_SNAPSHOT.tvl)
+    expect(metadata.title).toBe('yBOLD (yBOLD)')
+    expect(metadata.description).toContain('TVL $5.89M')
+    expect(metadata.description).not.toContain('Est. APY')
+    expect(structuredData.name).toBe('yBOLD (yBOLD)')
+    expect(structuredData.annualPercentageRate).toBeUndefined()
   })
 })

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -1,4 +1,4 @@
-import { mergeYBoldSnapshot } from '@pages/vaults/domain/normalizeVault'
+import { mergeYBoldSnapshot, stripYBoldBaseMetrics } from '@pages/vaults/domain/normalizeVault'
 import { isYBoldProductAddress, isYBoldVaultAddress, YBOLD_STAKING_ADDRESS } from '@pages/vaults/domain/yBoldProduct'
 import landingManifest from '@shared/data/landing-manifest.json'
 import { buildVaultSnapshotEndpoint } from '@shared/data/publicQueryEndpoints'
@@ -92,7 +92,10 @@ export const fetchVaultMetadataSnapshot = cache(async function fetchVaultMetadat
     fetchVaultMetadataSnapshotForAddress(chainID, address),
     fetchVaultMetadataSnapshotForAddress(chainID, YBOLD_STAKING_ADDRESS)
   ])
-  return snapshot && stakedSnapshot ? mergeYBoldSnapshot(snapshot, stakedSnapshot) : null
+  if (!snapshot) {
+    return null
+  }
+  return stakedSnapshot ? mergeYBoldSnapshot(snapshot, stakedSnapshot) : stripYBoldBaseMetrics(snapshot)
 })
 
 function pickFirstText(...values: Array<string | null | undefined>): string {

--- a/app/metadata.ts
+++ b/app/metadata.ts
@@ -1,3 +1,5 @@
+import { mergeYBoldSnapshot } from '@pages/vaults/domain/normalizeVault'
+import { isYBoldProductAddress, isYBoldVaultAddress, YBOLD_STAKING_ADDRESS } from '@pages/vaults/domain/yBoldProduct'
 import landingManifest from '@shared/data/landing-manifest.json'
 import { buildVaultSnapshotEndpoint } from '@shared/data/publicQueryEndpoints'
 import vaultsManifest from '@shared/data/vaults-manifest.json'
@@ -61,7 +63,7 @@ function isValidVaultMetadataParams(chainID: string, address: string): boolean {
 
 const VAULT_METADATA_TIMEOUT_MS = 7000
 
-export const fetchVaultMetadataSnapshot = cache(async function fetchVaultMetadataSnapshot(
+async function fetchVaultMetadataSnapshotForAddress(
   chainID: string,
   address: string
 ): Promise<TKongVaultSnapshot | null> {
@@ -76,6 +78,21 @@ export const fetchVaultMetadataSnapshot = cache(async function fetchVaultMetadat
     console.warn(`[Metadata] Failed to fetch vault snapshot ${chainID}/${address}`, error)
     return null
   }
+}
+
+export const fetchVaultMetadataSnapshot = cache(async function fetchVaultMetadataSnapshot(
+  chainID: string,
+  address: string
+): Promise<TKongVaultSnapshot | null> {
+  if (Number(chainID) !== 1 || !isYBoldVaultAddress(address)) {
+    return fetchVaultMetadataSnapshotForAddress(chainID, address)
+  }
+
+  const [snapshot, stakedSnapshot] = await Promise.all([
+    fetchVaultMetadataSnapshotForAddress(chainID, address),
+    fetchVaultMetadataSnapshotForAddress(chainID, YBOLD_STAKING_ADDRESS)
+  ])
+  return snapshot && stakedSnapshot ? mergeYBoldSnapshot(snapshot, stakedSnapshot) : null
 })
 
 function pickFirstText(...values: Array<string | null | undefined>): string {
@@ -84,6 +101,27 @@ function pickFirstText(...values: Array<string | null | undefined>): string {
 
 function pickFirstNumber(...values: Array<number | null | undefined>): number | null {
   return values.find((value) => typeof value === 'number' && Number.isFinite(value)) ?? null
+}
+
+function pickMaximumNumber(...values: Array<number | null | undefined>): number | null {
+  const finiteValues = values.filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
+  return finiteValues.length > 0 ? Math.max(...finiteValues) : null
+}
+
+function resolveVaultMetadataApy(address: string, snapshot?: TKongVaultSnapshot | null): number | null {
+  if (isYBoldProductAddress(address)) {
+    return pickMaximumNumber(snapshot?.apy?.weeklyNet, snapshot?.performance?.oracle?.netAPY)
+  }
+
+  return pickFirstNumber(
+    snapshot?.apy?.net,
+    snapshot?.performance?.estimated?.apy,
+    snapshot?.performance?.estimated?.apr,
+    snapshot?.performance?.oracle?.netAPY,
+    snapshot?.performance?.oracle?.apy,
+    snapshot?.performance?.oracle?.netAPR,
+    snapshot?.performance?.oracle?.apr
+  )
 }
 
 function buildVaultDescription({
@@ -154,15 +192,7 @@ export function buildVaultMetadataFromInput({ chainID, address, snapshot }: TVau
   const symbol = pickFirstText(snapshot?.meta?.displaySymbol, snapshot?.symbol)
   const assetSymbol = pickFirstText(snapshot?.meta?.token?.symbol, snapshot?.asset?.symbol)
   const title = symbol ? `${name} (${symbol})` : name
-  const apy = pickFirstNumber(
-    snapshot?.apy?.net,
-    snapshot?.performance?.estimated?.apy,
-    snapshot?.performance?.estimated?.apr,
-    snapshot?.performance?.oracle?.netAPY,
-    snapshot?.performance?.oracle?.apy,
-    snapshot?.performance?.oracle?.netAPR,
-    snapshot?.performance?.oracle?.apr
-  )
+  const apy = resolveVaultMetadataApy(address, snapshot)
   const tvl = pickFirstNumber(snapshot?.tvl?.close)
   const description = snapshot
     ? buildVaultDescription({ assetSymbol, chainName, name, apy, tvl })
@@ -227,15 +257,7 @@ export function buildVaultStructuredDataFromInput({
   const name = pickFirstText(snapshot?.meta?.displayName, snapshot?.meta?.name, snapshot?.name, genericVaultTitle)
   const symbol = pickFirstText(snapshot?.meta?.displaySymbol, snapshot?.symbol)
   const assetSymbol = pickFirstText(snapshot?.meta?.token?.symbol, snapshot?.asset?.symbol)
-  const apy = pickFirstNumber(
-    snapshot?.apy?.net,
-    snapshot?.performance?.estimated?.apy,
-    snapshot?.performance?.estimated?.apr,
-    snapshot?.performance?.oracle?.netAPY,
-    snapshot?.performance?.oracle?.apy,
-    snapshot?.performance?.oracle?.netAPR,
-    snapshot?.performance?.oracle?.apr
-  )
+  const apy = resolveVaultMetadataApy(address, snapshot)
   const title = symbol ? `${name} (${symbol})` : name
   const description = snapshot
     ? buildVaultDescription({

--- a/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/src/components/pages/vaults/[chainID]/[address].tsx
@@ -34,6 +34,7 @@ import {
 import {
   mergeYBoldSnapshot,
   mergeYBoldVault,
+  stripYBoldBaseMetrics,
   YBOLD_STAKING_ADDRESS,
   YBOLD_VAULT_ADDRESS
 } from '@pages/vaults/domain/normalizeVault'
@@ -676,8 +677,8 @@ function Index(): ReactElement | null {
 
   const mergedSnapshot = useMemo(() => {
     if (!snapshotVault) return undefined
-    if (isYBold && yBoldSnapshot) {
-      return mergeYBoldSnapshot(snapshotVault, yBoldSnapshot)
+    if (isYBold) {
+      return yBoldSnapshot ? mergeYBoldSnapshot(snapshotVault, yBoldSnapshot) : stripYBoldBaseMetrics(snapshotVault)
     }
     return snapshotVault
   }, [isYBold, snapshotVault, yBoldSnapshot])

--- a/src/components/pages/vaults/components/detail/VaultDetailsHeader.test.tsx
+++ b/src/components/pages/vaults/components/detail/VaultDetailsHeader.test.tsx
@@ -392,12 +392,12 @@ describe('VaultDetailsHeaderPresentation', () => {
     )
   })
 
-  it('describes the 7 day historical basis for the yBOLD estimated APY', () => {
+  it('describes the Oracle and 7 day inputs for the yBOLD estimated APY', () => {
     const html = renderToStaticMarkup(
       <VaultDetailsHeaderPresentation currentVault={YBOLD_VAULT as never} depositedValue={0n} isCompressed={false} />
     )
 
-    expect(html).toContain('Projected APY based on 7 day historical performance')
+    expect(html).toContain('Higher of the Oracle APY and 7 day historical performance')
     expect(html).not.toContain('Projected APY based on underlying markets')
   })
 

--- a/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
+++ b/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
@@ -512,7 +512,7 @@ function VaultOverviewCard({
 }): ReactElement {
   const currentVault = getVaultView(currentVaultInput)
   const estimatedApyTooltip = isYBoldProductAddress(currentVault.address)
-    ? 'Projected APY based on 7 day historical performance'
+    ? 'Higher of the Oracle APY and 7 day historical performance'
     : 'Projected APY based on underlying markets'
   const totalAssets = toNormalizedBN(currentVault.tvl.totalAssets, currentVault.decimals).normalized
   const listKind = deriveListKind(currentVault)

--- a/src/components/pages/vaults/domain/kongVaultSelectors.test.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.test.ts
@@ -1,7 +1,7 @@
 import { calculateVaultEstimatedAPY } from '@shared/utils/vaultApy'
 import { describe, expect, it } from 'vitest'
 import { getVaultAPR, getVaultStaking, getVaultStrategies, getVaultTVL, getVaultView } from './kongVaultSelectors'
-import { YBOLD_VAULT_ADDRESS } from './normalizeVault'
+import { mergeYBoldVault, stripYBoldBaseMetrics, YBOLD_STAKING_ADDRESS, YBOLD_VAULT_ADDRESS } from './normalizeVault'
 
 const LIST_REWARD = {
   address: '0x3333333333333333333333333333333333333333',
@@ -208,6 +208,38 @@ describe('getVaultAPR', () => {
     expect(view.apr.forwardAPR.type).toBe('oracle')
     expect(view.apr.forwardAPR.netAPR).toBe(0.0495)
     expect(calculateVaultEstimatedAPY(view)).toBe(0.0495)
+  })
+
+  it('uses staked list metrics when the staked snapshot is unavailable', () => {
+    const mergedVault = mergeYBoldVault(
+      {
+        ...BASE_LIST_VAULT,
+        chainId: 1,
+        address: YBOLD_VAULT_ADDRESS,
+        performance: {
+          oracle: { netAPY: 0.0654 },
+          historical: { weeklyNet: 0.064 }
+        }
+      } as any,
+      {
+        address: YBOLD_STAKING_ADDRESS,
+        performance: {
+          oracle: { netAPY: 0.0587 },
+          historical: { weeklyNet: 0.055 }
+        }
+      } as any
+    )
+    const view = getVaultView(
+      mergedVault,
+      stripYBoldBaseMetrics({
+        apy: { weeklyNet: 0.064 },
+        performance: { oracle: { netAPY: 0.0654 } }
+      } as any)
+    )
+
+    expect(view.apr.points.weekAgo).toBe(0.055)
+    expect(view.apr.forwardAPR.netAPR).toBe(0.0587)
+    expect(calculateVaultEstimatedAPY(view)).toBe(0.0587)
   })
 
   it('uses list pricePerShare when snapshot pricePerShare is missing', () => {

--- a/src/components/pages/vaults/domain/kongVaultSelectors.test.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.test.ts
@@ -1,6 +1,7 @@
 import { calculateVaultEstimatedAPY } from '@shared/utils/vaultApy'
 import { describe, expect, it } from 'vitest'
-import { getVaultAPR, getVaultStaking, getVaultStrategies, getVaultTVL } from './kongVaultSelectors'
+import { getVaultAPR, getVaultStaking, getVaultStrategies, getVaultTVL, getVaultView } from './kongVaultSelectors'
+import { YBOLD_VAULT_ADDRESS } from './normalizeVault'
 
 const LIST_REWARD = {
   address: '0x3333333333333333333333333333333333333333',
@@ -183,6 +184,32 @@ describe('getVaultStaking', () => {
 })
 
 describe('getVaultAPR', () => {
+  it('uses staked yBOLD weeklyNet and oracle.netAPY even when estimated APY is present', () => {
+    const view = getVaultView(
+      {
+        ...BASE_LIST_VAULT,
+        chainId: 1,
+        address: YBOLD_VAULT_ADDRESS,
+        performance: {
+          oracle: { netAPY: 0.0551 },
+          historical: { weeklyNet: null }
+        }
+      } as any,
+      {
+        apy: { weeklyNet: 0.046 },
+        performance: {
+          estimated: { apy: 0.2 },
+          oracle: { netAPY: 0.0495 }
+        }
+      } as any
+    )
+
+    expect(view.apr.points.weekAgo).toBe(0.046)
+    expect(view.apr.forwardAPR.type).toBe('oracle')
+    expect(view.apr.forwardAPR.netAPR).toBe(0.0495)
+    expect(calculateVaultEstimatedAPY(view)).toBe(0.0495)
+  })
+
   it('uses list pricePerShare when snapshot pricePerShare is missing', () => {
     const apr = getVaultAPR({
       chainId: 1,

--- a/src/components/pages/vaults/domain/kongVaultSelectors.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.ts
@@ -1,4 +1,4 @@
-import { isYBoldProductAddress } from '@pages/vaults/domain/normalizeVault'
+import { isYBoldProductAddress } from '@pages/vaults/domain/yBoldProduct'
 import { normalizeVaultCategory } from '@pages/vaults/utils/normalizeVaultCategory'
 import { toAddress, toBigInt, toNormalizedBN } from '@shared/utils'
 import type { TKongVaultListItem, TKongVaultListItemStakingReward } from '@shared/utils/schemas/kongVaultListSchema'

--- a/src/components/pages/vaults/domain/kongVaultSelectors.ts
+++ b/src/components/pages/vaults/domain/kongVaultSelectors.ts
@@ -1,3 +1,4 @@
+import { isYBoldProductAddress } from '@pages/vaults/domain/normalizeVault'
 import { normalizeVaultCategory } from '@pages/vaults/utils/normalizeVaultCategory'
 import { toAddress, toBigInt, toNormalizedBN } from '@shared/utils'
 import type { TKongVaultListItem, TKongVaultListItemStakingReward } from '@shared/utils/schemas/kongVaultListSchema'
@@ -596,8 +597,9 @@ export const getVaultAPR = (vault: TKongVaultInput, snapshot?: TKongVaultSnapsho
   const oracle = snapshot?.performance?.oracle ?? vault.performance?.oracle
   const estimated = snapshot?.performance?.estimated ?? vault.performance?.estimated
   const isKatanaVault = getVaultChainID(vault) === 747474
+  const isYBoldVault = isYBoldProductAddress(getVaultAddress(vault))
 
-  const forwardNet = isKatanaVault
+  const defaultForwardNet = isKatanaVault
     ? pickNumber(
         snapshot?.performance?.estimated?.apy,
         snapshot?.performance?.estimated?.apr,
@@ -627,14 +629,18 @@ export const getVaultAPR = (vault: TKongVaultInput, snapshot?: TKongVaultSnapsho
         vault.performance?.historical?.net,
         historical?.net
       )
+  const forwardNet = isYBoldVault
+    ? pickNumber(snapshot?.performance?.oracle?.netAPY, vault.performance?.oracle?.netAPY)
+    : defaultForwardNet
 
-  const forwardType = snapshot?.performance?.estimated
+  const defaultForwardType = snapshot?.performance?.estimated
     ? 'estimated'
     : snapshot?.performance?.oracle?.apr !== null && snapshot?.performance?.oracle?.apr !== undefined
       ? 'oracle'
       : oracle?.apy !== null && oracle?.apy !== undefined
         ? 'oracle'
         : (estimated?.type ?? '')
+  const forwardType = isYBoldVault ? 'oracle' : defaultForwardType
 
   return {
     type:

--- a/src/components/pages/vaults/domain/normalizeVault.test.ts
+++ b/src/components/pages/vaults/domain/normalizeVault.test.ts
@@ -5,6 +5,7 @@ import {
   isYBoldProductAddress,
   mergeYBoldSnapshot,
   mergeYBoldVault,
+  stripYBoldBaseMetrics,
   YBOLD_STAKING_ADDRESS,
   YBOLD_VAULT_ADDRESS
 } from './normalizeVault'
@@ -51,6 +52,43 @@ describe('yBOLD product helpers', () => {
 
     expect(merged.performance?.oracle).toEqual(stakedOracle)
     expect(merged.apy?.weeklyNet).toBe(0.046)
+  })
+
+  it('does not fall back to vanilla metrics when staked snapshot fields are missing', () => {
+    const merged = mergeYBoldSnapshot(
+      {
+        apy: { net: 0.06, weeklyNet: 0.06, pricePerShare: '1100000000000000000' },
+        fees: { performanceFee: 0, managementFee: 0 },
+        performance: {
+          estimated: { apy: 0.06 },
+          oracle: { netAPY: 0.06 },
+          historical: { weeklyNet: 0.06 }
+        }
+      } as any,
+      {} as any
+    )
+
+    expect(merged.apy?.net).toBeNull()
+    expect(merged.apy?.weeklyNet).toBeNull()
+    expect(merged.apy?.pricePerShare).toBeNull()
+    expect(merged.fees?.performanceFee).toBeNull()
+    expect(merged.performance?.estimated).toBeUndefined()
+    expect(merged.performance?.oracle).toBeUndefined()
+    expect(merged.performance?.historical).toBeUndefined()
+  })
+
+  it('preserves base metadata while removing vanilla financial metrics', () => {
+    const stripped = stripYBoldBaseMetrics({
+      meta: { displayName: 'Yearn BOLD' },
+      tvl: { close: 5_000_000 },
+      apy: { weeklyNet: 0.06 },
+      performance: { oracle: { netAPY: 0.06 } }
+    } as any)
+
+    expect(stripped.meta?.displayName).toBe('Yearn BOLD')
+    expect(stripped.tvl?.close).toBe(5_000_000)
+    expect(stripped.apy?.weeklyNet).toBeNull()
+    expect(stripped.performance?.oracle).toBeUndefined()
   })
 })
 

--- a/src/components/pages/vaults/domain/normalizeVault.test.ts
+++ b/src/components/pages/vaults/domain/normalizeVault.test.ts
@@ -3,6 +3,8 @@ import {
   getCanonicalHoldingsVaultAddress,
   getHoldingsAliasVaultAddress,
   isYBoldProductAddress,
+  mergeYBoldSnapshot,
+  mergeYBoldVault,
   YBOLD_STAKING_ADDRESS,
   YBOLD_VAULT_ADDRESS
 } from './normalizeVault'
@@ -12,6 +14,43 @@ describe('yBOLD product helpers', () => {
     expect(isYBoldProductAddress(YBOLD_VAULT_ADDRESS)).toBe(true)
     expect(isYBoldProductAddress(YBOLD_STAKING_ADDRESS.toLowerCase())).toBe(true)
     expect(isYBoldProductAddress('0x0000000000000000000000000000000000000001')).toBe(false)
+  })
+
+  it('keeps the base Oracle while borrowing staked vault history', () => {
+    const baseOracle = { apr: 0.0537, apy: 0.0551, netAPR: 0.0537, netAPY: 0.0551 }
+    const stakedOracle = { apr: 0.0537, apy: 0.0551, netAPR: 0.0483, netAPY: 0.0495 }
+    const stakedHistorical = { net: 0.0617, weeklyNet: 0.046, monthlyNet: 0.0617, inceptionNet: 0.0726 }
+    const merged = mergeYBoldVault(
+      {
+        address: YBOLD_VAULT_ADDRESS,
+        performance: { oracle: baseOracle, historical: null }
+      } as any,
+      {
+        address: YBOLD_STAKING_ADDRESS,
+        performance: { oracle: stakedOracle, historical: stakedHistorical }
+      } as any
+    )
+
+    expect(merged.performance?.oracle).toEqual(baseOracle)
+    expect(merged.performance?.historical).toEqual(stakedHistorical)
+  })
+
+  it('keeps the base snapshot Oracle while borrowing staked snapshot APY history', () => {
+    const baseOracle = { apr: 0.0537, apy: 0.0551, netAPR: 0.0537, netAPY: 0.0551 }
+    const stakedOracle = { apr: 0.0537, apy: 0.0551, netAPR: 0.0483, netAPY: 0.0495 }
+    const merged = mergeYBoldSnapshot(
+      {
+        performance: { oracle: baseOracle },
+        apy: { weeklyNet: null }
+      } as any,
+      {
+        performance: { oracle: stakedOracle },
+        apy: { weeklyNet: 0.046 }
+      } as any
+    )
+
+    expect(merged.performance?.oracle).toEqual(baseOracle)
+    expect(merged.apy?.weeklyNet).toBe(0.046)
   })
 })
 

--- a/src/components/pages/vaults/domain/normalizeVault.test.ts
+++ b/src/components/pages/vaults/domain/normalizeVault.test.ts
@@ -16,7 +16,7 @@ describe('yBOLD product helpers', () => {
     expect(isYBoldProductAddress('0x0000000000000000000000000000000000000001')).toBe(false)
   })
 
-  it('keeps the base Oracle while borrowing staked vault history', () => {
+  it('uses the staked net Oracle and historical performance', () => {
     const baseOracle = { apr: 0.0537, apy: 0.0551, netAPR: 0.0537, netAPY: 0.0551 }
     const stakedOracle = { apr: 0.0537, apy: 0.0551, netAPR: 0.0483, netAPY: 0.0495 }
     const stakedHistorical = { net: 0.0617, weeklyNet: 0.046, monthlyNet: 0.0617, inceptionNet: 0.0726 }
@@ -31,11 +31,11 @@ describe('yBOLD product helpers', () => {
       } as any
     )
 
-    expect(merged.performance?.oracle).toEqual(baseOracle)
+    expect(merged.performance?.oracle).toEqual(stakedOracle)
     expect(merged.performance?.historical).toEqual(stakedHistorical)
   })
 
-  it('keeps the base snapshot Oracle while borrowing staked snapshot APY history', () => {
+  it('uses the staked snapshot Oracle and APY history', () => {
     const baseOracle = { apr: 0.0537, apy: 0.0551, netAPR: 0.0537, netAPY: 0.0551 }
     const stakedOracle = { apr: 0.0537, apy: 0.0551, netAPR: 0.0483, netAPY: 0.0495 }
     const merged = mergeYBoldSnapshot(
@@ -49,7 +49,7 @@ describe('yBOLD product helpers', () => {
       } as any
     )
 
-    expect(merged.performance?.oracle).toEqual(baseOracle)
+    expect(merged.performance?.oracle).toEqual(stakedOracle)
     expect(merged.apy?.weeklyNet).toBe(0.046)
   })
 })

--- a/src/components/pages/vaults/domain/normalizeVault.ts
+++ b/src/components/pages/vaults/domain/normalizeVault.ts
@@ -29,8 +29,8 @@ export function mergeYBoldVault(baseVault: TKongVaultListItem, stakedVault: TKon
     performance: {
       ...(baseVault.performance ?? {}),
       historical: stakedVault.performance?.historical ?? baseVault.performance?.historical,
-      estimated: baseVault.performance?.estimated ?? stakedVault.performance?.estimated,
-      oracle: baseVault.performance?.oracle ?? stakedVault.performance?.oracle
+      estimated: stakedVault.performance?.estimated ?? baseVault.performance?.estimated,
+      oracle: stakedVault.performance?.oracle ?? baseVault.performance?.oracle
     },
     fees: {
       managementFee: baseVault.fees?.managementFee ?? 0,
@@ -86,8 +86,8 @@ export function mergeYBoldSnapshot(
     performance: {
       ...(baseSnapshot.performance ?? {}),
       historical: stakedSnapshot.performance?.historical ?? baseSnapshot.performance?.historical,
-      oracle: baseSnapshot.performance?.oracle ?? stakedSnapshot.performance?.oracle,
-      estimated: baseSnapshot.performance?.estimated ?? stakedSnapshot.performance?.estimated
+      oracle: stakedSnapshot.performance?.oracle ?? baseSnapshot.performance?.oracle,
+      estimated: stakedSnapshot.performance?.estimated ?? baseSnapshot.performance?.estimated
     }
   }
 }

--- a/src/components/pages/vaults/domain/normalizeVault.ts
+++ b/src/components/pages/vaults/domain/normalizeVault.ts
@@ -1,20 +1,19 @@
+import { YBOLD_STAKING_ADDRESS, YBOLD_VAULT_ADDRESS } from '@pages/vaults/domain/yBoldProduct'
 import type { TDict } from '@shared/types'
 import { toAddress } from '@shared/utils'
 import type { TKongVaultListItem } from '@shared/utils/schemas/kongVaultListSchema'
 import type { TKongVaultSnapshot } from '@shared/utils/schemas/kongVaultSnapshotSchema'
 import { type Address, zeroAddress } from 'viem'
 
-export const YBOLD_VAULT_ADDRESS: Address = '0x9F4330700a36B29952869fac9b33f45EEdd8A3d8'
-export const YBOLD_STAKING_ADDRESS: Address = '0x23346B04a7f55b8760E5860AA5A77383D63491cD'
-
-const YBOLD_PRODUCT_ADDRESSES = new Set([toAddress(YBOLD_VAULT_ADDRESS), toAddress(YBOLD_STAKING_ADDRESS)])
+export {
+  isYBoldProductAddress,
+  isYBoldVaultAddress,
+  YBOLD_STAKING_ADDRESS,
+  YBOLD_VAULT_ADDRESS
+} from '@pages/vaults/domain/yBoldProduct'
 
 const HOLDINGS_ALIAS_BY_ADDRESS: Record<string, Address> = {
   [toAddress(YBOLD_STAKING_ADDRESS)]: YBOLD_VAULT_ADDRESS
-}
-
-export function isYBoldProductAddress(address: Address | string | undefined): boolean {
-  return Boolean(address && YBOLD_PRODUCT_ADDRESSES.has(toAddress(address)))
 }
 
 export function mergeYBoldVault(baseVault: TKongVaultListItem, stakedVault: TKongVaultListItem): TKongVaultListItem {

--- a/src/components/pages/vaults/domain/normalizeVault.ts
+++ b/src/components/pages/vaults/domain/normalizeVault.ts
@@ -29,8 +29,8 @@ export function mergeYBoldVault(baseVault: TKongVaultListItem, stakedVault: TKon
     performance: {
       ...(baseVault.performance ?? {}),
       historical: stakedVault.performance?.historical ?? baseVault.performance?.historical,
-      estimated: stakedVault.performance?.estimated ?? baseVault.performance?.estimated,
-      oracle: stakedVault.performance?.oracle ?? baseVault.performance?.oracle
+      estimated: baseVault.performance?.estimated ?? stakedVault.performance?.estimated,
+      oracle: baseVault.performance?.oracle ?? stakedVault.performance?.oracle
     },
     fees: {
       managementFee: baseVault.fees?.managementFee ?? 0,
@@ -86,8 +86,8 @@ export function mergeYBoldSnapshot(
     performance: {
       ...(baseSnapshot.performance ?? {}),
       historical: stakedSnapshot.performance?.historical ?? baseSnapshot.performance?.historical,
-      oracle: stakedSnapshot.performance?.oracle ?? baseSnapshot.performance?.oracle,
-      estimated: stakedSnapshot.performance?.estimated ?? baseSnapshot.performance?.estimated
+      oracle: baseSnapshot.performance?.oracle ?? stakedSnapshot.performance?.oracle,
+      estimated: baseSnapshot.performance?.estimated ?? stakedSnapshot.performance?.estimated
     }
   }
 }

--- a/src/components/pages/vaults/domain/normalizeVault.ts
+++ b/src/components/pages/vaults/domain/normalizeVault.ts
@@ -27,9 +27,9 @@ export function mergeYBoldVault(baseVault: TKongVaultListItem, stakedVault: TKon
     },
     performance: {
       ...(baseVault.performance ?? {}),
-      historical: stakedVault.performance?.historical ?? baseVault.performance?.historical,
-      estimated: stakedVault.performance?.estimated ?? baseVault.performance?.estimated,
-      oracle: stakedVault.performance?.oracle ?? baseVault.performance?.oracle
+      historical: stakedVault.performance?.historical ?? null,
+      estimated: stakedVault.performance?.estimated ?? null,
+      oracle: stakedVault.performance?.oracle ?? null
     },
     fees: {
       managementFee: baseVault.fees?.managementFee ?? 0,
@@ -38,12 +38,45 @@ export function mergeYBoldVault(baseVault: TKongVaultListItem, stakedVault: TKon
   }
 }
 
+export function stripYBoldBaseMetrics(baseSnapshot: TKongVaultSnapshot): TKongVaultSnapshot {
+  return {
+    ...baseSnapshot,
+    apy: baseSnapshot.apy
+      ? {
+          ...baseSnapshot.apy,
+          net: null,
+          grossApr: null,
+          weeklyNet: null,
+          monthlyNet: null,
+          inceptionNet: null,
+          pricePerShare: null,
+          weeklyPricePerShare: null,
+          monthlyPricePerShare: null
+        }
+      : baseSnapshot.apy,
+    fees: baseSnapshot.fees
+      ? {
+          ...baseSnapshot.fees,
+          performanceFee: null
+        }
+      : baseSnapshot.fees,
+    performance: {
+      ...baseSnapshot.performance,
+      historical: undefined,
+      oracle: undefined,
+      estimated: undefined
+    }
+  }
+}
+
 export function mergeYBoldSnapshot(
   baseSnapshot: TKongVaultSnapshot,
   stakedSnapshot: TKongVaultSnapshot
 ): TKongVaultSnapshot {
+  const baseSnapshotWithoutStakedMetrics = stripYBoldBaseMetrics(baseSnapshot)
+
   return {
-    ...baseSnapshot,
+    ...baseSnapshotWithoutStakedMetrics,
     staking: {
       ...(baseSnapshot.staking ?? {}),
       address: YBOLD_STAKING_ADDRESS,
@@ -67,26 +100,27 @@ export function mergeYBoldSnapshot(
             ]
     },
     apy: {
-      ...(baseSnapshot.apy ?? null),
-      net: stakedSnapshot.apy?.net ?? baseSnapshot.apy?.net,
-      weeklyNet: stakedSnapshot.apy?.weeklyNet ?? baseSnapshot.apy?.weeklyNet,
-      monthlyNet: stakedSnapshot.apy?.monthlyNet ?? baseSnapshot.apy?.monthlyNet,
-      inceptionNet: stakedSnapshot.apy?.inceptionNet ?? baseSnapshot.apy?.inceptionNet,
-      pricePerShare: stakedSnapshot.apy?.pricePerShare ?? baseSnapshot.apy?.pricePerShare,
-      weeklyPricePerShare: stakedSnapshot.apy?.weeklyPricePerShare ?? baseSnapshot.apy?.weeklyPricePerShare,
-      monthlyPricePerShare: stakedSnapshot.apy?.monthlyPricePerShare ?? baseSnapshot.apy?.monthlyPricePerShare,
+      ...(baseSnapshotWithoutStakedMetrics.apy ?? null),
+      net: stakedSnapshot.apy?.net ?? null,
+      grossApr: stakedSnapshot.apy?.grossApr ?? null,
+      weeklyNet: stakedSnapshot.apy?.weeklyNet ?? null,
+      monthlyNet: stakedSnapshot.apy?.monthlyNet ?? null,
+      inceptionNet: stakedSnapshot.apy?.inceptionNet ?? null,
+      pricePerShare: stakedSnapshot.apy?.pricePerShare ?? null,
+      weeklyPricePerShare: stakedSnapshot.apy?.weeklyPricePerShare ?? null,
+      monthlyPricePerShare: stakedSnapshot.apy?.monthlyPricePerShare ?? null,
       label: stakedSnapshot.apy?.label ?? baseSnapshot.apy?.label ?? ''
     },
     fees: {
-      ...(baseSnapshot.fees ?? null),
-      performanceFee: stakedSnapshot.fees?.performanceFee ?? baseSnapshot.fees?.performanceFee,
+      ...(baseSnapshotWithoutStakedMetrics.fees ?? null),
+      performanceFee: stakedSnapshot.fees?.performanceFee ?? null,
       managementFee: baseSnapshot.fees?.managementFee
     },
     performance: {
-      ...(baseSnapshot.performance ?? {}),
-      historical: stakedSnapshot.performance?.historical ?? baseSnapshot.performance?.historical,
-      oracle: stakedSnapshot.performance?.oracle ?? baseSnapshot.performance?.oracle,
-      estimated: stakedSnapshot.performance?.estimated ?? baseSnapshot.performance?.estimated
+      ...baseSnapshotWithoutStakedMetrics.performance,
+      historical: stakedSnapshot.performance?.historical,
+      oracle: stakedSnapshot.performance?.oracle,
+      estimated: stakedSnapshot.performance?.estimated
     }
   }
 }

--- a/src/components/pages/vaults/domain/yBoldProduct.ts
+++ b/src/components/pages/vaults/domain/yBoldProduct.ts
@@ -1,0 +1,15 @@
+import type { Address } from 'viem'
+
+export const YBOLD_VAULT_ADDRESS: Address = '0x9F4330700a36B29952869fac9b33f45EEdd8A3d8'
+export const YBOLD_STAKING_ADDRESS: Address = '0x23346B04a7f55b8760E5860AA5A77383D63491cD'
+
+const YBOLD_VAULT_ADDRESS_LOWERCASE = YBOLD_VAULT_ADDRESS.toLowerCase()
+const YBOLD_PRODUCT_ADDRESSES = new Set([YBOLD_VAULT_ADDRESS_LOWERCASE, YBOLD_STAKING_ADDRESS.toLowerCase()])
+
+export function isYBoldVaultAddress(address: Address | string | undefined): boolean {
+  return address?.toLowerCase() === YBOLD_VAULT_ADDRESS_LOWERCASE
+}
+
+export function isYBoldProductAddress(address: Address | string | undefined): boolean {
+  return Boolean(address && YBOLD_PRODUCT_ADDRESSES.has(address.toLowerCase()))
+}

--- a/src/components/shared/utils/vaultApy.test.ts
+++ b/src/components/shared/utils/vaultApy.test.ts
@@ -154,7 +154,7 @@ describe('vaultApy Katana calculations', () => {
 })
 
 describe('yBOLD estimated APY override', () => {
-  const createYBoldVault = (address: string): TKongVault =>
+  const createYBoldVault = (address: string, weeklyNet = 0.0725): TKongVault =>
     ({
       ...BASE_VAULT,
       chainId: 1,
@@ -169,7 +169,7 @@ describe('yBOLD estimated APY override', () => {
         },
         historical: {
           net: 0.08,
-          weeklyNet: 0.0725,
+          weeklyNet,
           monthlyNet: 0.081,
           inceptionNet: 0.09
         }
@@ -177,14 +177,21 @@ describe('yBOLD estimated APY override', () => {
     }) as TKongVault
 
   it.each([YBOLD_VAULT_ADDRESS, YBOLD_STAKING_ADDRESS])(
-    'uses 7 day historical net APY as the estimated APY for %s',
+    'uses the Oracle APY when it exceeds the 7 day historical net APY for %s',
     (address) => {
       const vault = createYBoldVault(address)
 
-      expect(getVaultForwardAPY(vault)).toBe(0.0725)
-      expect(calculateVaultEstimatedAPY(vault)).toBe(0.0725)
+      expect(getVaultForwardAPY(vault)).toBe(0.115)
+      expect(calculateVaultEstimatedAPY(vault)).toBe(0.115)
     }
   )
+
+  it('uses the 7 day historical net APY when it exceeds the Oracle APY', () => {
+    const vault = createYBoldVault(YBOLD_VAULT_ADDRESS, 0.125)
+
+    expect(getVaultForwardAPY(vault)).toBe(0.125)
+    expect(calculateVaultEstimatedAPY(vault)).toBe(0.125)
+  })
 
   it('keeps the forward APY for other vaults', () => {
     expect(getVaultForwardAPY(BASE_VAULT)).toBe(0.068)

--- a/src/components/shared/utils/vaultApy.ts
+++ b/src/components/shared/utils/vaultApy.ts
@@ -68,7 +68,7 @@ export function getVaultForwardAPY(vault: TKongVaultInput): number {
   const apr = getVaultAPR(vault)
 
   if (isYBoldProductAddress(getVaultAddress(vault))) {
-    return apr.points.weekAgo
+    return Math.max(apr.points.weekAgo, apr.forwardAPR.netAPR)
   }
 
   return apr.forwardAPR?.netAPR || 0

--- a/src/server/ssr/publicDataHydration.test.ts
+++ b/src/server/ssr/publicDataHydration.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { YBOLD_STAKING_ADDRESS, YBOLD_VAULT_ADDRESS } from '@/components/pages/vaults/domain/normalizeVault'
 import { YVBTC_CHAIN_ID, YVBTC_UNLOCKED_ADDRESS } from '@/components/pages/vaults/utils/yvBtc'
 import { YVUSD_CHAIN_ID, YVUSD_LOCKED_ADDRESS, YVUSD_UNLOCKED_ADDRESS } from '@/components/pages/vaults/utils/yvUsd'
 import {
@@ -99,5 +100,17 @@ describe('public data SSR hydration', () => {
     )
     expect(keys).not.toContainEqual(['fetch', YEARN_VAULT_LIST_ENDPOINT])
     expect(keys).not.toContainEqual(['fetch', buildVaultSnapshotEndpoint(YVBTC_CHAIN_ID, YVBTC_UNLOCKED_ADDRESS)])
+  })
+
+  it('hydrates the staked snapshot for vanilla yBOLD vault details', async () => {
+    const state = await getVaultDetailPageDehydratedState(1, YBOLD_VAULT_ADDRESS)
+    const keys = queryKeys(state)
+
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        ['fetch', buildVaultSnapshotEndpoint(1, YBOLD_VAULT_ADDRESS)],
+        ['fetch', buildVaultSnapshotEndpoint(1, YBOLD_STAKING_ADDRESS)]
+      ])
+    )
   })
 })

--- a/src/server/ssr/publicDataHydration.ts
+++ b/src/server/ssr/publicDataHydration.ts
@@ -1,6 +1,6 @@
 import { type DehydratedState, dehydrate, QueryClient } from '@tanstack/react-query'
 import * as z from 'zod'
-import { YBOLD_STAKING_ADDRESS, YBOLD_VAULT_ADDRESS } from '@/components/pages/vaults/domain/normalizeVault'
+import { YBOLD_STAKING_ADDRESS, YBOLD_VAULT_ADDRESS } from '@/components/pages/vaults/domain/yBoldProduct'
 import {
   buildVaultsInitialPayload,
   type TVaultsInitialPayload

--- a/src/server/ssr/publicDataHydration.ts
+++ b/src/server/ssr/publicDataHydration.ts
@@ -1,5 +1,6 @@
 import { type DehydratedState, dehydrate, QueryClient } from '@tanstack/react-query'
 import * as z from 'zod'
+import { YBOLD_STAKING_ADDRESS, YBOLD_VAULT_ADDRESS } from '@/components/pages/vaults/domain/normalizeVault'
 import {
   buildVaultsInitialPayload,
   type TVaultsInitialPayload
@@ -110,6 +111,11 @@ async function prefetchRelatedVaultDetailSnapshots(
   chainId?: number | string,
   address?: string
 ): Promise<void> {
+  if (isMatchingSnapshotRoute(chainId, address, 1, YBOLD_VAULT_ADDRESS)) {
+    await prefetchVaultSnapshot(queryClient, 1, YBOLD_STAKING_ADDRESS)
+    return
+  }
+
   if (Number(chainId) !== YVUSD_CHAIN_ID || !isYvUsdAddress(address)) {
     return
   }


### PR DESCRIPTION
### Summary
Per discussion with Strategists, yBOLD should use the higher of the staked 7-day net APY and staked Oracle net APY for the Est. APY in the interface, page metadata, and structured data. This change makes the Est. APY more faithful to the true rate.
<img width="1551" height="516" alt="image" src="https://github.com/user-attachments/assets/add62a3b-b9c7-4a0f-8ee2-d4f0f91e482c" />
The grey oracle line under-estimates significantly. The 7 day value is what is currently used, but but can drop below the oracle rate, which should rarely happen. 

This PR also fixes an issue with page hydration showing a gross APY estimated value for yBOLD momentarily before reverting to the netAPY value.

### How to review
Start with the yBOLD calculation in `vaultApy.ts` and the staked data selection in `kongVaultSelectors.ts`. Then review the related snapshot prefetch in `publicDataHydration.ts` and the server metadata handling in `app/metadata.ts`.

To check the main flow, hard refresh the vanilla yBOLD vault page. The estimated APY should remain stable during hydration, and the metadata description and JSON-LD value should match the visible APY.

### Test plan
- [x] Manual: Hard refreshed the yBOLD vault page and confirmed the visible APY remains 4.95% before and after hydration
- [x] Manual: Confirmed the metadata description and JSON-LD annual percentage rate also report 4.95%
- [x] Automated: `bun run lint`
- [x] Automated: `bun run tslint`
- [x] Automated: `bun run test` (175 files, 928 tests)
- [x] Automated: `bun run build`

### Risk / impact
This changes displayed yield data and metadata only. It does not change deposits, withdrawals, transaction construction, or other funds-moving behavior.

The vanilla yBOLD metadata path makes one additional request for the staked snapshot. If either required snapshot is unavailable, the page omits the yBOLD-specific metadata instead of publishing the incorrect vanilla yield. Reverting this PR restores the previous behavior.
