### PR TITLE
Restore additive portfolio growth charts

### DIFF
--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.test.ts
@@ -10,7 +10,11 @@ describe('getPortfolioGrowthStackDomain', () => {
   })
 
   it('uses 100 as the visible floor for Index attribution', () => {
-    expect(getPortfolioGrowthStackDomain([0, 100, 135], 100)).toEqual([100, 136.75])
+    expect(getPortfolioGrowthStackDomain([100, 135], 100)).toEqual([100, 136.75])
+  })
+
+  it('includes Index attribution losses below 100', () => {
+    expect(getPortfolioGrowthStackDomain([90, 100], 100)).toEqual([89.5, 101])
   })
 })
 

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.test.ts
@@ -1,15 +1,8 @@
-import { getPortfolioGrowthLineDomain } from '@pages/portfolio/components/PortfolioGrowthContributionsChart'
-import type { TPortfolioGrowthContributionChartPoint } from '@pages/portfolio/utils/portfolioGrowthContributions'
+import { getPortfolioGrowthStackDomain } from '@pages/portfolio/components/PortfolioGrowthContributionsChart'
 import { describe, expect, it } from 'vitest'
 
-describe('getPortfolioGrowthLineDomain', () => {
-  it('scales independent mixed-sign lines instead of their stack', () => {
-    const data: TPortfolioGrowthContributionChartPoint[] = [
-      { date: '2026-01-01', portfolioGrowth: 10, vault_0: 100, vault_1: 50, vault_2: -140 }
-    ]
-
-    expect(getPortfolioGrowthLineDomain(data, [{ key: 'vault_0' }, { key: 'vault_1' }, { key: 'vault_2' }])).toEqual([
-      -147, 105
-    ])
+describe('getPortfolioGrowthStackDomain', () => {
+  it('includes intermediate mixed-sign band boundaries', () => {
+    expect(getPortfolioGrowthStackDomain([-90, 0, 10, 100])).toEqual([-94.5, 105])
   })
 })

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.test.ts
@@ -1,4 +1,7 @@
-import { getPortfolioGrowthStackDomain } from '@pages/portfolio/components/PortfolioGrowthContributionsChart'
+import {
+  buildPortfolioGrowthVaultColorMap,
+  getPortfolioGrowthStackDomain
+} from '@pages/portfolio/components/PortfolioGrowthContributionsChart'
 import { describe, expect, it } from 'vitest'
 
 describe('getPortfolioGrowthStackDomain', () => {
@@ -8,5 +11,20 @@ describe('getPortfolioGrowthStackDomain', () => {
 
   it('uses 100 as the visible floor for Index attribution', () => {
     expect(getPortfolioGrowthStackDomain([0, 100, 135], 100)).toEqual([100, 136.75])
+  })
+})
+
+describe('buildPortfolioGrowthVaultColorMap', () => {
+  it('keeps vault colors stable when contribution ranking changes', () => {
+    const firstVault = { chainId: 1, vaultAddress: '0xa89e83e39c8a1cb173d7a0c0201cd3956b57db6d' }
+    const secondVault = { chainId: 1, vaultAddress: '0xbf319ddc2edc1eb6fdf9910e39b37be221c8805f' }
+    const rankedFirst = buildPortfolioGrowthVaultColorMap([firstVault, secondVault])
+    const rankedSecond = buildPortfolioGrowthVaultColorMap([
+      { ...secondVault, vaultAddress: secondVault.vaultAddress.toUpperCase() },
+      firstVault
+    ])
+
+    expect(rankedFirst).toEqual(rankedSecond)
+    expect(new Set(rankedFirst.values())).toHaveLength(2)
   })
 })

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.test.ts
@@ -5,4 +5,8 @@ describe('getPortfolioGrowthStackDomain', () => {
   it('includes intermediate mixed-sign band boundaries', () => {
     expect(getPortfolioGrowthStackDomain([-90, 0, 10, 100])).toEqual([-94.5, 105])
   })
+
+  it('uses 100 as the visible floor for Index attribution', () => {
+    expect(getPortfolioGrowthStackDomain([0, 100, 135], 100)).toEqual([100, 136.75])
+  })
 })

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
@@ -141,8 +141,12 @@ function formatGrowthTick(value: number | string, mode: 'usd' | 'eth' | 'index')
 
 export function getPortfolioGrowthStackDomain(values: number[], floor?: number): AxisDomain {
   if (floor !== undefined) {
+    const minimum = Math.min(floor, ...values)
     const maximum = Math.max(floor, ...values)
-    return [floor, maximum > floor ? floor + (maximum - floor) * LINE_HEADROOM : floor + 1]
+    return [
+      minimum < floor ? floor - (floor - minimum) * LINE_HEADROOM : floor,
+      maximum > floor ? floor + (maximum - floor) * LINE_HEADROOM : floor + 1
+    ]
   }
 
   const bounds = values.reduce(

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
@@ -30,7 +30,7 @@ type TPortfolioGrowthContributionsChartProps = {
   totalPoints: Array<{ date: string; value: number | null; isEstimated?: boolean }>
   familySeries: TPortfolioGrowthContributionFamily[]
   timeframe: TPortfolioHistoryChartTimeframe
-  mode: 'usd' | 'eth'
+  mode: 'usd' | 'eth' | 'index'
 }
 
 type TTooltipProps = {
@@ -56,6 +56,7 @@ const CONTRIBUTION_COLORS = [
   '#94adf2'
 ] as const
 const OTHER_COLOR = '#94a3b8'
+const INDEX_BASE_COLOR = '#80b7f4'
 const TOTAL_COLOR = '#2578ff'
 const LINE_HEADROOM = 1.05
 const CHART_MARGIN = {
@@ -75,8 +76,17 @@ function formatEthValue(value: number): string {
   return `${formattedValue} ETH`
 }
 
-function formatSignedGrowth(value: number, mode: 'usd' | 'eth', isEstimated = false): string {
-  const formatted = mode === 'eth' ? formatEthValue(value) : formatUSD(Math.abs(value), 2, 2)
+function formatIndexValue(value: number): string {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2 })
+}
+
+function formatSignedGrowth(value: number, mode: 'usd' | 'eth' | 'index', isEstimated = false): string {
+  const formatted =
+    mode === 'eth'
+      ? formatEthValue(value)
+      : mode === 'index'
+        ? formatIndexValue(Math.abs(value))
+        : formatUSD(Math.abs(value), 2, 2)
   const estimateSuffix = isEstimated ? '*' : ''
   if (value > 0) {
     return `+${formatted}${estimateSuffix}`
@@ -87,14 +97,17 @@ function formatSignedGrowth(value: number, mode: 'usd' | 'eth', isEstimated = fa
   return `${formatted}${estimateSuffix}`
 }
 
-function formatGrowthTick(value: number | string, mode: 'usd' | 'eth'): string {
+function formatGrowthTick(value: number | string, mode: 'usd' | 'eth' | 'index'): string {
   const numericValue = Number(value)
   const absoluteValue = Math.abs(numericValue)
   if (!Number.isFinite(numericValue)) {
     return ''
   }
   if (numericValue === 0) {
-    return mode === 'eth' ? '0' : '$0'
+    return mode === 'usd' ? '$0' : '0'
+  }
+  if (mode === 'index') {
+    return formatIndexValue(numericValue)
   }
   if (mode === 'eth') {
     if (absoluteValue >= 1_000) {
@@ -115,23 +128,9 @@ function formatGrowthTick(value: number | string, mode: 'usd' | 'eth'): string {
   return `${numericValue < 0 ? '−' : ''}$${absoluteValue.toFixed(0)}`
 }
 
-export function getPortfolioGrowthLineDomain(
-  data: TPortfolioGrowthContributionChartPoint[],
-  series: Array<Pick<TPresentedContributionSeries, 'key'>>
-): AxisDomain {
-  const dataKeys = ['portfolioGrowth', ...series.map((item) => item.key)]
-  const bounds = data.reduce(
-    (result, point) => {
-      return dataKeys.reduce((nextBounds, dataKey) => {
-        const value = point[dataKey]
-        if (typeof value !== 'number' || !Number.isFinite(value)) {
-          return nextBounds
-        }
-        nextBounds.min = Math.min(nextBounds.min, value)
-        nextBounds.max = Math.max(nextBounds.max, value)
-        return nextBounds
-      }, result)
-    },
+export function getPortfolioGrowthStackDomain(values: number[]): AxisDomain {
+  const bounds = values.reduce(
+    (result, value) => ({ min: Math.min(result.min, value), max: Math.max(result.max, value) }),
     { min: 0, max: 0 }
   )
 
@@ -149,7 +148,7 @@ function PortfolioGrowthContributionsTooltip({
   mode
 }: TTooltipProps & {
   series: TPresentedContributionSeries[]
-  mode: 'usd' | 'eth'
+  mode: 'usd' | 'eth' | 'index'
 }): ReactElement | null {
   if (!active || !payload?.length) {
     return null
@@ -160,8 +159,14 @@ function PortfolioGrowthContributionsTooltip({
     return null
   }
 
+  const baseRows = series
+    .filter((item) => item.isBase)
+    .flatMap((item) => {
+      const value = point[item.key]
+      return typeof value === 'number' && Number.isFinite(value) ? [{ ...item, value, isEstimated: false }] : []
+    })
   const namedRows = series
-    .filter((item) => !item.isOther)
+    .filter((item) => !item.isOther && !item.isBase)
     .flatMap((item) => {
       const value = point[item.key]
       return typeof value === 'number' && Number.isFinite(value)
@@ -174,6 +179,7 @@ function PortfolioGrowthContributionsTooltip({
   const rows =
     otherSeries && typeof otherValue === 'number' && Number.isFinite(otherValue)
       ? [
+          ...baseRows,
           ...namedRows,
           {
             ...otherSeries,
@@ -181,7 +187,7 @@ function PortfolioGrowthContributionsTooltip({
             isEstimated: Boolean(point[`${otherSeries.key}Estimated`])
           }
         ]
-      : namedRows
+      : [...baseRows, ...namedRows]
   const hasEstimatedValue = Boolean(point.portfolioGrowthEstimated) || rows.some((row) => row.isEstimated)
 
   return (
@@ -194,14 +200,18 @@ function PortfolioGrowthContributionsTooltip({
         {formatChartTooltipDate(point.date)}
       </span>
       <div className={'mt-1 flex items-center justify-between gap-5'}>
-        <span className={'text-xs text-text-secondary'}>{'Portfolio growth'}</span>
+        <span className={'text-xs text-text-secondary'}>
+          {mode === 'index' ? 'Portfolio index' : 'Portfolio growth'}
+        </span>
         <strong className={'font-number text-sm font-semibold text-text-primary'}>
-          {formatSignedGrowth(point.portfolioGrowth, mode, Boolean(point.portfolioGrowthEstimated))}
+          {mode === 'index'
+            ? formatIndexValue(point.portfolioGrowth)
+            : formatSignedGrowth(point.portfolioGrowth, mode, Boolean(point.portfolioGrowthEstimated))}
         </strong>
       </div>
       <div className={'my-1.5 border-t border-border'} />
       <span className={'text-[11px] font-medium uppercase tracking-[0.12em] text-text-tertiary'}>
-        {'Vault contributions'}
+        {mode === 'index' ? 'Index attribution' : 'Vault contributions'}
       </span>
       <div className={'mt-1 flex flex-col gap-0.5'}>
         {rows.map((row) => (
@@ -237,7 +247,10 @@ export function PortfolioGrowthContributionsChart({
         totalPoints,
         familySeries,
         maxVaults: MAX_VAULTS,
-        preserveNullValues: mode === 'eth'
+        preserveNullValues: mode === 'eth',
+        ...(mode === 'index'
+          ? { baseContribution: { key: 'starting_index', label: 'Starting index', value: 100 } }
+          : {})
       }),
     [familySeries, mode, totalPoints]
   )
@@ -245,23 +258,29 @@ export function PortfolioGrowthContributionsChart({
     () =>
       contributionChart.series.map((item, index) => ({
         ...item,
-        color: item.isOther ? OTHER_COLOR : (CONTRIBUTION_COLORS[index] ?? CONTRIBUTION_COLORS[0])
+        color: item.isBase
+          ? INDEX_BASE_COLOR
+          : item.isOther
+            ? OTHER_COLOR
+            : (CONTRIBUTION_COLORS[index - Number(mode === 'index')] ?? CONTRIBUTION_COLORS[0])
       })),
-    [contributionChart.series]
+    [contributionChart.series, mode]
   )
   const chartConfig = useMemo<ChartConfig>(
     () =>
       Object.fromEntries([
         ...series.map((item) => [item.key, { label: item.label, color: item.color }] as const),
-        ['portfolioGrowth', { label: `Portfolio growth (${mode.toUpperCase()})`, color: TOTAL_COLOR }]
+        [
+          'portfolioGrowth',
+          {
+            label: mode === 'index' ? 'Portfolio index' : `Portfolio growth (${mode.toUpperCase()})`,
+            color: TOTAL_COLOR
+          }
+        ]
       ]),
     [mode, series]
   )
-  const plottedSeries = useMemo(() => series.filter((item) => !item.isOther), [series])
-  const yAxisDomain = useMemo(
-    () => getPortfolioGrowthLineDomain(contributionChart.data, plottedSeries),
-    [contributionChart.data, plottedSeries]
-  )
+  const yAxisDomain = useMemo(() => getPortfolioGrowthStackDomain(contributionChart.bounds), [contributionChart.bounds])
   const isShortRange = timeframe === '30d' || contributionChart.data.length <= 45
   const ticks = isShortRange
     ? getChartWeeklyTicks(contributionChart.data)
@@ -297,28 +316,19 @@ export function PortfolioGrowthContributionsChart({
           wrapperStyle={{ zIndex: 20 }}
           content={(props) => <PortfolioGrowthContributionsTooltip {...props} series={series} mode={mode} />}
         />
-        <Area
-          type={'monotone'}
-          dataKey={'portfolioGrowth'}
-          baseValue={0}
-          fill={TOTAL_COLOR}
-          fillOpacity={0.1}
-          stroke={'none'}
-          tooltipType={'none'}
-          activeDot={false}
-          isAnimationActive={false}
-        />
         <ReferenceLine y={0} stroke={'var(--chart-axis)'} strokeOpacity={0.6} />
-        {plottedSeries.map((item) => (
-          <Line
+        {series.map((item) => (
+          <Area
             key={item.key}
             type={'monotone'}
-            dataKey={item.key}
+            dataKey={(point: TPortfolioGrowthContributionChartPoint | undefined) => point?.stackBands[item.key] ?? null}
             name={item.label}
             stroke={item.color}
-            strokeWidth={1.5}
-            dot={false}
-            activeDot={{ r: 4, strokeWidth: 0, fill: item.color }}
+            strokeWidth={0.75}
+            fill={item.color}
+            fillOpacity={item.isBase ? 0.38 : item.isOther ? 0.4 : 0.68}
+            connectNulls={mode !== 'eth'}
+            tooltipType={'none'}
             isAnimationActive={false}
           />
         ))}
@@ -329,6 +339,7 @@ export function PortfolioGrowthContributionsChart({
           strokeWidth={3}
           dot={false}
           activeDot={{ r: 4, strokeWidth: 0, fill: TOTAL_COLOR }}
+          connectNulls={mode !== 'eth'}
           isAnimationActive={false}
         />
       </ComposedChart>

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
@@ -128,7 +128,12 @@ function formatGrowthTick(value: number | string, mode: 'usd' | 'eth' | 'index')
   return `${numericValue < 0 ? '−' : ''}$${absoluteValue.toFixed(0)}`
 }
 
-export function getPortfolioGrowthStackDomain(values: number[]): AxisDomain {
+export function getPortfolioGrowthStackDomain(values: number[], floor?: number): AxisDomain {
+  if (floor !== undefined) {
+    const maximum = Math.max(floor, ...values)
+    return [floor, maximum > floor ? floor + (maximum - floor) * LINE_HEADROOM : floor + 1]
+  }
+
   const bounds = values.reduce(
     (result, value) => ({ min: Math.min(result.min, value), max: Math.max(result.max, value) }),
     { min: 0, max: 0 }
@@ -280,7 +285,10 @@ export function PortfolioGrowthContributionsChart({
       ]),
     [mode, series]
   )
-  const yAxisDomain = useMemo(() => getPortfolioGrowthStackDomain(contributionChart.bounds), [contributionChart.bounds])
+  const yAxisDomain = useMemo(
+    () => getPortfolioGrowthStackDomain(contributionChart.bounds, mode === 'index' ? 100 : undefined),
+    [contributionChart.bounds, mode]
+  )
   const isShortRange = timeframe === '30d' || contributionChart.data.length <= 45
   const ticks = isShortRange
     ? getChartWeeklyTicks(contributionChart.data)

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
@@ -20,7 +20,6 @@ import {
   getChartMonthlyTicks,
   getChartWeeklyTicks
 } from '@pages/vaults/utils/charts'
-import { LIGHT_MODE_COLORS } from '@shared/components/AllocationChart'
 import { formatUSD } from '@shared/utils'
 import type { ReactElement } from 'react'
 import { useMemo } from 'react'
@@ -28,7 +27,7 @@ import { Area, CartesianGrid, ComposedChart, Line, ReferenceLine, XAxis, YAxis }
 import type { AxisDomain } from 'recharts/types/util/types'
 
 type TPortfolioGrowthContributionsChartProps = {
-  totalPoints: Array<{ date: string; value: number | null; isEstimated?: boolean }>
+  totalPoints: Array<{ date: string; value: number | null }>
   familySeries: TPortfolioGrowthContributionFamily[]
   timeframe: TPortfolioHistoryChartTimeframe
   mode: 'usd' | 'eth' | 'index'
@@ -46,10 +45,19 @@ type TPresentedContributionSeries = TPortfolioGrowthContributionSeries & {
 }
 
 const MAX_VAULTS = 8
-const CONTRIBUTION_COLORS = LIGHT_MODE_COLORS
-const OTHER_COLOR = '#d7e6ff'
-const INDEX_BASE_COLOR = '#e8f1ff'
-const TOTAL_COLOR = '#0657f9'
+const CONTRIBUTION_COLORS = [
+  '#46a2ff',
+  '#7bb3a8',
+  '#e1a23b',
+  '#b67ae5',
+  '#f472b6',
+  '#f97316',
+  '#14b8a6',
+  '#94adf2'
+] as const
+const OTHER_COLOR = '#94a3b8'
+const INDEX_BASE_COLOR = '#80b7f4'
+const TOTAL_COLOR = '#2578ff'
 const LINE_HEADROOM = 1.05
 const CHART_MARGIN = {
   ...CHART_WITH_AXES_MARGIN,
@@ -91,21 +99,20 @@ function formatIndexValue(value: number): string {
   return value.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2 })
 }
 
-function formatSignedGrowth(value: number, mode: 'usd' | 'eth' | 'index', isEstimated = false): string {
+function formatSignedGrowth(value: number, mode: 'usd' | 'eth' | 'index'): string {
   const formatted =
     mode === 'eth'
       ? formatEthValue(value)
       : mode === 'index'
         ? formatIndexValue(Math.abs(value))
         : formatUSD(Math.abs(value), 2, 2)
-  const estimateSuffix = isEstimated ? '*' : ''
   if (value > 0) {
-    return `+${formatted}${estimateSuffix}`
+    return `+${formatted}`
   }
   if (value < 0) {
-    return `−${formatted}${estimateSuffix}`
+    return `−${formatted}`
   }
-  return `${formatted}${estimateSuffix}`
+  return formatted
 }
 
 function formatGrowthTick(value: number | string, mode: 'usd' | 'eth' | 'index'): string {
@@ -183,15 +190,13 @@ function PortfolioGrowthContributionsTooltip({
     .filter((item) => item.isBase)
     .flatMap((item) => {
       const value = point[item.key]
-      return typeof value === 'number' && Number.isFinite(value) ? [{ ...item, value, isEstimated: false }] : []
+      return typeof value === 'number' && Number.isFinite(value) ? [{ ...item, value }] : []
     })
   const namedRows = series
     .filter((item) => !item.isOther && !item.isBase)
     .flatMap((item) => {
       const value = point[item.key]
-      return typeof value === 'number' && Number.isFinite(value)
-        ? [{ ...item, value, isEstimated: Boolean(point[`${item.key}Estimated`]) }]
-        : []
+      return typeof value === 'number' && Number.isFinite(value) ? [{ ...item, value }] : []
     })
     .toSorted((left, right) => Math.abs(right.value) - Math.abs(left.value))
   const otherSeries = series.find((item) => item.isOther)
@@ -203,12 +208,10 @@ function PortfolioGrowthContributionsTooltip({
           ...namedRows,
           {
             ...otherSeries,
-            value: otherValue,
-            isEstimated: Boolean(point[`${otherSeries.key}Estimated`])
+            value: otherValue
           }
         ]
       : [...baseRows, ...namedRows]
-  const hasEstimatedValue = Boolean(point.portfolioGrowthEstimated) || rows.some((row) => row.isEstimated)
 
   return (
     <div
@@ -224,9 +227,7 @@ function PortfolioGrowthContributionsTooltip({
           {mode === 'index' ? 'Portfolio index' : 'Portfolio growth'}
         </span>
         <strong className={'font-number text-sm font-semibold text-text-primary'}>
-          {mode === 'index'
-            ? formatIndexValue(point.portfolioGrowth)
-            : formatSignedGrowth(point.portfolioGrowth, mode, Boolean(point.portfolioGrowthEstimated))}
+          {mode === 'index' ? formatIndexValue(point.portfolioGrowth) : formatSignedGrowth(point.portfolioGrowth, mode)}
         </strong>
       </div>
       <div className={'my-1.5 border-t border-border'} />
@@ -241,16 +242,11 @@ function PortfolioGrowthContributionsTooltip({
               <span className={'truncate'}>{row.label}</span>
             </span>
             <span className={'font-number shrink-0 text-xs font-medium text-text-primary'}>
-              {formatSignedGrowth(row.value, mode, row.isEstimated)}
+              {formatSignedGrowth(row.value, mode)}
             </span>
           </div>
         ))}
       </div>
-      {hasEstimatedValue ? (
-        <p className={'mt-1.5 border-t border-border pt-1 text-[11px] text-text-tertiary'}>
-          {'* Growth may be approximate.'}
-        </p>
-      ) : null}
     </div>
   )
 }
@@ -267,7 +263,6 @@ export function PortfolioGrowthContributionsChart({
         totalPoints,
         familySeries,
         maxVaults: MAX_VAULTS,
-        preserveNullValues: mode === 'eth',
         ...(mode === 'index'
           ? { baseContribution: { key: 'starting_index', label: 'Starting index', value: 100 } }
           : {})
@@ -353,8 +348,7 @@ export function PortfolioGrowthContributionsChart({
             stroke={item.color}
             strokeWidth={0.75}
             fill={item.color}
-            fillOpacity={item.isBase ? 0.28 : item.isOther ? 0.3 : 0.45}
-            connectNulls={mode !== 'eth'}
+            fillOpacity={0.1}
             tooltipType={'none'}
             isAnimationActive={false}
           />
@@ -366,7 +360,6 @@ export function PortfolioGrowthContributionsChart({
           strokeWidth={3}
           dot={false}
           activeDot={{ r: 4, strokeWidth: 0, fill: TOTAL_COLOR }}
-          connectNulls={mode !== 'eth'}
           isAnimationActive={false}
         />
       </ComposedChart>

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
@@ -20,6 +20,7 @@ import {
   getChartMonthlyTicks,
   getChartWeeklyTicks
 } from '@pages/vaults/utils/charts'
+import { LIGHT_MODE_COLORS } from '@shared/components/AllocationChart'
 import { formatUSD } from '@shared/utils'
 import type { ReactElement } from 'react'
 import { useMemo } from 'react'
@@ -45,23 +46,33 @@ type TPresentedContributionSeries = TPortfolioGrowthContributionSeries & {
 }
 
 const MAX_VAULTS = 8
-const CONTRIBUTION_COLORS = [
-  '#46a2ff',
-  '#7bb3a8',
-  '#e1a23b',
-  '#b67ae5',
-  '#f472b6',
-  '#f97316',
-  '#14b8a6',
-  '#94adf2'
-] as const
-const OTHER_COLOR = '#94a3b8'
-const INDEX_BASE_COLOR = '#80b7f4'
-const TOTAL_COLOR = '#2578ff'
+const CONTRIBUTION_COLORS = LIGHT_MODE_COLORS
+const OTHER_COLOR = '#d7e6ff'
+const INDEX_BASE_COLOR = '#e8f1ff'
+const TOTAL_COLOR = '#0657f9'
 const LINE_HEADROOM = 1.05
 const CHART_MARGIN = {
   ...CHART_WITH_AXES_MARGIN,
   bottom: 4
+}
+
+function getPortfolioGrowthVaultKey(chainId: number, vaultAddress: string): string {
+  return `${chainId}:${vaultAddress.toLowerCase()}`
+}
+
+export function buildPortfolioGrowthVaultColorMap(
+  families: Array<Pick<TPortfolioGrowthContributionFamily, 'chainId' | 'vaultAddress'>>
+): Map<string, string> {
+  const vaultKeys = Array.from(
+    new Set(families.map((family) => getPortfolioGrowthVaultKey(family.chainId, family.vaultAddress)))
+  ).toSorted()
+
+  return new Map(
+    vaultKeys.map((vaultKey, index) => [
+      vaultKey,
+      CONTRIBUTION_COLORS[index % CONTRIBUTION_COLORS.length] ?? CONTRIBUTION_COLORS[0]
+    ])
+  )
 }
 
 function formatEthValue(value: number): string {
@@ -259,17 +270,21 @@ export function PortfolioGrowthContributionsChart({
       }),
     [familySeries, mode, totalPoints]
   )
+  const vaultColorMap = useMemo(() => buildPortfolioGrowthVaultColorMap(familySeries), [familySeries])
   const series = useMemo<TPresentedContributionSeries[]>(
     () =>
-      contributionChart.series.map((item, index) => ({
+      contributionChart.series.map((item) => ({
         ...item,
         color: item.isBase
           ? INDEX_BASE_COLOR
           : item.isOther
             ? OTHER_COLOR
-            : (CONTRIBUTION_COLORS[index - Number(mode === 'index')] ?? CONTRIBUTION_COLORS[0])
+            : item.chainId !== null && item.vaultAddress !== null
+              ? (vaultColorMap.get(getPortfolioGrowthVaultKey(item.chainId, item.vaultAddress)) ??
+                CONTRIBUTION_COLORS[0])
+              : CONTRIBUTION_COLORS[0]
       })),
-    [contributionChart.series, mode]
+    [contributionChart.series, vaultColorMap]
   )
   const chartConfig = useMemo<ChartConfig>(
     () =>
@@ -334,7 +349,7 @@ export function PortfolioGrowthContributionsChart({
             stroke={item.color}
             strokeWidth={0.75}
             fill={item.color}
-            fillOpacity={item.isBase ? 0.38 : item.isOther ? 0.4 : 0.68}
+            fillOpacity={item.isBase ? 0.28 : item.isOther ? 0.3 : 0.45}
             connectNulls={mode !== 'eth'}
             tooltipType={'none'}
             isAnimationActive={false}

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
@@ -77,10 +77,10 @@ describe('portfolio growth pricing availability', () => {
     expect(html).toContain('<option value="eth" selected="">ETH</option>')
   })
 
-  it.each(['usd', 'index'] as const)('warns when the %s growth history is incomplete', (mode) => {
+  it.each(['usd', 'index'] as const)('keeps incomplete %s history diagnostics in the console only', (mode) => {
     const html = renderToStaticMarkup(<PortfolioHistoryChart {...props} growthDisplayModeOverride={mode} />)
 
-    expect(html).toContain('History is incomplete: some historical prices or vault data are missing.')
+    expect(html).not.toContain('History is incomplete')
     expect(html).toContain('Contribution chart')
   })
 

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
@@ -79,7 +79,7 @@ describe('portfolio growth pricing availability', () => {
     const html = renderToStaticMarkup(<PortfolioHistoryChart {...props} growthDisplayModeOverride={mode} />)
 
     expect(html).toContain('History is incomplete: some historical prices or vault data are missing.')
-    expect(html).toContain(mode === 'usd' ? 'Contribution chart' : 'Index chart')
+    expect(html).toContain('Contribution chart')
   })
 
   it('does not show an incomplete-history warning for complete USD history', () => {
@@ -107,7 +107,39 @@ describe('portfolio growth pricing availability', () => {
       />
     )
 
-    expect(html).toContain('Some ETH growth history is unavailable because historical prices are missing.')
+    expect(html).toContain('ETH growth is partial: historical prices are missing for one or more vaults.')
     expect(html).toContain('Contribution chart')
+  })
+
+  it('renders available ETH growth while warning that the total is partial', () => {
+    const html = renderToStaticMarkup(
+      <PortfolioHistoryChart
+        {...props}
+        protocolReturnData={[{ ...props.protocolReturnData![0]!, growthWeightEth: 1 }]}
+        protocolReturnFamilySeries={[
+          {
+            chainId: 1,
+            vaultAddress: '0x456',
+            symbol: 'yvETH',
+            status: 'missing_receipt_price',
+            dataPoints: [
+              {
+                timestamp: Date.parse('2026-01-01T00:00:00.000Z') / 1000,
+                growthWeightUsd: 0,
+                growthWeightEth: null,
+                growthUsd: 0,
+                growthUsdEstimated: false,
+                growthIndex: 100,
+                growthIndexContribution: 0
+              }
+            ]
+          }
+        ]}
+      />
+    )
+
+    expect(html).toContain('ETH growth is partial: historical prices are missing for one or more vaults.')
+    expect(html).toContain('Contribution chart')
+    expect(html).not.toContain('ETH growth unavailable')
   })
 })

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
@@ -26,7 +26,7 @@ const props: ComponentProps<typeof PortfolioHistoryChart> = {
       growthWeightUsd: 100,
       growthUsd: 100,
       growthUsdEstimated: false,
-      growthWeightEth: null,
+      growthWeightEth: 1,
       protocolReturnPct: 1,
       annualizedProtocolReturnPct: 10,
       growthIndex: 101
@@ -52,13 +52,52 @@ const props: ComponentProps<typeof PortfolioHistoryChart> = {
 }
 
 describe('portfolio growth pricing availability', () => {
-  it('keeps ETH selected and explains missing prices instead of silently rendering Index', () => {
-    const html = renderToStaticMarkup(<PortfolioHistoryChart {...props} />)
+  it.each(['usd', 'eth', 'index'] as const)(
+    'uses the server coverage flag for %s even without named series',
+    (mode) => {
+      const label = mode === 'index' ? 'Index' : mode.toUpperCase()
+      const summary = {
+        ...props.protocolReturnSummary!,
+        isComplete: true,
+        growthIsPartial: { usd: false, eth: false, index: false, [mode]: true }
+      }
+      const html = renderToStaticMarkup(
+        <PortfolioHistoryChart {...props} protocolReturnSummary={summary} growthDisplayModeOverride={mode} />
+      )
 
-    expect(html).toContain('ETH growth unavailable: historical prices are missing for one or more vaults.')
-    expect(html).not.toContain('Index chart')
-    expect(html).not.toContain('Contribution chart')
-  })
+      expect(html).toContain(`Some vaults could not be valued. ${label} data may be partial.`)
+      expect(html).not.toContain('vault excluded')
+      expect(html).toContain('Contribution chart')
+    }
+  )
+
+  it.each(['usd', 'eth', 'index'] as const)(
+    'explains fully unavailable %s valuation without switching charts',
+    (mode) => {
+      const label = mode === 'index' ? 'Index' : mode.toUpperCase()
+      const html = renderToStaticMarkup(
+        <PortfolioHistoryChart
+          {...props}
+          growthDisplayModeOverride={mode}
+          protocolReturnSummary={{
+            ...props.protocolReturnSummary!,
+            growthIsPartial: { usd: true, eth: true, index: true }
+          }}
+          protocolReturnData={[
+            {
+              ...props.protocolReturnData![0]!,
+              growthWeightUsd: null,
+              growthWeightEth: null,
+              growthIndex: null
+            }
+          ]}
+        />
+      )
+
+      expect(html).toContain(`${label} growth unavailable: vault valuation data is incomplete.`)
+      expect(html).not.toContain('Contribution chart')
+    }
+  )
 
   it('keeps ETH available in the growth selector', () => {
     const html = renderToStaticMarkup(
@@ -77,27 +116,36 @@ describe('portfolio growth pricing availability', () => {
     expect(html).toContain('<option value="eth" selected="">ETH</option>')
   })
 
-  it.each(['usd', 'index'] as const)('keeps incomplete %s history diagnostics in the console only', (mode) => {
-    const html = renderToStaticMarkup(<PortfolioHistoryChart {...props} growthDisplayModeOverride={mode} />)
+  it.each(['usd', 'eth', 'index'] as const)(
+    'does not infer %s coverage from the row summary or missing points',
+    (mode) => {
+      const html = renderToStaticMarkup(
+        <PortfolioHistoryChart
+          {...props}
+          growthDisplayModeOverride={mode}
+          protocolReturnSummary={{
+            ...props.protocolReturnSummary!,
+            growthIsPartial: { usd: false, eth: false, index: false }
+          }}
+          protocolReturnData={[
+            ...props.protocolReturnData!,
+            {
+              ...props.protocolReturnData![0]!,
+              date: '2026-01-02',
+              growthWeightUsd: null,
+              growthWeightEth: null,
+              growthIndex: null
+            }
+          ]}
+        />
+      )
 
-    expect(html).not.toContain('History is incomplete')
-    expect(html).toContain('Contribution chart')
-  })
+      expect(html).not.toContain('data may be partial.')
+      expect(html).toContain('Contribution chart')
+    }
+  )
 
-  it('does not show an incomplete-history warning for complete USD history', () => {
-    const html = renderToStaticMarkup(
-      <PortfolioHistoryChart
-        {...props}
-        growthDisplayModeOverride={'usd'}
-        protocolReturnSummary={{ ...props.protocolReturnSummary!, isComplete: true }}
-      />
-    )
-
-    expect(html).not.toContain('History is incomplete')
-    expect(html).toContain('Contribution chart')
-  })
-
-  it('preserves estimated USD pricing through total-series rebasing', () => {
+  it('does not label receipt-weighted growth estimated because mark-to-market growth was estimated', () => {
     const html = renderToStaticMarkup(
       <PortfolioHistoryChart
         {...props}
@@ -106,54 +154,23 @@ describe('portfolio growth pricing availability', () => {
       />
     )
 
-    expect(html).toContain('Contribution chart:estimated')
+    expect(html).toContain('Contribution chart:exact')
   })
 
-  it('warns about ETH gaps even when USD receipt pricing is complete', () => {
+  it.each(['balance', 'annualized'] as const)('does not show growth coverage warnings on %s', (activeTab) => {
     const html = renderToStaticMarkup(
       <PortfolioHistoryChart
         {...props}
-        protocolReturnSummary={{ ...props.protocolReturnSummary!, isComplete: true }}
-        protocolReturnData={[
-          { ...props.protocolReturnData![0]!, growthWeightEth: 1 },
-          { ...props.protocolReturnData![0]!, date: '2026-01-02' }
-        ]}
+        activeTab={activeTab}
+        growthDisplayModeOverride={'index'}
+        protocolReturnSummary={{
+          ...props.protocolReturnSummary!,
+          growthIsPartial: { usd: true, eth: true, index: true }
+        }}
       />
     )
 
-    expect(html).toContain('ETH growth is partial: historical prices are missing for one or more vaults.')
-    expect(html).toContain('Contribution chart')
-  })
-
-  it('renders available ETH growth while warning that the total is partial', () => {
-    const html = renderToStaticMarkup(
-      <PortfolioHistoryChart
-        {...props}
-        protocolReturnData={[{ ...props.protocolReturnData![0]!, growthWeightEth: 1 }]}
-        protocolReturnFamilySeries={[
-          {
-            chainId: 1,
-            vaultAddress: '0x456',
-            symbol: 'yvETH',
-            status: 'missing_receipt_price',
-            dataPoints: [
-              {
-                timestamp: Date.parse('2026-01-01T00:00:00.000Z') / 1000,
-                growthWeightUsd: 0,
-                growthWeightEth: null,
-                growthUsd: 0,
-                growthUsdEstimated: false,
-                growthIndex: 100,
-                growthIndexContribution: 0
-              }
-            ]
-          }
-        ]}
-      />
-    )
-
-    expect(html).toContain('ETH growth is partial: historical prices are missing for one or more vaults.')
-    expect(html).toContain('Contribution chart')
-    expect(html).not.toContain('ETH growth unavailable')
+    expect(html).not.toContain('data may be partial.')
+    expect(html).not.toContain('growth unavailable')
   })
 })

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
@@ -7,7 +7,9 @@ vi.mock('@hooks/usePlausible', () => ({ usePlausible: () => vi.fn() }))
 vi.mock('@shared/contexts/useWeb3', () => ({ useWeb3: () => ({ address: '0x123' }) }))
 vi.mock('@shared/contexts/useYearn', () => ({ useYearn: () => ({ allVaults: {} }) }))
 vi.mock('@pages/portfolio/components/PortfolioGrowthContributionsChart', () => ({
-  PortfolioGrowthContributionsChart: () => <div>{'Contribution chart'}</div>
+  PortfolioGrowthContributionsChart: ({ totalPoints }: { totalPoints: Array<{ isEstimated?: boolean }> }) => (
+    <div>{`Contribution chart:${totalPoints.some((point) => point.isEstimated) ? 'estimated' : 'exact'}`}</div>
+  )
 }))
 vi.mock('@pages/portfolio/components/PortfolioGrowthIndexChart', () => ({
   PortfolioGrowthIndexChart: () => <div>{'Index chart'}</div>
@@ -93,6 +95,18 @@ describe('portfolio growth pricing availability', () => {
 
     expect(html).not.toContain('History is incomplete')
     expect(html).toContain('Contribution chart')
+  })
+
+  it('preserves estimated USD pricing through total-series rebasing', () => {
+    const html = renderToStaticMarkup(
+      <PortfolioHistoryChart
+        {...props}
+        growthDisplayModeOverride={'usd'}
+        protocolReturnData={[{ ...props.protocolReturnData![0]!, growthUsdEstimated: true }]}
+      />
+    )
+
+    expect(html).toContain('Contribution chart:estimated')
   })
 
   it('warns about ETH gaps even when USD receipt pricing is complete', () => {

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -750,9 +750,7 @@ export function PortfolioHistoryChart({
     )
   const historyWarning = hasMissingEthGrowth
     ? 'ETH growth is partial: historical prices are missing for one or more vaults.'
-    : protocolReturnSummary?.isComplete === false
-      ? 'History is incomplete: some historical prices or vault data are missing.'
-      : null
+    : null
   const yAxisFloor = activeTab === 'growth' && resolvedGrowthDisplayMode === 'index' ? 100 : 0
   const yAxisTicks = useMemo(
     () =>

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -74,7 +74,6 @@ type TChartPoint = {
   date: string
   value: number | null
   isLive?: boolean
-  isEstimated?: boolean
 }
 
 type TPortfolioHistoryTooltipProps = {
@@ -264,9 +263,7 @@ function rebaseDeltaPoints(points: TChartPoint[]): TChartPoint[] {
 
   return points.map((point) => ({
     ...point,
-    value:
-      typeof point.value === 'number' && Number.isFinite(point.value) ? point.value - basePoint.value : point.value,
-    ...(point.isEstimated || basePoint.isEstimated ? { isEstimated: true } : {})
+    value: typeof point.value === 'number' && Number.isFinite(point.value) ? point.value - basePoint.value : point.value
   }))
 }
 
@@ -596,7 +593,7 @@ export function PortfolioHistoryChart({
     return points.map((point) => ({ date: point.date, value: point.value, isLive: point.isLive }))
   }, [balanceData, timeframe])
 
-  const filteredGrowthUsdData = useMemo<TChartPoint[]>(() => {
+  const filteredGrowthAmountData = useMemo<TChartPoint[]>(() => {
     if (!protocolReturnData) {
       return []
     }
@@ -610,30 +607,10 @@ export function PortfolioHistoryChart({
     return rebaseDeltaPoints(
       points.map((point) => ({
         date: point.date,
-        value: point.growthWeightUsd,
-        isEstimated: point.growthUsdEstimated
+        value: resolvedGrowthDisplayMode === 'eth' ? point.growthWeightEth : point.growthWeightUsd
       }))
     )
-  }, [protocolReturnData, timeframe])
-
-  const filteredGrowthEthData = useMemo<TChartPoint[]>(() => {
-    if (!protocolReturnData) {
-      return []
-    }
-
-    const limit = getTimeframeLimit(timeframe)
-    const points =
-      !Number.isFinite(limit) || limit >= protocolReturnData.length
-        ? protocolReturnData
-        : protocolReturnData.slice(-limit)
-
-    return rebaseDeltaPoints(
-      points.map((point) => ({
-        date: point.date,
-        value: point.growthWeightEth
-      }))
-    )
-  }, [protocolReturnData, timeframe])
+  }, [protocolReturnData, resolvedGrowthDisplayMode, timeframe])
 
   const filteredRawGrowthIndexData = useMemo<TChartPoint[]>(() => {
     if (!protocolReturnData) {
@@ -718,39 +695,16 @@ export function PortfolioHistoryChart({
     activeTab === 'balance'
       ? filteredBalanceData
       : activeTab === 'growth'
-        ? resolvedGrowthDisplayMode === 'eth'
-          ? filteredGrowthEthData
-          : resolvedGrowthDisplayMode === 'usd'
-            ? filteredGrowthUsdData
-            : filteredGrowthIndexData
+        ? resolvedGrowthDisplayMode === 'index'
+          ? filteredGrowthIndexData
+          : filteredGrowthAmountData
         : filteredAnnualizedReturnData
   const activeIsLoading = activeTab === 'balance' ? balanceIsLoading : protocolReturnIsLoading
   const activeIsEmpty = activeTab === 'balance' ? balanceIsEmpty : protocolReturnIsEmpty
   const activeError = activeTab === 'balance' ? balanceError : protocolReturnError
   const activeHasRenderableValue = activeData.some((point) => point.value !== null)
-  const firstActiveDate = activeData[0]?.date
-  const hasMissingEthGrowth =
-    activeTab === 'growth' &&
-    resolvedGrowthDisplayMode === 'eth' &&
-    Boolean(
-      firstActiveDate &&
-        (protocolReturnData?.some(
-          (point) => point.date >= firstActiveDate && point.growthWeightEth === null && point.growthIndex !== null
-        ) ||
-          visibleProtocolReturnFamilySeries.some((series) =>
-            series.dataPoints.some((point) => {
-              const timestamp = point.timestamp > 1_000_000_000_000 ? point.timestamp : point.timestamp * 1000
-              return (
-                new Date(timestamp).toISOString().slice(0, 10) >= firstActiveDate &&
-                point.growthWeightEth === null &&
-                point.growthIndex !== null
-              )
-            })
-          ))
-    )
-  const historyWarning = hasMissingEthGrowth
-    ? 'ETH growth is partial: historical prices are missing for one or more vaults.'
-    : null
+  const growthIsPartial = activeTab === 'growth' && protocolReturnSummary?.growthIsPartial?.[resolvedGrowthDisplayMode]
+  const growthLabel = resolvedGrowthDisplayMode === 'index' ? 'Index' : resolvedGrowthDisplayMode.toUpperCase()
   const yAxisFloor = activeTab === 'growth' && resolvedGrowthDisplayMode === 'index' ? 100 : 0
   const yAxisTicks = useMemo(
     () =>
@@ -1028,8 +982,8 @@ export function PortfolioHistoryChart({
       <section className={cl(sectionClassName, className)}>
         <div className={'flex min-h-[240px] items-center justify-center'}>
           <p className={'text-center text-base text-text-secondary'}>
-            {hasMissingEthGrowth
-              ? 'ETH growth unavailable: historical prices are missing for one or more vaults.'
+            {growthIsPartial
+              ? `${growthLabel} growth unavailable: vault valuation data is incomplete.`
               : getEmptyMessage(activeTab, resolvedGrowthDisplayMode)}
           </p>
         </div>
@@ -1040,16 +994,14 @@ export function PortfolioHistoryChart({
   if (activeTab === 'growth') {
     return (
       <section className={cl(sectionClassName, className)}>
-        {historyWarning ? <p className={'mb-2 text-xs text-text-secondary'}>{historyWarning}</p> : null}
+        {growthIsPartial ? (
+          <p className={'mb-2 text-xs text-text-secondary'}>
+            {`Some vaults could not be valued. ${growthLabel} data may be partial.`}
+          </p>
+        ) : null}
         <div className={'min-h-0 flex-1'}>
           <PortfolioGrowthContributionsChart
-            totalPoints={
-              resolvedGrowthDisplayMode === 'eth'
-                ? filteredGrowthEthData
-                : resolvedGrowthDisplayMode === 'index'
-                  ? filteredGrowthIndexData
-                  : filteredGrowthUsdData
-            }
+            totalPoints={activeData}
             familySeries={growthContributionFamilySeries}
             timeframe={timeframe}
             mode={resolvedGrowthDisplayMode}

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -610,7 +610,8 @@ export function PortfolioHistoryChart({
     return rebaseDeltaPoints(
       points.map((point) => ({
         date: point.date,
-        value: point.growthWeightUsd
+        value: point.growthWeightUsd,
+        isEstimated: point.growthUsdEstimated
       }))
     )
   }, [protocolReturnData, timeframe])

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -38,7 +38,6 @@ import type {
   TPortfolioProtocolReturnHistorySummary
 } from '../types/api'
 import { PortfolioGrowthContributionsChart } from './PortfolioGrowthContributionsChart'
-import { PortfolioGrowthIndexChart } from './PortfolioGrowthIndexChart'
 import { PortfolioHistoryBreakdownModal } from './PortfolioHistoryBreakdownModal'
 
 export type TPortfolioHistoryChartTimeframe = '30d' | '90d' | '1y' | 'all'
@@ -635,7 +634,7 @@ export function PortfolioHistoryChart({
     )
   }, [protocolReturnData, timeframe])
 
-  const filteredGrowthIndexData = useMemo<TChartPoint[]>(() => {
+  const filteredRawGrowthIndexData = useMemo<TChartPoint[]>(() => {
     if (!protocolReturnData) {
       return []
     }
@@ -646,13 +645,23 @@ export function PortfolioHistoryChart({
         ? protocolReturnData
         : protocolReturnData.slice(-limit)
 
-    return rebaseIndexPoints(
-      points.map((point) => ({
-        date: point.date,
-        value: point.growthIndex
-      }))
-    )
+    return points.map((point) => ({
+      date: point.date,
+      value: point.growthIndex
+    }))
   }, [protocolReturnData, timeframe])
+  const filteredGrowthIndexData = useMemo(
+    () => rebaseIndexPoints(filteredRawGrowthIndexData),
+    [filteredRawGrowthIndexData]
+  )
+  const growthIndexContributionScale = useMemo(() => {
+    const baseValue = filteredRawGrowthIndexData.find(
+      (point): point is { date: string; value: number } =>
+        typeof point.value === 'number' && Number.isFinite(point.value) && point.value !== 0
+    )?.value
+
+    return baseValue ? 100 / baseValue : 1
+  }, [filteredRawGrowthIndexData])
 
   const filteredAnnualizedReturnData = useMemo<TChartPoint[]>(() => {
     if (!protocolReturnData) {
@@ -687,24 +696,21 @@ export function PortfolioHistoryChart({
         chainId: series.chainId,
         vaultAddress: series.vaultAddress,
         label: getPortfolioVaultSeriesLabel(series, familyLabelByVaultKey),
-        dataPoints: series.dataPoints.map((point) =>
-          toPortfolioGrowthContributionPoint(point, resolvedGrowthDisplayMode === 'eth' ? 'eth' : 'usd')
-        )
+        dataPoints: series.dataPoints.map((point) => {
+          if (resolvedGrowthDisplayMode === 'index') {
+            return {
+              timestamp: point.timestamp,
+              value:
+                point.growthIndexContribution === null
+                  ? null
+                  : point.growthIndexContribution * growthIndexContributionScale
+            }
+          }
+
+          return toPortfolioGrowthContributionPoint(point, resolvedGrowthDisplayMode)
+        })
       })),
-    [familyLabelByVaultKey, resolvedGrowthDisplayMode, visibleProtocolReturnFamilySeries]
-  )
-  const growthIndexFamilySeries = useMemo(
-    () =>
-      visibleProtocolReturnFamilySeries.map((series) => ({
-        chainId: series.chainId,
-        vaultAddress: series.vaultAddress,
-        label: getPortfolioVaultSeriesLabel(series, familyLabelByVaultKey),
-        dataPoints: series.dataPoints.map((point) => ({
-          timestamp: point.timestamp,
-          value: point.growthIndex
-        }))
-      })),
-    [familyLabelByVaultKey, visibleProtocolReturnFamilySeries]
+    [familyLabelByVaultKey, growthIndexContributionScale, resolvedGrowthDisplayMode, visibleProtocolReturnFamilySeries]
   )
 
   const activeData =
@@ -727,16 +733,25 @@ export function PortfolioHistoryChart({
     resolvedGrowthDisplayMode === 'eth' &&
     Boolean(
       firstActiveDate &&
-        protocolReturnData?.some(
+        (protocolReturnData?.some(
           (point) => point.date >= firstActiveDate && point.growthWeightEth === null && point.growthIndex !== null
-        )
+        ) ||
+          visibleProtocolReturnFamilySeries.some((series) =>
+            series.dataPoints.some((point) => {
+              const timestamp = point.timestamp > 1_000_000_000_000 ? point.timestamp : point.timestamp * 1000
+              return (
+                new Date(timestamp).toISOString().slice(0, 10) >= firstActiveDate &&
+                point.growthWeightEth === null &&
+                point.growthIndex !== null
+              )
+            })
+          ))
     )
-  const historyWarning =
-    protocolReturnSummary?.isComplete === false
+  const historyWarning = hasMissingEthGrowth
+    ? 'ETH growth is partial: historical prices are missing for one or more vaults.'
+    : protocolReturnSummary?.isComplete === false
       ? 'History is incomplete: some historical prices or vault data are missing.'
-      : hasMissingEthGrowth
-        ? 'Some ETH growth history is unavailable because historical prices are missing.'
-        : null
+      : null
   const yAxisFloor = activeTab === 'growth' && resolvedGrowthDisplayMode === 'index' ? 100 : 0
   const yAxisTicks = useMemo(
     () =>
@@ -1023,36 +1038,22 @@ export function PortfolioHistoryChart({
     )
   }
 
-  if (activeTab === 'growth' && resolvedGrowthDisplayMode === 'index') {
-    return (
-      <section className={cl(sectionClassName, className)}>
-        {historyWarning ? <p className={'mb-2 text-xs text-text-secondary'}>{historyWarning}</p> : null}
-        <div className={'min-h-0 flex-1'}>
-          <PortfolioGrowthIndexChart
-            totalPoints={filteredGrowthIndexData}
-            familySeries={growthIndexFamilySeries}
-            timeframe={timeframe}
-          />
-        </div>
-        <PortfolioHistoryBreakdownModal
-          date={selectedBreakdownDate}
-          isOpen={isBreakdownModalOpen}
-          onClose={() => setIsBreakdownModalOpen(false)}
-        />
-      </section>
-    )
-  }
-
   if (activeTab === 'growth') {
     return (
       <section className={cl(sectionClassName, className)}>
         {historyWarning ? <p className={'mb-2 text-xs text-text-secondary'}>{historyWarning}</p> : null}
         <div className={'min-h-0 flex-1'}>
           <PortfolioGrowthContributionsChart
-            totalPoints={resolvedGrowthDisplayMode === 'eth' ? filteredGrowthEthData : filteredGrowthUsdData}
+            totalPoints={
+              resolvedGrowthDisplayMode === 'eth'
+                ? filteredGrowthEthData
+                : resolvedGrowthDisplayMode === 'index'
+                  ? filteredGrowthIndexData
+                  : filteredGrowthUsdData
+            }
             familySeries={growthContributionFamilySeries}
             timeframe={timeframe}
-            mode={resolvedGrowthDisplayMode === 'eth' ? 'eth' : 'usd'}
+            mode={resolvedGrowthDisplayMode}
           />
         </div>
         <PortfolioHistoryBreakdownModal

--- a/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioGrowth.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioGrowth.test.ts
@@ -96,6 +96,15 @@ describe('portfolio growth helpers', () => {
     expect(toPortfolioGrowthDisplay(combined)).toBeNull()
   })
 
+  it('preserves unavailable values when combining vault variants', () => {
+    const unlocked = makeGrowthVault(YVUSD_UNLOCKED_ADDRESS)
+    const locked = makeGrowthVault(YVUSD_LOCKED_ADDRESS, { growthUnderlying: null, growthUsd: null })
+    const combined = mapPortfolioGrowthVaults([unlocked, locked]).get(getPortfolioGrowthVaultKey(unlocked))
+
+    expect(combined).toMatchObject({ growthUnderlying: null, growthUsd: null, assetGrowth: [] })
+    expect(toPortfolioGrowthDisplay(combined)).toBeNull()
+  })
+
   it('shows yvUSD growth when only one complete variant was returned', () => {
     const unlocked = makeGrowthVault(YVUSD_UNLOCKED_ADDRESS, {
       baselineExposureUsdYears: 50,

--- a/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioGrowth.ts
+++ b/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioGrowth.ts
@@ -18,8 +18,7 @@ export type TPortfolioGrowthAssetDisplay = {
   symbol: string | null
 }
 
-export type TMappedPortfolioGrowthVault = Omit<TPortfolioGrowthVault, 'growthUnderlying'> & {
-  growthUnderlying: number | null
+export type TMappedPortfolioGrowthVault = TPortfolioGrowthVault & {
   assetGrowth: TPortfolioGrowthAssetDisplay[]
 }
 
@@ -29,7 +28,7 @@ export function getPortfolioGrowthVaultKey(vault: Pick<TPortfolioGrowthVault, 'c
 
 function sumGrowthField(
   vaults: readonly TMappedPortfolioGrowthVault[],
-  field: 'baselineUsd' | 'baselineExposureUsdYears' | 'growthUsd'
+  field: 'baselineUsd' | 'baselineExposureUsdYears'
 ): number {
   return vaults.reduce((total, vault) => total + vault[field], 0)
 }
@@ -76,10 +75,13 @@ function combineGrowthVariants(
     )
   const baselineUsd = sumGrowthField(variants, 'baselineUsd')
   const baselineExposureUsdYears = sumGrowthField(variants, 'baselineExposureUsdYears')
-  const growthUnderlying = combineAssetGrowth
-    ? variants.reduce((total, vault) => total + (vault.growthUnderlying ?? 0), 0)
+  const growthUnderlying =
+    combineAssetGrowth && variants.every((vault) => vault.growthUnderlying !== null)
+      ? variants.reduce((total, vault) => total + vault.growthUnderlying!, 0)
+      : null
+  const growthUsd = variants.every((vault) => vault.growthUsd !== null)
+    ? variants.reduce((total, vault) => total + vault.growthUsd!, 0)
     : null
-  const growthUsd = sumGrowthField(variants, 'growthUsd')
   const issues = Array.from(new Set(variants.flatMap((vault) => vault.issues)))
   const isComplete = variants.every((vault) => vault.status === 'ok')
 
@@ -91,9 +93,12 @@ function combineGrowthVariants(
     baselineUsd,
     baselineExposureUsdYears,
     growthUnderlying,
-    assetGrowth: combineAssetGrowth
-      ? [{ amount: growthUnderlying ?? 0, symbol: representative.metadata.symbol }]
-      : variants.flatMap((vault) => vault.assetGrowth),
+    assetGrowth:
+      growthUnderlying !== null
+        ? [{ amount: growthUnderlying, symbol: representative.metadata.symbol }]
+        : combineAssetGrowth
+          ? []
+          : variants.flatMap((vault) => vault.assetGrowth),
     growthUsd,
     growthPct: combineGrowthRate(variants, 'growthPct', 'baselineUsd'),
     annualizedProtocolReturnPct: combineGrowthRate(variants, 'annualizedProtocolReturnPct', 'baselineExposureUsdYears')
@@ -124,7 +129,8 @@ export function mapPortfolioGrowthVaults(
           getPortfolioGrowthVaultKey(vault),
           {
             ...vault,
-            assetGrowth: [{ amount: vault.growthUnderlying, symbol: vault.metadata.symbol }]
+            assetGrowth:
+              vault.growthUnderlying === null ? [] : [{ amount: vault.growthUnderlying, symbol: vault.metadata.symbol }]
           }
         ] as const
     )
@@ -171,7 +177,7 @@ export function comparePortfolioGrowthVaults(
 export function toPortfolioGrowthDisplay(
   vault: TMappedPortfolioGrowthVault | undefined
 ): TPortfolioGrowthDisplay | null {
-  if (vault?.status !== 'ok' || !Number.isFinite(vault.growthUsd)) {
+  if (vault?.status !== 'ok' || vault.growthUsd === null || !Number.isFinite(vault.growthUsd)) {
     return null
   }
 

--- a/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioHistoryBundle.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioHistoryBundle.test.ts
@@ -1,4 +1,5 @@
 import {
+  getIncompletePortfolioHistoryDiagnostics,
   resolvePortfolioHistoryBundleData,
   resolvePortfolioHistoryBundleLoading
 } from '@pages/portfolio/hooks/usePortfolioHistoryBundle'
@@ -155,6 +156,53 @@ describe('resolvePortfolioHistoryBundleLoading', () => {
         isPlaceholderData: false
       })
     ).toEqual({ historyIsLoading: true, growthIsLoading: true })
+  })
+})
+
+describe('getIncompletePortfolioHistoryDiagnostics', () => {
+  it('returns the vaults and issue codes responsible for incomplete history', () => {
+    const response = createPortfolioResponse()
+    response.protocolReturn.summary = {
+      ...response.protocolReturn.summary,
+      completeVaults: 0,
+      partialVaults: 1,
+      incompleteVaults: [
+        {
+          chainId: 1,
+          vaultAddress: VAULT_ADDRESS,
+          symbol: 'yvUSDC',
+          tokenAddress: '0x3333333333333333333333333333333333333333',
+          status: 'missing_pps',
+          issues: ['missing_pps', 'missing_exit_price']
+        }
+      ],
+      isComplete: false
+    }
+
+    expect(getIncompletePortfolioHistoryDiagnostics(response)).toEqual({
+      address: USER_ADDRESS,
+      timeframe: '1y',
+      generatedAt: '2026-09-02T00:00:00.000Z',
+      summary: {
+        totalVaults: 1,
+        completeVaults: 0,
+        partialVaults: 1
+      },
+      missingVaults: [
+        {
+          chainId: 1,
+          vaultAddress: VAULT_ADDRESS,
+          symbol: 'yvUSDC',
+          tokenAddress: '0x3333333333333333333333333333333333333333',
+          status: 'missing_pps',
+          issues: ['missing_pps', 'missing_exit_price']
+        }
+      ]
+    })
+  })
+
+  it('returns no diagnostics for complete history', () => {
+    expect(getIncompletePortfolioHistoryDiagnostics(createPortfolioResponse())).toBeNull()
   })
 })
 

--- a/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioHistoryBundle.ts
+++ b/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioHistoryBundle.ts
@@ -17,7 +17,7 @@ import {
 import { useWeb3 } from '@shared/contexts/useWeb3'
 import { useFetch } from '@shared/hooks/useFetch'
 import { PLAUSIBLE_EVENTS } from '@shared/utils/plausible'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { env } from '@/env'
 
 const PORTFOLIO_HISTORY_CACHE_DURATION = 60 * 60 * 1000
@@ -85,6 +85,35 @@ export function resolvePortfolioHistoryBundleLoading(args: {
   }
 }
 
+export function getIncompletePortfolioHistoryDiagnostics(data: TPortfolioResponse | null) {
+  if (!data || data.protocolReturn.summary.isComplete) {
+    return null
+  }
+
+  return {
+    address: data.address,
+    timeframe: data.protocolReturn.timeframe,
+    generatedAt: data.growth.generatedAt,
+    summary: {
+      totalVaults: data.protocolReturn.summary.totalVaults,
+      completeVaults: data.protocolReturn.summary.completeVaults,
+      partialVaults: data.protocolReturn.summary.partialVaults
+    },
+    missingVaults:
+      data.protocolReturn.summary.incompleteVaults ??
+      data.growth.vaults
+        .filter((vault) => vault.status !== 'ok')
+        .map((vault) => ({
+          chainId: vault.chainId,
+          vaultAddress: vault.vaultAddress,
+          symbol: vault.metadata.symbol,
+          tokenAddress: vault.metadata.tokenAddress,
+          status: vault.status,
+          issues: vault.issues
+        }))
+  }
+}
+
 export function usePortfolioHistoryBundle(
   denomination: TPortfolioHistoryDenomination = 'usd',
   timeframe: TPortfolioHistoryTimeframe = '1y',
@@ -127,6 +156,15 @@ export function usePortfolioHistoryBundle(
     data,
     isPlaceholderData
   })
+  const incompleteHistoryDiagnostics = useMemo(
+    () => getIncompletePortfolioHistoryDiagnostics(retainedData),
+    [retainedData]
+  )
+  useEffect(() => {
+    if (incompleteHistoryDiagnostics) {
+      console.warn('[Portfolio history] Historical data is incomplete', incompleteHistoryDiagnostics)
+    }
+  }, [incompleteHistoryDiagnostics])
   const balanceData = useMemo<TPortfolioHistoryChartData | null>(() => {
     if (!currentData?.balance.dataPoints) {
       return null

--- a/apps/yearn/src/components/pages/portfolio/types/api.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/types/api.test.ts
@@ -90,7 +90,8 @@ describe('portfolioResponseSchema', () => {
     expect(parsed.protocolReturn.dataPoints[0]?.growthUsdEstimated).toBe(false)
     expect(parsed.protocolReturn.familySeries[0]?.dataPoints[0]).toMatchObject({
       growthWeightEth: 0.001,
-      growthUsdEstimated: false
+      growthUsdEstimated: false,
+      growthIndexContribution: null
     })
   })
 })

--- a/apps/yearn/src/components/pages/portfolio/types/api.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/types/api.test.ts
@@ -19,12 +19,22 @@ describe('portfolioResponseSchema', () => {
         timeframe: '1y',
         summary: {
           totalVaults: 1,
-          completeVaults: 1,
-          partialVaults: 0,
+          completeVaults: 0,
+          partialVaults: 1,
           recommendedGrowthDisplay: 'usd',
           recommendedGrowthDisplayReason: 'stable_dominant',
           openBaselineCompositionUsd: { stable: 100, ethFamily: 0, other: 0 },
-          isComplete: true
+          incompleteVaults: [
+            {
+              chainId: 1,
+              vaultAddress: '0x5555555555555555555555555555555555555555',
+              symbol: 'yvMISSING',
+              tokenAddress: '0x6666666666666666666666666666666666666666',
+              status: 'missing_pps',
+              issues: ['missing_pps']
+            }
+          ],
+          isComplete: false
         },
         dataPoints: [
           {
@@ -87,6 +97,11 @@ describe('portfolioResponseSchema', () => {
     })
 
     expect(parsed.growth.vaults[0]?.issues).toEqual(['missing_exit_price'])
+    expect(parsed.protocolReturn.summary.incompleteVaults?.[0]).toMatchObject({
+      vaultAddress: '0x5555555555555555555555555555555555555555',
+      status: 'missing_pps',
+      issues: ['missing_pps']
+    })
     expect(parsed.protocolReturn.dataPoints[0]?.growthUsdEstimated).toBe(false)
     expect(parsed.protocolReturn.familySeries[0]?.dataPoints[0]).toMatchObject({
       growthWeightEth: 0.001,

--- a/apps/yearn/src/components/pages/portfolio/types/api.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/types/api.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { portfolioActivityFacetsResponseSchema, portfolioActivityResponseSchema, portfolioResponseSchema } from './api'
 
 describe('portfolioResponseSchema', () => {
-  it('accepts the non-fatal missing exit-price warning and defaults legacy estimate flags', () => {
+  it.each([2, null])('accepts available or unavailable growth (%s) and metric completeness', (growth) => {
     const parsed = portfolioResponseSchema.parse({
       address: '0x2222222222222222222222222222222222222222',
       version: 'all',
@@ -24,6 +24,7 @@ describe('portfolioResponseSchema', () => {
           recommendedGrowthDisplay: 'usd',
           recommendedGrowthDisplayReason: 'stable_dominant',
           openBaselineCompositionUsd: { stable: 100, ethFamily: 0, other: 0 },
+          growthIsPartial: { usd: true, eth: true, index: true },
           incompleteVaults: [
             {
               chainId: 1,
@@ -39,8 +40,8 @@ describe('portfolioResponseSchema', () => {
         dataPoints: [
           {
             date: '2026-08-23',
-            growthWeightUsd: 2,
-            growthUsd: 2,
+            growthWeightUsd: growth,
+            growthUsd: growth,
             growthWeightEth: null,
             protocolReturnPct: 2,
             annualizedProtocolReturnPct: 2,
@@ -81,8 +82,8 @@ describe('portfolioResponseSchema', () => {
             issues: ['missing_exit_price'],
             baselineUsd: 100,
             baselineExposureUsdYears: 1,
-            growthUnderlying: 2,
-            growthUsd: 2,
+            growthUnderlying: growth,
+            growthUsd: growth,
             growthPct: 2,
             annualizedProtocolReturnPct: 2,
             metadata: {
@@ -97,6 +98,9 @@ describe('portfolioResponseSchema', () => {
     })
 
     expect(parsed.growth.vaults[0]?.issues).toEqual(['missing_exit_price'])
+    expect(parsed.protocolReturn.summary.growthIsPartial).toEqual({ usd: true, eth: true, index: true })
+    expect(parsed.protocolReturn.dataPoints[0]?.growthWeightUsd).toBe(growth)
+    expect(parsed.growth.vaults[0]?.growthUnderlying).toBe(growth)
     expect(parsed.protocolReturn.summary.incompleteVaults?.[0]).toMatchObject({
       vaultAddress: '0x5555555555555555555555555555555555555555',
       status: 'missing_pps',

--- a/apps/yearn/src/components/pages/portfolio/types/api.ts
+++ b/apps/yearn/src/components/pages/portfolio/types/api.ts
@@ -36,7 +36,8 @@ const portfolioProtocolReturnHistoryFamilyPointSchema = z.object({
   growthWeightEth: z.number().nullable(),
   growthUsd: z.number().nullable(),
   growthUsdEstimated: z.boolean().optional().default(false),
-  growthIndex: z.number().nullable()
+  growthIndex: z.number().nullable(),
+  growthIndexContribution: z.number().nullable().optional().default(null)
 })
 
 const portfolioProtocolReturnHistoryFamilySeriesSchema = z.object({
@@ -263,5 +264,6 @@ export type TPortfolioProtocolReturnHistoryFamilySeries = Array<{
     growthUsd: number | null
     growthUsdEstimated: boolean
     growthIndex: number | null
+    growthIndexContribution: number | null
   }>
 }>

--- a/apps/yearn/src/components/pages/portfolio/types/api.ts
+++ b/apps/yearn/src/components/pages/portfolio/types/api.ts
@@ -16,6 +16,17 @@ const portfolioProtocolReturnHistoryDataPointSchema = z.object({
   growthIndex: z.number().nullable()
 })
 
+const portfolioProtocolReturnIncompleteVaultSchema = z.object({
+  chainId: z.number(),
+  vaultAddress: z.string(),
+  symbol: z.string().nullable(),
+  tokenAddress: z.string().nullable(),
+  status: z.enum(['missing_metadata', 'missing_pps', 'missing_receipt_price', 'partial']),
+  issues: z.array(
+    z.enum(['missing_metadata', 'missing_pps', 'missing_receipt_price', 'missing_exit_price', 'unmatched_exit'])
+  )
+})
+
 const portfolioProtocolReturnHistorySummarySchema = z.object({
   totalVaults: z.number(),
   completeVaults: z.number(),
@@ -27,6 +38,7 @@ const portfolioProtocolReturnHistorySummarySchema = z.object({
     ethFamily: z.number(),
     other: z.number()
   }),
+  incompleteVaults: z.array(portfolioProtocolReturnIncompleteVaultSchema).optional(),
   isComplete: z.boolean()
 })
 

--- a/apps/yearn/src/components/pages/portfolio/types/api.ts
+++ b/apps/yearn/src/components/pages/portfolio/types/api.ts
@@ -7,8 +7,8 @@ const portfolioHistorySimpleDataPointSchema = z.object({
 
 const portfolioProtocolReturnHistoryDataPointSchema = z.object({
   date: z.string(),
-  growthWeightUsd: z.number(),
-  growthUsd: z.number(),
+  growthWeightUsd: z.number().nullable(),
+  growthUsd: z.number().nullable(),
   growthUsdEstimated: z.boolean().optional().default(false),
   growthWeightEth: z.number().nullable(),
   protocolReturnPct: z.number().nullable(),
@@ -39,6 +39,7 @@ const portfolioProtocolReturnHistorySummarySchema = z.object({
     other: z.number()
   }),
   incompleteVaults: z.array(portfolioProtocolReturnIncompleteVaultSchema).optional(),
+  growthIsPartial: z.object({ usd: z.boolean(), eth: z.boolean(), index: z.boolean() }).optional(),
   isComplete: z.boolean()
 })
 
@@ -69,8 +70,8 @@ const portfolioGrowthVaultSchema = z.object({
   ),
   baselineUsd: z.number(),
   baselineExposureUsdYears: z.number(),
-  growthUnderlying: z.number(),
-  growthUsd: z.number(),
+  growthUnderlying: z.number().nullable(),
+  growthUsd: z.number().nullable(),
   growthPct: z.number().nullable(),
   annualizedProtocolReturnPct: z.number().nullable(),
   metadata: z.object({
@@ -256,8 +257,8 @@ export type TPortfolioLiveBalanceSnapshot = {
 }
 export type TPortfolioProtocolReturnHistoryChartData = Array<{
   date: string
-  growthWeightUsd: number
-  growthUsd: number
+  growthWeightUsd: number | null
+  growthUsd: number | null
   growthUsdEstimated: boolean
   growthWeightEth: number | null
   protocolReturnPct: number | null

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
@@ -52,7 +52,8 @@ describe('buildPortfolioGrowthContributionChart', () => {
 
     expect(toPortfolioGrowthContributionPoint(point, 'usd')).toEqual({
       timestamp: point.timestamp,
-      value: 25
+      value: 25,
+      isEstimated: true
     })
     expect(toPortfolioGrowthContributionPoint(point, 'eth')).toEqual({
       timestamp: point.timestamp,
@@ -321,6 +322,8 @@ describe('buildPortfolioGrowthContributionChart', () => {
       vault_0: [95, 105],
       other: [105, 108]
     })
+    expect(chart.bounds).not.toContain(0)
+    expect(chart.bounds).toContain(95)
     expectConservation(chart)
   })
 

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
@@ -11,7 +11,7 @@ function timestamp(date: string): number {
 
 function makeFamily(args: {
   label: string
-  values: Array<{ date: string; value: number | null; milliseconds?: boolean; estimated?: boolean }>
+  values: Array<{ date: string; value: number | null; milliseconds?: boolean }>
   chainId?: number
   vaultAddress?: string
 }): TPortfolioGrowthContributionFamily {
@@ -21,8 +21,7 @@ function makeFamily(args: {
     label: args.label,
     dataPoints: args.values.map((point) => ({
       timestamp: timestamp(point.date) * (point.milliseconds ? 1000 : 1),
-      value: point.value,
-      isEstimated: point.estimated
+      value: point.value
     }))
   }
 }
@@ -52,8 +51,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
 
     expect(toPortfolioGrowthContributionPoint(point, 'usd')).toEqual({
       timestamp: point.timestamp,
-      value: 25,
-      isEstimated: true
+      value: 25
     })
     expect(toPortfolioGrowthContributionPoint(point, 'eth')).toEqual({
       timestamp: point.timestamp,
@@ -144,6 +142,13 @@ describe('buildPortfolioGrowthContributionChart', () => {
       { date: dates[1], portfolioGrowth: 31, vault_0: 20, vault_1: 5, vault_2: 4, vault_3: 1, other: 1 },
       { date: dates[2], portfolioGrowth: 56, vault_0: 30, vault_1: 15, vault_2: 6, vault_3: 3, other: 2 }
     ])
+    expect(chart.data.at(-1)?.stackBands).toEqual({
+      other: [0, 2],
+      vault_3: [2, 5],
+      vault_2: [5, 11],
+      vault_1: [11, 26],
+      vault_0: [26, 56]
+    })
     expectConservation(chart)
   })
 
@@ -222,7 +227,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
     expectConservation(chart)
   })
 
-  it('carries sparse and null family values forward and normalizes millisecond timestamps', () => {
+  it('carries sparse values forward but preserves explicit nulls and normalizes millisecond timestamps', () => {
     const chart = buildPortfolioGrowthContributionChart({
       totalPoints: [
         { date: '2026-01-01', value: 0 },
@@ -242,7 +247,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
       ]
     })
 
-    expect(chart.data.map((point) => point.vault_0)).toEqual([0, 0, 7, 7])
+    expect(chart.data.map((point) => point.vault_0)).toEqual([0, null, 7, 7])
     expect(chart.data.map((point) => point.other)).toEqual([0, 5, 0, 3])
     expect(chart.series[0]?.terminalValue).toBe(7)
     expectConservation(chart)
@@ -276,7 +281,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
     expect(chart.data.at(-1)?.stackBands).toMatchObject({
       vault_1: [-90, 0],
       vault_0: [-90, 10],
-      other: [10, 10]
+      other: [-90, -90]
     })
     expect(chart.bounds).toContain(-90)
     expect(chart.bounds).toContain(10)
@@ -319,8 +324,8 @@ describe('buildPortfolioGrowthContributionChart', () => {
     expect(chart.data.at(-1)?.stackBands).toMatchObject({
       starting_index: [0, 100],
       vault_1: [95, 100],
-      vault_0: [95, 105],
-      other: [105, 108]
+      vault_0: [98, 108],
+      other: [95, 98]
     })
     expect(chart.bounds).not.toContain(0)
     expect(chart.bounds).toContain(95)
@@ -360,7 +365,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
     expectConservation(chart)
   })
 
-  it('preserves unavailable ETH totals and family values as gaps', () => {
+  it('preserves unavailable totals and family values as gaps', () => {
     const dates = ['2026-02-01', '2026-02-02', '2026-02-03', '2026-02-04']
     const chart = buildPortfolioGrowthContributionChart({
       totalPoints: [
@@ -374,8 +379,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
           label: 'Unavailable ETH growth',
           values: dates.map((date, index) => ({ date, value: [0, 1, null, 2][index]! }))
         })
-      ],
-      preserveNullValues: true
+      ]
     })
 
     expect(withoutStackBands(chart)).toEqual([
@@ -399,8 +403,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
           label: 'Unavailable ETH growth',
           values: dates.map((date, index) => ({ date, value: [0, 1, null][index]! }))
         })
-      ],
-      preserveNullValues: true
+      ]
     })
 
     expect(chart.series.map((series) => series.label)).toEqual(['Other'])
@@ -410,35 +413,6 @@ describe('buildPortfolioGrowthContributionChart', () => {
       other: 1.5
     })
     expectConservation(chart)
-  })
-
-  it('propagates estimated pricing through rebased total, vault, and Other values', () => {
-    const chart = buildPortfolioGrowthContributionChart({
-      totalPoints: [
-        { date: '2026-02-01', value: 0, isEstimated: true },
-        { date: '2026-02-02', value: 5, isEstimated: true }
-      ],
-      familySeries: [
-        makeFamily({
-          label: 'Estimated vault',
-          values: [
-            { date: '2026-02-01', value: 10, estimated: true },
-            { date: '2026-02-02', value: 15 }
-          ]
-        })
-      ]
-    })
-
-    expect(chart.data[0]).toMatchObject({
-      portfolioGrowthEstimated: true,
-      vault_0Estimated: true,
-      otherEstimated: true
-    })
-    expect(chart.data[1]).toMatchObject({
-      portfolioGrowthEstimated: true,
-      vault_0Estimated: true,
-      otherEstimated: true
-    })
   })
 
   it('uses stable input-order ties while keeping same-address vaults on different chains distinct', () => {

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
@@ -36,6 +36,10 @@ function expectConservation(chart: ReturnType<typeof buildPortfolioGrowthContrib
   })
 }
 
+function withoutStackBands(chart: ReturnType<typeof buildPortfolioGrowthContributionChart>) {
+  return chart.data.map(({ stackBands: _stackBands, ...point }) => point)
+}
+
 describe('buildPortfolioGrowthContributionChart', () => {
   it('selects the matching per-vault value for USD and ETH modes', () => {
     const point = {
@@ -134,7 +138,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
       { key: 'vault_3', label: 'D', terminalValue: 3 },
       { key: 'other', label: 'Other', terminalValue: 2 }
     ])
-    expect(chart.data).toEqual([
+    expect(withoutStackBands(chart)).toEqual([
       { date: dates[0], portfolioGrowth: 0, vault_0: 0, vault_1: 0, vault_2: 0, vault_3: 0, other: 0 },
       { date: dates[1], portfolioGrowth: 31, vault_0: 20, vault_1: 5, vault_2: 4, vault_3: 1, other: 1 },
       { date: dates[2], portfolioGrowth: 56, vault_0: 30, vault_1: 15, vault_2: 6, vault_3: 3, other: 2 }
@@ -268,6 +272,55 @@ describe('buildPortfolioGrowthContributionChart', () => {
       ['Loss', -90]
     ])
     expect(chart.data.at(-1)).toMatchObject({ portfolioGrowth: 10, vault_0: 100, vault_1: -90, other: 0 })
+    expect(chart.data.at(-1)?.stackBands).toMatchObject({
+      vault_1: [-90, 0],
+      vault_0: [-90, 10],
+      other: [10, 10]
+    })
+    expect(chart.bounds).toContain(-90)
+    expect(chart.bounds).toContain(10)
+    expectConservation(chart)
+  })
+
+  it('adds a 100-point base and reconciles Index attribution to the portfolio line', () => {
+    const chart = buildPortfolioGrowthContributionChart({
+      totalPoints: [
+        { date: '2026-01-01', value: 100 },
+        { date: '2026-01-02', value: 108 }
+      ],
+      familySeries: [
+        makeFamily({
+          label: 'Gain',
+          values: [
+            { date: '2026-01-01', value: 5 },
+            { date: '2026-01-02', value: 15 }
+          ]
+        }),
+        makeFamily({
+          label: 'Loss',
+          values: [
+            { date: '2026-01-01', value: 2 },
+            { date: '2026-01-02', value: -3 }
+          ]
+        })
+      ],
+      baseContribution: { key: 'starting_index', label: 'Starting index', value: 100 }
+    })
+
+    expect(chart.series.map((series) => series.label)).toEqual(['Starting index', 'Gain', 'Loss', 'Other'])
+    expect(chart.data.at(-1)).toMatchObject({
+      portfolioGrowth: 108,
+      starting_index: 100,
+      vault_0: 10,
+      vault_1: -5,
+      other: 3
+    })
+    expect(chart.data.at(-1)?.stackBands).toMatchObject({
+      starting_index: [0, 100],
+      vault_1: [95, 100],
+      vault_0: [95, 105],
+      other: [105, 108]
+    })
     expectConservation(chart)
   })
 
@@ -322,7 +375,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
       preserveNullValues: true
     })
 
-    expect(chart.data).toEqual([
+    expect(withoutStackBands(chart)).toEqual([
       { date: dates[0], portfolioGrowth: 0, vault_0: 0, other: 0 },
       { date: dates[1], portfolioGrowth: 1, vault_0: 1, other: 0 },
       { date: dates[2], portfolioGrowth: null, vault_0: null, other: null },
@@ -348,7 +401,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
     })
 
     expect(chart.series.map((series) => series.label)).toEqual(['Other'])
-    expect(chart.data.at(-1)).toEqual({
+    expect(withoutStackBands(chart).at(-1)).toEqual({
       date: dates[2],
       portfolioGrowth: 1.5,
       other: 1.5
@@ -471,10 +524,11 @@ describe('buildPortfolioGrowthContributionChart', () => {
         chainId: null,
         vaultAddress: null,
         isOther: true,
+        isBase: false,
         terminalValue: 4
       }
     ])
-    expect(chart.data).toEqual([
+    expect(withoutStackBands(chart)).toEqual([
       { date: '2026-04-01', portfolioGrowth: 0, other: 0 },
       { date: '2026-04-02', portfolioGrowth: 4, other: 4 }
     ])

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
@@ -8,7 +8,6 @@ export type TPortfolioGrowthContributionFamily = {
   dataPoints: Array<{
     timestamp: number
     value: number | null
-    isEstimated?: boolean
   }>
 }
 
@@ -25,7 +24,6 @@ export type TPortfolioGrowthContributionSeries = {
 export type TPortfolioGrowthContributionChartPoint = {
   date: string
   portfolioGrowth: number | null
-  portfolioGrowthEstimated?: boolean
   stackBands: Record<string, [number, number] | null>
   [key: string]: string | number | boolean | null | undefined | Record<string, [number, number] | null>
 }
@@ -39,8 +37,6 @@ export type TPortfolioGrowthContributionChart = {
 export function toPortfolioGrowthContributionPoint(
   point: {
     timestamp: number
-    growthUsd: number | null
-    growthUsdEstimated: boolean
     growthWeightUsd: number | null
     growthWeightEth: number | null
   },
@@ -48,15 +44,13 @@ export function toPortfolioGrowthContributionPoint(
 ): TPortfolioGrowthContributionFamily['dataPoints'][number] {
   return {
     timestamp: point.timestamp,
-    value: mode === 'eth' ? point.growthWeightEth : point.growthWeightUsd,
-    ...(mode === 'usd' && point.growthUsdEstimated ? { isEstimated: true } : {})
+    value: mode === 'eth' ? point.growthWeightEth : point.growthWeightUsd
   }
 }
 
 type TPreparedFamily = TPortfolioGrowthContributionFamily & {
   originalIndex: number
   values: Array<number | null>
-  estimatedValues: boolean[]
   terminalValue: number
 }
 
@@ -83,71 +77,50 @@ function normalizeZero(value: number): number {
 
 function buildRebasedFamilyValues(
   points: TPortfolioGrowthContributionFamily['dataPoints'],
-  dates: string[],
-  preserveNullValues: boolean
-): { values: Array<number | null>; estimatedValues: boolean[] } {
+  dates: string[]
+): Array<number | null> {
   const sortedPoints = points
     .flatMap((point) => {
       const date = timestampToUtcDate(point.timestamp)
-      return date ? [{ date, value: point.value, isEstimated: point.isEstimated ?? false }] : []
+      return date ? [{ date, value: point.value }] : []
     })
     .toSorted((left, right) => left.date.localeCompare(right.date))
 
   const initialState = {
     pointIndex: 0,
     baselineValue: null as number | null,
-    baselineEstimated: false,
     lastValue: null as number | null,
-    lastEstimated: false,
-    values: [] as Array<number | null>,
-    estimatedValues: [] as boolean[]
+    values: [] as Array<number | null>
   }
 
   return dates.reduce<typeof initialState>((state, date) => {
     while (state.pointIndex < sortedPoints.length && sortedPoints[state.pointIndex]!.date <= date) {
       const nextValue = sortedPoints[state.pointIndex]!.value
-      if (isFiniteNumber(nextValue)) {
-        state.lastValue = nextValue
-        state.lastEstimated = sortedPoints[state.pointIndex]!.isEstimated
-      } else if (preserveNullValues) {
-        state.lastValue = null
-        state.lastEstimated = false
-      }
+      state.lastValue = isFiniteNumber(nextValue) ? nextValue : null
       state.pointIndex += 1
     }
 
     if (state.baselineValue === null && state.lastValue !== null) {
       state.baselineValue = state.lastValue
-      state.baselineEstimated = state.lastEstimated
     }
 
     state.values.push(
       state.baselineValue !== null && state.lastValue !== null
         ? normalizeZero(state.lastValue - state.baselineValue)
-        : preserveNullValues
-          ? null
-          : 0
-    )
-    state.estimatedValues.push(
-      state.baselineValue !== null && state.lastValue !== null ? state.baselineEstimated || state.lastEstimated : false
+        : null
     )
     return state
-  }, initialState)
+  }, initialState).values
 }
 
-function prepareFamilies(
-  familySeries: TPortfolioGrowthContributionFamily[],
-  dates: string[],
-  preserveNullValues: boolean
-): TPreparedFamily[] {
+function prepareFamilies(familySeries: TPortfolioGrowthContributionFamily[], dates: string[]): TPreparedFamily[] {
   return familySeries
     .map((family, originalIndex) => {
-      const { values, estimatedValues } = buildRebasedFamilyValues(family.dataPoints, dates, preserveNullValues)
+      const values = buildRebasedFamilyValues(family.dataPoints, dates)
       return {
         ...family,
         originalIndex,
         values,
-        estimatedValues,
         terminalValue: values.at(-1) ?? 0
       }
     })
@@ -159,10 +132,9 @@ function prepareFamilies(
 }
 
 export function buildPortfolioGrowthContributionChart(args: {
-  totalPoints: Array<{ date: string; value: number | null; isEstimated?: boolean }>
+  totalPoints: Array<{ date: string; value: number | null }>
   familySeries: TPortfolioGrowthContributionFamily[]
   maxVaults?: number
-  preserveNullValues?: boolean
   baseContribution?: { key: string; label: string; value: number }
 }): TPortfolioGrowthContributionChart {
   const dates = args.totalPoints.map((point) => point.date)
@@ -170,8 +142,7 @@ export function buildPortfolioGrowthContributionChart(args: {
   const maxVaults = Number.isFinite(requestedMaxVaults)
     ? Math.max(0, Math.floor(requestedMaxVaults))
     : DEFAULT_MAX_VAULTS
-  const preserveNullValues = args.preserveNullValues ?? false
-  const selectedFamilies = prepareFamilies(args.familySeries, dates, preserveNullValues).slice(0, maxVaults)
+  const selectedFamilies = prepareFamilies(args.familySeries, dates).slice(0, maxVaults)
   const namedSeries: TPortfolioGrowthContributionSeries[] = selectedFamilies.map((family, index) => ({
     key: `vault_${index}`,
     label: family.label,
@@ -209,16 +180,12 @@ export function buildPortfolioGrowthContributionChart(args: {
     const row: TPortfolioGrowthContributionChartPoint = {
       date: totalPoint.date,
       portfolioGrowth,
-      stackBands: {},
-      ...(totalPoint.isEstimated ? { portfolioGrowthEstimated: true } : {})
+      stackBands: {}
     }
 
     selectedFamilies.forEach((family, familyIndex) => {
       const value = family.values[pointIndex]
       row[`vault_${familyIndex}`] = value
-      if (isFiniteNumber(value) && family.estimatedValues[pointIndex]) {
-        row[`vault_${familyIndex}Estimated`] = true
-      }
     })
 
     const displayedGrowth = selectedFamilies.reduce((total, family) => {
@@ -226,9 +193,6 @@ export function buildPortfolioGrowthContributionChart(args: {
       return total + (isFiniteNumber(value) ? value : 0)
     }, 0)
     row.other = normalizeZero(portfolioGrowth - baseValue - displayedGrowth)
-    if (totalPoint.isEstimated || selectedFamilies.some((family) => family.estimatedValues[pointIndex])) {
-      row.otherEstimated = true
-    }
 
     if (baseSeries) {
       row[baseSeries.key] = baseValue
@@ -253,7 +217,9 @@ export function buildPortfolioGrowthContributionChart(args: {
         } satisfies TPortfolioGrowthContributionSeries,
         value: isFiniteNumber(row.other) ? row.other : 0
       }
-    ].toSorted((left, right) => Number(left.value >= 0) - Number(right.value >= 0))
+    ]
+      .toReversed()
+      .toSorted((left, right) => Number(left.value >= 0) - Number(right.value >= 0))
     contributionRows.reduce((runningTotal, contribution) => {
       const nextTotal = runningTotal + contribution.value
       row.stackBands[contribution.series.key] = [Math.min(runningTotal, nextTotal), Math.max(runningTotal, nextTotal)]

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
@@ -18,6 +18,7 @@ export type TPortfolioGrowthContributionSeries = {
   chainId: number | null
   vaultAddress: string | null
   isOther: boolean
+  isBase: boolean
   terminalValue: number
 }
 
@@ -25,12 +26,14 @@ export type TPortfolioGrowthContributionChartPoint = {
   date: string
   portfolioGrowth: number | null
   portfolioGrowthEstimated?: boolean
-  [key: string]: string | number | boolean | null | undefined
+  stackBands: Record<string, [number, number] | null>
+  [key: string]: string | number | boolean | null | undefined | Record<string, [number, number] | null>
 }
 
 export type TPortfolioGrowthContributionChart = {
   data: TPortfolioGrowthContributionChartPoint[]
   series: TPortfolioGrowthContributionSeries[]
+  bounds: number[]
 }
 
 export function toPortfolioGrowthContributionPoint(
@@ -159,6 +162,7 @@ export function buildPortfolioGrowthContributionChart(args: {
   familySeries: TPortfolioGrowthContributionFamily[]
   maxVaults?: number
   preserveNullValues?: boolean
+  baseContribution?: { key: string; label: string; value: number }
 }): TPortfolioGrowthContributionChart {
   const dates = args.totalPoints.map((point) => point.date)
   const requestedMaxVaults = args.maxVaults ?? DEFAULT_MAX_VAULTS
@@ -173,22 +177,38 @@ export function buildPortfolioGrowthContributionChart(args: {
     chainId: family.chainId,
     vaultAddress: family.vaultAddress,
     isOther: false,
+    isBase: false,
     terminalValue: family.terminalValue
   }))
+  const baseSeries: TPortfolioGrowthContributionSeries | null = args.baseContribution
+    ? {
+        key: args.baseContribution.key,
+        label: args.baseContribution.label,
+        chainId: null,
+        vaultAddress: null,
+        isOther: false,
+        isBase: true,
+        terminalValue: args.baseContribution.value
+      }
+    : null
+  const bounds: number[] = []
 
   const data = args.totalPoints.map<TPortfolioGrowthContributionChartPoint>((totalPoint, pointIndex) => {
     if (!isFiniteNumber(totalPoint.value)) {
       return {
         date: totalPoint.date,
         portfolioGrowth: null,
+        stackBands: {},
         ...Object.fromEntries([...selectedFamilies.map((_, index) => [`vault_${index}`, null]), ['other', null]])
       }
     }
 
     const portfolioGrowth = totalPoint.value
+    const baseValue = args.baseContribution?.value ?? 0
     const row: TPortfolioGrowthContributionChartPoint = {
       date: totalPoint.date,
       portfolioGrowth,
+      stackBands: {},
       ...(totalPoint.isEstimated ? { portfolioGrowthEstimated: true } : {})
     }
 
@@ -204,10 +224,41 @@ export function buildPortfolioGrowthContributionChart(args: {
       const value = family.values[pointIndex]
       return total + (isFiniteNumber(value) ? value : 0)
     }, 0)
-    row.other = normalizeZero(portfolioGrowth - displayedGrowth)
+    row.other = normalizeZero(portfolioGrowth - baseValue - displayedGrowth)
     if (totalPoint.isEstimated || selectedFamilies.some((family) => family.estimatedValues[pointIndex])) {
       row.otherEstimated = true
     }
+
+    if (baseSeries) {
+      row[baseSeries.key] = baseValue
+      row.stackBands[baseSeries.key] = [Math.min(0, baseValue), Math.max(0, baseValue)]
+      bounds.push(0, baseValue)
+    }
+
+    const contributionRows: Array<{ series: TPortfolioGrowthContributionSeries; value: number }> = [
+      ...namedSeries.map((series) => {
+        const value = row[series.key]
+        return { series, value: isFiniteNumber(value) ? value : 0 }
+      }),
+      {
+        series: {
+          key: 'other',
+          label: 'Other',
+          chainId: null,
+          vaultAddress: null,
+          isOther: true,
+          isBase: false,
+          terminalValue: 0
+        } satisfies TPortfolioGrowthContributionSeries,
+        value: isFiniteNumber(row.other) ? row.other : 0
+      }
+    ].toSorted((left, right) => Number(left.value >= 0) - Number(right.value >= 0))
+    contributionRows.reduce((runningTotal, contribution) => {
+      const nextTotal = runningTotal + contribution.value
+      row.stackBands[contribution.series.key] = [Math.min(runningTotal, nextTotal), Math.max(runningTotal, nextTotal)]
+      bounds.push(runningTotal, nextTotal)
+      return nextTotal
+    }, baseValue)
     return row
   })
   const otherTerminalValue = data.map((point) => point.other).findLast(isFiniteNumber) ?? 0
@@ -215,6 +266,7 @@ export function buildPortfolioGrowthContributionChart(args: {
   return {
     data,
     series: [
+      ...(baseSeries ? [baseSeries] : []),
       ...namedSeries,
       {
         key: 'other',
@@ -222,8 +274,10 @@ export function buildPortfolioGrowthContributionChart(args: {
         chainId: null,
         vaultAddress: null,
         isOther: true,
+        isBase: false,
         terminalValue: otherTerminalValue
       }
-    ]
+    ],
+    bounds
   }
 }

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
@@ -48,7 +48,8 @@ export function toPortfolioGrowthContributionPoint(
 ): TPortfolioGrowthContributionFamily['dataPoints'][number] {
   return {
     timestamp: point.timestamp,
-    value: mode === 'eth' ? point.growthWeightEth : point.growthWeightUsd
+    value: mode === 'eth' ? point.growthWeightEth : point.growthWeightUsd,
+    ...(mode === 'usd' && point.growthUsdEstimated ? { isEstimated: true } : {})
   }
 }
 
@@ -232,7 +233,7 @@ export function buildPortfolioGrowthContributionChart(args: {
     if (baseSeries) {
       row[baseSeries.key] = baseValue
       row.stackBands[baseSeries.key] = [Math.min(0, baseValue), Math.max(0, baseValue)]
-      bounds.push(0, baseValue)
+      bounds.push(baseValue)
     }
 
     const contributionRows: Array<{ series: TPortfolioGrowthContributionSeries; value: number }> = [

--- a/apps/yearn/src/components/pages/vaults/components/list/VaultsListRow.tsx
+++ b/apps/yearn/src/components/pages/vaults/components/list/VaultsListRow.tsx
@@ -537,18 +537,18 @@ function VaultsListRowPresentationComponent({
         tooltip={
           <div
             className={
-              'w-48 max-w-[calc(100vw-2rem)] rounded-xl border border-border bg-surface-secondary p-3 text-xs text-text-primary'
+              'w-max min-w-48 max-w-[calc(100vw-2rem)] rounded-xl border border-border bg-surface-secondary p-3 text-xs text-text-primary'
             }
           >
             <p className={'mb-2 font-semibold'}>{'Your vault growth'}</p>
             <div className={'flex flex-col gap-2'}>
               <div className={'flex items-center justify-between gap-2'}>
-                <span className={'text-text-secondary'}>{'Asset growth'}</span>
-                <strong className={'font-semibold'}>{assetValue ?? '—'}</strong>
+                <span className={'shrink-0 whitespace-nowrap text-text-secondary'}>{'Asset growth'}</span>
+                <strong className={'shrink-0 whitespace-nowrap font-semibold'}>{assetValue ?? '—'}</strong>
               </div>
               <div className={'flex items-center justify-between gap-2'}>
-                <span className={'text-text-secondary'}>{'Real APY'}</span>
-                <strong className={'font-semibold'}>{annualizedPercent ?? '—'}</strong>
+                <span className={'shrink-0 whitespace-nowrap text-text-secondary'}>{'Real APY'}</span>
+                <strong className={'shrink-0 whitespace-nowrap font-semibold'}>{annualizedPercent ?? '—'}</strong>
               </div>
               {portfolioGrowth.isUsdEstimated ? (
                 <p className={'border-t border-border pt-2 text-text-secondary'}>{'* Growth may be approximate.'}</p>

--- a/apps/yearn/src/components/pages/vaults/hooks/useVaultUserHistory.ts
+++ b/apps/yearn/src/components/pages/vaults/hooks/useVaultUserHistory.ts
@@ -17,9 +17,9 @@ type TUseVaultUserHistoryParams = {
 
 const vaultUserHistoryPointSchema = z.object({
   date: z.string(),
-  growthWeightUsd: z.number().optional().default(0),
-  currentUnderlying: z.number().optional().default(0),
-  growthUnderlying: z.number().optional().default(0),
+  growthWeightUsd: z.number().nullable().optional().default(null),
+  currentUnderlying: z.number().nullable().optional().default(null),
+  growthUnderlying: z.number().nullable().optional().default(null),
   sharesFormatted: z.number().optional().default(0),
   pricePerShare: z.number().optional().default(0)
 })

--- a/apps/yearn/src/server/lib/holdings/services/cache.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.test.ts
@@ -98,7 +98,7 @@ describe('protocol return history snapshot cache', () => {
     const savedValue = setMock.mock.calls[0]?.[1]
 
     expect(saved).toBe(true)
-    expect(key).toMatch(/^holdings:protocol-return-history:v18:[a-f0-9]{64}:1y:all$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v20:[a-f0-9]{64}:1y:all$/)
     expect(key).not.toContain(identity.userAddress)
     expect(savedValue).toEqual(expect.stringMatching(/^br1:/))
     expect(savedValue).not.toContain('2026-07-15')
@@ -202,7 +202,7 @@ describe('protocol return history snapshot cache', () => {
     const key = getProtocolReturnHistoryCacheKey(identity)
 
     expect(key).toBe(getProtocolReturnHistoryCacheKey(reversedIdentity))
-    expect(key).toMatch(/^holdings:protocol-return-history:v18:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v20:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
     expect(key).not.toContain(identity.vaultScope[0].address)
   })
 

--- a/apps/yearn/src/server/lib/holdings/services/cache.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.test.ts
@@ -98,7 +98,7 @@ describe('protocol return history snapshot cache', () => {
     const savedValue = setMock.mock.calls[0]?.[1]
 
     expect(saved).toBe(true)
-    expect(key).toMatch(/^holdings:protocol-return-history:v17:[a-f0-9]{64}:1y:all$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v18:[a-f0-9]{64}:1y:all$/)
     expect(key).not.toContain(identity.userAddress)
     expect(savedValue).toEqual(expect.stringMatching(/^br1:/))
     expect(savedValue).not.toContain('2026-07-15')
@@ -202,7 +202,7 @@ describe('protocol return history snapshot cache', () => {
     const key = getProtocolReturnHistoryCacheKey(identity)
 
     expect(key).toBe(getProtocolReturnHistoryCacheKey(reversedIdentity))
-    expect(key).toMatch(/^holdings:protocol-return-history:v17:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v18:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
     expect(key).not.toContain(identity.vaultScope[0].address)
   })
 

--- a/apps/yearn/src/server/lib/holdings/services/cache.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.test.ts
@@ -98,7 +98,7 @@ describe('protocol return history snapshot cache', () => {
     const savedValue = setMock.mock.calls[0]?.[1]
 
     expect(saved).toBe(true)
-    expect(key).toMatch(/^holdings:protocol-return-history:v16:[a-f0-9]{64}:1y:all$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v17:[a-f0-9]{64}:1y:all$/)
     expect(key).not.toContain(identity.userAddress)
     expect(savedValue).toEqual(expect.stringMatching(/^br1:/))
     expect(savedValue).not.toContain('2026-07-15')
@@ -202,7 +202,7 @@ describe('protocol return history snapshot cache', () => {
     const key = getProtocolReturnHistoryCacheKey(identity)
 
     expect(key).toBe(getProtocolReturnHistoryCacheKey(reversedIdentity))
-    expect(key).toMatch(/^holdings:protocol-return-history:v16:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v17:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
     expect(key).not.toContain(identity.vaultScope[0].address)
   })
 

--- a/apps/yearn/src/server/lib/holdings/services/cache.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.ts
@@ -34,8 +34,8 @@ const HOLDINGS_TOTALS_TTL_SECONDS = 30 * 24 * 60 * 60
 // Old hashes expire naturally and cannot reintroduce previously cached incomplete days.
 const HOLDINGS_TOTALS_KEY_PREFIX = 'holdings:totals:v3'
 const PROTOCOL_RETURN_HISTORY_TTL_SECONDS = 30 * 24 * 60 * 60
-// v16 links Index returns at cash flows and does not cache partial ETH totals as complete values.
-const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v16'
+// v17 includes additive Index attribution and preserves explicitly partial ETH totals.
+const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v17'
 const PROTOCOL_RETURN_HISTORY_VALUE_PREFIX = 'br1:'
 const PROTOCOL_RETURN_HISTORY_MAX_ENCODED_BYTES = 4 * 1024 * 1024
 const PROTOCOL_RETURN_HISTORY_MAX_DECODED_BYTES = 64 * 1024 * 1024

--- a/apps/yearn/src/server/lib/holdings/services/cache.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.ts
@@ -34,8 +34,8 @@ const HOLDINGS_TOTALS_TTL_SECONDS = 30 * 24 * 60 * 60
 // Old hashes expire naturally and cannot reintroduce previously cached incomplete days.
 const HOLDINGS_TOTALS_KEY_PREFIX = 'holdings:totals:v3'
 const PROTOCOL_RETURN_HISTORY_TTL_SECONDS = 30 * 24 * 60 * 60
-// v17 includes additive Index attribution and preserves explicitly partial ETH totals.
-const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v17'
+// v18 values chart flows consistently with the daily Kong PPS used by settled history points.
+const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v18'
 const PROTOCOL_RETURN_HISTORY_VALUE_PREFIX = 'br1:'
 const PROTOCOL_RETURN_HISTORY_MAX_ENCODED_BYTES = 4 * 1024 * 1024
 const PROTOCOL_RETURN_HISTORY_MAX_DECODED_BYTES = 64 * 1024 * 1024

--- a/apps/yearn/src/server/lib/holdings/services/cache.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.ts
@@ -34,8 +34,8 @@ const HOLDINGS_TOTALS_TTL_SECONDS = 30 * 24 * 60 * 60
 // Old hashes expire naturally and cannot reintroduce previously cached incomplete days.
 const HOLDINGS_TOTALS_KEY_PREFIX = 'holdings:totals:v3'
 const PROTOCOL_RETURN_HISTORY_TTL_SECONDS = 30 * 24 * 60 * 60
-// v18 values chart flows consistently with the daily Kong PPS used by settled history points.
-const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v18'
+// v20 uses fixed, currency-specific valuation coverage for every growth chart.
+const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v20'
 const PROTOCOL_RETURN_HISTORY_VALUE_PREFIX = 'br1:'
 const PROTOCOL_RETURN_HISTORY_MAX_ENCODED_BYTES = 4 * 1024 * 1024
 const PROTOCOL_RETURN_HISTORY_MAX_DECODED_BYTES = 64 * 1024 * 1024

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
@@ -199,7 +199,7 @@ describe('pnl simple protocol return', () => {
       withdrawn: 205868372846986582346156n
     },
     { wallet: 'short profitable holding', seconds: 48, shares: 100n * ONE, pps: 1, withdrawn: 101n * ONE }
-  ])('links the actual $wallet return without extrapolating $seconds seconds to a day', (fixture) => {
+  ])('uses one daily PPS mark for a same-day $wallet receipt and exit', (fixture) => {
     const day = 86_400
     const receiptTimestamp = day + 100
     const exitTimestamp = receiptTimestamp + fixture.seconds
@@ -237,25 +237,31 @@ describe('pnl simple protocol return', () => {
       ...inputs,
       timestamps: [day - 1, receiptTimestamp, exitTimestamp, 2 * day - 1, 3 * day - 1]
     })
-    const baseline = (Number(fixture.shares) / Number(ONE)) * fixture.pps
-    const growth = Number(fixture.withdrawn) / Number(ONE) - baseline
-    const expectedIndex = 100 * (1 + growth / baseline)
-
     expect(history[0]?.growthIndex).toBe(100)
-    expect(history[1]?.growthIndex).toBeCloseTo(expectedIndex, 10)
-    expect(history[2]?.growthIndex).toBeCloseTo(expectedIndex, 10)
-    expect(history[1]?.growthWeightUsd).toBeCloseTo(growth)
-    expect(history[1]?.growthWeightEth).toBeCloseTo(growth / 2)
-    expect(sampled.at(-1)?.growthIndex).toBeCloseTo(expectedIndex, 10)
+    expect(history[1]?.growthIndex).toBe(100)
+    expect(history[2]?.growthIndex).toBe(100)
+    expect(history[1]?.growthWeightUsd).toBe(0)
+    expect(history[1]?.growthWeightEth).toBe(0)
+    expect(sampled.at(-1)?.growthIndex).toBe(100)
     const tail = buildProtocolReturnHistorySeries({
       ...inputs,
       timestamps: [2 * day - 1, 3 * day - 1],
       growthIndexSeed: { timestamp: 2 * day - 1, growthIndex: history[1]!.growthIndex }
     })
-    expect(tail.at(-1)?.growthIndex).toBeCloseTo(expectedIndex, 10)
+    expect(tail.at(-1)?.growthIndex).toBe(100)
+
+    const realizedVault = materializeVault({
+      events,
+      ppsData: inputs.ppsData,
+      priceData: inputs.priceData,
+      currentTimestamp: 3 * day - 1
+    })
+    const transactionGrowth =
+      Number(fixture.withdrawn) / Number(ONE) - (Number(fixture.shares) / Number(ONE)) * fixture.pps
+    expect(realizedVault.growthWeightUsd).toBeCloseTo(transactionGrowth)
   })
 
-  it('keeps an exit correction proportional before reinvesting in the same transaction', () => {
+  it('does not treat same-day exit slippage as daily PPS growth before reinvesting', () => {
     const history = buildProtocolReturnHistorySeries({
       events: [
         baseEvent({ kind: 'transfer', id: 'receipt', blockTimestamp: 100 }),
@@ -287,8 +293,8 @@ describe('pnl simple protocol return', () => {
       priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
       timestamps: [100, 300]
     })
-    expect(history[1]?.growthWeightUsd).toBeCloseTo(-1)
-    expect(history[1]?.growthIndex).toBeCloseTo(99)
+    expect(history[1]?.growthWeightUsd).toBe(0)
+    expect(history[1]?.growthIndex).toBe(100)
   })
 
   it('does not turn unavailable PPS into an Index loss or silently restart at 100 after recovery', () => {

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import * as viem from 'viem'
+import { describe, expect, it, vi } from 'vitest'
 import type { VaultMetadata } from '../types'
 import type { TransactionActivityEvents } from './graphql'
 import { mergeAddressScopedRawPnlEventsWithTransactionActivity } from './pnlEvents'
@@ -13,6 +14,11 @@ import {
   materializeProtocolReturnVaults
 } from './pnlSimple'
 import type { TRawPnlEvent } from './pnlTypes'
+
+vi.mock('viem', async (importOriginal) => {
+  const original = await importOriginal<typeof import('viem')>()
+  return { ...original, formatUnits: vi.fn(original.formatUnits) }
+})
 
 const USER = '0x1111111111111111111111111111111111111111'
 const OTHER = '0x2222222222222222222222222222222222222222'
@@ -297,7 +303,7 @@ describe('pnl simple protocol return', () => {
     expect(history[1]?.growthIndex).toBe(100)
   })
 
-  it('does not turn unavailable PPS into an Index loss or silently restart at 100 after recovery', () => {
+  it('excludes a PPS gap from every growth metric instead of recording a loss and recovery', () => {
     const inputs = {
       events: [baseEvent({ kind: 'transfer', id: 'receipt', blockTimestamp: 100 })],
       userAddress: USER,
@@ -312,18 +318,368 @@ describe('pnl simple protocol return', () => {
           ])
         ]
       ]),
-      priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]])
+      priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
+      ethPriceData: new Map([[0, 2]])
     }
     const history = buildProtocolReturnHistorySeries({ ...inputs, timestamps: [100, 200, 300] })
-    expect(history[0]?.growthIndex).toBe(100)
-    expect(history[1]?.growthIndex).toBeNull()
-    expect(history[2]?.growthIndex).toBeNull()
+    expect(history.map((point) => point.growthIndex)).toEqual([null, null, null])
+    expect(history.map((point) => point.growthWeightUsd)).toEqual([null, null, null])
+    expect(history.map((point) => point.growthWeightEth)).toEqual([null, null, null])
+    expect(history[1]?.protocolReturnPct).toBeNull()
+    expect(history[1]?.annualizedProtocolReturnPct).toBeNull()
+    const unavailableVault = materializeProtocolReturnVaults({
+      ...inputs,
+      ledgers: buildProtocolReturnLedgers({ ...inputs, currentTimestamp: 200 }),
+      currentTimestamp: 200
+    })[0]!
+    expect(unavailableVault).toMatchObject({
+      currentUnderlying: null,
+      growthUnderlying: null,
+      growthWeightUsd: null,
+      growthWeightEth: null
+    })
     const tail = buildProtocolReturnHistorySeries({
       ...inputs,
       timestamps: [300, 400],
       growthIndexSeed: { timestamp: 300, growthIndex: null }
     })
     expect(tail.map((point) => point.growthIndex)).toEqual([null, null])
+    expect(tail.map((point) => point.growthWeightUsd)).toEqual([expect.closeTo(10), expect.closeTo(10)])
+    expect(tail.map((point) => point.growthWeightEth)).toEqual([expect.closeTo(5), expect.closeTo(5)])
+  })
+
+  it('does not repeat history valuations after discovering a PPS gap', () => {
+    const formatUnits = vi.mocked(viem.formatUnits)
+    formatUnits.mockClear()
+    const buildHistory = (middlePps: number) =>
+      buildProtocolReturnHistorySeries({
+        events: [baseEvent({ id: 'receipt', blockTimestamp: 100 })],
+        userAddress: USER,
+        metadata,
+        ppsData: new Map([
+          [
+            VAULT_KEY,
+            new Map([
+              [100, 1],
+              [200, middlePps],
+              [300, 1.1]
+            ])
+          ]
+        ]),
+        priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
+        ethPriceData: new Map([[0, 2]]),
+        timestamps: [100, 200, 300]
+      })
+    try {
+      buildHistory(1.05)
+      const completeValuations = formatUnits.mock.calls.length
+      formatUnits.mockClear()
+      const incompleteHistory = buildHistory(Number.NaN)
+      expect(incompleteHistory.map((point) => point.growthWeightUsd)).toEqual([null, null, null])
+      expect(formatUnits.mock.calls.length).toBe(completeValuations)
+    } finally {
+      formatUnits.mockRestore()
+    }
+  })
+
+  it.each([
+    { layer: 'outer', gapKey: NESTED_OUTER_KEY },
+    { layer: 'intermediate', gapKey: NESTED_MIDDLE_KEY }
+  ])("excludes an $layer PPS gap at another vault's flow between chart dates", ({ gapKey }) => {
+    const day = 86_400
+    const inputs = {
+      events: [
+        baseEvent({ id: 'good-receipt', blockTimestamp: 100 }),
+        baseEvent({
+          id: 'nested-receipt',
+          blockTimestamp: 100,
+          vaultAddress: NESTED_OUTER_VAULT,
+          familyVaultAddress: NESTED_OUTER_VAULT
+        }),
+        baseEvent({ id: 'good-addition', blockTimestamp: day + 100, blockNumber: 2, shares: 10n * ONE })
+      ],
+      userAddress: USER,
+      metadata: new Map([...metadata, ...nestedMetadata]),
+      ppsData: new Map([
+        [
+          VAULT_KEY,
+          new Map([
+            [0, 1],
+            [day, 1.1],
+            [2 * day, 1.2]
+          ])
+        ],
+        ...(
+          [
+            [NESTED_OUTER_KEY, 2],
+            [NESTED_MIDDLE_KEY, 3],
+            [NESTED_INNER_KEY, 5]
+          ] as const
+        ).map(
+          ([key, pps]) =>
+            [
+              key,
+              new Map([
+                [0, pps],
+                [day, key === gapKey ? Number.NaN : pps],
+                [2 * day, pps]
+              ])
+            ] as const
+        )
+      ]),
+      priceData: new Map([
+        [ASSET_PRICE_KEY, new Map([[0, 1]])],
+        [NESTED_TERMINAL_PRICE_KEY, new Map([[0, 1]])]
+      ]),
+      ethPriceData: new Map([[0, 2]]),
+      timestamps: [day - 1, 3 * day - 1]
+    }
+    const history = buildProtocolReturnHistorySeries(inputs)
+    const control = buildProtocolReturnHistorySeries({
+      ...inputs,
+      events: inputs.events.filter((event) => event.vaultAddress === VAULT)
+    })
+
+    history.forEach((point, index) => {
+      expect(point.growthIndex).toBeCloseTo(control[index]!.growthIndex!, 10)
+      expect(point.growthWeightUsd).toBeCloseTo(control[index]!.growthWeightUsd!, 10)
+      expect(point.growthWeightEth).toBeCloseTo(control[index]!.growthWeightEth!, 10)
+    })
+    expect(history.at(-1)?.growthWeightUsd).toBeCloseTo(21)
+    expect(history.at(-1)?.growthIndex).toBeCloseTo(120)
+  })
+
+  it('ignores PPS gaps before receipt and while fully exited, including after re-entry', () => {
+    const day = 86_400
+    const history = buildProtocolReturnHistorySeries({
+      events: [
+        baseEvent({ id: 'receipt', blockTimestamp: day + 100 }),
+        baseEvent({
+          kind: 'withdrawal',
+          id: 'full-exit',
+          blockTimestamp: 2 * day + 100,
+          blockNumber: 2,
+          owner: USER,
+          assets: 110n * ONE
+        }),
+        baseEvent({ id: 're-entry', blockTimestamp: 4 * day + 100, blockNumber: 3 })
+      ],
+      userAddress: USER,
+      metadata,
+      ppsData: new Map([
+        [
+          VAULT_KEY,
+          new Map([
+            [0, Number.NaN],
+            [day, 1],
+            [2 * day, 1.1],
+            [3 * day, Number.NaN],
+            [4 * day, 2],
+            [5 * day, 2.2]
+          ])
+        ]
+      ]),
+      priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
+      ethPriceData: new Map([[0, 2]]),
+      timestamps: [day - 1, 2 * day - 1, 3 * day - 1, 4 * day - 1, 5 * day - 1, 6 * day - 1]
+    })
+    expect(history.map((point) => point.growthWeightUsd)).toEqual([
+      null,
+      expect.closeTo(0),
+      expect.closeTo(10),
+      expect.closeTo(10),
+      expect.closeTo(10),
+      expect.closeTo(30)
+    ])
+    expect(history.map((point) => point.growthWeightEth)).toEqual([
+      null,
+      expect.closeTo(0),
+      expect.closeTo(5),
+      expect.closeTo(5),
+      expect.closeTo(5),
+      expect.closeTo(15)
+    ])
+    expect(history.at(-1)?.growthIndex).toBeCloseTo(121)
+  })
+
+  it.each(['zero PPS', 'missing metadata', 'missing receipt price', 'intermediate PPS gap'])(
+    'keeps consistent partial USD, ETH, and Index histories when another vault has %s',
+    (issue) => {
+      const badVault = '0x9999999999999999999999999999999999999999'
+      const badAsset = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      const badKey = toVaultKey(1, badVault)
+      const events = [
+        baseEvent({ kind: 'transfer', id: 'good', blockTimestamp: 100 }),
+        baseEvent({
+          kind: 'transfer',
+          id: 'bad',
+          blockTimestamp: 100,
+          vaultAddress: badVault,
+          familyVaultAddress: badVault,
+          shares: 1000n * ONE
+        })
+      ]
+      const inputs = {
+        events,
+        userAddress: USER,
+        metadata: new Map([
+          ...metadata,
+          ...(issue === 'missing metadata'
+            ? []
+            : [
+                [
+                  badKey,
+                  {
+                    ...metadata.get(VAULT_KEY)!,
+                    address: badVault,
+                    token: { address: badAsset, symbol: 'BAD', decimals: 18 }
+                  }
+                ] as const
+              ])
+        ]),
+        ppsData: new Map([
+          [
+            VAULT_KEY,
+            new Map([
+              [100, 1],
+              [200, 1.1],
+              [300, 1.2]
+            ])
+          ],
+          [
+            badKey,
+            new Map([
+              [100, issue === 'zero PPS' ? 0 : 1],
+              [200, issue === 'intermediate PPS gap' || issue === 'zero PPS' ? 0 : 1.1],
+              [300, 1.2]
+            ])
+          ]
+        ]),
+        priceData: new Map([
+          [ASSET_PRICE_KEY, new Map([[0, 1]])],
+          [`ethereum:${badAsset}`, new Map([[0, issue === 'missing receipt price' ? 0 : 1]])]
+        ]),
+        ethPriceData: new Map([[0, 2]]),
+        timestamps: [100, 200, 300]
+      }
+      const history = buildProtocolReturnHistorySeries(inputs)
+      const control = buildProtocolReturnHistorySeries({ ...inputs, events: events.slice(0, 1) })
+      history.forEach((point, index) => {
+        expect(point.growthIndex).toBeCloseTo(control[index]!.growthIndex!, 10)
+        expect(point.growthWeightUsd).toBeCloseTo(control[index]!.growthWeightUsd!, 10)
+        expect(point.growthWeightEth).toBeCloseTo(control[index]!.growthWeightEth!, 10)
+      })
+      expect(history.at(-1)?.growthIndex).toBeCloseTo(120)
+
+      const selectedVaults = materializeProtocolReturnVaults({
+        ...inputs,
+        ledgers: buildProtocolReturnLedgers({ ...inputs, currentTimestamp: 300 }),
+        currentTimestamp: 300
+      })
+      const familySeries = buildProtocolReturnFamilyHistorySeries({
+        ...inputs,
+        selectedVaults,
+        portfolioPoints: history,
+        excludedVaultKeys: { usd: new Set([badKey]), eth: new Set([badKey]) }
+      })
+      expect(
+        familySeries
+          .find((series) => series.vaultAddress === badVault)
+          ?.dataPoints.map((point) => point.growthIndexContribution)
+      ).toEqual([null, null, null])
+      const excludedFamily = familySeries.find((series) => series.vaultAddress === badVault)!
+      expect(excludedFamily.dataPoints.map((point) => point.growthWeightUsd)).toEqual([null, null, null])
+      expect(excludedFamily.dataPoints.map((point) => point.growthWeightEth)).toEqual([null, null, null])
+      expect(
+        familySeries.find((series) => series.vaultAddress === VAULT)?.dataPoints.at(-1)?.growthIndexContribution
+      ).toBeCloseTo(20)
+    }
+  )
+
+  it.each(['withdrawal', 'transfer'] as const)(
+    'keeps realized growth after a full %s without requiring current PPS or exit USD prices',
+    (kind) => {
+      const day = 86_400
+      const inputs = {
+        events: [
+          baseEvent({ id: 'receipt', blockTimestamp: 100 }),
+          baseEvent({
+            kind,
+            id: 'exit',
+            blockTimestamp: day + 100,
+            blockNumber: 2,
+            owner: USER,
+            sender: USER,
+            receiver: OTHER,
+            assets: 110n * ONE
+          })
+        ],
+        userAddress: USER,
+        metadata,
+        ppsData: new Map([
+          [
+            VAULT_KEY,
+            new Map([
+              [0, 1],
+              [day, 1.1],
+              [2 * day, 0]
+            ])
+          ]
+        ]),
+        priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
+        exitPriceData: new Map<string, Map<number, number>>(),
+        ethPriceData: new Map([[0, 2]]),
+        timestamps: [day - 1, 2 * day - 1, 3 * day - 1]
+      }
+      const history = buildProtocolReturnHistorySeries(inputs)
+      expect(history.map((point) => point.growthWeightUsd)).toEqual([
+        expect.closeTo(0),
+        expect.closeTo(10),
+        expect.closeTo(10)
+      ])
+      expect(history.map((point) => point.growthWeightEth)).toEqual([
+        expect.closeTo(0),
+        expect.closeTo(5),
+        expect.closeTo(5)
+      ])
+      expect(history.map((point) => point.growthIndex)).toEqual([
+        expect.closeTo(100),
+        expect.closeTo(110),
+        expect.closeTo(110)
+      ])
+      const vault = materializeProtocolReturnVaults({
+        ...inputs,
+        ledgers: buildProtocolReturnLedgers({ ...inputs, currentTimestamp: 3 * day - 1 }),
+        currentTimestamp: 3 * day - 1
+      })[0]!
+      expect(vault.issues).toEqual(['missing_exit_price'])
+      expect(vault.currentUnderlying).toBe(0)
+      expect(vault.growthWeightUsd).toBeCloseTo(10)
+      expect(vault.growthWeightEth).toBeCloseTo(5)
+    }
+  )
+
+  it('keeps USD and Index available when only the receipt ETH conversion price is missing', () => {
+    const history = buildProtocolReturnHistorySeries({
+      events: [baseEvent({ id: 'receipt', blockTimestamp: 100 })],
+      userAddress: USER,
+      metadata,
+      ppsData: new Map([
+        [
+          VAULT_KEY,
+          new Map([
+            [100, 1],
+            [200, 1.1]
+          ])
+        ]
+      ]),
+      priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
+      ethPriceData: new Map([[200, 2]]),
+      timestamps: [100, 200]
+    })
+    expect(history.map((point) => point.growthWeightUsd)).toEqual([expect.closeTo(0), expect.closeTo(10)])
+    expect(history.map((point) => point.growthIndex)).toEqual([expect.closeTo(100), expect.closeTo(110)])
+    expect(history.map((point) => point.growthWeightEth)).toEqual([null, null])
   })
 
   it('ignores events after an explicit ledger cutoff', () => {
@@ -2582,7 +2938,7 @@ describe('pnl simple protocol return', () => {
     expect(vault.baselineUnderlying).toBeCloseTo(300)
     expect(vault.realizedBaselineUnderlying).toBeCloseTo(0)
     expect(vault.realizedGrowthUnderlying).toBeCloseTo(0)
-    expect(vault.growthUnderlying).toBeCloseTo(300)
+    expect(vault.growthUnderlying).toBeNull()
     expect(vault.exitCount).toBe(0)
     expect(vault.unmatchedExitSharesFormatted).toBeCloseTo(0)
   })
@@ -2792,8 +3148,8 @@ describe('pnl simple protocol return', () => {
 
     expect(vault.status).toBe('missing_pps')
     expect(vault.baselineUnderlying).toBe(0)
-    expect(vault.currentUnderlying).toBe(0)
-    expect(vault.growthUnderlying).toBe(0)
+    expect(vault.currentUnderlying).toBeNull()
+    expect(vault.growthUnderlying).toBeNull()
   })
 
   it('preserves a locked yvUSD lot when its withdrawal and transfer-out lack unlocked PPS', () => {
@@ -2905,7 +3261,7 @@ describe('pnl simple protocol return', () => {
     expect(vault.currentUnderlying).toBeCloseTo(107.1)
     expect(vault.realizedBaselineUnderlying).toBeCloseTo(0)
     expect(vault.realizedGrowthUnderlying).toBeCloseTo(0)
-    expect(vault.growthUnderlying).toBeCloseTo(7.1)
+    expect(vault.growthUnderlying).toBeNull()
     expect(vault.exitCount).toBe(0)
     expect(vault.unmatchedExitSharesFormatted).toBeCloseTo(0)
   })

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
@@ -1318,7 +1318,7 @@ describe('pnl simple protocol return', () => {
     expect(history[1]?.growthUnderlying).toBeCloseTo(52)
   })
 
-  it('does not publish a partial ETH total when another vault is missing receipt prices', () => {
+  it('publishes the available ETH total when another vault is missing receipt prices', () => {
     const MISSING_VAULT = '0x5555555555555555555555555555555555555555'
     const MISSING_ASSET = '0x6666666666666666666666666666666666666666'
     const MISSING_VAULT_KEY = toVaultKey(1, MISSING_VAULT)
@@ -1395,7 +1395,7 @@ describe('pnl simple protocol return', () => {
 
     expect(history[0]?.growthWeightEth).toBeCloseTo(0)
     expect(history[1]?.growthWeightUsd).toBeCloseTo(10)
-    expect(history[1]?.growthWeightEth).toBeNull()
+    expect(history[1]?.growthWeightEth).toBeCloseTo(5)
   })
 
   it('does not double count the ERC4626 mint transfer alongside a deposit event', () => {
@@ -2206,7 +2206,31 @@ describe('pnl simple protocol return', () => {
       priceData: new Map([[ASSET_PRICE_KEY, new Map([[100, 1]])]]),
       ethPriceData: new Map([[100, 2]]),
       timestamps: [100, 200],
-      selectedVaults: [selectedVault]
+      selectedVaults: [selectedVault],
+      portfolioPoints: [
+        {
+          date: '1970-01-01',
+          timestamp: 100,
+          growthUsd: 0,
+          growthUsdEstimated: false,
+          growthWeightUsd: 0,
+          growthWeightEth: 0,
+          protocolReturnPct: 0,
+          annualizedProtocolReturnPct: 0,
+          growthIndex: 100
+        },
+        {
+          date: '1970-01-01',
+          timestamp: 200,
+          growthUsd: 10,
+          growthUsdEstimated: false,
+          growthWeightUsd: 10,
+          growthWeightEth: 5,
+          protocolReturnPct: 10,
+          annualizedProtocolReturnPct: 10,
+          growthIndex: 110
+        }
+      ]
     })
 
     expect(familyHistory).toHaveLength(1)
@@ -2215,6 +2239,10 @@ describe('pnl simple protocol return', () => {
     expect(familyHistory[0]?.dataPoints[0]?.growthWeightEth).toBeCloseTo(0)
     expect(familyHistory[0]?.dataPoints[1]?.growthIndex).toBeCloseTo(110)
     expect(familyHistory[0]?.dataPoints[1]?.growthWeightEth).toBeCloseTo(5)
+    expect(familyHistory[0]?.dataPoints.map((point) => point.growthIndexContribution)).toEqual([
+      expect.closeTo(0),
+      expect.closeTo(10)
+    ])
   })
 
   it('chains family PPS returns without treating added deposits or partial withdrawals as performance', () => {

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
@@ -226,6 +226,7 @@ export interface HoldingsPnLSimpleHistoryFamilyPoint {
   growthWeightUsd: number | null
   growthWeightEth: number | null
   growthIndex: number | null
+  growthIndexContribution: number | null
 }
 
 export interface HoldingsPnLSimpleHistoryFamilySeries {
@@ -2243,12 +2244,8 @@ function buildGrowthWeightEthSummary(args: {
     })
   )
 
-  return perVaultGrowthWeightEth.length > 0
-    ? perVaultGrowthWeightEth.reduce<number | null>(
-        (total, value) => (total === null || value === null ? null : total + value),
-        0
-      )
-    : null
+  const availableValues = perVaultGrowthWeightEth.filter((value): value is number => value !== null)
+  return availableValues.length > 0 ? availableValues.reduce((total, value) => total + value, 0) : null
 }
 
 function buildOpenBaselineCompositionUsd(args: {
@@ -2703,6 +2700,7 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
   ethPriceData?: Map<number, number>
   timestamps: number[]
   selectedVaults: HoldingsPnLSimpleVault[]
+  portfolioPoints?: HoldingsPnLSimpleHistoryPoint[]
 }): HoldingsPnLSimpleHistoryFamilySeries[] {
   if (args.selectedVaults.length === 0) {
     return []
@@ -2720,8 +2718,16 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
     Array.from(selectedVaultKeys, (key) => [key, []] as const)
   )
 
-  let transactionIndex = 0
   let ledgers = new Map<string, TProtocolReturnLedger>()
+  let transactionIndex = 0
+  let previousPortfolioPoint: HoldingsPnLSimpleHistoryPoint | null = null
+  const portfolioPointByTimestamp = new Map(
+    (args.portfolioPoints ?? []).map((point) => [point.timestamp, point] as const)
+  )
+  const previousFamilyGrowthWeightUsd = new Map<string, number>(
+    Array.from(selectedVaultKeys, (key) => [key, 0] as const)
+  )
+  const familyIndexContribution = new Map<string, number>(Array.from(selectedVaultKeys, (key) => [key, 0] as const))
   const familyIndexState = new Map<
     string,
     {
@@ -2777,6 +2783,30 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
         currentTimestamp: timestamp
       }).map((vault) => [toVaultKey(vault.chainId, vault.vaultAddress), vault] as const)
     )
+    const portfolioPoint = portfolioPointByTimestamp.get(timestamp) ?? null
+    const previousPortfolioIndex = previousPortfolioPoint?.growthIndex
+    const portfolioIndex = portfolioPoint?.growthIndex
+    const canAttributeIndex = typeof previousPortfolioIndex === 'number' && typeof portfolioIndex === 'number'
+    const growthWeightDelta =
+      portfolioPoint && previousPortfolioPoint
+        ? portfolioPoint.growthWeightUsd - previousPortfolioPoint.growthWeightUsd
+        : 0
+    const indexPointsPerGrowthUsd =
+      canAttributeIndex && Math.abs(growthWeightDelta) > Number.EPSILON
+        ? (portfolioIndex - previousPortfolioIndex) / growthWeightDelta
+        : 0
+
+    if (canAttributeIndex) {
+      selectedVaultKeys.forEach((vaultKey) => {
+        const currentGrowthWeightUsd = vaultsByKey.get(vaultKey)?.growthWeightUsd ?? 0
+        const previousGrowthWeightUsd = previousFamilyGrowthWeightUsd.get(vaultKey) ?? 0
+        familyIndexContribution.set(
+          vaultKey,
+          (familyIndexContribution.get(vaultKey) ?? 0) +
+            (currentGrowthWeightUsd - previousGrowthWeightUsd) * indexPointsPerGrowthUsd
+        )
+      })
+    }
 
     selectedVaultKeys.forEach((vaultKey) => {
       const familyVault = vaultsByKey.get(vaultKey)
@@ -2821,9 +2851,17 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
                 ppsData: args.ppsData,
                 currentTimestamp: timestamp
               }),
-        growthIndex: hasOpenPosition || closesPosition ? state.growthIndex : null
+        growthIndex: hasOpenPosition || closesPosition ? state.growthIndex : null,
+        growthIndexContribution:
+          familyLedger && typeof portfolioPoint?.growthIndex === 'number'
+            ? (familyIndexContribution.get(vaultKey) ?? 0)
+            : null
       })
     })
+    selectedVaultKeys.forEach((vaultKey) => {
+      previousFamilyGrowthWeightUsd.set(vaultKey, vaultsByKey.get(vaultKey)?.growthWeightUsd ?? 0)
+    })
+    previousPortfolioPoint = portfolioPoint
   })
 
   return Array.from(selectedVaultKeys).flatMap((vaultKey) => {
@@ -3054,7 +3092,8 @@ async function calculateHoldingsProtocolReturnHistory(
     exitPriceData,
     ethPriceData,
     timestamps,
-    selectedVaults: requestedVaults ? [] : eligibleHistoryFamilies
+    selectedVaults: requestedVaults ? [] : eligibleHistoryFamilies,
+    portfolioPoints: history
   })
   reportHoldingsProgress(92, 'Built historical chart series', `${history.length} chart points`)
   const openBaselineCompositionUsd = buildOpenBaselineCompositionUsd({

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
@@ -831,12 +831,13 @@ function valueDepositOrWithdrawalEvent(
     assetDecimals: number
     shareDecimals: number
     ppsMap: Map<number, number> | undefined
+    useDailyPps: boolean
   }
 ): {
   underlying: number
   missingPps: boolean
 } {
-  if (!isKnownStakingWrapperEvent(event)) {
+  if (!args.useDailyPps && !isKnownStakingWrapperEvent(event)) {
     return {
       underlying: formatAmount(event.assets, args.assetDecimals),
       missingPps: false
@@ -1091,6 +1092,7 @@ function processEvent(
     priceData: Map<string, Map<number, number>>
     exitPriceData: Map<string, Map<number, number>>
     ethPriceData: Map<number, number>
+    useDailyPpsForFlows?: boolean
   }
 ): Map<string, TProtocolReturnLedger> {
   const vaultKey = toVaultKey(event.chainId, event.familyVaultAddress)
@@ -1121,7 +1123,8 @@ function processEvent(
     const directValuation = valueDepositOrWithdrawalEvent(event, {
       assetDecimals,
       shareDecimals,
-      ppsMap
+      ppsMap,
+      useDailyPps: args.useDailyPpsForFlows ?? false
     })
     const valuation = convertUnderlyingToTerminalAsset({
       directUnderlying: directValuation.underlying,
@@ -1153,7 +1156,8 @@ function processEvent(
     const directValuation = valueDepositOrWithdrawalEvent(event, {
       assetDecimals,
       shareDecimals,
-      ppsMap
+      ppsMap,
+      useDailyPps: args.useDailyPpsForFlows ?? false
     })
     const valuation = convertUnderlyingToTerminalAsset({
       directUnderlying: directValuation.underlying,
@@ -2570,7 +2574,8 @@ export function buildProtocolReturnHistorySeries(args: {
     ppsData: args.ppsData,
     priceData: args.priceData,
     exitPriceData: args.exitPriceData ?? args.priceData,
-    ethPriceData: args.ethPriceData ?? new Map<number, number>()
+    ethPriceData: args.ethPriceData ?? new Map<number, number>(),
+    useDailyPpsForFlows: true
   }
   const markGrowthIndex = (timestamp: number, afterReceipt = false) => {
     const vaults = materializeProtocolReturnVaults({
@@ -2763,7 +2768,8 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
             ppsData: args.ppsData,
             priceData: args.priceData,
             exitPriceData: args.exitPriceData ?? args.priceData,
-            ethPriceData: args.ethPriceData ?? new Map()
+            ethPriceData: args.ethPriceData ?? new Map(),
+            useDailyPpsForFlows: true
           })
         })
       })

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
@@ -150,21 +150,22 @@ export interface HoldingsPnLSimpleVault {
   shares: string
   sharesFormatted: number
   pricePerShare: number
-  currentUnderlying: number
+  currentUnderlying: number | null
   baselineUnderlying: number
   baselineExposureUnderlyingYears: number
   baselineExposureWeightUsdYears: number
   realizedBaselineUnderlying: number
   unrealizedBaselineUnderlying: number
   realizedGrowthUnderlying: number
-  unrealizedGrowthUnderlying: number
+  unrealizedGrowthUnderlying: number | null
   realizedGrowthUsdAtExit: number
   unpricedRealizedGrowthUnderlying: number
-  growthUnderlying: number
+  growthUnderlying: number | null
   baselineWeightUsd: number
-  growthWeightUsd: number
+  growthWeightUsd: number | null
+  growthWeightEth: number | null
   realizedGrowthWeightUsd: number
-  unrealizedGrowthWeightUsd: number
+  unrealizedGrowthWeightUsd: number | null
   protocolReturnPct: number | null
   annualizedProtocolReturnPct: number | null
   receiptCount: number
@@ -206,15 +207,15 @@ export interface HoldingsPnLSimpleResponse {
 export interface HoldingsPnLSimpleHistoryPoint {
   date: string
   timestamp: number
-  growthUsd: number
+  growthUsd: number | null
   growthUsdEstimated: boolean
-  growthWeightUsd: number
+  growthWeightUsd: number | null
   growthWeightEth: number | null
   protocolReturnPct: number | null
   annualizedProtocolReturnPct: number | null
   growthIndex: number | null
-  currentUnderlying?: number
-  growthUnderlying?: number
+  currentUnderlying?: number | null
+  growthUnderlying?: number | null
   sharesFormatted?: number
   pricePerShare?: number
 }
@@ -261,6 +262,7 @@ export interface HoldingsPnLSimpleHistoryResponse {
       status: Exclude<THoldingsPnLSimpleStatus, 'ok'>
       issues: TProtocolReturnIssue[]
     }>
+    growthIsPartial?: Record<TGrowthDisplay, boolean>
     isComplete: boolean
   }
   dataPoints: HoldingsPnLSimpleHistoryPoint[]
@@ -274,8 +276,8 @@ export interface HoldingsPortfolioGrowthVault {
   issues: TProtocolReturnIssue[]
   baselineUsd: number
   baselineExposureUsdYears: number
-  growthUnderlying: number
-  growthUsd: number
+  growthUnderlying: number | null
+  growthUsd: number | null
   growthPct: number | null
   annualizedProtocolReturnPct: number | null
   metadata: {
@@ -404,12 +406,12 @@ function scaleNumber(value: number, numerator: bigint, denominator: bigint): num
   return denominator === ZERO ? 0 : value * (Number(numerator) / Number(denominator))
 }
 
-function protocolReturnPct(growth: number, baseline: number): number | null {
-  return baseline > 0 ? (growth / baseline) * 100 : null
+function protocolReturnPct(growth: number | null, baseline: number): number | null {
+  return growth !== null && baseline > 0 ? (growth / baseline) * 100 : null
 }
 
-function annualizedProtocolReturnPct(growth: number, exposureYears: number): number | null {
-  return exposureYears > 0 ? (growth / exposureYears) * 100 : null
+function annualizedProtocolReturnPct(growth: number | null, exposureYears: number): number | null {
+  return growth !== null && exposureYears > 0 ? (growth / exposureYears) * 100 : null
 }
 
 function advanceGrowthIndex(args: {
@@ -913,10 +915,6 @@ function getOutstandingBaselineUnderlying(lots: TProtocolReturnLot[]): number {
 
 function getOutstandingBaselineWeightUsd(lots: TProtocolReturnLot[]): number {
   return lots.reduce((total, lot) => total + lot.baselineUnderlying * lot.receiptPriceUsd, 0)
-}
-
-function getOutstandingBaselineWeightEth(lots: TProtocolReturnLot[]): number {
-  return lots.reduce((total, lot) => total + lot.baselineUnderlying * lot.receiptPriceEth, 0)
 }
 
 function accrueLedgerExposure(ledger: TProtocolReturnLedger, nextTimestamp: number): TProtocolReturnLedger {
@@ -2026,6 +2024,7 @@ function getProtocolReturnHistoryTailPlan(args: {
   if (
     !args.cached ||
     !protocolReturn ||
+    Object.values(protocolReturn.summary.growthIsPartial ?? {}).some(Boolean) ||
     protocolReturn.address !== lowerCaseAddress(args.userAddress) ||
     protocolReturn.timeframe !== args.timeframe
   ) {
@@ -2180,9 +2179,12 @@ function ledgerIssues(args: {
   missingMetadata: boolean
   currentPps: number | null
 }): TProtocolReturnIssue[] {
+  const hasOpenPosition = args.ledger.lots.some((lot) => lot.shares > ZERO)
   return [
-    ...(!args.metadata || args.ledger.missingMetadata || args.missingMetadata ? (['missing_metadata'] as const) : []),
-    ...(args.ledger.missingPps || (!args.missingMetadata && args.currentPps === null)
+    ...(args.ledger.missingMetadata || (hasOpenPosition && (!args.metadata || args.missingMetadata))
+      ? (['missing_metadata'] as const)
+      : []),
+    ...(args.ledger.missingPps || (hasOpenPosition && !args.missingMetadata && args.currentPps === null)
       ? (['missing_pps'] as const)
       : []),
     ...(args.ledger.missingReceiptPrice ? (['missing_receipt_price'] as const) : []),
@@ -2207,56 +2209,8 @@ function vaultStatus(issues: TProtocolReturnIssue[]): THoldingsPnLSimpleStatus {
   return issues.includes('unmatched_exit') ? 'partial' : 'ok'
 }
 
-function computeVaultGrowthWeightEth(args: {
-  ledger: TProtocolReturnLedger
-  metadata: Map<string, VaultMetadata>
-  ppsData: Map<string, Map<number, number>>
-  currentTimestamp: number
-}): number | null {
-  if (args.ledger.missingReceiptEthPrice) {
-    return null
-  }
-
-  const vaultKey = toVaultKey(args.ledger.chainId, args.ledger.vaultAddress)
-  const metadata = args.metadata.get(vaultKey)
-  const shareDecimals = metadata?.decimals ?? 18
-  const valuation = resolveNestedVaultValuation({
-    chainId: args.ledger.chainId,
-    vaultAddress: args.ledger.vaultAddress,
-    vaultMetadata: args.metadata,
-    ppsData: args.ppsData,
-    timestamp: args.currentTimestamp
-  })
-  const currentPps = valuation.pricePerShare
-  const currentShares = args.ledger.lots.reduce((total, lot) => total + lot.shares, ZERO)
-  const sharesFormatted = formatAmount(currentShares, shareDecimals)
-  const currentUnderlying = currentPps === null ? 0 : sharesFormatted * currentPps
-  const unrealizedBaselineWeightEth = getOutstandingBaselineWeightEth(args.ledger.lots)
-  const currentWeightEth = args.ledger.lots.reduce(
-    (total, lot) => total + scaleNumber(currentUnderlying, lot.shares, currentShares) * lot.receiptPriceEth,
-    0
-  )
-  const unrealizedGrowthWeightEth = currentWeightEth - unrealizedBaselineWeightEth
-
-  return args.ledger.realizedGrowthWeightEth + unrealizedGrowthWeightEth
-}
-
-function buildGrowthWeightEthSummary(args: {
-  ledgers: Map<string, TProtocolReturnLedger>
-  metadata: Map<string, VaultMetadata>
-  ppsData: Map<string, Map<number, number>>
-  currentTimestamp: number
-}): number | null {
-  const perVaultGrowthWeightEth = Array.from(args.ledgers.values()).map((ledger) =>
-    computeVaultGrowthWeightEth({
-      ledger,
-      metadata: args.metadata,
-      ppsData: args.ppsData,
-      currentTimestamp: args.currentTimestamp
-    })
-  )
-
-  const availableValues = perVaultGrowthWeightEth.filter((value): value is number => value !== null)
+function sumAvailable(values: Array<number | null>): number | null {
+  const availableValues = values.filter((value): value is number => value !== null)
   return availableValues.length > 0 ? availableValues.reduce((total, value) => total + value, 0) : null
 }
 
@@ -2316,23 +2270,34 @@ export function materializeProtocolReturnVaults(args: {
     const terminalAsset = valuation.terminalAsset
     const currentShares = ledger.lots.reduce((total, lot) => total + lot.shares, ZERO)
     const sharesFormatted = formatAmount(currentShares, shareDecimals)
-    const currentUnderlying = currentPps === null ? 0 : sharesFormatted * currentPps
+    const currentUnderlying = currentShares === ZERO ? 0 : currentPps === null ? null : sharesFormatted * currentPps
+    const issues = ledgerIssues({ ledger, metadata, missingMetadata: valuation.missingMetadata, currentPps })
+    const underlyingComplete = !issues.some((issue) =>
+      ['missing_metadata', 'missing_pps', 'unmatched_exit'].includes(issue)
+    )
     const unrealizedBaselineUnderlying = ledger.lots.reduce((total, lot) => total + lot.baselineUnderlying, 0)
     const unrealizedBaselineWeightUsd = ledger.lots.reduce(
       (total, lot) => total + lot.baselineUnderlying * lot.receiptPriceUsd,
       0
     )
-    const currentWeightUsd = ledger.lots.reduce(
-      (total, lot) => total + scaleNumber(currentUnderlying, lot.shares, currentShares) * lot.receiptPriceUsd,
-      0
-    )
-    const unrealizedGrowthUnderlying = currentUnderlying - unrealizedBaselineUnderlying
-    const unrealizedGrowthWeightUsd = currentWeightUsd - unrealizedBaselineWeightUsd
+    const unrealizedGrowthUnderlying =
+      underlyingComplete && currentUnderlying !== null ? currentUnderlying - unrealizedBaselineUnderlying : null
+    const unrealizedGrowthWeight = (priceKey: 'receiptPriceUsd' | 'receiptPriceEth'): number | null =>
+      unrealizedGrowthUnderlying === null || currentUnderlying === null
+        ? null
+        : ledger.lots.reduce(
+            (total, lot) =>
+              total +
+              (scaleNumber(currentUnderlying, lot.shares, currentShares) - lot.baselineUnderlying) * lot[priceKey],
+            0
+          )
+    const unrealizedGrowthWeightUsd = ledger.missingReceiptPrice ? null : unrealizedGrowthWeight('receiptPriceUsd')
+    const unrealizedGrowthWeightEth = ledger.missingReceiptEthPrice ? null : unrealizedGrowthWeight('receiptPriceEth')
     const baselineExposureUnderlyingYears = ledger.baselineExposureUnderlyingSeconds / SECONDS_PER_YEAR
     const baselineExposureWeightUsdYears = ledger.baselineExposureWeightUsdSeconds / SECONDS_PER_YEAR
     const baselineWeightUsd = ledger.realizedBaselineWeightUsd + unrealizedBaselineWeightUsd
-    const growthWeightUsd = ledger.realizedGrowthWeightUsd + unrealizedGrowthWeightUsd
-    const issues = ledgerIssues({ ledger, metadata, missingMetadata: valuation.missingMetadata, currentPps })
+    const growthWeightUsd =
+      unrealizedGrowthWeightUsd === null ? null : ledger.realizedGrowthWeightUsd + unrealizedGrowthWeightUsd
     const status = vaultStatus(issues)
 
     return {
@@ -2353,9 +2318,12 @@ export function materializeProtocolReturnVaults(args: {
       unrealizedGrowthUnderlying,
       realizedGrowthUsdAtExit: ledger.realizedGrowthUsdAtExit,
       unpricedRealizedGrowthUnderlying: ledger.unpricedRealizedGrowthUnderlying,
-      growthUnderlying: ledger.realizedGrowthUnderlying + unrealizedGrowthUnderlying,
+      growthUnderlying:
+        unrealizedGrowthUnderlying === null ? null : ledger.realizedGrowthUnderlying + unrealizedGrowthUnderlying,
       baselineWeightUsd,
       growthWeightUsd,
+      growthWeightEth:
+        unrealizedGrowthWeightEth === null ? null : ledger.realizedGrowthWeightEth + unrealizedGrowthWeightEth,
       realizedGrowthWeightUsd: ledger.realizedGrowthWeightUsd,
       unrealizedGrowthWeightUsd,
       protocolReturnPct: protocolReturnPct(growthWeightUsd, baselineWeightUsd),
@@ -2429,7 +2397,10 @@ function buildLatestAssetPriceUsdByVaultKey(
   )
 }
 
-function getGrowthUsd(vault: HoldingsPnLSimpleVault, latestAssetPriceUsd: number | null): number {
+function getGrowthUsd(vault: HoldingsPnLSimpleVault, latestAssetPriceUsd: number | null): number | null {
+  if (vault.unrealizedGrowthUnderlying === null) {
+    return null
+  }
   const growthValuedAtLatestPrice =
     latestAssetPriceUsd === null
       ? 0
@@ -2511,14 +2482,15 @@ function normalizeProtocolReturnPortfolioResponse(
 }
 
 function buildSummary(vaults: HoldingsPnLSimpleVault[]): HoldingsPnLSimpleResponse['summary'] {
+  const growthComplete = vaults.every((vault) => vault.growthWeightUsd !== null)
   const baselineWeightUsd = vaults.reduce((total, vault) => total + vault.baselineWeightUsd, 0)
-  const growthWeightUsd = vaults.reduce((total, vault) => total + vault.growthWeightUsd, 0)
+  const growthWeightUsd = vaults.reduce((total, vault) => total + (vault.growthWeightUsd ?? 0), 0)
   const baselineExposureWeightUsdYears = vaults.reduce(
     (total, vault) => total + vault.baselineExposureWeightUsdYears,
     0
   )
   const realizedGrowthWeightUsd = vaults.reduce((total, vault) => total + vault.realizedGrowthWeightUsd, 0)
-  const unrealizedGrowthWeightUsd = vaults.reduce((total, vault) => total + vault.unrealizedGrowthWeightUsd, 0)
+  const unrealizedGrowthWeightUsd = vaults.reduce((total, vault) => total + (vault.unrealizedGrowthWeightUsd ?? 0), 0)
   const completeVaults = vaults.filter((vault) => vault.status === 'ok').length
   const partialVaults = vaults.length - completeVaults
 
@@ -2531,8 +2503,11 @@ function buildSummary(vaults: HoldingsPnLSimpleVault[]): HoldingsPnLSimpleRespon
     baselineExposureWeightUsdYears,
     realizedGrowthWeightUsd,
     unrealizedGrowthWeightUsd,
-    protocolReturnPct: protocolReturnPct(growthWeightUsd, baselineWeightUsd),
-    annualizedProtocolReturnPct: annualizedProtocolReturnPct(growthWeightUsd, baselineExposureWeightUsdYears),
+    protocolReturnPct: protocolReturnPct(growthComplete ? growthWeightUsd : null, baselineWeightUsd),
+    annualizedProtocolReturnPct: annualizedProtocolReturnPct(
+      growthComplete ? growthWeightUsd : null,
+      baselineExposureWeightUsdYears
+    ),
     isComplete: partialVaults === 0
   }
 }
@@ -2561,6 +2536,72 @@ export function buildProtocolReturnHistorySeries(args: {
   selectedVaultKeys?: string[]
   growthIndexSeed?: { timestamp: number; growthIndex: number | null }
 }): HoldingsPnLSimpleHistoryPoint[] {
+  return calculateProtocolReturnHistorySeries(args).dataPoints
+}
+
+type TGrowthExclusions = { usd: Set<string>; eth: Set<string> }
+
+function getProtocolReturnHistoryExclusions(
+  timeline: Array<{ timestamp: number; event: TRawPnlEvent | null }>,
+  eventContext: Parameters<typeof processEvent>[2]
+): TGrowthExclusions {
+  const excluded: TGrowthExclusions = { usd: new Set(), eth: new Set() }
+  const ledgers = new Map<string, TProtocolReturnLedger>()
+  const state = { initialized: false }
+  const validate = (ledger: TProtocolReturnLedger, timestamp: number): void => {
+    const key = toVaultKey(ledger.chainId, ledger.vaultAddress)
+    if (excluded.usd.has(key)) {
+      return
+    }
+
+    const valuation = ledger.lots.some((lot) => lot.shares > ZERO)
+      ? resolveNestedVaultValuation({
+          chainId: ledger.chainId,
+          vaultAddress: ledger.vaultAddress,
+          vaultMetadata: eventContext.metadata,
+          ppsData: eventContext.ppsData,
+          timestamp
+        })
+      : null
+    const issues = ledgerIssues({
+      ledger,
+      metadata: eventContext.metadata.get(key),
+      missingMetadata: valuation?.missingMetadata ?? false,
+      currentPps: valuation?.pricePerShare ?? null
+    })
+    // Receipt-weighted growth does not need exit USD prices or PPS after a full exit.
+    if (issues.some((issue) => issue !== 'missing_exit_price')) {
+      excluded.usd.add(key)
+      excluded.eth.add(key)
+    } else if (ledger.missingReceiptEthPrice) {
+      excluded.eth.add(key)
+    }
+  }
+
+  // Check coverage before calculating returns, including gaps at other vaults' flow timestamps.
+  timeline.forEach(({ timestamp, event }) => {
+    if (state.initialized || event === null) {
+      ledgers.forEach((ledger) => {
+        validate(ledger, timestamp)
+      })
+    }
+    if (event) {
+      processEvent(ledgers, event, eventContext)
+      const ledger = ledgers.get(toVaultKey(event.chainId, event.familyVaultAddress))
+      if (state.initialized && ledger) {
+        validate(ledger, timestamp)
+      }
+    } else {
+      state.initialized = true
+    }
+  })
+  return excluded
+}
+
+function calculateProtocolReturnHistorySeries(args: Parameters<typeof buildProtocolReturnHistorySeries>[0]): {
+  dataPoints: HoldingsPnLSimpleHistoryPoint[]
+  excludedVaultKeys: TGrowthExclusions
+} {
   const userAddress = lowerCaseAddress(args.userAddress)
   const effectiveEvents = buildEffectiveSimpleEvents(args.events, userAddress)
   const groupedTransactions = groupEventsByTransaction(effectiveEvents)
@@ -2585,39 +2626,6 @@ export function buildProtocolReturnHistorySeries(args: {
     ethPriceData: args.ethPriceData ?? new Map<number, number>(),
     useDailyPpsForFlows: true
   }
-  const markGrowthIndex = (timestamp: number, afterReceipt = false) => {
-    const vaults = materializeProtocolReturnVaults({
-      ledgers,
-      metadata: args.metadata,
-      ppsData: args.ppsData,
-      currentTimestamp: timestamp
-    })
-    const summary = buildSummary(vaults)
-    const receivedCapital = afterReceipt ? Math.max(0, summary.baselineWeightUsd - state.baselineWeightUsd) : 0
-    const hasValuation =
-      state.indexValuationComplete &&
-      vaults.every((vault) => !vault.issues.includes('missing_metadata') && !vault.issues.includes('missing_pps'))
-    // An unknown return cannot be linked later by silently starting again at 100.
-    state.indexValuationComplete = hasValuation
-    state.growthIndex = !hasValuation
-      ? null
-      : state.initialized
-        ? advanceGrowthIndex({
-            previousIndex: state.growthIndex,
-            deltaGrowthWeightUsd: summary.growthWeightUsd - state.growthWeightUsd,
-            capitalWeightUsd: state.openCapitalWeightUsd + receivedCapital
-          })
-        : summary.baselineWeightUsd > 0 || summary.growthWeightUsd !== 0
-          ? 100
-          : null
-    state.growthWeightUsd = summary.growthWeightUsd
-    state.baselineWeightUsd = summary.baselineWeightUsd
-    // Previously withdrawn gains are not capital in the next holding period.
-    state.openCapitalWeightUsd =
-      Array.from(ledgers.values()).reduce((total, ledger) => total + getOutstandingBaselineWeightUsd(ledger.lots), 0) +
-      summary.unrealizedGrowthWeightUsd
-    return { vaults, summary }
-  }
   const normalizedEvents = groupedTransactions.flatMap((txEvents) =>
     sortEvents(
       groupTransactionEventsByFamily(txEvents).flatMap((familyEvents) =>
@@ -2630,13 +2638,51 @@ export function buildProtocolReturnHistorySeries(args: {
       .filter((event) => event.blockTimestamp <= (args.timestamps.at(-1) ?? 0))
       .map((event) => ({ timestamp: event.blockTimestamp, event })),
     ...args.timestamps.map((timestamp) => ({ timestamp, event: null }))
-  ]
-
-  return timeline
-    .toSorted(
-      (left, right) => left.timestamp - right.timestamp || Number(left.event === null) - Number(right.event === null)
+  ].toSorted(
+    (left, right) => left.timestamp - right.timestamp || Number(left.event === null) - Number(right.event === null)
+  )
+  const excludedVaultKeys = getProtocolReturnHistoryExclusions(timeline, eventContext)
+  const growthIndexSeed = excludedVaultKeys.eth.size === 0 ? args.growthIndexSeed : undefined
+  const markGrowthIndex = (timestamp: number, afterReceipt = false) => {
+    const vaults = materializeProtocolReturnVaults({
+      ledgers,
+      metadata: args.metadata,
+      ppsData: args.ppsData,
+      currentTimestamp: timestamp
+    })
+    const summary = buildSummary(vaults)
+    const indexVaults = vaults.filter(
+      (vault) => !excludedVaultKeys.usd.has(toVaultKey(vault.chainId, vault.vaultAddress))
     )
-    .reduce<HoldingsPnLSimpleHistoryPoint[]>((history, { timestamp, event }) => {
+    const indexSummary = buildSummary(indexVaults)
+    const receivedCapital = afterReceipt ? Math.max(0, indexSummary.baselineWeightUsd - state.baselineWeightUsd) : 0
+    // An unknown cached return cannot be linked later by silently starting again at 100.
+    state.growthIndex = !state.indexValuationComplete
+      ? null
+      : state.initialized
+        ? advanceGrowthIndex({
+            previousIndex: state.growthIndex,
+            deltaGrowthWeightUsd: indexSummary.growthWeightUsd - state.growthWeightUsd,
+            capitalWeightUsd: state.openCapitalWeightUsd + receivedCapital
+          })
+        : indexSummary.baselineWeightUsd > 0 || indexSummary.growthWeightUsd !== 0
+          ? 100
+          : null
+    state.growthWeightUsd = indexSummary.growthWeightUsd
+    state.baselineWeightUsd = indexSummary.baselineWeightUsd
+    // Previously withdrawn gains are not capital in the next holding period.
+    state.openCapitalWeightUsd =
+      Array.from(ledgers.entries()).reduce(
+        (total, [key, ledger]) =>
+          total + (excludedVaultKeys.usd.has(key) ? 0 : getOutstandingBaselineWeightUsd(ledger.lots)),
+        0
+      ) + indexSummary.unrealizedGrowthWeightUsd
+    return { vaults, summary, indexVaults }
+  }
+
+  return {
+    excludedVaultKeys,
+    dataPoints: timeline.reduce<HoldingsPnLSimpleHistoryPoint[]>((history, { timestamp, event }) => {
       if (event) {
         // Value existing capital before the flow and its exact receipt/exit adjustment afterwards.
         if (state.initialized) {
@@ -2652,10 +2698,10 @@ export function buildProtocolReturnHistorySeries(args: {
       ledgers.forEach((ledger, key) => {
         ledgers.set(key, accrueLedgerExposure(ledger, timestamp))
       })
-      const { vaults, summary } = markGrowthIndex(timestamp)
+      const { vaults, summary, indexVaults } = markGrowthIndex(timestamp)
       state.initialized = true
-      if (state.indexValuationComplete && args.growthIndexSeed?.timestamp === timestamp) {
-        state.growthIndex = args.growthIndexSeed.growthIndex
+      if (state.indexValuationComplete && growthIndexSeed?.timestamp === timestamp) {
+        state.growthIndex = growthIndexSeed.growthIndex
         if (state.growthIndex === null && (summary.baselineWeightUsd > 0 || summary.growthWeightUsd !== 0)) {
           state.indexValuationComplete = false
         }
@@ -2663,37 +2709,36 @@ export function buildProtocolReturnHistorySeries(args: {
       const selectedVaults = selectedVaultKeys.length
         ? vaults.filter((vault) => selectedVaultKeySet.has(toVaultKey(vault.chainId, vault.vaultAddress)))
         : []
-      const growthUsd = vaults.reduce(
-        (total, vault) =>
-          total +
-          getGrowthUsd(vault, latestAssetPriceUsdByVaultKey.get(toVaultKey(vault.chainId, vault.vaultAddress)) ?? null),
-        0
-      )
-      const growthWeightEth = buildGrowthWeightEthSummary({
-        ledgers,
-        metadata: args.metadata,
-        ppsData: args.ppsData,
-        currentTimestamp: timestamp
-      })
       history.push({
         date: timestampToDateString(timestamp),
         timestamp,
-        growthUsd,
+        growthUsd: sumAvailable(
+          vaults.map((vault) =>
+            getGrowthUsd(
+              vault,
+              latestAssetPriceUsdByVaultKey.get(toVaultKey(vault.chainId, vault.vaultAddress)) ?? null
+            )
+          )
+        ),
         growthUsdEstimated: vaults.some((vault) =>
           isGrowthUsdEstimated(
             vault,
             latestAssetPriceUsdByVaultKey.get(toVaultKey(vault.chainId, vault.vaultAddress)) ?? null
           )
         ),
-        growthWeightUsd: summary.growthWeightUsd,
-        growthWeightEth,
+        growthWeightUsd: sumAvailable(indexVaults.map((vault) => vault.growthWeightUsd)),
+        growthWeightEth: sumAvailable(
+          vaults
+            .filter((vault) => !excludedVaultKeys.eth.has(toVaultKey(vault.chainId, vault.vaultAddress)))
+            .map((vault) => vault.growthWeightEth)
+        ),
         protocolReturnPct: summary.protocolReturnPct,
         annualizedProtocolReturnPct: summary.annualizedProtocolReturnPct,
         growthIndex: state.growthIndex,
         ...(selectedVaultKeys.length > 0
           ? {
-              currentUnderlying: selectedVaults.reduce((sum, vault) => sum + vault.currentUnderlying, 0),
-              growthUnderlying: selectedVaults.reduce((sum, vault) => sum + vault.growthUnderlying, 0),
+              currentUnderlying: sumAvailable(selectedVaults.map((vault) => vault.currentUnderlying)),
+              growthUnderlying: sumAvailable(selectedVaults.map((vault) => vault.growthUnderlying)),
               sharesFormatted: selectedVaults.reduce((sum, vault) => sum + vault.sharesFormatted, 0),
               pricePerShare: selectedVaults.length === 1 ? selectedVaults[0]!.pricePerShare : 0
             }
@@ -2701,6 +2746,7 @@ export function buildProtocolReturnHistorySeries(args: {
       })
       return history
     }, [])
+  }
 }
 
 export function buildProtocolReturnFamilyHistorySeries(args: {
@@ -2714,6 +2760,7 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
   timestamps: number[]
   selectedVaults: HoldingsPnLSimpleVault[]
   portfolioPoints?: HoldingsPnLSimpleHistoryPoint[]
+  excludedVaultKeys?: TGrowthExclusions
 }): HoldingsPnLSimpleHistoryFamilySeries[] {
   if (args.selectedVaults.length === 0) {
     return []
@@ -2801,10 +2848,13 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
     const previousPortfolioIndex = previousPortfolioPoint?.growthIndex
     const portfolioIndex = portfolioPoint?.growthIndex
     const canAttributeIndex = typeof previousPortfolioIndex === 'number' && typeof portfolioIndex === 'number'
-    const growthWeightDelta =
-      portfolioPoint && previousPortfolioPoint
-        ? portfolioPoint.growthWeightUsd - previousPortfolioPoint.growthWeightUsd
-        : 0
+    const growthWeightDelta = Array.from(vaultsByKey.entries()).reduce(
+      (total, [key, vault]) =>
+        args.excludedVaultKeys?.usd.has(key)
+          ? total
+          : total + (vault.growthWeightUsd ?? 0) - (previousFamilyGrowthWeightUsd.get(key) ?? 0),
+      0
+    )
     const indexPointsPerGrowthUsd =
       canAttributeIndex && Math.abs(growthWeightDelta) > Number.EPSILON
         ? (portfolioIndex - previousPortfolioIndex) / growthWeightDelta
@@ -2812,6 +2862,9 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
 
     if (canAttributeIndex) {
       selectedVaultKeys.forEach((vaultKey) => {
+        if (args.excludedVaultKeys?.usd.has(vaultKey)) {
+          return
+        }
         const currentGrowthWeightUsd = vaultsByKey.get(vaultKey)?.growthWeightUsd ?? 0
         const previousGrowthWeightUsd = previousFamilyGrowthWeightUsd.get(vaultKey) ?? 0
         familyIndexContribution.set(
@@ -2824,7 +2877,6 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
 
     selectedVaultKeys.forEach((vaultKey) => {
       const familyVault = vaultsByKey.get(vaultKey)
-      const familyLedger = ledgers.get(vaultKey)
       const state = familyIndexState.get(vaultKey)
 
       if (!state) {
@@ -2855,25 +2907,25 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
           familyVault === undefined
             ? false
             : isGrowthUsdEstimated(familyVault, latestAssetPriceUsdByVaultKey.get(vaultKey) ?? null),
-        growthWeightUsd: familyVault?.growthWeightUsd ?? null,
-        growthWeightEth:
-          familyLedger === undefined
-            ? null
-            : computeVaultGrowthWeightEth({
-                ledger: familyLedger,
-                metadata: args.metadata,
-                ppsData: args.ppsData,
-                currentTimestamp: timestamp
-              }),
+        growthWeightUsd: args.excludedVaultKeys?.usd.has(vaultKey)
+          ? null
+          : familyVault
+            ? familyVault.growthWeightUsd
+            : 0,
+        growthWeightEth: args.excludedVaultKeys?.eth.has(vaultKey)
+          ? null
+          : familyVault
+            ? familyVault.growthWeightEth
+            : 0,
         growthIndex: hasOpenPosition || closesPosition ? state.growthIndex : null,
         growthIndexContribution:
-          familyLedger && typeof portfolioPoint?.growthIndex === 'number'
+          !args.excludedVaultKeys?.usd.has(vaultKey) && typeof portfolioPoint?.growthIndex === 'number'
             ? (familyIndexContribution.get(vaultKey) ?? 0)
             : null
       })
     })
-    selectedVaultKeys.forEach((vaultKey) => {
-      previousFamilyGrowthWeightUsd.set(vaultKey, vaultsByKey.get(vaultKey)?.growthWeightUsd ?? 0)
+    vaultsByKey.forEach((vault, vaultKey) => {
+      previousFamilyGrowthWeightUsd.set(vaultKey, vault.growthWeightUsd ?? 0)
     })
     previousPortfolioPoint = portfolioPoint
   })
@@ -3060,7 +3112,7 @@ async function calculateHoldingsProtocolReturnHistory(
     historyTimestamps: number[],
     growthIndexSeed?: { timestamp: number; growthIndex: number | null }
   ) =>
-    buildProtocolReturnHistorySeries({
+    calculateProtocolReturnHistorySeries({
       events: settledEvents,
       userAddress,
       metadata: vaultMetadata,
@@ -3072,20 +3124,19 @@ async function calculateHoldingsProtocolReturnHistory(
       selectedVaultKeys,
       ...(growthIndexSeed ? { growthIndexSeed } : {})
     })
-  const tailHistory = buildHistory(tailPlan?.calculationTimestamps ?? timestamps, tailPlan?.growthIndexSeed)
+  const tailResult = buildHistory(tailPlan?.calculationTimestamps ?? timestamps, tailPlan?.growthIndexSeed)
+  const tailHistory = tailResult.dataPoints
   const canAppend = Boolean(
     tailPlan &&
       cached &&
+      tailResult.excludedVaultKeys.eth.size === 0 &&
       tailHistory[0] &&
       isProtocolReturnHistoryOverlapEqual(tailPlan.cachedPoints[tailPlan.cachedPoints.length - 1]!, tailHistory[0]) &&
       haveSameProtocolReturnVaults(cached.response, finalVaults)
   )
-  const history =
-    tailPlan && canAppend
-      ? [...tailPlan.cachedPoints, ...tailHistory.slice(1)]
-      : tailPlan
-        ? buildHistory(timestamps)
-        : tailHistory
+  const historyResult = tailPlan && !canAppend ? buildHistory(timestamps) : tailResult
+  const history = tailPlan && canAppend ? [...tailPlan.cachedPoints, ...tailHistory.slice(1)] : historyResult.dataPoints
+  const excludedVaultKeys = historyResult.excludedVaultKeys
   debugLog(
     'protocol-return-history',
     tailPlan && canAppend ? 'appended missing protocol return dates' : 'rebuilt protocol return history',
@@ -3107,7 +3158,8 @@ async function calculateHoldingsProtocolReturnHistory(
     ethPriceData,
     timestamps,
     selectedVaults: requestedVaults ? [] : eligibleHistoryFamilies,
-    portfolioPoints: history
+    portfolioPoints: history,
+    excludedVaultKeys
   })
   reportHoldingsProgress(92, 'Built historical chart series', `${history.length} chart points`)
   const openBaselineCompositionUsd = buildOpenBaselineCompositionUsd({
@@ -3159,6 +3211,11 @@ async function calculateHoldingsProtocolReturnHistory(
                 }
               ]
         ),
+        growthIsPartial: {
+          usd: excludedVaultKeys.usd.size > 0,
+          eth: excludedVaultKeys.eth.size > 0,
+          index: excludedVaultKeys.usd.size > 0
+        },
         isComplete: finalVaults.every((vault) => vault.status === 'ok')
       },
       dataPoints: history,

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
@@ -253,6 +253,14 @@ export interface HoldingsPnLSimpleHistoryResponse {
       ethFamily: number
       other: number
     }
+    incompleteVaults?: Array<{
+      chainId: number
+      vaultAddress: string
+      symbol: string | null
+      tokenAddress: string | null
+      status: Exclude<THoldingsPnLSimpleStatus, 'ok'>
+      issues: TProtocolReturnIssue[]
+    }>
     isComplete: boolean
   }
   dataPoints: HoldingsPnLSimpleHistoryPoint[]
@@ -3137,6 +3145,20 @@ async function calculateHoldingsProtocolReturnHistory(
         recommendedGrowthDisplay,
         recommendedGrowthDisplayReason,
         openBaselineCompositionUsd,
+        incompleteVaults: finalVaults.flatMap((vault) =>
+          vault.status === 'ok'
+            ? []
+            : [
+                {
+                  chainId: vault.chainId,
+                  vaultAddress: vault.vaultAddress,
+                  symbol: vault.metadata.symbol,
+                  tokenAddress: vault.metadata.tokenAddress,
+                  status: vault.status,
+                  issues: vault.issues
+                }
+              ]
+        ),
         isComplete: finalVaults.every((vault) => vault.status === 'ok')
       },
       dataPoints: history,

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimpleHistory.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimpleHistory.test.ts
@@ -642,6 +642,14 @@ describe('getHoldingsProtocolReturnHistory', () => {
     const growthVault = response.growth.vaults[0]
 
     expect(response.protocolReturn.summary.isComplete).toBe(false)
+    expect(response.protocolReturn.summary.incompleteVaults).toEqual([
+      expect.objectContaining({
+        chainId: 1,
+        vaultAddress: VAULT,
+        status: 'missing_receipt_price',
+        issues: ['missing_receipt_price']
+      })
+    ])
     expect(growthVault).toMatchObject({
       status: 'ok',
       issues: [],

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimpleHistory.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimpleHistory.test.ts
@@ -622,7 +622,7 @@ describe('getHoldingsProtocolReturnHistory', () => {
     expect(scenario.response.protocolReturn.familySeries[0]?.dataPoints.at(-1)?.growthUsdEstimated).toBe(true)
   })
 
-  it('values growth history at the latest price and keeps recoverable missing-price families eligible', async () => {
+  it('keeps latest-price row growth but excludes a vault with missing receipt prices from weighted charts', async () => {
     const firstTimestamp = event.blockTimestamp + 1
     const secondTimestamp = firstTimestamp + 100
     generateDailyTimestampsMock.mockReturnValue([event.blockTimestamp, event.blockTimestamp + 100])
@@ -661,17 +661,25 @@ describe('getHoldingsProtocolReturnHistory', () => {
     expect(growthVault?.growthPct).toBeCloseTo(10)
     expect(response.protocolReturn.dataPoints[0]?.growthUsd).toBe(0)
     expect(response.protocolReturn.dataPoints[1]?.growthUsd).toBeCloseTo(30)
-    expect(response.protocolReturn.dataPoints.map((point) => point.growthWeightUsd)).toEqual([0, 0])
-    expect(response.protocolReturn.familySeries).toHaveLength(1)
-    expect(response.protocolReturn.familySeries[0]).toMatchObject({
-      chainId: 1,
-      vaultAddress: VAULT,
-      dataPoints: [
-        { timestamp: firstTimestamp, growthUsd: 0, growthWeightUsd: 0, growthWeightEth: null },
-        { timestamp: secondTimestamp, growthWeightUsd: 0, growthWeightEth: null }
-      ]
-    })
-    expect(response.protocolReturn.familySeries[0]?.dataPoints[1]?.growthUsd).toBeCloseTo(30)
+    expect(response.protocolReturn.dataPoints.map((point) => point.growthWeightUsd)).toEqual([null, null])
+    expect(response.protocolReturn.summary.growthIsPartial).toEqual({ usd: true, eth: true, index: true })
+    expect(response.protocolReturn.familySeries).toEqual([])
+  })
+
+  it('reports ETH-only incomplete coverage without excluding USD or Index', async () => {
+    const assetPrices = new Map([[EVENT_RECEIPT_DAY_TIMESTAMP, 1]])
+    const ethPrices = new Map([[EVENT_RECEIPT_DAY_TIMESTAMP, 2]])
+    fetchHistoricalPricesForTokenTimestampsMock.mockResolvedValue(
+      new Map([
+        [ASSET_PRICE_KEY, assetPrices],
+        [WETH_PRICE_KEY, ethPrices]
+      ])
+    )
+    getPriceAtTimestampMock.mockImplementation((prices: Map<number, number>) => (prices === ethPrices ? 0 : 1))
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    const response = await getHoldingsProtocolReturnHistory(USER, '1y')
+    expect(response.summary.growthIsPartial).toEqual({ usd: false, eth: true, index: false })
+    expect(response.dataPoints[0]).toMatchObject({ growthWeightUsd: 0, growthWeightEth: null, growthIndex: 100 })
   })
 
   it('normalizes string decimals in cached portfolio growth metadata', async () => {
@@ -840,6 +848,46 @@ describe('getHoldingsProtocolReturnHistory', () => {
       ],
       expect.objectContaining({ protocolReturn: response }),
       expect.any(Number)
+    )
+  })
+
+  it.each(['disappears', 'recovers'])('rebuilds every growth chart when PPS %s', async (change) => {
+    const firstDay = 1_800_000_000
+    const secondDay = firstDay + 86_400
+    const thirdDay = secondDay + 86_400
+    getPPSMock.mockReturnValue(change === 'recovers' ? 0 : 1)
+    generateDailyTimestampsMock.mockReturnValue([firstDay, secondDay])
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    await getHoldingsProtocolReturnHistory(USER, '1y')
+    const cachedResponse = saveCachedProtocolReturnHistoryMock.mock.calls[0]![3]
+    getCachedProtocolReturnHistoryMock.mockResolvedValue({
+      settledDate: `date-${secondDay + 1}`,
+      response: cachedResponse
+    })
+    generateDailyTimestampsMock.mockReturnValue([firstDay, secondDay, thirdDay])
+    getPPSMock.mockImplementation((_timeline: Map<number, number>, timestamp: number) =>
+      change === 'disappears' && timestamp >= thirdDay ? 0 : 1
+    )
+    debugLogMock.mockClear()
+    const result = await getHoldingsProtocolReturnHistory(USER, '1y')
+    expect(result.dataPoints.map((point) => point.growthIndex)).toEqual(
+      change === 'disappears' ? [null, null, null] : [100, 100, 100]
+    )
+    expect(result.dataPoints.map((point) => point.growthWeightUsd)).toEqual(
+      change === 'disappears' ? [null, null, null] : [0, 0, 0]
+    )
+    expect(result.dataPoints.map((point) => point.growthWeightEth)).toEqual(
+      change === 'disappears' ? [null, null, null] : [0, 0, 0]
+    )
+    expect(result.summary.growthIsPartial).toEqual({
+      usd: change === 'disappears',
+      eth: change === 'disappears',
+      index: change === 'disappears'
+    })
+    expect(debugLogMock).toHaveBeenCalledWith(
+      'protocol-return-history',
+      'rebuilt protocol return history',
+      expect.objectContaining({ overlapMatched: change === 'disappears' ? false : null })
     )
   })
 

--- a/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.test.ts
@@ -29,7 +29,8 @@ function buildIsolatedSeries(args: { id: string; mode: TMode; window: TWindow; s
       growthUsd: args.mode === 'position' ? (index === windowStartIndex ? 0 : args.score) : null,
       growthWeightUsd: args.mode === 'position' ? (index === windowStartIndex ? 0 : args.score * 100) : null,
       growthWeightEth: args.mode === 'eth' ? (index === windowStartIndex ? 0 : args.score) : null,
-      growthIndex: args.mode === 'index' ? (index === windowStartIndex ? 100 : 100 + args.score) : null
+      growthIndex: args.mode === 'index' ? (index === windowStartIndex ? 100 : 100 + args.score) : null,
+      growthIndexContribution: args.mode === 'index' ? (index === windowStartIndex ? 0 : args.score) : null
     }))
   }
 }
@@ -101,7 +102,8 @@ describe('selectProtocolReturnFamilySeriesCandidates', () => {
       growthUsdEstimated: false,
       growthWeightUsd: 500,
       growthWeightEth: null,
-      growthIndex: null
+      growthIndex: null,
+      growthIndexContribution: null
     })
   })
 

--- a/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.test.ts
@@ -150,4 +150,29 @@ describe('selectProtocolReturnFamilySeriesCandidates', () => {
     expect(selected.map((series) => series.vaultAddress)).not.toContain('eth-growth-10')
     expect(selected.find((series) => series.vaultAddress === 'eth-growth-19')?.dataPoints[1]?.growthWeightEth).toBe(19)
   })
+
+  it.each(['position', 'index'] as const)('does not let excluded vaults displace eligible %s contributors', (mode) => {
+    const excluded = Array.from({ length: 16 }, (_, index) => {
+      const series = buildIsolatedSeries({
+        id: `excluded-${index}`,
+        mode,
+        window: '1y',
+        score: index < 8 ? 100 + index : -100 - index,
+        pointCount: 2
+      })
+      return {
+        ...series,
+        dataPoints: series.dataPoints.map((point) => ({
+          ...point,
+          growthWeightUsd: null,
+          growthIndexContribution: null
+        }))
+      }
+    })
+    const healthy = buildIsolatedSeries({ id: 'healthy', mode, window: '1y', score: 5, pointCount: 2 })
+
+    expect(
+      selectProtocolReturnFamilySeriesCandidates([...excluded, healthy], '1y').map((series) => series.vaultAddress)
+    ).toEqual(['healthy'])
+  })
 })

--- a/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.ts
+++ b/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.ts
@@ -57,7 +57,7 @@ function isFiniteNumber(value: unknown): value is number {
 
 function buildPositionRankPoints(
   points: TProtocolReturnFamilyPoint[],
-  valueKey: 'growthUsd' | 'growthWeightUsd' | 'growthWeightEth' | 'growthIndexContribution'
+  valueKey: 'growthWeightUsd' | 'growthWeightEth' | 'growthIndexContribution'
 ): Array<{ value: number | null }> {
   const firstFiniteIndex = points.findIndex((point) => isFiniteNumber(point[valueKey]))
   if (firstFiniteIndex < 0 || points.length - firstFiniteIndex < 2) {
@@ -71,18 +71,6 @@ function buildPositionRankPoints(
   }
 
   return [{ value: 0 }, { value: lastValue - firstValue }]
-}
-
-function buildIndexRankPoints(points: TProtocolReturnFamilyPoint[]): Array<{ value: number | null }> {
-  const contributionPoints = buildPositionRankPoints(points, 'growthIndexContribution')
-  if (contributionPoints.some((point) => Math.abs(point.value ?? 0) > Number.EPSILON)) {
-    return contributionPoints
-  }
-
-  const baseValue = points.find((point) => isFiniteNumber(point.growthIndex))?.growthIndex
-  return points.map((point) => ({
-    value: baseValue && isFiniteNumber(point.growthIndex) ? (point.growthIndex / baseValue) * 100 : null
-  }))
 }
 
 /**
@@ -106,15 +94,11 @@ export function selectProtocolReturnFamilySeriesCandidates<TSeries extends TProt
       const limit = FAMILY_SERIES_WINDOW_LIMITS[window]
       const rankableSeries = preparedSeries.map((series) => {
         const points = limit >= series.sortedPoints.length ? series.sortedPoints : series.sortedPoints.slice(-limit)
-        const weightedPositionPoints = buildPositionRankPoints(points, 'growthWeightUsd')
-        const positionPoints = weightedPositionPoints.some((point) => Math.abs(point.value ?? 0) > Number.EPSILON)
-          ? weightedPositionPoints
-          : buildPositionRankPoints(points, 'growthUsd')
         return {
           originalIndex: series.originalIndex,
-          positionPoints,
+          positionPoints: buildPositionRankPoints(points, 'growthWeightUsd'),
           ethPoints: buildPositionRankPoints(points, 'growthWeightEth'),
-          indexPoints: buildIndexRankPoints(points)
+          indexPoints: buildPositionRankPoints(points, 'growthIndexContribution')
         }
       })
 

--- a/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.ts
+++ b/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.ts
@@ -11,14 +11,19 @@ type TProtocolReturnFamilyPoint = {
   growthWeightUsd: number | null
   growthWeightEth: number | null
   growthIndex: number | null
+  growthIndexContribution?: number | null
 }
 
 type TProtocolReturnFamilySeries = {
   dataPoints: TProtocolReturnFamilyPoint[]
 }
 
-type TCompactProtocolReturnFamilyPoint = Omit<TProtocolReturnFamilyPoint, 'growthUsdEstimated'> & {
+type TCompactProtocolReturnFamilyPoint = Omit<
+  TProtocolReturnFamilyPoint,
+  'growthUsdEstimated' | 'growthIndexContribution'
+> & {
   growthUsdEstimated: boolean
+  growthIndexContribution: number | null
 }
 
 type TCompactProtocolReturnFamilySeries<TSeries extends TProtocolReturnFamilySeries> = Omit<TSeries, 'dataPoints'> & {
@@ -52,7 +57,7 @@ function isFiniteNumber(value: unknown): value is number {
 
 function buildPositionRankPoints(
   points: TProtocolReturnFamilyPoint[],
-  valueKey: 'growthWeightUsd' | 'growthWeightEth'
+  valueKey: 'growthUsd' | 'growthWeightUsd' | 'growthWeightEth' | 'growthIndexContribution'
 ): Array<{ value: number | null }> {
   const firstFiniteIndex = points.findIndex((point) => isFiniteNumber(point[valueKey]))
   if (firstFiniteIndex < 0 || points.length - firstFiniteIndex < 2) {
@@ -69,8 +74,12 @@ function buildPositionRankPoints(
 }
 
 function buildIndexRankPoints(points: TProtocolReturnFamilyPoint[]): Array<{ value: number | null }> {
-  const baseValue = points.find((point) => isFiniteNumber(point.growthIndex))?.growthIndex
+  const contributionPoints = buildPositionRankPoints(points, 'growthIndexContribution')
+  if (contributionPoints.some((point) => Math.abs(point.value ?? 0) > Number.EPSILON)) {
+    return contributionPoints
+  }
 
+  const baseValue = points.find((point) => isFiniteNumber(point.growthIndex))?.growthIndex
   return points.map((point) => ({
     value: baseValue && isFiniteNumber(point.growthIndex) ? (point.growthIndex / baseValue) * 100 : null
   }))
@@ -97,9 +106,13 @@ export function selectProtocolReturnFamilySeriesCandidates<TSeries extends TProt
       const limit = FAMILY_SERIES_WINDOW_LIMITS[window]
       const rankableSeries = preparedSeries.map((series) => {
         const points = limit >= series.sortedPoints.length ? series.sortedPoints : series.sortedPoints.slice(-limit)
+        const weightedPositionPoints = buildPositionRankPoints(points, 'growthWeightUsd')
+        const positionPoints = weightedPositionPoints.some((point) => Math.abs(point.value ?? 0) > Number.EPSILON)
+          ? weightedPositionPoints
+          : buildPositionRankPoints(points, 'growthUsd')
         return {
           originalIndex: series.originalIndex,
-          positionPoints: buildPositionRankPoints(points, 'growthWeightUsd'),
+          positionPoints,
           ethPoints: buildPositionRankPoints(points, 'growthWeightEth'),
           indexPoints: buildIndexRankPoints(points)
         }
@@ -136,7 +149,8 @@ export function selectProtocolReturnFamilySeriesCandidates<TSeries extends TProt
           growthUsdEstimated: point.growthUsdEstimated ?? false,
           growthWeightUsd: point.growthWeightUsd,
           growthWeightEth: point.growthWeightEth,
-          growthIndex: point.growthIndex
+          growthIndex: point.growthIndex,
+          growthIndexContribution: point.growthIndexContribution ?? null
         }))
       }
     ]


### PR DESCRIPTION
### Summary

Restore additive stacked attribution for the portfolio Growth chart. USD, ETH, and Index now use the same range-band model, and every stack ends at the portfolio total.

The history API now includes per-vault Index contributions. Partial ETH history renders the available total with a clear warning instead of hiding the full chart when one vault is missing a historical price.

Historical Growth and Index flows now use the same daily Kong price per share (PPS) as settled chart points. This prevents same-day share claims and redemptions from creating small artificial gains or losses when transaction asset amounts differ from the daily PPS mark. Transaction-actual amounts remain unchanged in the non-chart realized ledger.

This addresses the remaining chart requests from the review on #1385.

### How to review

1. Open Portfolio and select Growth.
2. Switch between USD, ETH, and Index for each timeframe.
3. Confirm the colored areas are stacked and the blue portfolio line follows the final stack boundary.
4. Check a mixed-sign point in the tooltip. Named vault values plus Other should equal the portfolio total.
5. For Index, confirm the stack starts with 100 and the remaining bands add to the portfolio index.
6. For incomplete ETH pricing, confirm available history still renders with a partial-data warning.
7. Check a same-day share claim and redemption. Confirm the daily chart records zero PPS growth instead of an artificial transaction-price difference.

### Test plan

- [x] Manual: verified the supplied portfolio through the production build API. The two reported residuals are zero, and no sign-transition seams remain in the highlighted March and September windows.
- [x] Automated: `bun run test` in `apps/yearn` (173 files, 939 tests)
- [x] Automated: `bun run tslint`
- [x] Automated: `bun run build`
- [x] Automated: Biome checks for all changed files

### Risk / impact

This changes portfolio history calculation, cache data, and chart rendering. It does not submit transactions or move funds. Daily charts intentionally measure PPS performance using one settled mark per day; intraday execution differences remain available to the non-chart realized ledger. The v18 cache prefix prevents older mixed-valuation history from being reused. Reverting this PR restores the previous flow valuation, independent-line charts, and ETH availability behavior.
