### PR TITLE
Fix portfolio growth continuity

### DIFF
--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -640,8 +640,7 @@ export function PortfolioHistoryChart({
     return rebaseDeltaPoints(
       points.map((point) => ({
         date: point.date,
-        value: point.growthUsd,
-        isEstimated: point.growthUsdEstimated
+        value: point.growthWeightUsd
       }))
     )
   }, [protocolReturnData, timeframe])

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
@@ -40,20 +40,59 @@ describe('buildPortfolioGrowthContributionChart', () => {
   it('selects the matching per-vault value for USD and ETH modes', () => {
     const point = {
       timestamp: timestamp('2026-01-01'),
-      growthUsd: 25,
+      growthUsd: -75,
       growthUsdEstimated: true,
+      growthWeightUsd: 25,
       growthWeightEth: 0.01
     }
 
     expect(toPortfolioGrowthContributionPoint(point, 'usd')).toEqual({
       timestamp: point.timestamp,
-      value: 25,
-      isEstimated: true
+      value: 25
     })
     expect(toPortfolioGrowthContributionPoint(point, 'eth')).toEqual({
       timestamp: point.timestamp,
       value: 0.01
     })
+  })
+
+  it('keeps USD contributions continuous when an exit changes mark-to-market valuation', () => {
+    const rawPoints = [
+      {
+        timestamp: timestamp('2026-02-08'),
+        growthUsd: 34_172,
+        growthUsdEstimated: true,
+        growthWeightUsd: 29_557,
+        growthWeightEth: 8.59
+      },
+      {
+        timestamp: timestamp('2026-02-09'),
+        growthUsd: 24_280,
+        growthUsdEstimated: true,
+        growthWeightUsd: 29_562,
+        growthWeightEth: 8.6
+      }
+    ]
+    const chart = buildPortfolioGrowthContributionChart({
+      totalPoints: [
+        { date: '2026-02-08', value: 0 },
+        { date: '2026-02-09', value: 5 }
+      ],
+      familySeries: [
+        {
+          chainId: 1,
+          vaultAddress: '0x0000000000000000000000000000000000000001',
+          label: 'Volatile vault',
+          dataPoints: rawPoints.map((point) => toPortfolioGrowthContributionPoint(point, 'usd'))
+        }
+      ]
+    })
+
+    expect(chart.data.map((point) => [point.portfolioGrowth, point.vault_0, point.other])).toEqual([
+      [0, 0, 0],
+      [5, 5, 0]
+    ])
+    expectConservation(chart)
   })
 
   it('keeps the top four vaults and puts the remaining contribution in Other', () => {

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
@@ -38,14 +38,14 @@ export function toPortfolioGrowthContributionPoint(
     timestamp: number
     growthUsd: number | null
     growthUsdEstimated: boolean
+    growthWeightUsd: number | null
     growthWeightEth: number | null
   },
   mode: 'usd' | 'eth'
 ): TPortfolioGrowthContributionFamily['dataPoints'][number] {
   return {
     timestamp: point.timestamp,
-    value: mode === 'eth' ? point.growthWeightEth : point.growthUsd,
-    ...(mode === 'usd' ? { isEstimated: point.growthUsdEstimated } : {})
+    value: mode === 'eth' ? point.growthWeightEth : point.growthWeightUsd
   }
 }
 

--- a/apps/yearn/src/server/lib/holdings/README.md
+++ b/apps/yearn/src/server/lib/holdings/README.md
@@ -184,7 +184,7 @@ Keys:
 
 - `holdings:wallet-events:*`: combined wallet event history.
 - `holdings:totals:v3:<walletHash>`: aggregate settled USD totals by date.
-- `holdings:protocol-return-history:v13:<walletHash>:<timeframe>:<vaultScope>`: compressed protocol-return and Growth snapshot.
+- `holdings:protocol-return-history:v14:<walletHash>:<timeframe>:<vaultScope>`: compressed protocol-return and Growth snapshot.
 - `holdings:vault-invalidated:<chainId>:<vaultAddress>`: lazy invalidation timestamp.
 - `holdings:progress:*`: short-lived route progress.
 

--- a/apps/yearn/src/server/lib/holdings/services/cache.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.test.ts
@@ -98,7 +98,7 @@ describe('protocol return history snapshot cache', () => {
     const savedValue = setMock.mock.calls[0]?.[1]
 
     expect(saved).toBe(true)
-    expect(key).toMatch(/^holdings:protocol-return-history:v13:[a-f0-9]{64}:1y:all$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v14:[a-f0-9]{64}:1y:all$/)
     expect(key).not.toContain(identity.userAddress)
     expect(savedValue).toEqual(expect.stringMatching(/^br1:/))
     expect(savedValue).not.toContain('2026-07-15')
@@ -202,7 +202,7 @@ describe('protocol return history snapshot cache', () => {
     const key = getProtocolReturnHistoryCacheKey(identity)
 
     expect(key).toBe(getProtocolReturnHistoryCacheKey(reversedIdentity))
-    expect(key).toMatch(/^holdings:protocol-return-history:v13:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v14:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
     expect(key).not.toContain(identity.vaultScope[0].address)
   })
 

--- a/apps/yearn/src/server/lib/holdings/services/cache.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.ts
@@ -34,8 +34,8 @@ const HOLDINGS_TOTALS_TTL_SECONDS = 30 * 24 * 60 * 60
 // Old hashes expire naturally and cannot reintroduce previously cached incomplete days.
 const HOLDINGS_TOTALS_KEY_PREFIX = 'holdings:totals:v3'
 const PROTOCOL_RETURN_HISTORY_TTL_SECONDS = 30 * 24 * 60 * 60
-// v13 retains enough compact vault-family candidates for eight-vault growth charts.
-const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v13'
+// v14 ranks compact vault-family candidates by receipt-weighted USD growth.
+const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v14'
 const PROTOCOL_RETURN_HISTORY_VALUE_PREFIX = 'br1:'
 const PROTOCOL_RETURN_HISTORY_MAX_ENCODED_BYTES = 4 * 1024 * 1024
 const PROTOCOL_RETURN_HISTORY_MAX_DECODED_BYTES = 64 * 1024 * 1024

--- a/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.test.ts
@@ -27,7 +27,7 @@ function buildIsolatedSeries(args: { id: string; mode: TMode; window: TWindow; s
       timestamp: index,
       protocolReturnPct: 123,
       growthUsd: args.mode === 'position' ? (index === windowStartIndex ? 0 : args.score) : null,
-      growthWeightUsd: args.mode === 'position' ? args.score * 100 : null,
+      growthWeightUsd: args.mode === 'position' ? (index === windowStartIndex ? 0 : args.score * 100) : null,
       growthWeightEth: args.mode === 'eth' ? (index === windowStartIndex ? 0 : args.score) : null,
       growthIndex: args.mode === 'index' ? (index === windowStartIndex ? 100 : 100 + args.score) : null
     }))
@@ -105,7 +105,7 @@ describe('selectProtocolReturnFamilySeriesCandidates', () => {
     })
   })
 
-  it('ranks position candidates by latest-price growth instead of receipt-weighted growth', () => {
+  it('ranks USD position candidates by receipt-weighted growth', () => {
     const familySeries = Array.from({ length: 20 }, (_, index) => ({
       chainId: 1,
       vaultAddress: `latest-price-${index}`,
@@ -124,9 +124,10 @@ describe('selectProtocolReturnFamilySeriesCandidates', () => {
     }))
 
     const selected = selectProtocolReturnFamilySeriesCandidates(familySeries, '1y')
+    const selectedAddresses = selected.map((series) => series.vaultAddress)
 
-    expect(selected.map((series) => series.vaultAddress)).toContain('latest-price-19')
-    expect(selected.map((series) => series.vaultAddress)).not.toContain('latest-price-10')
+    expect(selectedAddresses).toContain('latest-price-10')
+    expect(selectedAddresses).not.toContain('latest-price-12')
   })
 
   it('keeps candidates that are relevant only to receipt-weighted ETH growth', () => {

--- a/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.ts
+++ b/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.ts
@@ -52,7 +52,7 @@ function isFiniteNumber(value: unknown): value is number {
 
 function buildPositionRankPoints(
   points: TProtocolReturnFamilyPoint[],
-  valueKey: 'growthUsd' | 'growthWeightEth'
+  valueKey: 'growthWeightUsd' | 'growthWeightEth'
 ): Array<{ value: number | null }> {
   const firstFiniteIndex = points.findIndex((point) => isFiniteNumber(point[valueKey]))
   if (firstFiniteIndex < 0 || points.length - firstFiniteIndex < 2) {
@@ -99,7 +99,7 @@ export function selectProtocolReturnFamilySeriesCandidates<TSeries extends TProt
         const points = limit >= series.sortedPoints.length ? series.sortedPoints : series.sortedPoints.slice(-limit)
         return {
           originalIndex: series.originalIndex,
-          positionPoints: buildPositionRankPoints(points, 'growthUsd'),
+          positionPoints: buildPositionRankPoints(points, 'growthWeightUsd'),
           ethPoints: buildPositionRankPoints(points, 'growthWeightEth'),
           indexPoints: buildIndexRankPoints(points)
         }


### PR DESCRIPTION
### Summary
The Portfolio Growth chart could show an artificial USD drop when a user exited a volatile vault. Use receipt-weighted USD growth for both the portfolio total and each vault contribution so the chart keeps one valuation basis across the full period.

### How to review
Review the USD field selection in `PortfolioHistoryChart.tsx`, then check the matching per-vault selection and regression test in `portfolioGrowthContributions.ts`.

### Test plan
- [x] Manual: Replayed the reported wallet data and confirmed growth moves from $4,254.97 to $4,259.62 across February 8-9 instead of dropping below zero.
- [x] Automated: `bun run --cwd apps/yearn test -- src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts src/components/pages/portfolio/utils/portfolioGrowthIndexComparison.test.ts src/components/pages/portfolio/hooks/usePortfolioHistory.test.ts`
- [x] Automated: `bun run tslint`
- [x] Automated: `bun run lint:fix`
- [x] Automated: `bun run build`

### Risk / impact
This changes only the USD series selected for the Portfolio Growth chart. It does not change the portfolio ledger, API calculations, deposits, withdrawals, or funds. Reverting this commit restores the previous display behavior.

### Screenshots

Before:
<img width="883" height="354" alt="Screenshot 2026-09-04 104157" src="https://github.com/user-attachments/assets/66506231-8a03-4992-9e4f-48ac91de24fb" />

After:
<img width="840" height="322" alt="Screenshot 2026-09-04 111653" src="https://github.com/user-attachments/assets/a62df845-efcb-40b3-b865-889fb436e94b" />
