### PR TITLE
Improve vault page layout at compact widths

### DIFF
--- a/apps/yearn/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/apps/yearn/src/components/pages/vaults/[chainID]/[address].tsx
@@ -1971,13 +1971,16 @@ function Index(): ReactElement | null {
           </section>
         </div>
 
-        <section className={'grid grid-cols-1 gap-4 md:gap-6 md:grid-cols-20 md:items-start bg-app'}>
+        <section
+          className={
+            'grid grid-cols-1 gap-4 bg-app md:items-start md:gap-6 min-[1100px]:grid-cols-[minmax(0,1fr)_408px]'
+          }
+        >
           <div
             ref={widgetContainerRef}
             className={cl(
-              'hidden md:block',
-              'order-1 md:order-2',
-              'md:col-span-7 md:col-start-14 md:sticky pt-4',
+              'hidden min-[1100px]:block',
+              'min-[1100px]:col-start-2 min-[1100px]:row-start-1 min-[1100px]:sticky pt-4',
               'flex flex-col overflow-hidden',
               desktopWidgetHeightClassNames.container
             )}
@@ -2042,7 +2045,7 @@ function Index(): ReactElement | null {
             </div>
           </div>
 
-          <div className={'hidden md:block space-y-4 md:col-span-13 order-2 md:order-1 py-4'}>
+          <div className={'hidden space-y-4 py-4 md:block min-[1100px]:col-start-1 min-[1100px]:row-start-1'}>
             {isRetired && retiredVaultAlertMessage ? (
               <VaultWarningAlert message={retiredVaultAlertMessage} className="px-6 py-4" />
             ) : null}
@@ -2136,11 +2139,11 @@ function Index(): ReactElement | null {
         </section>
       </div>
 
-      {/* Mobile Floating Action Buttons - visible until desktop widget appears (md:), hidden when drawer is open */}
+      {/* Floating action buttons remain available until the fixed-width desktop widget appears. */}
       {!isMobileDrawerOpen && (
         <div
           className={cl(
-            'fixed bottom-0 left-0 right-0 z-50 px-4 pt-4 md:hidden',
+            'fixed bottom-0 left-0 right-0 z-50 px-4 pt-4 min-[1100px]:hidden',
             'backdrop-blur-md',
             'pb-[calc(1rem+env(safe-area-inset-bottom,0px))]'
           )}

--- a/apps/yearn/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/apps/yearn/src/components/pages/vaults/[chainID]/[address].tsx
@@ -544,7 +544,7 @@ function Index(): ReactElement | null {
   })
   const isDualVariantVault = isYvUsd || isYvBtc
   const isDesktopViewport = useMediaQuery('(min-width: 768px)', { initializeWithValue: false })
-  const isBelowDesktopWidgetBreakpoint = useMediaQuery('(max-width: 1099px)', { initializeWithValue: false }) ?? false
+  const isBelowDesktopWidgetBreakpoint = useMediaQuery('(max-width: 1100px)', { initializeWithValue: false }) ?? false
   const shouldRenderCompactHeaderBanner = isYvUsd && isBelowDesktopWidgetBreakpoint
   const shouldRenderDesktopCharts = isDesktopViewport === true
   const shouldRenderMobileCharts = isDesktopViewport === false
@@ -1784,7 +1784,7 @@ function Index(): ReactElement | null {
     )
   }
 
-  function renderDrawerActionButtons(): ReactElement {
+  function renderDrawerActionButtons({ isCompactHeader }: { isCompactHeader: boolean }): ReactElement {
     return (
       <div className={'flex w-full gap-3'}>
         <button
@@ -1798,9 +1798,10 @@ function Index(): ReactElement | null {
         <button
           type={'button'}
           onClick={() => handleFloatingButtonClick(widgetActions[1])}
-          className={
-            'yearn--button flex-1 border-border! bg-surface! hover:border-border-hover! hover:bg-surface-tertiary!'
-          }
+          className={cl(
+            'yearn--button flex-1',
+            isCompactHeader ? 'border-border! bg-surface! hover:border-border-hover! hover:bg-surface-tertiary!' : ''
+          )}
           data-variant={'light'}
         >
           {'Withdraw'}
@@ -1901,7 +1902,7 @@ function Index(): ReactElement | null {
                   'hidden w-full rounded-b-lg border border-t-0 border-border bg-surface-secondary p-2 md:block'
                 }
               >
-                {renderDrawerActionButtons()}
+                {renderDrawerActionButtons({ isCompactHeader: true })}
               </div>
             ) : null}
           </header>
@@ -2032,14 +2033,14 @@ function Index(): ReactElement | null {
 
         <section
           className={
-            'grid grid-cols-1 gap-4 bg-app md:items-start md:gap-6 min-[1100px]:grid-cols-[minmax(0,1fr)_408px]'
+            'grid grid-cols-1 gap-4 bg-app md:items-start md:gap-6 min-[1101px]:grid-cols-[minmax(0,1fr)_408px]'
           }
         >
           <div
             ref={widgetContainerRef}
             className={cl(
-              'hidden min-[1100px]:block',
-              'min-[1100px]:col-start-2 min-[1100px]:row-start-1 min-[1100px]:sticky pt-4',
+              'hidden min-[1101px]:block',
+              'min-[1101px]:col-start-2 min-[1101px]:row-start-1 min-[1101px]:sticky pt-4',
               'flex flex-col overflow-hidden',
               desktopWidgetHeightClassNames.container
             )}
@@ -2104,7 +2105,7 @@ function Index(): ReactElement | null {
             </div>
           </div>
 
-          <div className={'hidden space-y-4 py-4 md:block min-[1100px]:col-start-1 min-[1100px]:row-start-1'}>
+          <div className={'hidden space-y-4 py-4 md:block min-[1101px]:col-start-1 min-[1101px]:row-start-1'}>
             {isRetired && retiredVaultAlertMessage ? (
               <VaultWarningAlert message={retiredVaultAlertMessage} className="px-6 py-4" />
             ) : null}
@@ -2208,7 +2209,7 @@ function Index(): ReactElement | null {
             'pb-[calc(1rem+env(safe-area-inset-bottom,0px))]'
           )}
         >
-          <div className={'mx-auto max-w-[1232px]'}>{renderDrawerActionButtons()}</div>
+          <div className={'mx-auto max-w-[1232px]'}>{renderDrawerActionButtons({ isCompactHeader: false })}</div>
         </div>
       )}
 

--- a/apps/yearn/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/apps/yearn/src/components/pages/vaults/[chainID]/[address].tsx
@@ -1798,7 +1798,9 @@ function Index(): ReactElement | null {
         <button
           type={'button'}
           onClick={() => handleFloatingButtonClick(widgetActions[1])}
-          className={'yearn--button flex-1 border-border! hover:border-border-hover!'}
+          className={
+            'yearn--button flex-1 border-border! bg-surface! hover:border-border-hover! hover:bg-surface-tertiary!'
+          }
           data-variant={'light'}
         >
           {'Withdraw'}
@@ -1885,17 +1887,24 @@ function Index(): ReactElement | null {
               onWidgetCloseOverlays={closeWidgetOverlays}
               forceCompressed={isBelowDesktopWidgetBreakpoint}
               hideBreadcrumbs={shouldRenderCompactHeaderBanner}
+              hasActionFooter={isBelowDesktopWidgetBreakpoint}
               onCompressionChange={setIsHeaderCompressed}
               onCompressionStateChange={({ isCompressed, isForceCompressed }): void => {
                 setIsHeaderCompressed(isCompressed)
                 setIsHeaderAutoCompressed(isForceCompressed)
               }}
             />
-          </header>
 
-          {isBelowDesktopWidgetBreakpoint ? (
-            <div className={'hidden pt-4 md:block'}>{renderDrawerActionButtons()}</div>
-          ) : null}
+            {isBelowDesktopWidgetBreakpoint ? (
+              <div
+                className={
+                  'hidden w-full rounded-b-lg border border-t-0 border-border bg-surface-secondary p-2 md:block'
+                }
+              >
+                {renderDrawerActionButtons()}
+              </div>
+            ) : null}
+          </header>
         </div>
 
         {shouldRenderCompactHeaderBanner ? <YvUsdHeaderBanner className={'mt-3 hidden min-h-26 md:flex'} /> : null}

--- a/apps/yearn/src/components/pages/vaults/[chainID]/[address].tsx
+++ b/apps/yearn/src/components/pages/vaults/[chainID]/[address].tsx
@@ -544,6 +544,8 @@ function Index(): ReactElement | null {
   })
   const isDualVariantVault = isYvUsd || isYvBtc
   const isDesktopViewport = useMediaQuery('(min-width: 768px)', { initializeWithValue: false })
+  const isBelowDesktopWidgetBreakpoint = useMediaQuery('(max-width: 1099px)', { initializeWithValue: false }) ?? false
+  const shouldRenderCompactHeaderBanner = isYvUsd && isBelowDesktopWidgetBreakpoint
   const shouldRenderDesktopCharts = isDesktopViewport === true
   const shouldRenderMobileCharts = isDesktopViewport === false
   const isLockedYvUsdRoute =
@@ -559,6 +561,7 @@ function Index(): ReactElement | null {
   const mobileDrawerPanelRef = useRef<HTMLDivElement>(null)
   const detailsRef = useRef<HTMLDivElement>(null)
   const headerRef = useRef<HTMLElement | null>(null)
+  const vaultHeaderStackRef = useRef<HTMLDivElement>(null)
   const compressedHeaderMeasureRef = useRef<HTMLDivElement>(null)
   const sectionSelectorRef = useRef<HTMLDivElement>(null)
   const widgetRef = useRef<TWidgetRef>(null)
@@ -605,7 +608,10 @@ function Index(): ReactElement | null {
   const updateSectionScrollOffset = useCallback((): number => {
     if (typeof window === 'undefined') return 0
     const baseOffset = resolveHeaderOffset()
-    const headerHeight = headerRef.current?.getBoundingClientRect().height ?? 0
+    const headerHeight =
+      vaultHeaderStackRef.current?.getBoundingClientRect().height ??
+      headerRef.current?.getBoundingClientRect().height ??
+      0
     const nextOffset = Math.round(baseOffset + headerHeight)
     document.documentElement.style.setProperty('--vault-header-height', `${nextOffset}px`)
     setSectionScrollOffset((prev) => (Math.abs(prev - nextOffset) > 1 ? nextOffset : prev))
@@ -1365,7 +1371,7 @@ function Index(): ReactElement | null {
   }, [isHeaderCompressed, updateSectionScrollOffset])
 
   useEffect(() => {
-    const element = headerRef.current
+    const element = vaultHeaderStackRef.current ?? headerRef.current
     if (!element || typeof ResizeObserver === 'undefined') return
 
     let frame = 0
@@ -1778,6 +1784,29 @@ function Index(): ReactElement | null {
     )
   }
 
+  function renderDrawerActionButtons(): ReactElement {
+    return (
+      <div className={'flex w-full gap-3'}>
+        <button
+          type={'button'}
+          onClick={() => handleFloatingButtonClick(widgetActions[0])}
+          className={'yearn--button--nextgen flex-1'}
+          data-variant={'filled'}
+        >
+          {widgetActions[0] === WidgetActionType.Migrate ? 'Migrate' : 'Deposit'}
+        </button>
+        <button
+          type={'button'}
+          onClick={() => handleFloatingButtonClick(widgetActions[1])}
+          className={'yearn--button flex-1 border-border! hover:border-border-hover!'}
+          data-variant={'light'}
+        >
+          {'Withdraw'}
+        </button>
+      </div>
+    )
+  }
+
   return (
     <div
       className={
@@ -1816,39 +1845,60 @@ function Index(): ReactElement | null {
           </div>
         ) : null}
 
-        <header
-          className={cl(
-            'h-full rounded-3xl',
-            'relative flex-col items-center justify-center',
-            'hidden md:flex',
-            'md:sticky md:z-30'
-          )}
+        {shouldRenderCompactHeaderBanner ? (
+          <div className={'hidden md:block'}>
+            <Breadcrumbs
+              className={'mb-3'}
+              items={[
+                { label: 'Home', href: '/' },
+                { label: 'Vaults', href: '/vaults' },
+                { label: `${getVaultName(currentVault)}`, isCurrent: true }
+              ]}
+            />
+          </div>
+        ) : null}
+
+        <div
+          ref={vaultHeaderStackRef}
+          className={'relative md:sticky md:z-30 md:bg-app'}
           style={{ top: headerStickyTop }}
-          ref={headerRef}
         >
-          <VaultDetailsHeader
-            currentVault={currentVault}
-            depositedValue={vaultUserData.depositedValue}
-            yvUsdApyVariant={yvUsdApyVariant}
-            isCollapsibleMode={isCollapsibleMode}
-            sectionTabs={sectionTabs}
-            activeSectionKey={activeSection}
-            onSelectSection={(key): void => handleSelectSection(key as SectionKey)}
-            sectionSelectorRef={sectionSelectorRef}
-            widgetActions={widgetActions}
-            widgetMode={resolvedWidgetMode}
-            onWidgetModeChange={handleWidgetModeChange}
-            onYvUsdApyVariantChange={setYvUsdApyVariant}
-            isWidgetWalletOpen={isWidgetWalletOpen}
-            onWidgetWalletOpen={openWidgetWallet}
-            onWidgetCloseOverlays={closeWidgetOverlays}
-            onCompressionChange={setIsHeaderCompressed}
-            onCompressionStateChange={({ isCompressed, isForceCompressed }): void => {
-              setIsHeaderCompressed(isCompressed)
-              setIsHeaderAutoCompressed(isForceCompressed)
-            }}
-          />
-        </header>
+          <header
+            className={cl('h-full rounded-3xl', 'relative flex-col items-center justify-center', 'hidden md:flex')}
+            ref={headerRef}
+          >
+            <VaultDetailsHeader
+              currentVault={currentVault}
+              depositedValue={vaultUserData.depositedValue}
+              yvUsdApyVariant={yvUsdApyVariant}
+              isCollapsibleMode={isCollapsibleMode}
+              sectionTabs={sectionTabs}
+              activeSectionKey={activeSection}
+              onSelectSection={(key): void => handleSelectSection(key as SectionKey)}
+              sectionSelectorRef={sectionSelectorRef}
+              widgetActions={widgetActions}
+              widgetMode={resolvedWidgetMode}
+              onWidgetModeChange={handleWidgetModeChange}
+              onYvUsdApyVariantChange={setYvUsdApyVariant}
+              isWidgetWalletOpen={isWidgetWalletOpen}
+              onWidgetWalletOpen={openWidgetWallet}
+              onWidgetCloseOverlays={closeWidgetOverlays}
+              forceCompressed={isBelowDesktopWidgetBreakpoint}
+              hideBreadcrumbs={shouldRenderCompactHeaderBanner}
+              onCompressionChange={setIsHeaderCompressed}
+              onCompressionStateChange={({ isCompressed, isForceCompressed }): void => {
+                setIsHeaderCompressed(isCompressed)
+                setIsHeaderAutoCompressed(isForceCompressed)
+              }}
+            />
+          </header>
+
+          {isBelowDesktopWidgetBreakpoint ? (
+            <div className={'hidden pt-4 md:block'}>{renderDrawerActionButtons()}</div>
+          ) : null}
+        </div>
+
+        {shouldRenderCompactHeaderBanner ? <YvUsdHeaderBanner className={'mt-3 hidden min-h-26 md:flex'} /> : null}
 
         <div className="md:hidden md:mt-4 mb-4">
           <Breadcrumbs
@@ -2069,7 +2119,8 @@ function Index(): ReactElement | null {
                 section.key === 'risk' ||
                 section.key === 'strategies' ||
                 section.key === 'info'
-              const needsScaledYvUsdBanner = isYvUsd && isHeaderAutoCompressed && section.key === 'charts'
+              const needsScaledYvUsdBanner =
+                isYvUsd && isHeaderAutoCompressed && !isBelowDesktopWidgetBreakpoint && section.key === 'charts'
 
               const sectionNode = (() => {
                 if (isCollapsible) {
@@ -2139,33 +2190,16 @@ function Index(): ReactElement | null {
         </section>
       </div>
 
-      {/* Floating action buttons remain available until the fixed-width desktop widget appears. */}
+      {/* Phones retain the fixed action bar; compact desktop layouts render these actions inline above. */}
       {!isMobileDrawerOpen && (
         <div
           className={cl(
-            'fixed bottom-0 left-0 right-0 z-50 px-4 pt-4 min-[1100px]:hidden',
+            'fixed bottom-0 left-0 right-0 z-50 px-4 pt-4 md:hidden',
             'backdrop-blur-md',
             'pb-[calc(1rem+env(safe-area-inset-bottom,0px))]'
           )}
         >
-          <div className="flex gap-3 max-w-[1232px] mx-auto">
-            <button
-              type="button"
-              onClick={() => handleFloatingButtonClick(widgetActions[0])}
-              className="yearn--button--nextgen flex-1"
-              data-variant="filled"
-            >
-              {widgetActions[0] === WidgetActionType.Migrate ? 'Migrate' : 'Deposit'}
-            </button>
-            <button
-              type="button"
-              onClick={() => handleFloatingButtonClick(widgetActions[1])}
-              className="yearn--button flex-1"
-              data-variant="light"
-            >
-              Withdraw
-            </button>
-          </div>
+          <div className={'mx-auto max-w-[1232px]'}>{renderDrawerActionButtons()}</div>
         </div>
       )}
 

--- a/apps/yearn/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
+++ b/apps/yearn/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
@@ -412,6 +412,7 @@ function SectionSelectorBar({
   sectionSelectorRef,
   sectionTabs,
   isCompressed,
+  hasActionFooter = false,
   includeTourAttributes = true
 }: {
   activeSectionKey?: string
@@ -425,6 +426,7 @@ function SectionSelectorBar({
     notificationAriaLabel?: string
   }[]
   isCompressed: boolean
+  hasActionFooter?: boolean
   includeTourAttributes?: boolean
 }): ReactElement {
   return (
@@ -435,7 +437,8 @@ function SectionSelectorBar({
     >
       <div
         className={cl(
-          'flex w-full flex-wrap justify-between gap-2 rounded-b-lg border-border bg-surface-secondary p-1',
+          'flex w-full flex-wrap justify-between gap-2 border-border bg-surface-secondary p-1',
+          hasActionFooter ? 'rounded-none' : 'rounded-b-lg',
           isCompressed ? 'border-t' : 'border-x border-b'
         )}
       >
@@ -1111,6 +1114,7 @@ type TVaultDetailsHeaderBaseProps = {
   isWidgetWalletOpen?: boolean
   onWidgetCloseOverlays?: () => void
   hideBreadcrumbs?: boolean
+  hasActionFooter?: boolean
 }
 
 type TVaultDetailsHeaderPresentationProps = TVaultDetailsHeaderBaseProps & {
@@ -1134,6 +1138,7 @@ export function VaultDetailsHeaderPresentation({
   isWidgetWalletOpen,
   onWidgetCloseOverlays,
   hideBreadcrumbs = false,
+  hasActionFooter = false,
   isCompressed,
   includeTourAttributes = true
 }: TVaultDetailsHeaderPresentationProps): ReactElement {
@@ -1172,8 +1177,8 @@ export function VaultDetailsHeaderPresentation({
         <div className={cl('pt-4 min-[1100px]:col-start-1', hideBreadcrumbs ? 'md:row-start-1' : 'md:row-start-2')}>
           <div
             className={cl(
-              'rounded-lg border border-border bg-surface'
-              // 'border border-border',
+              'border border-border bg-surface',
+              hasActionFooter ? 'rounded-t-lg border-b-0' : 'rounded-lg'
             )}
           >
             <div className={'flex flex-col'}>
@@ -1202,6 +1207,7 @@ export function VaultDetailsHeaderPresentation({
                     sectionSelectorRef={sectionSelectorRef}
                     sectionTabs={sectionTabs}
                     isCompressed={isCompressed}
+                    hasActionFooter={hasActionFooter}
                     includeTourAttributes={includeTourAttributes}
                   />
                 </div>

--- a/apps/yearn/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
+++ b/apps/yearn/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
@@ -1157,11 +1157,11 @@ export function VaultDetailsHeaderPresentation({
   return (
     <div
       className={
-        'grid w-full grid-cols-1 gap-x-6 gap-y-0 rounded-lg bg-app text-left md:auto-rows-min min-[1100px]:grid-cols-[minmax(0,1fr)_408px]'
+        'grid w-full grid-cols-1 gap-x-6 gap-y-0 rounded-lg bg-app text-left md:auto-rows-min min-[1101px]:grid-cols-[minmax(0,1fr)_408px]'
       }
     >
       {!hideBreadcrumbs ? (
-        <div className={'hidden items-center gap-2 px-1 text-sm text-text-secondary md:flex min-[1100px]:col-span-2'}>
+        <div className={'hidden items-center gap-2 px-1 text-sm text-text-secondary md:flex min-[1101px]:col-span-2'}>
           <a href={'/'} className={'transition-colors hover:text-text-primary'}>
             {'Home'}
           </a>
@@ -1174,7 +1174,7 @@ export function VaultDetailsHeaderPresentation({
         </div>
       ) : null}
       {isCompressed ? (
-        <div className={cl('pt-4 min-[1100px]:col-start-1', hideBreadcrumbs ? 'md:row-start-1' : 'md:row-start-2')}>
+        <div className={cl('pt-4 min-[1101px]:col-start-1', hideBreadcrumbs ? 'md:row-start-1' : 'md:row-start-2')}>
           <div
             className={cl(
               'border border-border bg-surface',
@@ -1218,7 +1218,7 @@ export function VaultDetailsHeaderPresentation({
       ) : (
         <>
           {isYvUsd ? (
-            <div className={'md:row-start-2 md:flex md:items-stretch md:gap-6 min-[1100px]:col-span-2'}>
+            <div className={'md:row-start-2 md:flex md:items-stretch md:gap-6 min-[1101px]:col-span-2'}>
               <VaultHeaderIdentity
                 currentVault={currentVault}
                 isCompressed={isCompressed}
@@ -1233,11 +1233,11 @@ export function VaultDetailsHeaderPresentation({
             <VaultHeaderIdentity
               currentVault={currentVault}
               isCompressed={isCompressed}
-              className={'md:row-start-2 min-[1100px]:col-span-2'}
+              className={'md:row-start-2 min-[1101px]:col-span-2'}
               includeTourAttributes={includeTourAttributes}
             />
           )}
-          <div className={'md:row-start-3 min-[1100px]:col-start-1'}>
+          <div className={'md:row-start-3 min-[1101px]:col-start-1'}>
             {' '}
             {/* step 2 should be here*/}
             <div className={'flex flex-col'}>
@@ -1267,8 +1267,8 @@ export function VaultDetailsHeaderPresentation({
 
       <div
         className={cl(
-          'hidden flex-col pt-4 min-[1100px]:col-start-2 min-[1100px]:flex',
-          isCompressed ? 'min-[1100px]:row-start-2' : 'min-[1100px]:row-start-3'
+          'hidden flex-col pt-4 min-[1101px]:col-start-2 min-[1101px]:flex',
+          isCompressed ? 'min-[1101px]:row-start-2' : 'min-[1101px]:row-start-3'
         )}
       >
         {' '}

--- a/apps/yearn/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
+++ b/apps/yearn/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
@@ -1110,6 +1110,7 @@ type TVaultDetailsHeaderBaseProps = {
   onWidgetWalletOpen?: () => void
   isWidgetWalletOpen?: boolean
   onWidgetCloseOverlays?: () => void
+  hideBreadcrumbs?: boolean
 }
 
 type TVaultDetailsHeaderPresentationProps = TVaultDetailsHeaderBaseProps & {
@@ -1132,6 +1133,7 @@ export function VaultDetailsHeaderPresentation({
   onWidgetWalletOpen,
   isWidgetWalletOpen,
   onWidgetCloseOverlays,
+  hideBreadcrumbs = false,
   isCompressed,
   includeTourAttributes = true
 }: TVaultDetailsHeaderPresentationProps): ReactElement {
@@ -1153,19 +1155,21 @@ export function VaultDetailsHeaderPresentation({
         'grid w-full grid-cols-1 gap-x-6 gap-y-0 rounded-lg bg-app text-left md:auto-rows-min min-[1100px]:grid-cols-[minmax(0,1fr)_408px]'
       }
     >
-      <div className={'hidden items-center gap-2 px-1 text-sm text-text-secondary md:flex min-[1100px]:col-span-2'}>
-        <a href={'/'} className={'transition-colors hover:text-text-primary'}>
-          {'Home'}
-        </a>
-        <span>{'>'}</span>
-        <Link href={'/v3'} className={'transition-colors hover:text-text-primary'}>
-          {'Vaults'}
-        </Link>
-        <span>{'>'}</span>
-        <span className={'font-medium text-text-primary'}>{getVaultName(currentVault)}</span>
-      </div>
+      {!hideBreadcrumbs ? (
+        <div className={'hidden items-center gap-2 px-1 text-sm text-text-secondary md:flex min-[1100px]:col-span-2'}>
+          <a href={'/'} className={'transition-colors hover:text-text-primary'}>
+            {'Home'}
+          </a>
+          <span>{'>'}</span>
+          <Link href={'/v3'} className={'transition-colors hover:text-text-primary'}>
+            {'Vaults'}
+          </Link>
+          <span>{'>'}</span>
+          <span className={'font-medium text-text-primary'}>{getVaultName(currentVault)}</span>
+        </div>
+      ) : null}
       {isCompressed ? (
-        <div className={'pt-4 md:row-start-2 min-[1100px]:col-start-1'}>
+        <div className={cl('pt-4 min-[1100px]:col-start-1', hideBreadcrumbs ? 'md:row-start-1' : 'md:row-start-2')}>
           <div
             className={cl(
               'rounded-lg border border-border bg-surface'
@@ -1290,21 +1294,27 @@ export function VaultDetailsHeaderPresentation({
 
 export function VaultDetailsHeader({
   isCollapsibleMode = true,
+  forceCompressed = false,
   onCompressionChange,
   onCompressionStateChange,
   ...presentationProps
 }: TVaultDetailsHeaderBaseProps & {
   isCollapsibleMode?: boolean
+  forceCompressed?: boolean
   onCompressionChange?: (isCompressed: boolean) => void
   onCompressionStateChange?: (state: { isCompressed: boolean; isForceCompressed: boolean }) => void
 }): ReactElement {
-  const [forceCompressed, setForceCompressed] = useState(false)
-  const { isCompressed } = useHeaderCompression({ enabled: isCollapsibleMode, forceCompressed })
+  const [forceCompressedByHeight, setForceCompressedByHeight] = useState(false)
+  const shouldForceCompressed = forceCompressed || forceCompressedByHeight
+  const { isCompressed } = useHeaderCompression({
+    enabled: isCollapsibleMode,
+    forceCompressed: shouldForceCompressed
+  })
 
   useEffect(() => {
     if (typeof window === 'undefined') return
     const updateViewport = (): void => {
-      setForceCompressed(window.innerHeight < 890)
+      setForceCompressedByHeight(window.innerHeight < 890)
     }
     updateViewport()
     window.addEventListener('resize', updateViewport)
@@ -1316,8 +1326,8 @@ export function VaultDetailsHeader({
   }, [isCompressed, onCompressionChange])
 
   useEffect(() => {
-    onCompressionStateChange?.({ isCompressed, isForceCompressed: forceCompressed })
-  }, [isCompressed, forceCompressed, onCompressionStateChange])
+    onCompressionStateChange?.({ isCompressed, isForceCompressed: shouldForceCompressed })
+  }, [isCompressed, onCompressionStateChange, shouldForceCompressed])
 
   return <VaultDetailsHeaderPresentation {...presentationProps} isCompressed={isCompressed} />
 }

--- a/apps/yearn/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
+++ b/apps/yearn/src/components/pages/vaults/components/detail/VaultDetailsHeader.tsx
@@ -1149,9 +1149,11 @@ export function VaultDetailsHeaderPresentation({
 
   return (
     <div
-      className={'grid w-full grid-cols-1 gap-y-0 gap-x-6 text-left md:auto-rows-min md:grid-cols-20 bg-app rounded-lg'}
+      className={
+        'grid w-full grid-cols-1 gap-x-6 gap-y-0 rounded-lg bg-app text-left md:auto-rows-min min-[1100px]:grid-cols-[minmax(0,1fr)_408px]'
+      }
     >
-      <div className={'hidden md:flex items-center gap-2 text-sm text-text-secondary md:col-span-20 px-1'}>
+      <div className={'hidden items-center gap-2 px-1 text-sm text-text-secondary md:flex min-[1100px]:col-span-2'}>
         <a href={'/'} className={'transition-colors hover:text-text-primary'}>
           {'Home'}
         </a>
@@ -1163,7 +1165,7 @@ export function VaultDetailsHeaderPresentation({
         <span className={'font-medium text-text-primary'}>{getVaultName(currentVault)}</span>
       </div>
       {isCompressed ? (
-        <div className={'md:col-span-13 md:row-start-2 pt-4'}>
+        <div className={'pt-4 md:row-start-2 min-[1100px]:col-start-1'}>
           <div
             className={cl(
               'rounded-lg border border-border bg-surface'
@@ -1206,7 +1208,7 @@ export function VaultDetailsHeaderPresentation({
       ) : (
         <>
           {isYvUsd ? (
-            <div className={'md:col-span-20 md:row-start-2 md:flex md:items-stretch md:gap-6'}>
+            <div className={'md:row-start-2 md:flex md:items-stretch md:gap-6 min-[1100px]:col-span-2'}>
               <VaultHeaderIdentity
                 currentVault={currentVault}
                 isCompressed={isCompressed}
@@ -1221,11 +1223,11 @@ export function VaultDetailsHeaderPresentation({
             <VaultHeaderIdentity
               currentVault={currentVault}
               isCompressed={isCompressed}
-              className={'md:col-span-20 md:row-start-2'}
+              className={'md:row-start-2 min-[1100px]:col-span-2'}
               includeTourAttributes={includeTourAttributes}
             />
           )}
-          <div className={cl('md:col-span-13 md:row-start-3')}>
+          <div className={'md:row-start-3 min-[1100px]:col-start-1'}>
             {' '}
             {/* step 2 should be here*/}
             <div className={'flex flex-col'}>
@@ -1255,8 +1257,8 @@ export function VaultDetailsHeaderPresentation({
 
       <div
         className={cl(
-          'flex flex-col pt-4',
-          isCompressed ? 'md:col-span-7 md:col-start-14 md:row-start-2' : 'md:col-span-7 md:col-start-14 md:row-start-3'
+          'hidden flex-col pt-4 min-[1100px]:col-start-2 min-[1100px]:flex',
+          isCompressed ? 'min-[1100px]:row-start-2' : 'min-[1100px]:row-start-3'
         )}
       >
         {' '}


### PR DESCRIPTION
### Summary
At narrower desktop widths, the vault widget and main column compete for space. This keeps the desktop widget fixed at 408px on larger screens and switches to a compact sticky header with Deposit and Withdraw actions at 1100px and below.

The yvUSD banner now sits below the compact actions, and the phone action bar keeps its existing styling.

### How to review
Start with the responsive layout in `src/components/pages/vaults/[chainID]/[address].tsx`, then review the connected header styling in `VaultDetailsHeader.tsx`.

- At 1100px, confirm the compact header and action footer are visible and the desktop widget is hidden.
- At 1101px and above, confirm the widget is 408px wide and the main column uses the remaining width.
- Confirm the compact header, navigation, and actions stay sticky while scrolling.
- On yvUSD, confirm the order is header, actions, banner, then charts.
- Below 768px, confirm the existing fixed phone action bar is unchanged.

### Test plan
- [x] Manual: Checked 767px, 768px, 1100px, 1101px, and 1250px with Playwright.
- [x] Manual: Verified Deposit and Withdraw open the correct drawer mode.
- [x] Automated: `bun run lint`
- [x] Automated: `bun run tslint`
- [x] Automated: Focused vault header, widget sizing, and yvUSD banner tests (12 passed).
- [x] Automated: `bun run build`

### Risk / impact
This changes responsive layout and sticky positioning on vault detail pages. It does not change transaction or funds-moving logic. Reverting this PR restores the previous breakpoints and layout.