### PR TITLE
Codex/restore stacked growth attribution 2

### DIFF
--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
@@ -20,7 +20,6 @@ import {
   getChartMonthlyTicks,
   getChartWeeklyTicks
 } from '@pages/vaults/utils/charts'
-import { LIGHT_MODE_COLORS } from '@shared/components/AllocationChart'
 import { formatUSD } from '@shared/utils'
 import type { ReactElement } from 'react'
 import { useMemo } from 'react'
@@ -46,10 +45,19 @@ type TPresentedContributionSeries = TPortfolioGrowthContributionSeries & {
 }
 
 const MAX_VAULTS = 8
-const CONTRIBUTION_COLORS = LIGHT_MODE_COLORS
-const OTHER_COLOR = '#d7e6ff'
-const INDEX_BASE_COLOR = '#e8f1ff'
-const TOTAL_COLOR = '#0657f9'
+const CONTRIBUTION_COLORS = [
+  '#46a2ff',
+  '#7bb3a8',
+  '#e1a23b',
+  '#b67ae5',
+  '#f472b6',
+  '#f97316',
+  '#14b8a6',
+  '#94adf2'
+] as const
+const OTHER_COLOR = '#94a3b8'
+const INDEX_BASE_COLOR = '#80b7f4'
+const TOTAL_COLOR = '#2578ff'
 const LINE_HEADROOM = 1.05
 const CHART_MARGIN = {
   ...CHART_WITH_AXES_MARGIN,
@@ -353,7 +361,7 @@ export function PortfolioGrowthContributionsChart({
             stroke={item.color}
             strokeWidth={0.75}
             fill={item.color}
-            fillOpacity={item.isBase ? 0.28 : item.isOther ? 0.3 : 0.45}
+            fillOpacity={0.1}
             connectNulls={mode !== 'eth'}
             tooltipType={'none'}
             isAnimationActive={false}

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioGrowthContributionsChart.tsx
@@ -27,7 +27,7 @@ import { Area, CartesianGrid, ComposedChart, Line, ReferenceLine, XAxis, YAxis }
 import type { AxisDomain } from 'recharts/types/util/types'
 
 type TPortfolioGrowthContributionsChartProps = {
-  totalPoints: Array<{ date: string; value: number | null; isEstimated?: boolean }>
+  totalPoints: Array<{ date: string; value: number | null }>
   familySeries: TPortfolioGrowthContributionFamily[]
   timeframe: TPortfolioHistoryChartTimeframe
   mode: 'usd' | 'eth' | 'index'
@@ -99,21 +99,20 @@ function formatIndexValue(value: number): string {
   return value.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2 })
 }
 
-function formatSignedGrowth(value: number, mode: 'usd' | 'eth' | 'index', isEstimated = false): string {
+function formatSignedGrowth(value: number, mode: 'usd' | 'eth' | 'index'): string {
   const formatted =
     mode === 'eth'
       ? formatEthValue(value)
       : mode === 'index'
         ? formatIndexValue(Math.abs(value))
         : formatUSD(Math.abs(value), 2, 2)
-  const estimateSuffix = isEstimated ? '*' : ''
   if (value > 0) {
-    return `+${formatted}${estimateSuffix}`
+    return `+${formatted}`
   }
   if (value < 0) {
-    return `−${formatted}${estimateSuffix}`
+    return `−${formatted}`
   }
-  return `${formatted}${estimateSuffix}`
+  return formatted
 }
 
 function formatGrowthTick(value: number | string, mode: 'usd' | 'eth' | 'index'): string {
@@ -191,15 +190,13 @@ function PortfolioGrowthContributionsTooltip({
     .filter((item) => item.isBase)
     .flatMap((item) => {
       const value = point[item.key]
-      return typeof value === 'number' && Number.isFinite(value) ? [{ ...item, value, isEstimated: false }] : []
+      return typeof value === 'number' && Number.isFinite(value) ? [{ ...item, value }] : []
     })
   const namedRows = series
     .filter((item) => !item.isOther && !item.isBase)
     .flatMap((item) => {
       const value = point[item.key]
-      return typeof value === 'number' && Number.isFinite(value)
-        ? [{ ...item, value, isEstimated: Boolean(point[`${item.key}Estimated`]) }]
-        : []
+      return typeof value === 'number' && Number.isFinite(value) ? [{ ...item, value }] : []
     })
     .toSorted((left, right) => Math.abs(right.value) - Math.abs(left.value))
   const otherSeries = series.find((item) => item.isOther)
@@ -211,12 +208,10 @@ function PortfolioGrowthContributionsTooltip({
           ...namedRows,
           {
             ...otherSeries,
-            value: otherValue,
-            isEstimated: Boolean(point[`${otherSeries.key}Estimated`])
+            value: otherValue
           }
         ]
       : [...baseRows, ...namedRows]
-  const hasEstimatedValue = Boolean(point.portfolioGrowthEstimated) || rows.some((row) => row.isEstimated)
 
   return (
     <div
@@ -232,9 +227,7 @@ function PortfolioGrowthContributionsTooltip({
           {mode === 'index' ? 'Portfolio index' : 'Portfolio growth'}
         </span>
         <strong className={'font-number text-sm font-semibold text-text-primary'}>
-          {mode === 'index'
-            ? formatIndexValue(point.portfolioGrowth)
-            : formatSignedGrowth(point.portfolioGrowth, mode, Boolean(point.portfolioGrowthEstimated))}
+          {mode === 'index' ? formatIndexValue(point.portfolioGrowth) : formatSignedGrowth(point.portfolioGrowth, mode)}
         </strong>
       </div>
       <div className={'my-1.5 border-t border-border'} />
@@ -249,16 +242,11 @@ function PortfolioGrowthContributionsTooltip({
               <span className={'truncate'}>{row.label}</span>
             </span>
             <span className={'font-number shrink-0 text-xs font-medium text-text-primary'}>
-              {formatSignedGrowth(row.value, mode, row.isEstimated)}
+              {formatSignedGrowth(row.value, mode)}
             </span>
           </div>
         ))}
       </div>
-      {hasEstimatedValue ? (
-        <p className={'mt-1.5 border-t border-border pt-1 text-[11px] text-text-tertiary'}>
-          {'* Growth may be approximate.'}
-        </p>
-      ) : null}
     </div>
   )
 }
@@ -275,7 +263,6 @@ export function PortfolioGrowthContributionsChart({
         totalPoints,
         familySeries,
         maxVaults: MAX_VAULTS,
-        preserveNullValues: mode === 'eth',
         ...(mode === 'index'
           ? { baseContribution: { key: 'starting_index', label: 'Starting index', value: 100 } }
           : {})
@@ -362,7 +349,6 @@ export function PortfolioGrowthContributionsChart({
             strokeWidth={0.75}
             fill={item.color}
             fillOpacity={0.1}
-            connectNulls={mode !== 'eth'}
             tooltipType={'none'}
             isAnimationActive={false}
           />
@@ -374,7 +360,6 @@ export function PortfolioGrowthContributionsChart({
           strokeWidth={3}
           dot={false}
           activeDot={{ r: 4, strokeWidth: 0, fill: TOTAL_COLOR }}
-          connectNulls={mode !== 'eth'}
           isAnimationActive={false}
         />
       </ComposedChart>

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
@@ -26,7 +26,7 @@ const props: ComponentProps<typeof PortfolioHistoryChart> = {
       growthWeightUsd: 100,
       growthUsd: 100,
       growthUsdEstimated: false,
-      growthWeightEth: null,
+      growthWeightEth: 1,
       protocolReturnPct: 1,
       annualizedProtocolReturnPct: 10,
       growthIndex: 101
@@ -52,30 +52,52 @@ const props: ComponentProps<typeof PortfolioHistoryChart> = {
 }
 
 describe('portfolio growth pricing availability', () => {
-  it('labels an Index built from a subset without changing USD warnings', () => {
-    const summary = {
-      ...props.protocolReturnSummary!,
-      indexExcludedVaults: [{ chainId: 1, vaultAddress: '0x456', symbol: 'HBTC' }]
-    }
-    const html = renderToStaticMarkup(
-      <PortfolioHistoryChart {...props} protocolReturnSummary={summary} growthDisplayModeOverride={'index'} />
-    )
-    expect(html).toContain('Some vaults could not be valued. Index data may be partial.')
-    expect(html).not.toContain('vault excluded')
-    expect(html).toContain('Contribution chart')
-    const usd = renderToStaticMarkup(
-      <PortfolioHistoryChart {...props} protocolReturnSummary={summary} growthDisplayModeOverride={'usd'} />
-    )
-    expect(usd).not.toContain('Index data may be partial.')
-    expect(usd).toContain('Some vaults could not be valued. USD data may be partial.')
-  })
-  it('keeps ETH selected and explains missing prices instead of silently rendering Index', () => {
-    const html = renderToStaticMarkup(<PortfolioHistoryChart {...props} />)
+  it.each(['usd', 'eth', 'index'] as const)(
+    'uses the server coverage flag for %s even without named series',
+    (mode) => {
+      const label = mode === 'index' ? 'Index' : mode.toUpperCase()
+      const summary = {
+        ...props.protocolReturnSummary!,
+        isComplete: true,
+        growthIsPartial: { usd: false, eth: false, index: false, [mode]: true }
+      }
+      const html = renderToStaticMarkup(
+        <PortfolioHistoryChart {...props} protocolReturnSummary={summary} growthDisplayModeOverride={mode} />
+      )
 
-    expect(html).toContain('ETH growth unavailable: historical prices are missing for one or more vaults.')
-    expect(html).not.toContain('Index chart')
-    expect(html).not.toContain('Contribution chart')
-  })
+      expect(html).toContain(`Some vaults could not be valued. ${label} data may be partial.`)
+      expect(html).not.toContain('vault excluded')
+      expect(html).toContain('Contribution chart')
+    }
+  )
+
+  it.each(['usd', 'eth', 'index'] as const)(
+    'explains fully unavailable %s valuation without switching charts',
+    (mode) => {
+      const label = mode === 'index' ? 'Index' : mode.toUpperCase()
+      const html = renderToStaticMarkup(
+        <PortfolioHistoryChart
+          {...props}
+          growthDisplayModeOverride={mode}
+          protocolReturnSummary={{
+            ...props.protocolReturnSummary!,
+            growthIsPartial: { usd: true, eth: true, index: true }
+          }}
+          protocolReturnData={[
+            {
+              ...props.protocolReturnData![0]!,
+              growthWeightUsd: null,
+              growthWeightEth: null,
+              growthIndex: null
+            }
+          ]}
+        />
+      )
+
+      expect(html).toContain(`${label} growth unavailable: vault valuation data is incomplete.`)
+      expect(html).not.toContain('Contribution chart')
+    }
+  )
 
   it('keeps ETH available in the growth selector', () => {
     const html = renderToStaticMarkup(
@@ -94,28 +116,36 @@ describe('portfolio growth pricing availability', () => {
     expect(html).toContain('<option value="eth" selected="">ETH</option>')
   })
 
-  it.each(['usd', 'index'] as const)('keeps incomplete %s history diagnostics in the console only', (mode) => {
-    const html = renderToStaticMarkup(<PortfolioHistoryChart {...props} growthDisplayModeOverride={mode} />)
+  it.each(['usd', 'eth', 'index'] as const)(
+    'does not infer %s coverage from the row summary or missing points',
+    (mode) => {
+      const html = renderToStaticMarkup(
+        <PortfolioHistoryChart
+          {...props}
+          growthDisplayModeOverride={mode}
+          protocolReturnSummary={{
+            ...props.protocolReturnSummary!,
+            growthIsPartial: { usd: false, eth: false, index: false }
+          }}
+          protocolReturnData={[
+            ...props.protocolReturnData!,
+            {
+              ...props.protocolReturnData![0]!,
+              date: '2026-01-02',
+              growthWeightUsd: null,
+              growthWeightEth: null,
+              growthIndex: null
+            }
+          ]}
+        />
+      )
 
-    expect(html).not.toContain('History is incomplete')
-    expect(html).toContain('Contribution chart')
-  })
+      expect(html).not.toContain('data may be partial.')
+      expect(html).toContain('Contribution chart')
+    }
+  )
 
-  it('does not show an incomplete-history warning for complete USD history', () => {
-    const html = renderToStaticMarkup(
-      <PortfolioHistoryChart
-        {...props}
-        growthDisplayModeOverride={'usd'}
-        protocolReturnSummary={{ ...props.protocolReturnSummary!, isComplete: true }}
-      />
-    )
-
-    expect(html).not.toContain('History is incomplete')
-    expect(html).not.toContain('USD data may be partial.')
-    expect(html).toContain('Contribution chart')
-  })
-
-  it('preserves estimated USD pricing through total-series rebasing', () => {
+  it('does not label receipt-weighted growth estimated because mark-to-market growth was estimated', () => {
     const html = renderToStaticMarkup(
       <PortfolioHistoryChart
         {...props}
@@ -124,54 +154,23 @@ describe('portfolio growth pricing availability', () => {
       />
     )
 
-    expect(html).toContain('Contribution chart:estimated')
+    expect(html).toContain('Contribution chart:exact')
   })
 
-  it('warns about ETH gaps even when USD receipt pricing is complete', () => {
+  it.each(['balance', 'annualized'] as const)('does not show growth coverage warnings on %s', (activeTab) => {
     const html = renderToStaticMarkup(
       <PortfolioHistoryChart
         {...props}
-        protocolReturnSummary={{ ...props.protocolReturnSummary!, isComplete: true }}
-        protocolReturnData={[
-          { ...props.protocolReturnData![0]!, growthWeightEth: 1 },
-          { ...props.protocolReturnData![0]!, date: '2026-01-02' }
-        ]}
+        activeTab={activeTab}
+        growthDisplayModeOverride={'index'}
+        protocolReturnSummary={{
+          ...props.protocolReturnSummary!,
+          growthIsPartial: { usd: true, eth: true, index: true }
+        }}
       />
     )
 
-    expect(html).toContain('Some vaults could not be valued. ETH data may be partial.')
-    expect(html).toContain('Contribution chart')
-  })
-
-  it('renders available ETH growth while warning that the total is partial', () => {
-    const html = renderToStaticMarkup(
-      <PortfolioHistoryChart
-        {...props}
-        protocolReturnData={[{ ...props.protocolReturnData![0]!, growthWeightEth: 1 }]}
-        protocolReturnFamilySeries={[
-          {
-            chainId: 1,
-            vaultAddress: '0x456',
-            symbol: 'yvETH',
-            status: 'missing_receipt_price',
-            dataPoints: [
-              {
-                timestamp: Date.parse('2026-01-01T00:00:00.000Z') / 1000,
-                growthWeightUsd: 0,
-                growthWeightEth: null,
-                growthUsd: 0,
-                growthUsdEstimated: false,
-                growthIndex: 100,
-                growthIndexContribution: 0
-              }
-            ]
-          }
-        ]}
-      />
-    )
-
-    expect(html).toContain('Some vaults could not be valued. ETH data may be partial.')
-    expect(html).toContain('Contribution chart')
-    expect(html).not.toContain('ETH growth unavailable')
+    expect(html).not.toContain('data may be partial.')
+    expect(html).not.toContain('growth unavailable')
   })
 })

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
@@ -60,12 +60,14 @@ describe('portfolio growth pricing availability', () => {
     const html = renderToStaticMarkup(
       <PortfolioHistoryChart {...props} protocolReturnSummary={summary} growthDisplayModeOverride={'index'} />
     )
-    expect(html).toContain('Partial Index: 1 vault excluded because valuation data is incomplete.')
+    expect(html).toContain('Some vaults could not be valued. Index data may be partial.')
+    expect(html).not.toContain('vault excluded')
     expect(html).toContain('Contribution chart')
     const usd = renderToStaticMarkup(
       <PortfolioHistoryChart {...props} protocolReturnSummary={summary} growthDisplayModeOverride={'usd'} />
     )
-    expect(usd).not.toContain('Partial Index')
+    expect(usd).not.toContain('Index data may be partial.')
+    expect(usd).toContain('Some vaults could not be valued. USD data may be partial.')
   })
   it('keeps ETH selected and explains missing prices instead of silently rendering Index', () => {
     const html = renderToStaticMarkup(<PortfolioHistoryChart {...props} />)
@@ -109,6 +111,7 @@ describe('portfolio growth pricing availability', () => {
     )
 
     expect(html).not.toContain('History is incomplete')
+    expect(html).not.toContain('USD data may be partial.')
     expect(html).toContain('Contribution chart')
   })
 
@@ -136,7 +139,7 @@ describe('portfolio growth pricing availability', () => {
       />
     )
 
-    expect(html).toContain('ETH growth is partial: historical prices are missing for one or more vaults.')
+    expect(html).toContain('Some vaults could not be valued. ETH data may be partial.')
     expect(html).toContain('Contribution chart')
   })
 
@@ -167,7 +170,7 @@ describe('portfolio growth pricing availability', () => {
       />
     )
 
-    expect(html).toContain('ETH growth is partial: historical prices are missing for one or more vaults.')
+    expect(html).toContain('Some vaults could not be valued. ETH data may be partial.')
     expect(html).toContain('Contribution chart')
     expect(html).not.toContain('ETH growth unavailable')
   })

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.test.tsx
@@ -52,6 +52,21 @@ const props: ComponentProps<typeof PortfolioHistoryChart> = {
 }
 
 describe('portfolio growth pricing availability', () => {
+  it('labels an Index built from a subset without changing USD warnings', () => {
+    const summary = {
+      ...props.protocolReturnSummary!,
+      indexExcludedVaults: [{ chainId: 1, vaultAddress: '0x456', symbol: 'HBTC' }]
+    }
+    const html = renderToStaticMarkup(
+      <PortfolioHistoryChart {...props} protocolReturnSummary={summary} growthDisplayModeOverride={'index'} />
+    )
+    expect(html).toContain('Partial Index: 1 vault excluded because valuation data is incomplete.')
+    expect(html).toContain('Contribution chart')
+    const usd = renderToStaticMarkup(
+      <PortfolioHistoryChart {...props} protocolReturnSummary={summary} growthDisplayModeOverride={'usd'} />
+    )
+    expect(usd).not.toContain('Partial Index')
+  })
   it('keeps ETH selected and explains missing prices instead of silently rendering Index', () => {
     const html = renderToStaticMarkup(<PortfolioHistoryChart {...props} />)
 

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -751,10 +751,12 @@ export function PortfolioHistoryChart({
   const excludedIndexVaultCount = protocolReturnSummary?.indexExcludedVaults?.length ?? 0
   const historyWarning =
     resolvedGrowthDisplayMode === 'index' && excludedIndexVaultCount > 0
-      ? `Partial Index: ${excludedIndexVaultCount} ${excludedIndexVaultCount === 1 ? 'vault excluded' : 'vaults excluded'} because valuation data is incomplete.`
+      ? 'Some vaults could not be valued. Index data may be partial.'
       : hasMissingEthGrowth
-        ? 'ETH growth is partial: historical prices are missing for one or more vaults.'
-        : null
+        ? 'Some vaults could not be valued. ETH data may be partial.'
+        : activeTab === 'growth' && resolvedGrowthDisplayMode === 'usd' && protocolReturnSummary?.isComplete === false
+          ? 'Some vaults could not be valued. USD data may be partial.'
+          : null
   const yAxisFloor = activeTab === 'growth' && resolvedGrowthDisplayMode === 'index' ? 100 : 0
   const yAxisTicks = useMemo(
     () =>

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -748,9 +748,13 @@ export function PortfolioHistoryChart({
             })
           ))
     )
-  const historyWarning = hasMissingEthGrowth
-    ? 'ETH growth is partial: historical prices are missing for one or more vaults.'
-    : null
+  const excludedIndexVaultCount = protocolReturnSummary?.indexExcludedVaults?.length ?? 0
+  const historyWarning =
+    resolvedGrowthDisplayMode === 'index' && excludedIndexVaultCount > 0
+      ? `Partial Index: ${excludedIndexVaultCount} ${excludedIndexVaultCount === 1 ? 'vault excluded' : 'vaults excluded'} because valuation data is incomplete.`
+      : hasMissingEthGrowth
+        ? 'ETH growth is partial: historical prices are missing for one or more vaults.'
+        : null
   const yAxisFloor = activeTab === 'growth' && resolvedGrowthDisplayMode === 'index' ? 100 : 0
   const yAxisTicks = useMemo(
     () =>

--- a/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
+++ b/apps/yearn/src/components/pages/portfolio/components/PortfolioHistoryChart.tsx
@@ -74,7 +74,6 @@ type TChartPoint = {
   date: string
   value: number | null
   isLive?: boolean
-  isEstimated?: boolean
 }
 
 type TPortfolioHistoryTooltipProps = {
@@ -264,9 +263,7 @@ function rebaseDeltaPoints(points: TChartPoint[]): TChartPoint[] {
 
   return points.map((point) => ({
     ...point,
-    value:
-      typeof point.value === 'number' && Number.isFinite(point.value) ? point.value - basePoint.value : point.value,
-    ...(point.isEstimated || basePoint.isEstimated ? { isEstimated: true } : {})
+    value: typeof point.value === 'number' && Number.isFinite(point.value) ? point.value - basePoint.value : point.value
   }))
 }
 
@@ -596,7 +593,7 @@ export function PortfolioHistoryChart({
     return points.map((point) => ({ date: point.date, value: point.value, isLive: point.isLive }))
   }, [balanceData, timeframe])
 
-  const filteredGrowthUsdData = useMemo<TChartPoint[]>(() => {
+  const filteredGrowthAmountData = useMemo<TChartPoint[]>(() => {
     if (!protocolReturnData) {
       return []
     }
@@ -610,30 +607,10 @@ export function PortfolioHistoryChart({
     return rebaseDeltaPoints(
       points.map((point) => ({
         date: point.date,
-        value: point.growthWeightUsd,
-        isEstimated: point.growthUsdEstimated
+        value: resolvedGrowthDisplayMode === 'eth' ? point.growthWeightEth : point.growthWeightUsd
       }))
     )
-  }, [protocolReturnData, timeframe])
-
-  const filteredGrowthEthData = useMemo<TChartPoint[]>(() => {
-    if (!protocolReturnData) {
-      return []
-    }
-
-    const limit = getTimeframeLimit(timeframe)
-    const points =
-      !Number.isFinite(limit) || limit >= protocolReturnData.length
-        ? protocolReturnData
-        : protocolReturnData.slice(-limit)
-
-    return rebaseDeltaPoints(
-      points.map((point) => ({
-        date: point.date,
-        value: point.growthWeightEth
-      }))
-    )
-  }, [protocolReturnData, timeframe])
+  }, [protocolReturnData, resolvedGrowthDisplayMode, timeframe])
 
   const filteredRawGrowthIndexData = useMemo<TChartPoint[]>(() => {
     if (!protocolReturnData) {
@@ -718,45 +695,16 @@ export function PortfolioHistoryChart({
     activeTab === 'balance'
       ? filteredBalanceData
       : activeTab === 'growth'
-        ? resolvedGrowthDisplayMode === 'eth'
-          ? filteredGrowthEthData
-          : resolvedGrowthDisplayMode === 'usd'
-            ? filteredGrowthUsdData
-            : filteredGrowthIndexData
+        ? resolvedGrowthDisplayMode === 'index'
+          ? filteredGrowthIndexData
+          : filteredGrowthAmountData
         : filteredAnnualizedReturnData
   const activeIsLoading = activeTab === 'balance' ? balanceIsLoading : protocolReturnIsLoading
   const activeIsEmpty = activeTab === 'balance' ? balanceIsEmpty : protocolReturnIsEmpty
   const activeError = activeTab === 'balance' ? balanceError : protocolReturnError
   const activeHasRenderableValue = activeData.some((point) => point.value !== null)
-  const firstActiveDate = activeData[0]?.date
-  const hasMissingEthGrowth =
-    activeTab === 'growth' &&
-    resolvedGrowthDisplayMode === 'eth' &&
-    Boolean(
-      firstActiveDate &&
-        (protocolReturnData?.some(
-          (point) => point.date >= firstActiveDate && point.growthWeightEth === null && point.growthIndex !== null
-        ) ||
-          visibleProtocolReturnFamilySeries.some((series) =>
-            series.dataPoints.some((point) => {
-              const timestamp = point.timestamp > 1_000_000_000_000 ? point.timestamp : point.timestamp * 1000
-              return (
-                new Date(timestamp).toISOString().slice(0, 10) >= firstActiveDate &&
-                point.growthWeightEth === null &&
-                point.growthIndex !== null
-              )
-            })
-          ))
-    )
-  const excludedIndexVaultCount = protocolReturnSummary?.indexExcludedVaults?.length ?? 0
-  const historyWarning =
-    resolvedGrowthDisplayMode === 'index' && excludedIndexVaultCount > 0
-      ? 'Some vaults could not be valued. Index data may be partial.'
-      : hasMissingEthGrowth
-        ? 'Some vaults could not be valued. ETH data may be partial.'
-        : activeTab === 'growth' && resolvedGrowthDisplayMode === 'usd' && protocolReturnSummary?.isComplete === false
-          ? 'Some vaults could not be valued. USD data may be partial.'
-          : null
+  const growthIsPartial = activeTab === 'growth' && protocolReturnSummary?.growthIsPartial?.[resolvedGrowthDisplayMode]
+  const growthLabel = resolvedGrowthDisplayMode === 'index' ? 'Index' : resolvedGrowthDisplayMode.toUpperCase()
   const yAxisFloor = activeTab === 'growth' && resolvedGrowthDisplayMode === 'index' ? 100 : 0
   const yAxisTicks = useMemo(
     () =>
@@ -1034,8 +982,8 @@ export function PortfolioHistoryChart({
       <section className={cl(sectionClassName, className)}>
         <div className={'flex min-h-[240px] items-center justify-center'}>
           <p className={'text-center text-base text-text-secondary'}>
-            {hasMissingEthGrowth
-              ? 'ETH growth unavailable: historical prices are missing for one or more vaults.'
+            {growthIsPartial
+              ? `${growthLabel} growth unavailable: vault valuation data is incomplete.`
               : getEmptyMessage(activeTab, resolvedGrowthDisplayMode)}
           </p>
         </div>
@@ -1046,16 +994,14 @@ export function PortfolioHistoryChart({
   if (activeTab === 'growth') {
     return (
       <section className={cl(sectionClassName, className)}>
-        {historyWarning ? <p className={'mb-2 text-xs text-text-secondary'}>{historyWarning}</p> : null}
+        {growthIsPartial ? (
+          <p className={'mb-2 text-xs text-text-secondary'}>
+            {`Some vaults could not be valued. ${growthLabel} data may be partial.`}
+          </p>
+        ) : null}
         <div className={'min-h-0 flex-1'}>
           <PortfolioGrowthContributionsChart
-            totalPoints={
-              resolvedGrowthDisplayMode === 'eth'
-                ? filteredGrowthEthData
-                : resolvedGrowthDisplayMode === 'index'
-                  ? filteredGrowthIndexData
-                  : filteredGrowthUsdData
-            }
+            totalPoints={activeData}
             familySeries={growthContributionFamilySeries}
             timeframe={timeframe}
             mode={resolvedGrowthDisplayMode}

--- a/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioGrowth.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioGrowth.test.ts
@@ -96,6 +96,15 @@ describe('portfolio growth helpers', () => {
     expect(toPortfolioGrowthDisplay(combined)).toBeNull()
   })
 
+  it('preserves unavailable values when combining vault variants', () => {
+    const unlocked = makeGrowthVault(YVUSD_UNLOCKED_ADDRESS)
+    const locked = makeGrowthVault(YVUSD_LOCKED_ADDRESS, { growthUnderlying: null, growthUsd: null })
+    const combined = mapPortfolioGrowthVaults([unlocked, locked]).get(getPortfolioGrowthVaultKey(unlocked))
+
+    expect(combined).toMatchObject({ growthUnderlying: null, growthUsd: null, assetGrowth: [] })
+    expect(toPortfolioGrowthDisplay(combined)).toBeNull()
+  })
+
   it('shows yvUSD growth when only one complete variant was returned', () => {
     const unlocked = makeGrowthVault(YVUSD_UNLOCKED_ADDRESS, {
       baselineExposureUsdYears: 50,

--- a/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioGrowth.ts
+++ b/apps/yearn/src/components/pages/portfolio/hooks/usePortfolioGrowth.ts
@@ -18,8 +18,7 @@ export type TPortfolioGrowthAssetDisplay = {
   symbol: string | null
 }
 
-export type TMappedPortfolioGrowthVault = Omit<TPortfolioGrowthVault, 'growthUnderlying'> & {
-  growthUnderlying: number | null
+export type TMappedPortfolioGrowthVault = TPortfolioGrowthVault & {
   assetGrowth: TPortfolioGrowthAssetDisplay[]
 }
 
@@ -29,7 +28,7 @@ export function getPortfolioGrowthVaultKey(vault: Pick<TPortfolioGrowthVault, 'c
 
 function sumGrowthField(
   vaults: readonly TMappedPortfolioGrowthVault[],
-  field: 'baselineUsd' | 'baselineExposureUsdYears' | 'growthUsd'
+  field: 'baselineUsd' | 'baselineExposureUsdYears'
 ): number {
   return vaults.reduce((total, vault) => total + vault[field], 0)
 }
@@ -76,10 +75,13 @@ function combineGrowthVariants(
     )
   const baselineUsd = sumGrowthField(variants, 'baselineUsd')
   const baselineExposureUsdYears = sumGrowthField(variants, 'baselineExposureUsdYears')
-  const growthUnderlying = combineAssetGrowth
-    ? variants.reduce((total, vault) => total + (vault.growthUnderlying ?? 0), 0)
+  const growthUnderlying =
+    combineAssetGrowth && variants.every((vault) => vault.growthUnderlying !== null)
+      ? variants.reduce((total, vault) => total + vault.growthUnderlying!, 0)
+      : null
+  const growthUsd = variants.every((vault) => vault.growthUsd !== null)
+    ? variants.reduce((total, vault) => total + vault.growthUsd!, 0)
     : null
-  const growthUsd = sumGrowthField(variants, 'growthUsd')
   const issues = Array.from(new Set(variants.flatMap((vault) => vault.issues)))
   const isComplete = variants.every((vault) => vault.status === 'ok')
 
@@ -91,9 +93,12 @@ function combineGrowthVariants(
     baselineUsd,
     baselineExposureUsdYears,
     growthUnderlying,
-    assetGrowth: combineAssetGrowth
-      ? [{ amount: growthUnderlying ?? 0, symbol: representative.metadata.symbol }]
-      : variants.flatMap((vault) => vault.assetGrowth),
+    assetGrowth:
+      growthUnderlying !== null
+        ? [{ amount: growthUnderlying, symbol: representative.metadata.symbol }]
+        : combineAssetGrowth
+          ? []
+          : variants.flatMap((vault) => vault.assetGrowth),
     growthUsd,
     growthPct: combineGrowthRate(variants, 'growthPct', 'baselineUsd'),
     annualizedProtocolReturnPct: combineGrowthRate(variants, 'annualizedProtocolReturnPct', 'baselineExposureUsdYears')
@@ -124,7 +129,8 @@ export function mapPortfolioGrowthVaults(
           getPortfolioGrowthVaultKey(vault),
           {
             ...vault,
-            assetGrowth: [{ amount: vault.growthUnderlying, symbol: vault.metadata.symbol }]
+            assetGrowth:
+              vault.growthUnderlying === null ? [] : [{ amount: vault.growthUnderlying, symbol: vault.metadata.symbol }]
           }
         ] as const
     )
@@ -171,7 +177,7 @@ export function comparePortfolioGrowthVaults(
 export function toPortfolioGrowthDisplay(
   vault: TMappedPortfolioGrowthVault | undefined
 ): TPortfolioGrowthDisplay | null {
-  if (vault?.status !== 'ok' || !Number.isFinite(vault.growthUsd)) {
+  if (vault?.status !== 'ok' || vault.growthUsd === null || !Number.isFinite(vault.growthUsd)) {
     return null
   }
 

--- a/apps/yearn/src/components/pages/portfolio/types/api.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/types/api.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { portfolioActivityFacetsResponseSchema, portfolioActivityResponseSchema, portfolioResponseSchema } from './api'
 
 describe('portfolioResponseSchema', () => {
-  it('accepts the non-fatal missing exit-price warning and defaults legacy estimate flags', () => {
+  it.each([2, null])('accepts available or unavailable growth (%s) and metric completeness', (growth) => {
     const parsed = portfolioResponseSchema.parse({
       address: '0x2222222222222222222222222222222222222222',
       version: 'all',
@@ -24,9 +24,7 @@ describe('portfolioResponseSchema', () => {
           recommendedGrowthDisplay: 'usd',
           recommendedGrowthDisplayReason: 'stable_dominant',
           openBaselineCompositionUsd: { stable: 100, ethFamily: 0, other: 0 },
-          indexExcludedVaults: [
-            { chainId: 1, vaultAddress: '0x5555555555555555555555555555555555555555', symbol: 'yvMISSING' }
-          ],
+          growthIsPartial: { usd: true, eth: true, index: true },
           incompleteVaults: [
             {
               chainId: 1,
@@ -42,8 +40,8 @@ describe('portfolioResponseSchema', () => {
         dataPoints: [
           {
             date: '2026-08-23',
-            growthWeightUsd: 2,
-            growthUsd: 2,
+            growthWeightUsd: growth,
+            growthUsd: growth,
             growthWeightEth: null,
             protocolReturnPct: 2,
             annualizedProtocolReturnPct: 2,
@@ -84,8 +82,8 @@ describe('portfolioResponseSchema', () => {
             issues: ['missing_exit_price'],
             baselineUsd: 100,
             baselineExposureUsdYears: 1,
-            growthUnderlying: 2,
-            growthUsd: 2,
+            growthUnderlying: growth,
+            growthUsd: growth,
             growthPct: 2,
             annualizedProtocolReturnPct: 2,
             metadata: {
@@ -100,9 +98,9 @@ describe('portfolioResponseSchema', () => {
     })
 
     expect(parsed.growth.vaults[0]?.issues).toEqual(['missing_exit_price'])
-    expect(parsed.protocolReturn.summary.indexExcludedVaults).toEqual([
-      { chainId: 1, vaultAddress: '0x5555555555555555555555555555555555555555', symbol: 'yvMISSING' }
-    ])
+    expect(parsed.protocolReturn.summary.growthIsPartial).toEqual({ usd: true, eth: true, index: true })
+    expect(parsed.protocolReturn.dataPoints[0]?.growthWeightUsd).toBe(growth)
+    expect(parsed.growth.vaults[0]?.growthUnderlying).toBe(growth)
     expect(parsed.protocolReturn.summary.incompleteVaults?.[0]).toMatchObject({
       vaultAddress: '0x5555555555555555555555555555555555555555',
       status: 'missing_pps',

--- a/apps/yearn/src/components/pages/portfolio/types/api.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/types/api.test.ts
@@ -24,6 +24,9 @@ describe('portfolioResponseSchema', () => {
           recommendedGrowthDisplay: 'usd',
           recommendedGrowthDisplayReason: 'stable_dominant',
           openBaselineCompositionUsd: { stable: 100, ethFamily: 0, other: 0 },
+          indexExcludedVaults: [
+            { chainId: 1, vaultAddress: '0x5555555555555555555555555555555555555555', symbol: 'yvMISSING' }
+          ],
           incompleteVaults: [
             {
               chainId: 1,
@@ -97,6 +100,9 @@ describe('portfolioResponseSchema', () => {
     })
 
     expect(parsed.growth.vaults[0]?.issues).toEqual(['missing_exit_price'])
+    expect(parsed.protocolReturn.summary.indexExcludedVaults).toEqual([
+      { chainId: 1, vaultAddress: '0x5555555555555555555555555555555555555555', symbol: 'yvMISSING' }
+    ])
     expect(parsed.protocolReturn.summary.incompleteVaults?.[0]).toMatchObject({
       vaultAddress: '0x5555555555555555555555555555555555555555',
       status: 'missing_pps',

--- a/apps/yearn/src/components/pages/portfolio/types/api.ts
+++ b/apps/yearn/src/components/pages/portfolio/types/api.ts
@@ -39,6 +39,9 @@ const portfolioProtocolReturnHistorySummarySchema = z.object({
     other: z.number()
   }),
   incompleteVaults: z.array(portfolioProtocolReturnIncompleteVaultSchema).optional(),
+  indexExcludedVaults: z
+    .array(z.object({ chainId: z.number(), vaultAddress: z.string(), symbol: z.string().nullable() }))
+    .optional(),
   isComplete: z.boolean()
 })
 

--- a/apps/yearn/src/components/pages/portfolio/types/api.ts
+++ b/apps/yearn/src/components/pages/portfolio/types/api.ts
@@ -7,8 +7,8 @@ const portfolioHistorySimpleDataPointSchema = z.object({
 
 const portfolioProtocolReturnHistoryDataPointSchema = z.object({
   date: z.string(),
-  growthWeightUsd: z.number(),
-  growthUsd: z.number(),
+  growthWeightUsd: z.number().nullable(),
+  growthUsd: z.number().nullable(),
   growthUsdEstimated: z.boolean().optional().default(false),
   growthWeightEth: z.number().nullable(),
   protocolReturnPct: z.number().nullable(),
@@ -39,9 +39,7 @@ const portfolioProtocolReturnHistorySummarySchema = z.object({
     other: z.number()
   }),
   incompleteVaults: z.array(portfolioProtocolReturnIncompleteVaultSchema).optional(),
-  indexExcludedVaults: z
-    .array(z.object({ chainId: z.number(), vaultAddress: z.string(), symbol: z.string().nullable() }))
-    .optional(),
+  growthIsPartial: z.object({ usd: z.boolean(), eth: z.boolean(), index: z.boolean() }).optional(),
   isComplete: z.boolean()
 })
 
@@ -72,8 +70,8 @@ const portfolioGrowthVaultSchema = z.object({
   ),
   baselineUsd: z.number(),
   baselineExposureUsdYears: z.number(),
-  growthUnderlying: z.number(),
-  growthUsd: z.number(),
+  growthUnderlying: z.number().nullable(),
+  growthUsd: z.number().nullable(),
   growthPct: z.number().nullable(),
   annualizedProtocolReturnPct: z.number().nullable(),
   metadata: z.object({
@@ -259,8 +257,8 @@ export type TPortfolioLiveBalanceSnapshot = {
 }
 export type TPortfolioProtocolReturnHistoryChartData = Array<{
   date: string
-  growthWeightUsd: number
-  growthUsd: number
+  growthWeightUsd: number | null
+  growthUsd: number | null
   growthUsdEstimated: boolean
   growthWeightEth: number | null
   protocolReturnPct: number | null

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
@@ -11,7 +11,7 @@ function timestamp(date: string): number {
 
 function makeFamily(args: {
   label: string
-  values: Array<{ date: string; value: number | null; milliseconds?: boolean; estimated?: boolean }>
+  values: Array<{ date: string; value: number | null; milliseconds?: boolean }>
   chainId?: number
   vaultAddress?: string
 }): TPortfolioGrowthContributionFamily {
@@ -21,8 +21,7 @@ function makeFamily(args: {
     label: args.label,
     dataPoints: args.values.map((point) => ({
       timestamp: timestamp(point.date) * (point.milliseconds ? 1000 : 1),
-      value: point.value,
-      isEstimated: point.estimated
+      value: point.value
     }))
   }
 }
@@ -52,8 +51,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
 
     expect(toPortfolioGrowthContributionPoint(point, 'usd')).toEqual({
       timestamp: point.timestamp,
-      value: 25,
-      isEstimated: true
+      value: 25
     })
     expect(toPortfolioGrowthContributionPoint(point, 'eth')).toEqual({
       timestamp: point.timestamp,
@@ -229,7 +227,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
     expectConservation(chart)
   })
 
-  it('carries sparse and null family values forward and normalizes millisecond timestamps', () => {
+  it('carries sparse values forward but preserves explicit nulls and normalizes millisecond timestamps', () => {
     const chart = buildPortfolioGrowthContributionChart({
       totalPoints: [
         { date: '2026-01-01', value: 0 },
@@ -249,7 +247,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
       ]
     })
 
-    expect(chart.data.map((point) => point.vault_0)).toEqual([0, 0, 7, 7])
+    expect(chart.data.map((point) => point.vault_0)).toEqual([0, null, 7, 7])
     expect(chart.data.map((point) => point.other)).toEqual([0, 5, 0, 3])
     expect(chart.series[0]?.terminalValue).toBe(7)
     expectConservation(chart)
@@ -367,7 +365,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
     expectConservation(chart)
   })
 
-  it('preserves unavailable ETH totals and family values as gaps', () => {
+  it('preserves unavailable totals and family values as gaps', () => {
     const dates = ['2026-02-01', '2026-02-02', '2026-02-03', '2026-02-04']
     const chart = buildPortfolioGrowthContributionChart({
       totalPoints: [
@@ -381,8 +379,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
           label: 'Unavailable ETH growth',
           values: dates.map((date, index) => ({ date, value: [0, 1, null, 2][index]! }))
         })
-      ],
-      preserveNullValues: true
+      ]
     })
 
     expect(withoutStackBands(chart)).toEqual([
@@ -406,8 +403,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
           label: 'Unavailable ETH growth',
           values: dates.map((date, index) => ({ date, value: [0, 1, null][index]! }))
         })
-      ],
-      preserveNullValues: true
+      ]
     })
 
     expect(chart.series.map((series) => series.label)).toEqual(['Other'])
@@ -417,35 +413,6 @@ describe('buildPortfolioGrowthContributionChart', () => {
       other: 1.5
     })
     expectConservation(chart)
-  })
-
-  it('propagates estimated pricing through rebased total, vault, and Other values', () => {
-    const chart = buildPortfolioGrowthContributionChart({
-      totalPoints: [
-        { date: '2026-02-01', value: 0, isEstimated: true },
-        { date: '2026-02-02', value: 5, isEstimated: true }
-      ],
-      familySeries: [
-        makeFamily({
-          label: 'Estimated vault',
-          values: [
-            { date: '2026-02-01', value: 10, estimated: true },
-            { date: '2026-02-02', value: 15 }
-          ]
-        })
-      ]
-    })
-
-    expect(chart.data[0]).toMatchObject({
-      portfolioGrowthEstimated: true,
-      vault_0Estimated: true,
-      otherEstimated: true
-    })
-    expect(chart.data[1]).toMatchObject({
-      portfolioGrowthEstimated: true,
-      vault_0Estimated: true,
-      otherEstimated: true
-    })
   })
 
   it('uses stable input-order ties while keeping same-address vaults on different chains distinct', () => {

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.test.ts
@@ -144,6 +144,13 @@ describe('buildPortfolioGrowthContributionChart', () => {
       { date: dates[1], portfolioGrowth: 31, vault_0: 20, vault_1: 5, vault_2: 4, vault_3: 1, other: 1 },
       { date: dates[2], portfolioGrowth: 56, vault_0: 30, vault_1: 15, vault_2: 6, vault_3: 3, other: 2 }
     ])
+    expect(chart.data.at(-1)?.stackBands).toEqual({
+      other: [0, 2],
+      vault_3: [2, 5],
+      vault_2: [5, 11],
+      vault_1: [11, 26],
+      vault_0: [26, 56]
+    })
     expectConservation(chart)
   })
 
@@ -276,7 +283,7 @@ describe('buildPortfolioGrowthContributionChart', () => {
     expect(chart.data.at(-1)?.stackBands).toMatchObject({
       vault_1: [-90, 0],
       vault_0: [-90, 10],
-      other: [10, 10]
+      other: [-90, -90]
     })
     expect(chart.bounds).toContain(-90)
     expect(chart.bounds).toContain(10)
@@ -319,8 +326,8 @@ describe('buildPortfolioGrowthContributionChart', () => {
     expect(chart.data.at(-1)?.stackBands).toMatchObject({
       starting_index: [0, 100],
       vault_1: [95, 100],
-      vault_0: [95, 105],
-      other: [105, 108]
+      vault_0: [98, 108],
+      other: [95, 98]
     })
     expect(chart.bounds).not.toContain(0)
     expect(chart.bounds).toContain(95)

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
@@ -253,7 +253,9 @@ export function buildPortfolioGrowthContributionChart(args: {
         } satisfies TPortfolioGrowthContributionSeries,
         value: isFiniteNumber(row.other) ? row.other : 0
       }
-    ].toSorted((left, right) => Number(left.value >= 0) - Number(right.value >= 0))
+    ]
+      .toReversed()
+      .toSorted((left, right) => Number(left.value >= 0) - Number(right.value >= 0))
     contributionRows.reduce((runningTotal, contribution) => {
       const nextTotal = runningTotal + contribution.value
       row.stackBands[contribution.series.key] = [Math.min(runningTotal, nextTotal), Math.max(runningTotal, nextTotal)]

--- a/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
+++ b/apps/yearn/src/components/pages/portfolio/utils/portfolioGrowthContributions.ts
@@ -8,7 +8,6 @@ export type TPortfolioGrowthContributionFamily = {
   dataPoints: Array<{
     timestamp: number
     value: number | null
-    isEstimated?: boolean
   }>
 }
 
@@ -25,7 +24,6 @@ export type TPortfolioGrowthContributionSeries = {
 export type TPortfolioGrowthContributionChartPoint = {
   date: string
   portfolioGrowth: number | null
-  portfolioGrowthEstimated?: boolean
   stackBands: Record<string, [number, number] | null>
   [key: string]: string | number | boolean | null | undefined | Record<string, [number, number] | null>
 }
@@ -39,8 +37,6 @@ export type TPortfolioGrowthContributionChart = {
 export function toPortfolioGrowthContributionPoint(
   point: {
     timestamp: number
-    growthUsd: number | null
-    growthUsdEstimated: boolean
     growthWeightUsd: number | null
     growthWeightEth: number | null
   },
@@ -48,15 +44,13 @@ export function toPortfolioGrowthContributionPoint(
 ): TPortfolioGrowthContributionFamily['dataPoints'][number] {
   return {
     timestamp: point.timestamp,
-    value: mode === 'eth' ? point.growthWeightEth : point.growthWeightUsd,
-    ...(mode === 'usd' && point.growthUsdEstimated ? { isEstimated: true } : {})
+    value: mode === 'eth' ? point.growthWeightEth : point.growthWeightUsd
   }
 }
 
 type TPreparedFamily = TPortfolioGrowthContributionFamily & {
   originalIndex: number
   values: Array<number | null>
-  estimatedValues: boolean[]
   terminalValue: number
 }
 
@@ -83,71 +77,50 @@ function normalizeZero(value: number): number {
 
 function buildRebasedFamilyValues(
   points: TPortfolioGrowthContributionFamily['dataPoints'],
-  dates: string[],
-  preserveNullValues: boolean
-): { values: Array<number | null>; estimatedValues: boolean[] } {
+  dates: string[]
+): Array<number | null> {
   const sortedPoints = points
     .flatMap((point) => {
       const date = timestampToUtcDate(point.timestamp)
-      return date ? [{ date, value: point.value, isEstimated: point.isEstimated ?? false }] : []
+      return date ? [{ date, value: point.value }] : []
     })
     .toSorted((left, right) => left.date.localeCompare(right.date))
 
   const initialState = {
     pointIndex: 0,
     baselineValue: null as number | null,
-    baselineEstimated: false,
     lastValue: null as number | null,
-    lastEstimated: false,
-    values: [] as Array<number | null>,
-    estimatedValues: [] as boolean[]
+    values: [] as Array<number | null>
   }
 
   return dates.reduce<typeof initialState>((state, date) => {
     while (state.pointIndex < sortedPoints.length && sortedPoints[state.pointIndex]!.date <= date) {
       const nextValue = sortedPoints[state.pointIndex]!.value
-      if (isFiniteNumber(nextValue)) {
-        state.lastValue = nextValue
-        state.lastEstimated = sortedPoints[state.pointIndex]!.isEstimated
-      } else if (preserveNullValues) {
-        state.lastValue = null
-        state.lastEstimated = false
-      }
+      state.lastValue = isFiniteNumber(nextValue) ? nextValue : null
       state.pointIndex += 1
     }
 
     if (state.baselineValue === null && state.lastValue !== null) {
       state.baselineValue = state.lastValue
-      state.baselineEstimated = state.lastEstimated
     }
 
     state.values.push(
       state.baselineValue !== null && state.lastValue !== null
         ? normalizeZero(state.lastValue - state.baselineValue)
-        : preserveNullValues
-          ? null
-          : 0
-    )
-    state.estimatedValues.push(
-      state.baselineValue !== null && state.lastValue !== null ? state.baselineEstimated || state.lastEstimated : false
+        : null
     )
     return state
-  }, initialState)
+  }, initialState).values
 }
 
-function prepareFamilies(
-  familySeries: TPortfolioGrowthContributionFamily[],
-  dates: string[],
-  preserveNullValues: boolean
-): TPreparedFamily[] {
+function prepareFamilies(familySeries: TPortfolioGrowthContributionFamily[], dates: string[]): TPreparedFamily[] {
   return familySeries
     .map((family, originalIndex) => {
-      const { values, estimatedValues } = buildRebasedFamilyValues(family.dataPoints, dates, preserveNullValues)
+      const values = buildRebasedFamilyValues(family.dataPoints, dates)
       return {
         ...family,
         originalIndex,
         values,
-        estimatedValues,
         terminalValue: values.at(-1) ?? 0
       }
     })
@@ -159,10 +132,9 @@ function prepareFamilies(
 }
 
 export function buildPortfolioGrowthContributionChart(args: {
-  totalPoints: Array<{ date: string; value: number | null; isEstimated?: boolean }>
+  totalPoints: Array<{ date: string; value: number | null }>
   familySeries: TPortfolioGrowthContributionFamily[]
   maxVaults?: number
-  preserveNullValues?: boolean
   baseContribution?: { key: string; label: string; value: number }
 }): TPortfolioGrowthContributionChart {
   const dates = args.totalPoints.map((point) => point.date)
@@ -170,8 +142,7 @@ export function buildPortfolioGrowthContributionChart(args: {
   const maxVaults = Number.isFinite(requestedMaxVaults)
     ? Math.max(0, Math.floor(requestedMaxVaults))
     : DEFAULT_MAX_VAULTS
-  const preserveNullValues = args.preserveNullValues ?? false
-  const selectedFamilies = prepareFamilies(args.familySeries, dates, preserveNullValues).slice(0, maxVaults)
+  const selectedFamilies = prepareFamilies(args.familySeries, dates).slice(0, maxVaults)
   const namedSeries: TPortfolioGrowthContributionSeries[] = selectedFamilies.map((family, index) => ({
     key: `vault_${index}`,
     label: family.label,
@@ -209,16 +180,12 @@ export function buildPortfolioGrowthContributionChart(args: {
     const row: TPortfolioGrowthContributionChartPoint = {
       date: totalPoint.date,
       portfolioGrowth,
-      stackBands: {},
-      ...(totalPoint.isEstimated ? { portfolioGrowthEstimated: true } : {})
+      stackBands: {}
     }
 
     selectedFamilies.forEach((family, familyIndex) => {
       const value = family.values[pointIndex]
       row[`vault_${familyIndex}`] = value
-      if (isFiniteNumber(value) && family.estimatedValues[pointIndex]) {
-        row[`vault_${familyIndex}Estimated`] = true
-      }
     })
 
     const displayedGrowth = selectedFamilies.reduce((total, family) => {
@@ -226,9 +193,6 @@ export function buildPortfolioGrowthContributionChart(args: {
       return total + (isFiniteNumber(value) ? value : 0)
     }, 0)
     row.other = normalizeZero(portfolioGrowth - baseValue - displayedGrowth)
-    if (totalPoint.isEstimated || selectedFamilies.some((family) => family.estimatedValues[pointIndex])) {
-      row.otherEstimated = true
-    }
 
     if (baseSeries) {
       row[baseSeries.key] = baseValue

--- a/apps/yearn/src/components/pages/vaults/hooks/useVaultUserHistory.ts
+++ b/apps/yearn/src/components/pages/vaults/hooks/useVaultUserHistory.ts
@@ -17,9 +17,9 @@ type TUseVaultUserHistoryParams = {
 
 const vaultUserHistoryPointSchema = z.object({
   date: z.string(),
-  growthWeightUsd: z.number().optional().default(0),
-  currentUnderlying: z.number().optional().default(0),
-  growthUnderlying: z.number().optional().default(0),
+  growthWeightUsd: z.number().nullable().optional().default(null),
+  currentUnderlying: z.number().nullable().optional().default(null),
+  growthUnderlying: z.number().nullable().optional().default(null),
   sharesFormatted: z.number().optional().default(0),
   pricePerShare: z.number().optional().default(0)
 })

--- a/apps/yearn/src/server/lib/holdings/services/cache.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.test.ts
@@ -98,7 +98,7 @@ describe('protocol return history snapshot cache', () => {
     const savedValue = setMock.mock.calls[0]?.[1]
 
     expect(saved).toBe(true)
-    expect(key).toMatch(/^holdings:protocol-return-history:v19:[a-f0-9]{64}:1y:all$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v20:[a-f0-9]{64}:1y:all$/)
     expect(key).not.toContain(identity.userAddress)
     expect(savedValue).toEqual(expect.stringMatching(/^br1:/))
     expect(savedValue).not.toContain('2026-07-15')
@@ -202,7 +202,7 @@ describe('protocol return history snapshot cache', () => {
     const key = getProtocolReturnHistoryCacheKey(identity)
 
     expect(key).toBe(getProtocolReturnHistoryCacheKey(reversedIdentity))
-    expect(key).toMatch(/^holdings:protocol-return-history:v19:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v20:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
     expect(key).not.toContain(identity.vaultScope[0].address)
   })
 

--- a/apps/yearn/src/server/lib/holdings/services/cache.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.test.ts
@@ -98,7 +98,7 @@ describe('protocol return history snapshot cache', () => {
     const savedValue = setMock.mock.calls[0]?.[1]
 
     expect(saved).toBe(true)
-    expect(key).toMatch(/^holdings:protocol-return-history:v18:[a-f0-9]{64}:1y:all$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v19:[a-f0-9]{64}:1y:all$/)
     expect(key).not.toContain(identity.userAddress)
     expect(savedValue).toEqual(expect.stringMatching(/^br1:/))
     expect(savedValue).not.toContain('2026-07-15')
@@ -202,7 +202,7 @@ describe('protocol return history snapshot cache', () => {
     const key = getProtocolReturnHistoryCacheKey(identity)
 
     expect(key).toBe(getProtocolReturnHistoryCacheKey(reversedIdentity))
-    expect(key).toMatch(/^holdings:protocol-return-history:v18:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
+    expect(key).toMatch(/^holdings:protocol-return-history:v19:[a-f0-9]{64}:1y:[a-f0-9]{64}$/)
     expect(key).not.toContain(identity.vaultScope[0].address)
   })
 

--- a/apps/yearn/src/server/lib/holdings/services/cache.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.ts
@@ -34,8 +34,8 @@ const HOLDINGS_TOTALS_TTL_SECONDS = 30 * 24 * 60 * 60
 // Old hashes expire naturally and cannot reintroduce previously cached incomplete days.
 const HOLDINGS_TOTALS_KEY_PREFIX = 'holdings:totals:v3'
 const PROTOCOL_RETURN_HISTORY_TTL_SECONDS = 30 * 24 * 60 * 60
-// v19 computes partial Index history using a fixed set of reliably valued vaults.
-const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v19'
+// v20 uses fixed, currency-specific valuation coverage for every growth chart.
+const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v20'
 const PROTOCOL_RETURN_HISTORY_VALUE_PREFIX = 'br1:'
 const PROTOCOL_RETURN_HISTORY_MAX_ENCODED_BYTES = 4 * 1024 * 1024
 const PROTOCOL_RETURN_HISTORY_MAX_DECODED_BYTES = 64 * 1024 * 1024

--- a/apps/yearn/src/server/lib/holdings/services/cache.ts
+++ b/apps/yearn/src/server/lib/holdings/services/cache.ts
@@ -34,8 +34,8 @@ const HOLDINGS_TOTALS_TTL_SECONDS = 30 * 24 * 60 * 60
 // Old hashes expire naturally and cannot reintroduce previously cached incomplete days.
 const HOLDINGS_TOTALS_KEY_PREFIX = 'holdings:totals:v3'
 const PROTOCOL_RETURN_HISTORY_TTL_SECONDS = 30 * 24 * 60 * 60
-// v18 values chart flows consistently with the daily Kong PPS used by settled history points.
-const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v18'
+// v19 computes partial Index history using a fixed set of reliably valued vaults.
+const PROTOCOL_RETURN_HISTORY_KEY_PREFIX = 'holdings:protocol-return-history:v19'
 const PROTOCOL_RETURN_HISTORY_VALUE_PREFIX = 'br1:'
 const PROTOCOL_RETURN_HISTORY_MAX_ENCODED_BYTES = 4 * 1024 * 1024
 const PROTOCOL_RETURN_HISTORY_MAX_DECODED_BYTES = 64 * 1024 * 1024

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
@@ -315,9 +315,7 @@ describe('pnl simple protocol return', () => {
       priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]])
     }
     const history = buildProtocolReturnHistorySeries({ ...inputs, timestamps: [100, 200, 300] })
-    expect(history[0]?.growthIndex).toBe(100)
-    expect(history[1]?.growthIndex).toBeNull()
-    expect(history[2]?.growthIndex).toBeNull()
+    expect(history.map((point) => point.growthIndex)).toEqual([null, null, null])
     const tail = buildProtocolReturnHistorySeries({
       ...inputs,
       timestamps: [300, 400],
@@ -325,6 +323,94 @@ describe('pnl simple protocol return', () => {
     })
     expect(tail.map((point) => point.growthIndex)).toEqual([null, null])
   })
+
+  it.each(['zero PPS', 'missing metadata', 'missing receipt price', 'intermediate PPS gap'])(
+    'keeps a consistent partial Index when another vault has %s',
+    (issue) => {
+      const badVault = '0x9999999999999999999999999999999999999999'
+      const badAsset = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+      const badKey = toVaultKey(1, badVault)
+      const events = [
+        baseEvent({ kind: 'transfer', id: 'good', blockTimestamp: 100 }),
+        baseEvent({
+          kind: 'transfer',
+          id: 'bad',
+          blockTimestamp: 100,
+          vaultAddress: badVault,
+          familyVaultAddress: badVault,
+          shares: 1000n * ONE
+        })
+      ]
+      const inputs = {
+        events,
+        userAddress: USER,
+        metadata: new Map([
+          ...metadata,
+          ...(issue === 'missing metadata'
+            ? []
+            : [
+                [
+                  badKey,
+                  {
+                    ...metadata.get(VAULT_KEY)!,
+                    address: badVault,
+                    token: { address: badAsset, symbol: 'BAD', decimals: 18 }
+                  }
+                ] as const
+              ])
+        ]),
+        ppsData: new Map([
+          [
+            VAULT_KEY,
+            new Map([
+              [100, 1],
+              [200, 1.1],
+              [300, 1.2]
+            ])
+          ],
+          [
+            badKey,
+            new Map([
+              [100, issue === 'zero PPS' ? 0 : 1],
+              [200, issue === 'intermediate PPS gap' || issue === 'zero PPS' ? 0 : 1.1],
+              [300, 1.2]
+            ])
+          ]
+        ]),
+        priceData: new Map([
+          [ASSET_PRICE_KEY, new Map([[0, 1]])],
+          [`ethereum:${badAsset}`, new Map([[0, issue === 'missing receipt price' ? 0 : 1]])]
+        ]),
+        timestamps: [100, 200, 300]
+      }
+      const history = buildProtocolReturnHistorySeries(inputs)
+      const control = buildProtocolReturnHistorySeries({ ...inputs, events: events.slice(0, 1) })
+      history.forEach((point, index) => {
+        expect(point.growthIndex).toBeCloseTo(control[index]!.growthIndex!, 10)
+      })
+      expect(history.at(-1)?.growthIndex).toBeCloseTo(120)
+
+      const selectedVaults = materializeProtocolReturnVaults({
+        ...inputs,
+        ledgers: buildProtocolReturnLedgers({ ...inputs, currentTimestamp: 300 }),
+        currentTimestamp: 300
+      })
+      const familySeries = buildProtocolReturnFamilyHistorySeries({
+        ...inputs,
+        selectedVaults,
+        portfolioPoints: history,
+        excludedIndexVaultKeys: new Set([badKey])
+      })
+      expect(
+        familySeries
+          .find((series) => series.vaultAddress === badVault)
+          ?.dataPoints.map((point) => point.growthIndexContribution)
+      ).toEqual([null, null, null])
+      expect(
+        familySeries.find((series) => series.vaultAddress === VAULT)?.dataPoints.at(-1)?.growthIndexContribution
+      ).toBeCloseTo(20)
+    }
+  )
 
   it('ignores events after an explicit ledger cutoff', () => {
     const vault = materializeVault({

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
@@ -297,7 +297,7 @@ describe('pnl simple protocol return', () => {
     expect(history[1]?.growthIndex).toBe(100)
   })
 
-  it('does not turn unavailable PPS into an Index loss or silently restart at 100 after recovery', () => {
+  it('excludes a PPS gap from every growth metric instead of recording a loss and recovery', () => {
     const inputs = {
       events: [baseEvent({ kind: 'transfer', id: 'receipt', blockTimestamp: 100 })],
       userAddress: USER,
@@ -312,10 +312,26 @@ describe('pnl simple protocol return', () => {
           ])
         ]
       ]),
-      priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]])
+      priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
+      ethPriceData: new Map([[0, 2]])
     }
     const history = buildProtocolReturnHistorySeries({ ...inputs, timestamps: [100, 200, 300] })
     expect(history.map((point) => point.growthIndex)).toEqual([null, null, null])
+    expect(history.map((point) => point.growthWeightUsd)).toEqual([null, null, null])
+    expect(history.map((point) => point.growthWeightEth)).toEqual([null, null, null])
+    expect(history[1]?.protocolReturnPct).toBeNull()
+    expect(history[1]?.annualizedProtocolReturnPct).toBeNull()
+    const unavailableVault = materializeProtocolReturnVaults({
+      ...inputs,
+      ledgers: buildProtocolReturnLedgers({ ...inputs, currentTimestamp: 200 }),
+      currentTimestamp: 200
+    })[0]!
+    expect(unavailableVault).toMatchObject({
+      currentUnderlying: null,
+      growthUnderlying: null,
+      growthWeightUsd: null,
+      growthWeightEth: null
+    })
     const tail = buildProtocolReturnHistorySeries({
       ...inputs,
       timestamps: [300, 400],
@@ -325,7 +341,7 @@ describe('pnl simple protocol return', () => {
   })
 
   it.each(['zero PPS', 'missing metadata', 'missing receipt price', 'intermediate PPS gap'])(
-    'keeps a consistent partial Index when another vault has %s',
+    'keeps consistent partial USD, ETH, and Index histories when another vault has %s',
     (issue) => {
       const badVault = '0x9999999999999999999999999999999999999999'
       const badAsset = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
@@ -381,12 +397,15 @@ describe('pnl simple protocol return', () => {
           [ASSET_PRICE_KEY, new Map([[0, 1]])],
           [`ethereum:${badAsset}`, new Map([[0, issue === 'missing receipt price' ? 0 : 1]])]
         ]),
+        ethPriceData: new Map([[0, 2]]),
         timestamps: [100, 200, 300]
       }
       const history = buildProtocolReturnHistorySeries(inputs)
       const control = buildProtocolReturnHistorySeries({ ...inputs, events: events.slice(0, 1) })
       history.forEach((point, index) => {
         expect(point.growthIndex).toBeCloseTo(control[index]!.growthIndex!, 10)
+        expect(point.growthWeightUsd).toBeCloseTo(control[index]!.growthWeightUsd!, 10)
+        expect(point.growthWeightEth).toBeCloseTo(control[index]!.growthWeightEth!, 10)
       })
       expect(history.at(-1)?.growthIndex).toBeCloseTo(120)
 
@@ -399,18 +418,107 @@ describe('pnl simple protocol return', () => {
         ...inputs,
         selectedVaults,
         portfolioPoints: history,
-        excludedIndexVaultKeys: new Set([badKey])
+        excludedVaultKeys: { usd: new Set([badKey]), eth: new Set([badKey]) }
       })
       expect(
         familySeries
           .find((series) => series.vaultAddress === badVault)
           ?.dataPoints.map((point) => point.growthIndexContribution)
       ).toEqual([null, null, null])
+      const excludedFamily = familySeries.find((series) => series.vaultAddress === badVault)!
+      expect(excludedFamily.dataPoints.map((point) => point.growthWeightUsd)).toEqual([null, null, null])
+      expect(excludedFamily.dataPoints.map((point) => point.growthWeightEth)).toEqual([null, null, null])
       expect(
         familySeries.find((series) => series.vaultAddress === VAULT)?.dataPoints.at(-1)?.growthIndexContribution
       ).toBeCloseTo(20)
     }
   )
+
+  it.each(['withdrawal', 'transfer'] as const)(
+    'keeps realized growth after a full %s without requiring current PPS or exit USD prices',
+    (kind) => {
+      const day = 86_400
+      const inputs = {
+        events: [
+          baseEvent({ id: 'receipt', blockTimestamp: 100 }),
+          baseEvent({
+            kind,
+            id: 'exit',
+            blockTimestamp: day + 100,
+            blockNumber: 2,
+            owner: USER,
+            sender: USER,
+            receiver: OTHER,
+            assets: 110n * ONE
+          })
+        ],
+        userAddress: USER,
+        metadata,
+        ppsData: new Map([
+          [
+            VAULT_KEY,
+            new Map([
+              [0, 1],
+              [day, 1.1],
+              [2 * day, 0]
+            ])
+          ]
+        ]),
+        priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
+        exitPriceData: new Map<string, Map<number, number>>(),
+        ethPriceData: new Map([[0, 2]]),
+        timestamps: [day - 1, 2 * day - 1, 3 * day - 1]
+      }
+      const history = buildProtocolReturnHistorySeries(inputs)
+      expect(history.map((point) => point.growthWeightUsd)).toEqual([
+        expect.closeTo(0),
+        expect.closeTo(10),
+        expect.closeTo(10)
+      ])
+      expect(history.map((point) => point.growthWeightEth)).toEqual([
+        expect.closeTo(0),
+        expect.closeTo(5),
+        expect.closeTo(5)
+      ])
+      expect(history.map((point) => point.growthIndex)).toEqual([
+        expect.closeTo(100),
+        expect.closeTo(110),
+        expect.closeTo(110)
+      ])
+      const vault = materializeProtocolReturnVaults({
+        ...inputs,
+        ledgers: buildProtocolReturnLedgers({ ...inputs, currentTimestamp: 3 * day - 1 }),
+        currentTimestamp: 3 * day - 1
+      })[0]!
+      expect(vault.issues).toEqual(['missing_exit_price'])
+      expect(vault.currentUnderlying).toBe(0)
+      expect(vault.growthWeightUsd).toBeCloseTo(10)
+      expect(vault.growthWeightEth).toBeCloseTo(5)
+    }
+  )
+
+  it('keeps USD and Index available when only the receipt ETH conversion price is missing', () => {
+    const history = buildProtocolReturnHistorySeries({
+      events: [baseEvent({ id: 'receipt', blockTimestamp: 100 })],
+      userAddress: USER,
+      metadata,
+      ppsData: new Map([
+        [
+          VAULT_KEY,
+          new Map([
+            [100, 1],
+            [200, 1.1]
+          ])
+        ]
+      ]),
+      priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
+      ethPriceData: new Map([[200, 2]]),
+      timestamps: [100, 200]
+    })
+    expect(history.map((point) => point.growthWeightUsd)).toEqual([expect.closeTo(0), expect.closeTo(10)])
+    expect(history.map((point) => point.growthIndex)).toEqual([expect.closeTo(100), expect.closeTo(110)])
+    expect(history.map((point) => point.growthWeightEth)).toEqual([null, null])
+  })
 
   it('ignores events after an explicit ledger cutoff', () => {
     const vault = materializeVault({
@@ -2668,7 +2776,7 @@ describe('pnl simple protocol return', () => {
     expect(vault.baselineUnderlying).toBeCloseTo(300)
     expect(vault.realizedBaselineUnderlying).toBeCloseTo(0)
     expect(vault.realizedGrowthUnderlying).toBeCloseTo(0)
-    expect(vault.growthUnderlying).toBeCloseTo(300)
+    expect(vault.growthUnderlying).toBeNull()
     expect(vault.exitCount).toBe(0)
     expect(vault.unmatchedExitSharesFormatted).toBeCloseTo(0)
   })
@@ -2878,8 +2986,8 @@ describe('pnl simple protocol return', () => {
 
     expect(vault.status).toBe('missing_pps')
     expect(vault.baselineUnderlying).toBe(0)
-    expect(vault.currentUnderlying).toBe(0)
-    expect(vault.growthUnderlying).toBe(0)
+    expect(vault.currentUnderlying).toBeNull()
+    expect(vault.growthUnderlying).toBeNull()
   })
 
   it('preserves a locked yvUSD lot when its withdrawal and transfer-out lack unlocked PPS', () => {
@@ -2991,7 +3099,7 @@ describe('pnl simple protocol return', () => {
     expect(vault.currentUnderlying).toBeCloseTo(107.1)
     expect(vault.realizedBaselineUnderlying).toBeCloseTo(0)
     expect(vault.realizedGrowthUnderlying).toBeCloseTo(0)
-    expect(vault.growthUnderlying).toBeCloseTo(7.1)
+    expect(vault.growthUnderlying).toBeNull()
     expect(vault.exitCount).toBe(0)
     expect(vault.unmatchedExitSharesFormatted).toBeCloseTo(0)
   })

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import * as viem from 'viem'
+import { describe, expect, it, vi } from 'vitest'
 import type { VaultMetadata } from '../types'
 import type { TransactionActivityEvents } from './graphql'
 import { mergeAddressScopedRawPnlEventsWithTransactionActivity } from './pnlEvents'
@@ -13,6 +14,11 @@ import {
   materializeProtocolReturnVaults
 } from './pnlSimple'
 import type { TRawPnlEvent } from './pnlTypes'
+
+vi.mock('viem', async (importOriginal) => {
+  const original = await importOriginal<typeof import('viem')>()
+  return { ...original, formatUnits: vi.fn(original.formatUnits) }
+})
 
 const USER = '0x1111111111111111111111111111111111111111'
 const OTHER = '0x2222222222222222222222222222222222222222'
@@ -338,6 +344,162 @@ describe('pnl simple protocol return', () => {
       growthIndexSeed: { timestamp: 300, growthIndex: null }
     })
     expect(tail.map((point) => point.growthIndex)).toEqual([null, null])
+    expect(tail.map((point) => point.growthWeightUsd)).toEqual([expect.closeTo(10), expect.closeTo(10)])
+    expect(tail.map((point) => point.growthWeightEth)).toEqual([expect.closeTo(5), expect.closeTo(5)])
+  })
+
+  it('does not repeat history valuations after discovering a PPS gap', () => {
+    const formatUnits = vi.mocked(viem.formatUnits)
+    formatUnits.mockClear()
+    const buildHistory = (middlePps: number) =>
+      buildProtocolReturnHistorySeries({
+        events: [baseEvent({ id: 'receipt', blockTimestamp: 100 })],
+        userAddress: USER,
+        metadata,
+        ppsData: new Map([
+          [
+            VAULT_KEY,
+            new Map([
+              [100, 1],
+              [200, middlePps],
+              [300, 1.1]
+            ])
+          ]
+        ]),
+        priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
+        ethPriceData: new Map([[0, 2]]),
+        timestamps: [100, 200, 300]
+      })
+    try {
+      buildHistory(1.05)
+      const completeValuations = formatUnits.mock.calls.length
+      formatUnits.mockClear()
+      const incompleteHistory = buildHistory(Number.NaN)
+      expect(incompleteHistory.map((point) => point.growthWeightUsd)).toEqual([null, null, null])
+      expect(formatUnits.mock.calls.length).toBe(completeValuations)
+    } finally {
+      formatUnits.mockRestore()
+    }
+  })
+
+  it.each([
+    { layer: 'outer', gapKey: NESTED_OUTER_KEY },
+    { layer: 'intermediate', gapKey: NESTED_MIDDLE_KEY }
+  ])("excludes an $layer PPS gap at another vault's flow between chart dates", ({ gapKey }) => {
+    const day = 86_400
+    const inputs = {
+      events: [
+        baseEvent({ id: 'good-receipt', blockTimestamp: 100 }),
+        baseEvent({
+          id: 'nested-receipt',
+          blockTimestamp: 100,
+          vaultAddress: NESTED_OUTER_VAULT,
+          familyVaultAddress: NESTED_OUTER_VAULT
+        }),
+        baseEvent({ id: 'good-addition', blockTimestamp: day + 100, blockNumber: 2, shares: 10n * ONE })
+      ],
+      userAddress: USER,
+      metadata: new Map([...metadata, ...nestedMetadata]),
+      ppsData: new Map([
+        [
+          VAULT_KEY,
+          new Map([
+            [0, 1],
+            [day, 1.1],
+            [2 * day, 1.2]
+          ])
+        ],
+        ...(
+          [
+            [NESTED_OUTER_KEY, 2],
+            [NESTED_MIDDLE_KEY, 3],
+            [NESTED_INNER_KEY, 5]
+          ] as const
+        ).map(
+          ([key, pps]) =>
+            [
+              key,
+              new Map([
+                [0, pps],
+                [day, key === gapKey ? Number.NaN : pps],
+                [2 * day, pps]
+              ])
+            ] as const
+        )
+      ]),
+      priceData: new Map([
+        [ASSET_PRICE_KEY, new Map([[0, 1]])],
+        [NESTED_TERMINAL_PRICE_KEY, new Map([[0, 1]])]
+      ]),
+      ethPriceData: new Map([[0, 2]]),
+      timestamps: [day - 1, 3 * day - 1]
+    }
+    const history = buildProtocolReturnHistorySeries(inputs)
+    const control = buildProtocolReturnHistorySeries({
+      ...inputs,
+      events: inputs.events.filter((event) => event.vaultAddress === VAULT)
+    })
+
+    history.forEach((point, index) => {
+      expect(point.growthIndex).toBeCloseTo(control[index]!.growthIndex!, 10)
+      expect(point.growthWeightUsd).toBeCloseTo(control[index]!.growthWeightUsd!, 10)
+      expect(point.growthWeightEth).toBeCloseTo(control[index]!.growthWeightEth!, 10)
+    })
+    expect(history.at(-1)?.growthWeightUsd).toBeCloseTo(21)
+    expect(history.at(-1)?.growthIndex).toBeCloseTo(120)
+  })
+
+  it('ignores PPS gaps before receipt and while fully exited, including after re-entry', () => {
+    const day = 86_400
+    const history = buildProtocolReturnHistorySeries({
+      events: [
+        baseEvent({ id: 'receipt', blockTimestamp: day + 100 }),
+        baseEvent({
+          kind: 'withdrawal',
+          id: 'full-exit',
+          blockTimestamp: 2 * day + 100,
+          blockNumber: 2,
+          owner: USER,
+          assets: 110n * ONE
+        }),
+        baseEvent({ id: 're-entry', blockTimestamp: 4 * day + 100, blockNumber: 3 })
+      ],
+      userAddress: USER,
+      metadata,
+      ppsData: new Map([
+        [
+          VAULT_KEY,
+          new Map([
+            [0, Number.NaN],
+            [day, 1],
+            [2 * day, 1.1],
+            [3 * day, Number.NaN],
+            [4 * day, 2],
+            [5 * day, 2.2]
+          ])
+        ]
+      ]),
+      priceData: new Map([[ASSET_PRICE_KEY, new Map([[0, 1]])]]),
+      ethPriceData: new Map([[0, 2]]),
+      timestamps: [day - 1, 2 * day - 1, 3 * day - 1, 4 * day - 1, 5 * day - 1, 6 * day - 1]
+    })
+    expect(history.map((point) => point.growthWeightUsd)).toEqual([
+      null,
+      expect.closeTo(0),
+      expect.closeTo(10),
+      expect.closeTo(10),
+      expect.closeTo(10),
+      expect.closeTo(30)
+    ])
+    expect(history.map((point) => point.growthWeightEth)).toEqual([
+      null,
+      expect.closeTo(0),
+      expect.closeTo(5),
+      expect.closeTo(5),
+      expect.closeTo(5),
+      expect.closeTo(15)
+    ])
+    expect(history.at(-1)?.growthIndex).toBeCloseTo(121)
   })
 
   it.each(['zero PPS', 'missing metadata', 'missing receipt price', 'intermediate PPS gap'])(

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
@@ -2541,11 +2541,67 @@ export function buildProtocolReturnHistorySeries(args: {
 
 type TGrowthExclusions = { usd: Set<string>; eth: Set<string> }
 
-function calculateProtocolReturnHistorySeries(
-  args: Parameters<typeof buildProtocolReturnHistorySeries>[0],
-  excludedVaultKeys: TGrowthExclusions = { usd: new Set(), eth: new Set() }
-): { dataPoints: HoldingsPnLSimpleHistoryPoint[]; excludedVaultKeys: TGrowthExclusions } {
-  const initialExclusionCount = excludedVaultKeys.usd.size + excludedVaultKeys.eth.size
+function getProtocolReturnHistoryExclusions(
+  timeline: Array<{ timestamp: number; event: TRawPnlEvent | null }>,
+  eventContext: Parameters<typeof processEvent>[2]
+): TGrowthExclusions {
+  const excluded: TGrowthExclusions = { usd: new Set(), eth: new Set() }
+  const ledgers = new Map<string, TProtocolReturnLedger>()
+  const state = { initialized: false }
+  const validate = (ledger: TProtocolReturnLedger, timestamp: number): void => {
+    const key = toVaultKey(ledger.chainId, ledger.vaultAddress)
+    if (excluded.usd.has(key)) {
+      return
+    }
+
+    const valuation = ledger.lots.some((lot) => lot.shares > ZERO)
+      ? resolveNestedVaultValuation({
+          chainId: ledger.chainId,
+          vaultAddress: ledger.vaultAddress,
+          vaultMetadata: eventContext.metadata,
+          ppsData: eventContext.ppsData,
+          timestamp
+        })
+      : null
+    const issues = ledgerIssues({
+      ledger,
+      metadata: eventContext.metadata.get(key),
+      missingMetadata: valuation?.missingMetadata ?? false,
+      currentPps: valuation?.pricePerShare ?? null
+    })
+    // Receipt-weighted growth does not need exit USD prices or PPS after a full exit.
+    if (issues.some((issue) => issue !== 'missing_exit_price')) {
+      excluded.usd.add(key)
+      excluded.eth.add(key)
+    } else if (ledger.missingReceiptEthPrice) {
+      excluded.eth.add(key)
+    }
+  }
+
+  // Check coverage before calculating returns, including gaps at other vaults' flow timestamps.
+  timeline.forEach(({ timestamp, event }) => {
+    if (state.initialized || event === null) {
+      ledgers.forEach((ledger) => {
+        validate(ledger, timestamp)
+      })
+    }
+    if (event) {
+      processEvent(ledgers, event, eventContext)
+      const ledger = ledgers.get(toVaultKey(event.chainId, event.familyVaultAddress))
+      if (state.initialized && ledger) {
+        validate(ledger, timestamp)
+      }
+    } else {
+      state.initialized = true
+    }
+  })
+  return excluded
+}
+
+function calculateProtocolReturnHistorySeries(args: Parameters<typeof buildProtocolReturnHistorySeries>[0]): {
+  dataPoints: HoldingsPnLSimpleHistoryPoint[]
+  excludedVaultKeys: TGrowthExclusions
+} {
   const userAddress = lowerCaseAddress(args.userAddress)
   const effectiveEvents = buildEffectiveSimpleEvents(args.events, userAddress)
   const groupedTransactions = groupEventsByTransaction(effectiveEvents)
@@ -2570,6 +2626,23 @@ function calculateProtocolReturnHistorySeries(
     ethPriceData: args.ethPriceData ?? new Map<number, number>(),
     useDailyPpsForFlows: true
   }
+  const normalizedEvents = groupedTransactions.flatMap((txEvents) =>
+    sortEvents(
+      groupTransactionEventsByFamily(txEvents).flatMap((familyEvents) =>
+        normalizeStakingWrapperEvents(familyEvents, userAddress)
+      )
+    )
+  )
+  const timeline: Array<{ timestamp: number; event: TRawPnlEvent | null }> = [
+    ...normalizedEvents
+      .filter((event) => event.blockTimestamp <= (args.timestamps.at(-1) ?? 0))
+      .map((event) => ({ timestamp: event.blockTimestamp, event })),
+    ...args.timestamps.map((timestamp) => ({ timestamp, event: null }))
+  ].toSorted(
+    (left, right) => left.timestamp - right.timestamp || Number(left.event === null) - Number(right.event === null)
+  )
+  const excludedVaultKeys = getProtocolReturnHistoryExclusions(timeline, eventContext)
+  const growthIndexSeed = excludedVaultKeys.eth.size === 0 ? args.growthIndexSeed : undefined
   const markGrowthIndex = (timestamp: number, afterReceipt = false) => {
     const vaults = materializeProtocolReturnVaults({
       ledgers,
@@ -2578,15 +2651,6 @@ function calculateProtocolReturnHistorySeries(
       currentTimestamp: timestamp
     })
     const summary = buildSummary(vaults)
-    vaults.forEach((vault) => {
-      const key = toVaultKey(vault.chainId, vault.vaultAddress)
-      if (vault.growthWeightUsd === null) {
-        excludedVaultKeys.usd.add(key)
-      }
-      if (vault.growthWeightEth === null || excludedVaultKeys.usd.has(key)) {
-        excludedVaultKeys.eth.add(key)
-      }
-    })
     const indexVaults = vaults.filter(
       (vault) => !excludedVaultKeys.usd.has(toVaultKey(vault.chainId, vault.vaultAddress))
     )
@@ -2615,25 +2679,10 @@ function calculateProtocolReturnHistorySeries(
       ) + indexSummary.unrealizedGrowthWeightUsd
     return { vaults, summary, indexVaults }
   }
-  const normalizedEvents = groupedTransactions.flatMap((txEvents) =>
-    sortEvents(
-      groupTransactionEventsByFamily(txEvents).flatMap((familyEvents) =>
-        normalizeStakingWrapperEvents(familyEvents, userAddress)
-      )
-    )
-  )
-  const timeline: Array<{ timestamp: number; event: TRawPnlEvent | null }> = [
-    ...normalizedEvents
-      .filter((event) => event.blockTimestamp <= (args.timestamps.at(-1) ?? 0))
-      .map((event) => ({ timestamp: event.blockTimestamp, event })),
-    ...args.timestamps.map((timestamp) => ({ timestamp, event: null }))
-  ]
 
-  const dataPoints = timeline
-    .toSorted(
-      (left, right) => left.timestamp - right.timestamp || Number(left.event === null) - Number(right.event === null)
-    )
-    .reduce<HoldingsPnLSimpleHistoryPoint[]>((history, { timestamp, event }) => {
+  return {
+    excludedVaultKeys,
+    dataPoints: timeline.reduce<HoldingsPnLSimpleHistoryPoint[]>((history, { timestamp, event }) => {
       if (event) {
         // Value existing capital before the flow and its exact receipt/exit adjustment afterwards.
         if (state.initialized) {
@@ -2651,8 +2700,8 @@ function calculateProtocolReturnHistorySeries(
       })
       const { vaults, summary, indexVaults } = markGrowthIndex(timestamp)
       state.initialized = true
-      if (state.indexValuationComplete && args.growthIndexSeed?.timestamp === timestamp) {
-        state.growthIndex = args.growthIndexSeed.growthIndex
+      if (state.indexValuationComplete && growthIndexSeed?.timestamp === timestamp) {
+        state.growthIndex = growthIndexSeed.growthIndex
         if (state.growthIndex === null && (summary.baselineWeightUsd > 0 || summary.growthWeightUsd !== 0)) {
           state.indexValuationComplete = false
         }
@@ -2697,11 +2746,7 @@ function calculateProtocolReturnHistorySeries(
       })
       return history
     }, [])
-  // Replay with a fixed membership: losing a price must not look like a portfolio loss or a deposit.
-  // ponytail: exclude whole vaults for this window; lot-level recovery can be added if needed.
-  return excludedVaultKeys.usd.size + excludedVaultKeys.eth.size > initialExclusionCount
-    ? calculateProtocolReturnHistorySeries({ ...args, growthIndexSeed: undefined }, excludedVaultKeys)
-    : { dataPoints, excludedVaultKeys }
+  }
 }
 
 export function buildProtocolReturnFamilyHistorySeries(args: {

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
@@ -261,6 +261,7 @@ export interface HoldingsPnLSimpleHistoryResponse {
       status: Exclude<THoldingsPnLSimpleStatus, 'ok'>
       issues: TProtocolReturnIssue[]
     }>
+    indexExcludedVaults?: Array<{ chainId: number; vaultAddress: string; symbol: string | null }>
     isComplete: boolean
   }
   dataPoints: HoldingsPnLSimpleHistoryPoint[]
@@ -2026,6 +2027,7 @@ function getProtocolReturnHistoryTailPlan(args: {
   if (
     !args.cached ||
     !protocolReturn ||
+    (protocolReturn.summary.indexExcludedVaults?.length ?? 0) > 0 ||
     protocolReturn.address !== lowerCaseAddress(args.userAddress) ||
     protocolReturn.timeframe !== args.timeframe
   ) {
@@ -2561,6 +2563,14 @@ export function buildProtocolReturnHistorySeries(args: {
   selectedVaultKeys?: string[]
   growthIndexSeed?: { timestamp: number; growthIndex: number | null }
 }): HoldingsPnLSimpleHistoryPoint[] {
+  return calculateProtocolReturnHistorySeries(args).dataPoints
+}
+
+function calculateProtocolReturnHistorySeries(
+  args: Parameters<typeof buildProtocolReturnHistorySeries>[0],
+  excludedIndexVaultKeys = new Set<string>()
+): { dataPoints: HoldingsPnLSimpleHistoryPoint[]; excludedIndexVaultKeys: Set<string> } {
+  const initialExclusionCount = excludedIndexVaultKeys.size
   const userAddress = lowerCaseAddress(args.userAddress)
   const effectiveEvents = buildEffectiveSimpleEvents(args.events, userAddress)
   const groupedTransactions = groupEventsByTransaction(effectiveEvents)
@@ -2593,29 +2603,37 @@ export function buildProtocolReturnHistorySeries(args: {
       currentTimestamp: timestamp
     })
     const summary = buildSummary(vaults)
-    const receivedCapital = afterReceipt ? Math.max(0, summary.baselineWeightUsd - state.baselineWeightUsd) : 0
-    const hasValuation =
-      state.indexValuationComplete &&
-      vaults.every((vault) => !vault.issues.includes('missing_metadata') && !vault.issues.includes('missing_pps'))
-    // An unknown return cannot be linked later by silently starting again at 100.
-    state.indexValuationComplete = hasValuation
-    state.growthIndex = !hasValuation
+    vaults.forEach((vault) => {
+      if (vault.issues.some((issue) => issue !== 'missing_exit_price')) {
+        excludedIndexVaultKeys.add(toVaultKey(vault.chainId, vault.vaultAddress))
+      }
+    })
+    const indexVaults = vaults.filter(
+      (vault) => !excludedIndexVaultKeys.has(toVaultKey(vault.chainId, vault.vaultAddress))
+    )
+    const indexSummary = buildSummary(indexVaults)
+    const receivedCapital = afterReceipt ? Math.max(0, indexSummary.baselineWeightUsd - state.baselineWeightUsd) : 0
+    // An unknown cached return cannot be linked later by silently starting again at 100.
+    state.growthIndex = !state.indexValuationComplete
       ? null
       : state.initialized
         ? advanceGrowthIndex({
             previousIndex: state.growthIndex,
-            deltaGrowthWeightUsd: summary.growthWeightUsd - state.growthWeightUsd,
+            deltaGrowthWeightUsd: indexSummary.growthWeightUsd - state.growthWeightUsd,
             capitalWeightUsd: state.openCapitalWeightUsd + receivedCapital
           })
-        : summary.baselineWeightUsd > 0 || summary.growthWeightUsd !== 0
+        : indexSummary.baselineWeightUsd > 0 || indexSummary.growthWeightUsd !== 0
           ? 100
           : null
-    state.growthWeightUsd = summary.growthWeightUsd
-    state.baselineWeightUsd = summary.baselineWeightUsd
+    state.growthWeightUsd = indexSummary.growthWeightUsd
+    state.baselineWeightUsd = indexSummary.baselineWeightUsd
     // Previously withdrawn gains are not capital in the next holding period.
     state.openCapitalWeightUsd =
-      Array.from(ledgers.values()).reduce((total, ledger) => total + getOutstandingBaselineWeightUsd(ledger.lots), 0) +
-      summary.unrealizedGrowthWeightUsd
+      Array.from(ledgers.entries()).reduce(
+        (total, [key, ledger]) =>
+          total + (excludedIndexVaultKeys.has(key) ? 0 : getOutstandingBaselineWeightUsd(ledger.lots)),
+        0
+      ) + indexSummary.unrealizedGrowthWeightUsd
     return { vaults, summary }
   }
   const normalizedEvents = groupedTransactions.flatMap((txEvents) =>
@@ -2632,7 +2650,7 @@ export function buildProtocolReturnHistorySeries(args: {
     ...args.timestamps.map((timestamp) => ({ timestamp, event: null }))
   ]
 
-  return timeline
+  const dataPoints = timeline
     .toSorted(
       (left, right) => left.timestamp - right.timestamp || Number(left.event === null) - Number(right.event === null)
     )
@@ -2701,6 +2719,10 @@ export function buildProtocolReturnHistorySeries(args: {
       })
       return history
     }, [])
+  // Replay with a fixed membership: losing a price must not look like a portfolio loss or a deposit.
+  return excludedIndexVaultKeys.size > initialExclusionCount
+    ? calculateProtocolReturnHistorySeries({ ...args, growthIndexSeed: undefined }, excludedIndexVaultKeys)
+    : { dataPoints, excludedIndexVaultKeys }
 }
 
 export function buildProtocolReturnFamilyHistorySeries(args: {
@@ -2714,6 +2736,7 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
   timestamps: number[]
   selectedVaults: HoldingsPnLSimpleVault[]
   portfolioPoints?: HoldingsPnLSimpleHistoryPoint[]
+  excludedIndexVaultKeys?: ReadonlySet<string>
 }): HoldingsPnLSimpleHistoryFamilySeries[] {
   if (args.selectedVaults.length === 0) {
     return []
@@ -2801,10 +2824,13 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
     const previousPortfolioIndex = previousPortfolioPoint?.growthIndex
     const portfolioIndex = portfolioPoint?.growthIndex
     const canAttributeIndex = typeof previousPortfolioIndex === 'number' && typeof portfolioIndex === 'number'
-    const growthWeightDelta =
-      portfolioPoint && previousPortfolioPoint
-        ? portfolioPoint.growthWeightUsd - previousPortfolioPoint.growthWeightUsd
-        : 0
+    const growthWeightDelta = Array.from(vaultsByKey.entries()).reduce(
+      (total, [key, vault]) =>
+        args.excludedIndexVaultKeys?.has(key)
+          ? total
+          : total + vault.growthWeightUsd - (previousFamilyGrowthWeightUsd.get(key) ?? 0),
+      0
+    )
     const indexPointsPerGrowthUsd =
       canAttributeIndex && Math.abs(growthWeightDelta) > Number.EPSILON
         ? (portfolioIndex - previousPortfolioIndex) / growthWeightDelta
@@ -2812,6 +2838,9 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
 
     if (canAttributeIndex) {
       selectedVaultKeys.forEach((vaultKey) => {
+        if (args.excludedIndexVaultKeys?.has(vaultKey)) {
+          return
+        }
         const currentGrowthWeightUsd = vaultsByKey.get(vaultKey)?.growthWeightUsd ?? 0
         const previousGrowthWeightUsd = previousFamilyGrowthWeightUsd.get(vaultKey) ?? 0
         familyIndexContribution.set(
@@ -2867,13 +2896,13 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
               }),
         growthIndex: hasOpenPosition || closesPosition ? state.growthIndex : null,
         growthIndexContribution:
-          familyLedger && typeof portfolioPoint?.growthIndex === 'number'
+          familyLedger && !args.excludedIndexVaultKeys?.has(vaultKey) && typeof portfolioPoint?.growthIndex === 'number'
             ? (familyIndexContribution.get(vaultKey) ?? 0)
             : null
       })
     })
-    selectedVaultKeys.forEach((vaultKey) => {
-      previousFamilyGrowthWeightUsd.set(vaultKey, vaultsByKey.get(vaultKey)?.growthWeightUsd ?? 0)
+    vaultsByKey.forEach((vault, vaultKey) => {
+      previousFamilyGrowthWeightUsd.set(vaultKey, vault.growthWeightUsd)
     })
     previousPortfolioPoint = portfolioPoint
   })
@@ -3060,7 +3089,7 @@ async function calculateHoldingsProtocolReturnHistory(
     historyTimestamps: number[],
     growthIndexSeed?: { timestamp: number; growthIndex: number | null }
   ) =>
-    buildProtocolReturnHistorySeries({
+    calculateProtocolReturnHistorySeries({
       events: settledEvents,
       userAddress,
       metadata: vaultMetadata,
@@ -3072,20 +3101,19 @@ async function calculateHoldingsProtocolReturnHistory(
       selectedVaultKeys,
       ...(growthIndexSeed ? { growthIndexSeed } : {})
     })
-  const tailHistory = buildHistory(tailPlan?.calculationTimestamps ?? timestamps, tailPlan?.growthIndexSeed)
+  const tailResult = buildHistory(tailPlan?.calculationTimestamps ?? timestamps, tailPlan?.growthIndexSeed)
+  const tailHistory = tailResult.dataPoints
   const canAppend = Boolean(
     tailPlan &&
       cached &&
+      tailResult.excludedIndexVaultKeys.size === 0 &&
       tailHistory[0] &&
       isProtocolReturnHistoryOverlapEqual(tailPlan.cachedPoints[tailPlan.cachedPoints.length - 1]!, tailHistory[0]) &&
       haveSameProtocolReturnVaults(cached.response, finalVaults)
   )
-  const history =
-    tailPlan && canAppend
-      ? [...tailPlan.cachedPoints, ...tailHistory.slice(1)]
-      : tailPlan
-        ? buildHistory(timestamps)
-        : tailHistory
+  const historyResult = tailPlan && !canAppend ? buildHistory(timestamps) : tailResult
+  const history = tailPlan && canAppend ? [...tailPlan.cachedPoints, ...tailHistory.slice(1)] : historyResult.dataPoints
+  const excludedIndexVaultKeys = historyResult.excludedIndexVaultKeys
   debugLog(
     'protocol-return-history',
     tailPlan && canAppend ? 'appended missing protocol return dates' : 'rebuilt protocol return history',
@@ -3107,7 +3135,8 @@ async function calculateHoldingsProtocolReturnHistory(
     ethPriceData,
     timestamps,
     selectedVaults: requestedVaults ? [] : eligibleHistoryFamilies,
-    portfolioPoints: history
+    portfolioPoints: history,
+    excludedIndexVaultKeys
   })
   reportHoldingsProgress(92, 'Built historical chart series', `${history.length} chart points`)
   const openBaselineCompositionUsd = buildOpenBaselineCompositionUsd({
@@ -3159,6 +3188,13 @@ async function calculateHoldingsProtocolReturnHistory(
                 }
               ]
         ),
+        indexExcludedVaults: finalVaults
+          .filter((vault) => excludedIndexVaultKeys.has(toVaultKey(vault.chainId, vault.vaultAddress)))
+          .map((vault) => ({
+            chainId: vault.chainId,
+            vaultAddress: vault.vaultAddress,
+            symbol: vault.metadata.symbol
+          })),
         isComplete: finalVaults.every((vault) => vault.status === 'ok')
       },
       dataPoints: history,

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimple.ts
@@ -150,21 +150,22 @@ export interface HoldingsPnLSimpleVault {
   shares: string
   sharesFormatted: number
   pricePerShare: number
-  currentUnderlying: number
+  currentUnderlying: number | null
   baselineUnderlying: number
   baselineExposureUnderlyingYears: number
   baselineExposureWeightUsdYears: number
   realizedBaselineUnderlying: number
   unrealizedBaselineUnderlying: number
   realizedGrowthUnderlying: number
-  unrealizedGrowthUnderlying: number
+  unrealizedGrowthUnderlying: number | null
   realizedGrowthUsdAtExit: number
   unpricedRealizedGrowthUnderlying: number
-  growthUnderlying: number
+  growthUnderlying: number | null
   baselineWeightUsd: number
-  growthWeightUsd: number
+  growthWeightUsd: number | null
+  growthWeightEth: number | null
   realizedGrowthWeightUsd: number
-  unrealizedGrowthWeightUsd: number
+  unrealizedGrowthWeightUsd: number | null
   protocolReturnPct: number | null
   annualizedProtocolReturnPct: number | null
   receiptCount: number
@@ -206,15 +207,15 @@ export interface HoldingsPnLSimpleResponse {
 export interface HoldingsPnLSimpleHistoryPoint {
   date: string
   timestamp: number
-  growthUsd: number
+  growthUsd: number | null
   growthUsdEstimated: boolean
-  growthWeightUsd: number
+  growthWeightUsd: number | null
   growthWeightEth: number | null
   protocolReturnPct: number | null
   annualizedProtocolReturnPct: number | null
   growthIndex: number | null
-  currentUnderlying?: number
-  growthUnderlying?: number
+  currentUnderlying?: number | null
+  growthUnderlying?: number | null
   sharesFormatted?: number
   pricePerShare?: number
 }
@@ -261,7 +262,7 @@ export interface HoldingsPnLSimpleHistoryResponse {
       status: Exclude<THoldingsPnLSimpleStatus, 'ok'>
       issues: TProtocolReturnIssue[]
     }>
-    indexExcludedVaults?: Array<{ chainId: number; vaultAddress: string; symbol: string | null }>
+    growthIsPartial?: Record<TGrowthDisplay, boolean>
     isComplete: boolean
   }
   dataPoints: HoldingsPnLSimpleHistoryPoint[]
@@ -275,8 +276,8 @@ export interface HoldingsPortfolioGrowthVault {
   issues: TProtocolReturnIssue[]
   baselineUsd: number
   baselineExposureUsdYears: number
-  growthUnderlying: number
-  growthUsd: number
+  growthUnderlying: number | null
+  growthUsd: number | null
   growthPct: number | null
   annualizedProtocolReturnPct: number | null
   metadata: {
@@ -405,12 +406,12 @@ function scaleNumber(value: number, numerator: bigint, denominator: bigint): num
   return denominator === ZERO ? 0 : value * (Number(numerator) / Number(denominator))
 }
 
-function protocolReturnPct(growth: number, baseline: number): number | null {
-  return baseline > 0 ? (growth / baseline) * 100 : null
+function protocolReturnPct(growth: number | null, baseline: number): number | null {
+  return growth !== null && baseline > 0 ? (growth / baseline) * 100 : null
 }
 
-function annualizedProtocolReturnPct(growth: number, exposureYears: number): number | null {
-  return exposureYears > 0 ? (growth / exposureYears) * 100 : null
+function annualizedProtocolReturnPct(growth: number | null, exposureYears: number): number | null {
+  return growth !== null && exposureYears > 0 ? (growth / exposureYears) * 100 : null
 }
 
 function advanceGrowthIndex(args: {
@@ -914,10 +915,6 @@ function getOutstandingBaselineUnderlying(lots: TProtocolReturnLot[]): number {
 
 function getOutstandingBaselineWeightUsd(lots: TProtocolReturnLot[]): number {
   return lots.reduce((total, lot) => total + lot.baselineUnderlying * lot.receiptPriceUsd, 0)
-}
-
-function getOutstandingBaselineWeightEth(lots: TProtocolReturnLot[]): number {
-  return lots.reduce((total, lot) => total + lot.baselineUnderlying * lot.receiptPriceEth, 0)
 }
 
 function accrueLedgerExposure(ledger: TProtocolReturnLedger, nextTimestamp: number): TProtocolReturnLedger {
@@ -2027,7 +2024,7 @@ function getProtocolReturnHistoryTailPlan(args: {
   if (
     !args.cached ||
     !protocolReturn ||
-    (protocolReturn.summary.indexExcludedVaults?.length ?? 0) > 0 ||
+    Object.values(protocolReturn.summary.growthIsPartial ?? {}).some(Boolean) ||
     protocolReturn.address !== lowerCaseAddress(args.userAddress) ||
     protocolReturn.timeframe !== args.timeframe
   ) {
@@ -2182,9 +2179,12 @@ function ledgerIssues(args: {
   missingMetadata: boolean
   currentPps: number | null
 }): TProtocolReturnIssue[] {
+  const hasOpenPosition = args.ledger.lots.some((lot) => lot.shares > ZERO)
   return [
-    ...(!args.metadata || args.ledger.missingMetadata || args.missingMetadata ? (['missing_metadata'] as const) : []),
-    ...(args.ledger.missingPps || (!args.missingMetadata && args.currentPps === null)
+    ...(args.ledger.missingMetadata || (hasOpenPosition && (!args.metadata || args.missingMetadata))
+      ? (['missing_metadata'] as const)
+      : []),
+    ...(args.ledger.missingPps || (hasOpenPosition && !args.missingMetadata && args.currentPps === null)
       ? (['missing_pps'] as const)
       : []),
     ...(args.ledger.missingReceiptPrice ? (['missing_receipt_price'] as const) : []),
@@ -2209,56 +2209,8 @@ function vaultStatus(issues: TProtocolReturnIssue[]): THoldingsPnLSimpleStatus {
   return issues.includes('unmatched_exit') ? 'partial' : 'ok'
 }
 
-function computeVaultGrowthWeightEth(args: {
-  ledger: TProtocolReturnLedger
-  metadata: Map<string, VaultMetadata>
-  ppsData: Map<string, Map<number, number>>
-  currentTimestamp: number
-}): number | null {
-  if (args.ledger.missingReceiptEthPrice) {
-    return null
-  }
-
-  const vaultKey = toVaultKey(args.ledger.chainId, args.ledger.vaultAddress)
-  const metadata = args.metadata.get(vaultKey)
-  const shareDecimals = metadata?.decimals ?? 18
-  const valuation = resolveNestedVaultValuation({
-    chainId: args.ledger.chainId,
-    vaultAddress: args.ledger.vaultAddress,
-    vaultMetadata: args.metadata,
-    ppsData: args.ppsData,
-    timestamp: args.currentTimestamp
-  })
-  const currentPps = valuation.pricePerShare
-  const currentShares = args.ledger.lots.reduce((total, lot) => total + lot.shares, ZERO)
-  const sharesFormatted = formatAmount(currentShares, shareDecimals)
-  const currentUnderlying = currentPps === null ? 0 : sharesFormatted * currentPps
-  const unrealizedBaselineWeightEth = getOutstandingBaselineWeightEth(args.ledger.lots)
-  const currentWeightEth = args.ledger.lots.reduce(
-    (total, lot) => total + scaleNumber(currentUnderlying, lot.shares, currentShares) * lot.receiptPriceEth,
-    0
-  )
-  const unrealizedGrowthWeightEth = currentWeightEth - unrealizedBaselineWeightEth
-
-  return args.ledger.realizedGrowthWeightEth + unrealizedGrowthWeightEth
-}
-
-function buildGrowthWeightEthSummary(args: {
-  ledgers: Map<string, TProtocolReturnLedger>
-  metadata: Map<string, VaultMetadata>
-  ppsData: Map<string, Map<number, number>>
-  currentTimestamp: number
-}): number | null {
-  const perVaultGrowthWeightEth = Array.from(args.ledgers.values()).map((ledger) =>
-    computeVaultGrowthWeightEth({
-      ledger,
-      metadata: args.metadata,
-      ppsData: args.ppsData,
-      currentTimestamp: args.currentTimestamp
-    })
-  )
-
-  const availableValues = perVaultGrowthWeightEth.filter((value): value is number => value !== null)
+function sumAvailable(values: Array<number | null>): number | null {
+  const availableValues = values.filter((value): value is number => value !== null)
   return availableValues.length > 0 ? availableValues.reduce((total, value) => total + value, 0) : null
 }
 
@@ -2318,23 +2270,34 @@ export function materializeProtocolReturnVaults(args: {
     const terminalAsset = valuation.terminalAsset
     const currentShares = ledger.lots.reduce((total, lot) => total + lot.shares, ZERO)
     const sharesFormatted = formatAmount(currentShares, shareDecimals)
-    const currentUnderlying = currentPps === null ? 0 : sharesFormatted * currentPps
+    const currentUnderlying = currentShares === ZERO ? 0 : currentPps === null ? null : sharesFormatted * currentPps
+    const issues = ledgerIssues({ ledger, metadata, missingMetadata: valuation.missingMetadata, currentPps })
+    const underlyingComplete = !issues.some((issue) =>
+      ['missing_metadata', 'missing_pps', 'unmatched_exit'].includes(issue)
+    )
     const unrealizedBaselineUnderlying = ledger.lots.reduce((total, lot) => total + lot.baselineUnderlying, 0)
     const unrealizedBaselineWeightUsd = ledger.lots.reduce(
       (total, lot) => total + lot.baselineUnderlying * lot.receiptPriceUsd,
       0
     )
-    const currentWeightUsd = ledger.lots.reduce(
-      (total, lot) => total + scaleNumber(currentUnderlying, lot.shares, currentShares) * lot.receiptPriceUsd,
-      0
-    )
-    const unrealizedGrowthUnderlying = currentUnderlying - unrealizedBaselineUnderlying
-    const unrealizedGrowthWeightUsd = currentWeightUsd - unrealizedBaselineWeightUsd
+    const unrealizedGrowthUnderlying =
+      underlyingComplete && currentUnderlying !== null ? currentUnderlying - unrealizedBaselineUnderlying : null
+    const unrealizedGrowthWeight = (priceKey: 'receiptPriceUsd' | 'receiptPriceEth'): number | null =>
+      unrealizedGrowthUnderlying === null || currentUnderlying === null
+        ? null
+        : ledger.lots.reduce(
+            (total, lot) =>
+              total +
+              (scaleNumber(currentUnderlying, lot.shares, currentShares) - lot.baselineUnderlying) * lot[priceKey],
+            0
+          )
+    const unrealizedGrowthWeightUsd = ledger.missingReceiptPrice ? null : unrealizedGrowthWeight('receiptPriceUsd')
+    const unrealizedGrowthWeightEth = ledger.missingReceiptEthPrice ? null : unrealizedGrowthWeight('receiptPriceEth')
     const baselineExposureUnderlyingYears = ledger.baselineExposureUnderlyingSeconds / SECONDS_PER_YEAR
     const baselineExposureWeightUsdYears = ledger.baselineExposureWeightUsdSeconds / SECONDS_PER_YEAR
     const baselineWeightUsd = ledger.realizedBaselineWeightUsd + unrealizedBaselineWeightUsd
-    const growthWeightUsd = ledger.realizedGrowthWeightUsd + unrealizedGrowthWeightUsd
-    const issues = ledgerIssues({ ledger, metadata, missingMetadata: valuation.missingMetadata, currentPps })
+    const growthWeightUsd =
+      unrealizedGrowthWeightUsd === null ? null : ledger.realizedGrowthWeightUsd + unrealizedGrowthWeightUsd
     const status = vaultStatus(issues)
 
     return {
@@ -2355,9 +2318,12 @@ export function materializeProtocolReturnVaults(args: {
       unrealizedGrowthUnderlying,
       realizedGrowthUsdAtExit: ledger.realizedGrowthUsdAtExit,
       unpricedRealizedGrowthUnderlying: ledger.unpricedRealizedGrowthUnderlying,
-      growthUnderlying: ledger.realizedGrowthUnderlying + unrealizedGrowthUnderlying,
+      growthUnderlying:
+        unrealizedGrowthUnderlying === null ? null : ledger.realizedGrowthUnderlying + unrealizedGrowthUnderlying,
       baselineWeightUsd,
       growthWeightUsd,
+      growthWeightEth:
+        unrealizedGrowthWeightEth === null ? null : ledger.realizedGrowthWeightEth + unrealizedGrowthWeightEth,
       realizedGrowthWeightUsd: ledger.realizedGrowthWeightUsd,
       unrealizedGrowthWeightUsd,
       protocolReturnPct: protocolReturnPct(growthWeightUsd, baselineWeightUsd),
@@ -2431,7 +2397,10 @@ function buildLatestAssetPriceUsdByVaultKey(
   )
 }
 
-function getGrowthUsd(vault: HoldingsPnLSimpleVault, latestAssetPriceUsd: number | null): number {
+function getGrowthUsd(vault: HoldingsPnLSimpleVault, latestAssetPriceUsd: number | null): number | null {
+  if (vault.unrealizedGrowthUnderlying === null) {
+    return null
+  }
   const growthValuedAtLatestPrice =
     latestAssetPriceUsd === null
       ? 0
@@ -2513,14 +2482,15 @@ function normalizeProtocolReturnPortfolioResponse(
 }
 
 function buildSummary(vaults: HoldingsPnLSimpleVault[]): HoldingsPnLSimpleResponse['summary'] {
+  const growthComplete = vaults.every((vault) => vault.growthWeightUsd !== null)
   const baselineWeightUsd = vaults.reduce((total, vault) => total + vault.baselineWeightUsd, 0)
-  const growthWeightUsd = vaults.reduce((total, vault) => total + vault.growthWeightUsd, 0)
+  const growthWeightUsd = vaults.reduce((total, vault) => total + (vault.growthWeightUsd ?? 0), 0)
   const baselineExposureWeightUsdYears = vaults.reduce(
     (total, vault) => total + vault.baselineExposureWeightUsdYears,
     0
   )
   const realizedGrowthWeightUsd = vaults.reduce((total, vault) => total + vault.realizedGrowthWeightUsd, 0)
-  const unrealizedGrowthWeightUsd = vaults.reduce((total, vault) => total + vault.unrealizedGrowthWeightUsd, 0)
+  const unrealizedGrowthWeightUsd = vaults.reduce((total, vault) => total + (vault.unrealizedGrowthWeightUsd ?? 0), 0)
   const completeVaults = vaults.filter((vault) => vault.status === 'ok').length
   const partialVaults = vaults.length - completeVaults
 
@@ -2533,8 +2503,11 @@ function buildSummary(vaults: HoldingsPnLSimpleVault[]): HoldingsPnLSimpleRespon
     baselineExposureWeightUsdYears,
     realizedGrowthWeightUsd,
     unrealizedGrowthWeightUsd,
-    protocolReturnPct: protocolReturnPct(growthWeightUsd, baselineWeightUsd),
-    annualizedProtocolReturnPct: annualizedProtocolReturnPct(growthWeightUsd, baselineExposureWeightUsdYears),
+    protocolReturnPct: protocolReturnPct(growthComplete ? growthWeightUsd : null, baselineWeightUsd),
+    annualizedProtocolReturnPct: annualizedProtocolReturnPct(
+      growthComplete ? growthWeightUsd : null,
+      baselineExposureWeightUsdYears
+    ),
     isComplete: partialVaults === 0
   }
 }
@@ -2566,11 +2539,13 @@ export function buildProtocolReturnHistorySeries(args: {
   return calculateProtocolReturnHistorySeries(args).dataPoints
 }
 
+type TGrowthExclusions = { usd: Set<string>; eth: Set<string> }
+
 function calculateProtocolReturnHistorySeries(
   args: Parameters<typeof buildProtocolReturnHistorySeries>[0],
-  excludedIndexVaultKeys = new Set<string>()
-): { dataPoints: HoldingsPnLSimpleHistoryPoint[]; excludedIndexVaultKeys: Set<string> } {
-  const initialExclusionCount = excludedIndexVaultKeys.size
+  excludedVaultKeys: TGrowthExclusions = { usd: new Set(), eth: new Set() }
+): { dataPoints: HoldingsPnLSimpleHistoryPoint[]; excludedVaultKeys: TGrowthExclusions } {
+  const initialExclusionCount = excludedVaultKeys.usd.size + excludedVaultKeys.eth.size
   const userAddress = lowerCaseAddress(args.userAddress)
   const effectiveEvents = buildEffectiveSimpleEvents(args.events, userAddress)
   const groupedTransactions = groupEventsByTransaction(effectiveEvents)
@@ -2604,12 +2579,16 @@ function calculateProtocolReturnHistorySeries(
     })
     const summary = buildSummary(vaults)
     vaults.forEach((vault) => {
-      if (vault.issues.some((issue) => issue !== 'missing_exit_price')) {
-        excludedIndexVaultKeys.add(toVaultKey(vault.chainId, vault.vaultAddress))
+      const key = toVaultKey(vault.chainId, vault.vaultAddress)
+      if (vault.growthWeightUsd === null) {
+        excludedVaultKeys.usd.add(key)
+      }
+      if (vault.growthWeightEth === null || excludedVaultKeys.usd.has(key)) {
+        excludedVaultKeys.eth.add(key)
       }
     })
     const indexVaults = vaults.filter(
-      (vault) => !excludedIndexVaultKeys.has(toVaultKey(vault.chainId, vault.vaultAddress))
+      (vault) => !excludedVaultKeys.usd.has(toVaultKey(vault.chainId, vault.vaultAddress))
     )
     const indexSummary = buildSummary(indexVaults)
     const receivedCapital = afterReceipt ? Math.max(0, indexSummary.baselineWeightUsd - state.baselineWeightUsd) : 0
@@ -2631,10 +2610,10 @@ function calculateProtocolReturnHistorySeries(
     state.openCapitalWeightUsd =
       Array.from(ledgers.entries()).reduce(
         (total, [key, ledger]) =>
-          total + (excludedIndexVaultKeys.has(key) ? 0 : getOutstandingBaselineWeightUsd(ledger.lots)),
+          total + (excludedVaultKeys.usd.has(key) ? 0 : getOutstandingBaselineWeightUsd(ledger.lots)),
         0
       ) + indexSummary.unrealizedGrowthWeightUsd
-    return { vaults, summary }
+    return { vaults, summary, indexVaults }
   }
   const normalizedEvents = groupedTransactions.flatMap((txEvents) =>
     sortEvents(
@@ -2670,7 +2649,7 @@ function calculateProtocolReturnHistorySeries(
       ledgers.forEach((ledger, key) => {
         ledgers.set(key, accrueLedgerExposure(ledger, timestamp))
       })
-      const { vaults, summary } = markGrowthIndex(timestamp)
+      const { vaults, summary, indexVaults } = markGrowthIndex(timestamp)
       state.initialized = true
       if (state.indexValuationComplete && args.growthIndexSeed?.timestamp === timestamp) {
         state.growthIndex = args.growthIndexSeed.growthIndex
@@ -2681,37 +2660,36 @@ function calculateProtocolReturnHistorySeries(
       const selectedVaults = selectedVaultKeys.length
         ? vaults.filter((vault) => selectedVaultKeySet.has(toVaultKey(vault.chainId, vault.vaultAddress)))
         : []
-      const growthUsd = vaults.reduce(
-        (total, vault) =>
-          total +
-          getGrowthUsd(vault, latestAssetPriceUsdByVaultKey.get(toVaultKey(vault.chainId, vault.vaultAddress)) ?? null),
-        0
-      )
-      const growthWeightEth = buildGrowthWeightEthSummary({
-        ledgers,
-        metadata: args.metadata,
-        ppsData: args.ppsData,
-        currentTimestamp: timestamp
-      })
       history.push({
         date: timestampToDateString(timestamp),
         timestamp,
-        growthUsd,
+        growthUsd: sumAvailable(
+          vaults.map((vault) =>
+            getGrowthUsd(
+              vault,
+              latestAssetPriceUsdByVaultKey.get(toVaultKey(vault.chainId, vault.vaultAddress)) ?? null
+            )
+          )
+        ),
         growthUsdEstimated: vaults.some((vault) =>
           isGrowthUsdEstimated(
             vault,
             latestAssetPriceUsdByVaultKey.get(toVaultKey(vault.chainId, vault.vaultAddress)) ?? null
           )
         ),
-        growthWeightUsd: summary.growthWeightUsd,
-        growthWeightEth,
+        growthWeightUsd: sumAvailable(indexVaults.map((vault) => vault.growthWeightUsd)),
+        growthWeightEth: sumAvailable(
+          vaults
+            .filter((vault) => !excludedVaultKeys.eth.has(toVaultKey(vault.chainId, vault.vaultAddress)))
+            .map((vault) => vault.growthWeightEth)
+        ),
         protocolReturnPct: summary.protocolReturnPct,
         annualizedProtocolReturnPct: summary.annualizedProtocolReturnPct,
         growthIndex: state.growthIndex,
         ...(selectedVaultKeys.length > 0
           ? {
-              currentUnderlying: selectedVaults.reduce((sum, vault) => sum + vault.currentUnderlying, 0),
-              growthUnderlying: selectedVaults.reduce((sum, vault) => sum + vault.growthUnderlying, 0),
+              currentUnderlying: sumAvailable(selectedVaults.map((vault) => vault.currentUnderlying)),
+              growthUnderlying: sumAvailable(selectedVaults.map((vault) => vault.growthUnderlying)),
               sharesFormatted: selectedVaults.reduce((sum, vault) => sum + vault.sharesFormatted, 0),
               pricePerShare: selectedVaults.length === 1 ? selectedVaults[0]!.pricePerShare : 0
             }
@@ -2720,9 +2698,10 @@ function calculateProtocolReturnHistorySeries(
       return history
     }, [])
   // Replay with a fixed membership: losing a price must not look like a portfolio loss or a deposit.
-  return excludedIndexVaultKeys.size > initialExclusionCount
-    ? calculateProtocolReturnHistorySeries({ ...args, growthIndexSeed: undefined }, excludedIndexVaultKeys)
-    : { dataPoints, excludedIndexVaultKeys }
+  // ponytail: exclude whole vaults for this window; lot-level recovery can be added if needed.
+  return excludedVaultKeys.usd.size + excludedVaultKeys.eth.size > initialExclusionCount
+    ? calculateProtocolReturnHistorySeries({ ...args, growthIndexSeed: undefined }, excludedVaultKeys)
+    : { dataPoints, excludedVaultKeys }
 }
 
 export function buildProtocolReturnFamilyHistorySeries(args: {
@@ -2736,7 +2715,7 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
   timestamps: number[]
   selectedVaults: HoldingsPnLSimpleVault[]
   portfolioPoints?: HoldingsPnLSimpleHistoryPoint[]
-  excludedIndexVaultKeys?: ReadonlySet<string>
+  excludedVaultKeys?: TGrowthExclusions
 }): HoldingsPnLSimpleHistoryFamilySeries[] {
   if (args.selectedVaults.length === 0) {
     return []
@@ -2826,9 +2805,9 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
     const canAttributeIndex = typeof previousPortfolioIndex === 'number' && typeof portfolioIndex === 'number'
     const growthWeightDelta = Array.from(vaultsByKey.entries()).reduce(
       (total, [key, vault]) =>
-        args.excludedIndexVaultKeys?.has(key)
+        args.excludedVaultKeys?.usd.has(key)
           ? total
-          : total + vault.growthWeightUsd - (previousFamilyGrowthWeightUsd.get(key) ?? 0),
+          : total + (vault.growthWeightUsd ?? 0) - (previousFamilyGrowthWeightUsd.get(key) ?? 0),
       0
     )
     const indexPointsPerGrowthUsd =
@@ -2838,7 +2817,7 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
 
     if (canAttributeIndex) {
       selectedVaultKeys.forEach((vaultKey) => {
-        if (args.excludedIndexVaultKeys?.has(vaultKey)) {
+        if (args.excludedVaultKeys?.usd.has(vaultKey)) {
           return
         }
         const currentGrowthWeightUsd = vaultsByKey.get(vaultKey)?.growthWeightUsd ?? 0
@@ -2853,7 +2832,6 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
 
     selectedVaultKeys.forEach((vaultKey) => {
       const familyVault = vaultsByKey.get(vaultKey)
-      const familyLedger = ledgers.get(vaultKey)
       const state = familyIndexState.get(vaultKey)
 
       if (!state) {
@@ -2884,25 +2862,25 @@ export function buildProtocolReturnFamilyHistorySeries(args: {
           familyVault === undefined
             ? false
             : isGrowthUsdEstimated(familyVault, latestAssetPriceUsdByVaultKey.get(vaultKey) ?? null),
-        growthWeightUsd: familyVault?.growthWeightUsd ?? null,
-        growthWeightEth:
-          familyLedger === undefined
-            ? null
-            : computeVaultGrowthWeightEth({
-                ledger: familyLedger,
-                metadata: args.metadata,
-                ppsData: args.ppsData,
-                currentTimestamp: timestamp
-              }),
+        growthWeightUsd: args.excludedVaultKeys?.usd.has(vaultKey)
+          ? null
+          : familyVault
+            ? familyVault.growthWeightUsd
+            : 0,
+        growthWeightEth: args.excludedVaultKeys?.eth.has(vaultKey)
+          ? null
+          : familyVault
+            ? familyVault.growthWeightEth
+            : 0,
         growthIndex: hasOpenPosition || closesPosition ? state.growthIndex : null,
         growthIndexContribution:
-          familyLedger && !args.excludedIndexVaultKeys?.has(vaultKey) && typeof portfolioPoint?.growthIndex === 'number'
+          !args.excludedVaultKeys?.usd.has(vaultKey) && typeof portfolioPoint?.growthIndex === 'number'
             ? (familyIndexContribution.get(vaultKey) ?? 0)
             : null
       })
     })
     vaultsByKey.forEach((vault, vaultKey) => {
-      previousFamilyGrowthWeightUsd.set(vaultKey, vault.growthWeightUsd)
+      previousFamilyGrowthWeightUsd.set(vaultKey, vault.growthWeightUsd ?? 0)
     })
     previousPortfolioPoint = portfolioPoint
   })
@@ -3106,14 +3084,14 @@ async function calculateHoldingsProtocolReturnHistory(
   const canAppend = Boolean(
     tailPlan &&
       cached &&
-      tailResult.excludedIndexVaultKeys.size === 0 &&
+      tailResult.excludedVaultKeys.eth.size === 0 &&
       tailHistory[0] &&
       isProtocolReturnHistoryOverlapEqual(tailPlan.cachedPoints[tailPlan.cachedPoints.length - 1]!, tailHistory[0]) &&
       haveSameProtocolReturnVaults(cached.response, finalVaults)
   )
   const historyResult = tailPlan && !canAppend ? buildHistory(timestamps) : tailResult
   const history = tailPlan && canAppend ? [...tailPlan.cachedPoints, ...tailHistory.slice(1)] : historyResult.dataPoints
-  const excludedIndexVaultKeys = historyResult.excludedIndexVaultKeys
+  const excludedVaultKeys = historyResult.excludedVaultKeys
   debugLog(
     'protocol-return-history',
     tailPlan && canAppend ? 'appended missing protocol return dates' : 'rebuilt protocol return history',
@@ -3136,7 +3114,7 @@ async function calculateHoldingsProtocolReturnHistory(
     timestamps,
     selectedVaults: requestedVaults ? [] : eligibleHistoryFamilies,
     portfolioPoints: history,
-    excludedIndexVaultKeys
+    excludedVaultKeys
   })
   reportHoldingsProgress(92, 'Built historical chart series', `${history.length} chart points`)
   const openBaselineCompositionUsd = buildOpenBaselineCompositionUsd({
@@ -3188,13 +3166,11 @@ async function calculateHoldingsProtocolReturnHistory(
                 }
               ]
         ),
-        indexExcludedVaults: finalVaults
-          .filter((vault) => excludedIndexVaultKeys.has(toVaultKey(vault.chainId, vault.vaultAddress)))
-          .map((vault) => ({
-            chainId: vault.chainId,
-            vaultAddress: vault.vaultAddress,
-            symbol: vault.metadata.symbol
-          })),
+        growthIsPartial: {
+          usd: excludedVaultKeys.usd.size > 0,
+          eth: excludedVaultKeys.eth.size > 0,
+          index: excludedVaultKeys.usd.size > 0
+        },
         isComplete: finalVaults.every((vault) => vault.status === 'ok')
       },
       dataPoints: history,

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimpleHistory.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimpleHistory.test.ts
@@ -843,6 +843,38 @@ describe('getHoldingsProtocolReturnHistory', () => {
     )
   })
 
+  it.each(['disappears', 'recovers'])('rebuilds the whole Index when a price %s', async (change) => {
+    const firstDay = 1_800_000_000
+    const secondDay = firstDay + 86_400
+    const thirdDay = secondDay + 86_400
+    getPPSMock.mockReturnValue(change === 'recovers' ? 0 : 1)
+    generateDailyTimestampsMock.mockReturnValue([firstDay, secondDay])
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    await getHoldingsProtocolReturnHistory(USER, '1y')
+    const cachedResponse = saveCachedProtocolReturnHistoryMock.mock.calls[0]![3]
+    getCachedProtocolReturnHistoryMock.mockResolvedValue({
+      settledDate: `date-${secondDay + 1}`,
+      response: cachedResponse
+    })
+    generateDailyTimestampsMock.mockReturnValue([firstDay, secondDay, thirdDay])
+    getPPSMock.mockImplementation((_timeline: Map<number, number>, timestamp: number) =>
+      change === 'disappears' && timestamp >= thirdDay ? 0 : 1
+    )
+    debugLogMock.mockClear()
+    const result = await getHoldingsProtocolReturnHistory(USER, '1y')
+    expect(result.dataPoints.map((point) => point.growthIndex)).toEqual(
+      change === 'disappears' ? [null, null, null] : [100, 100, 100]
+    )
+    expect(result.summary.indexExcludedVaults).toEqual(
+      change === 'disappears' ? [{ chainId: 1, vaultAddress: VAULT, symbol: 'TST' }] : []
+    )
+    expect(debugLogMock).toHaveBeenCalledWith(
+      'protocol-return-history',
+      'rebuilt protocol return history',
+      expect.objectContaining({ overlapMatched: change === 'disappears' ? false : null })
+    )
+  })
+
   it('appends a missing settled date and matches a clean rebuild', async () => {
     const firstDay = 1_800_000_000
     const secondDay = firstDay + 86_400

--- a/apps/yearn/src/server/lib/holdings/services/pnlSimpleHistory.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/pnlSimpleHistory.test.ts
@@ -622,7 +622,7 @@ describe('getHoldingsProtocolReturnHistory', () => {
     expect(scenario.response.protocolReturn.familySeries[0]?.dataPoints.at(-1)?.growthUsdEstimated).toBe(true)
   })
 
-  it('values growth history at the latest price and keeps recoverable missing-price families eligible', async () => {
+  it('keeps latest-price row growth but excludes a vault with missing receipt prices from weighted charts', async () => {
     const firstTimestamp = event.blockTimestamp + 1
     const secondTimestamp = firstTimestamp + 100
     generateDailyTimestampsMock.mockReturnValue([event.blockTimestamp, event.blockTimestamp + 100])
@@ -661,17 +661,25 @@ describe('getHoldingsProtocolReturnHistory', () => {
     expect(growthVault?.growthPct).toBeCloseTo(10)
     expect(response.protocolReturn.dataPoints[0]?.growthUsd).toBe(0)
     expect(response.protocolReturn.dataPoints[1]?.growthUsd).toBeCloseTo(30)
-    expect(response.protocolReturn.dataPoints.map((point) => point.growthWeightUsd)).toEqual([0, 0])
-    expect(response.protocolReturn.familySeries).toHaveLength(1)
-    expect(response.protocolReturn.familySeries[0]).toMatchObject({
-      chainId: 1,
-      vaultAddress: VAULT,
-      dataPoints: [
-        { timestamp: firstTimestamp, growthUsd: 0, growthWeightUsd: 0, growthWeightEth: null },
-        { timestamp: secondTimestamp, growthWeightUsd: 0, growthWeightEth: null }
-      ]
-    })
-    expect(response.protocolReturn.familySeries[0]?.dataPoints[1]?.growthUsd).toBeCloseTo(30)
+    expect(response.protocolReturn.dataPoints.map((point) => point.growthWeightUsd)).toEqual([null, null])
+    expect(response.protocolReturn.summary.growthIsPartial).toEqual({ usd: true, eth: true, index: true })
+    expect(response.protocolReturn.familySeries).toEqual([])
+  })
+
+  it('reports ETH-only incomplete coverage without excluding USD or Index', async () => {
+    const assetPrices = new Map([[EVENT_RECEIPT_DAY_TIMESTAMP, 1]])
+    const ethPrices = new Map([[EVENT_RECEIPT_DAY_TIMESTAMP, 2]])
+    fetchHistoricalPricesForTokenTimestampsMock.mockResolvedValue(
+      new Map([
+        [ASSET_PRICE_KEY, assetPrices],
+        [WETH_PRICE_KEY, ethPrices]
+      ])
+    )
+    getPriceAtTimestampMock.mockImplementation((prices: Map<number, number>) => (prices === ethPrices ? 0 : 1))
+    const { getHoldingsProtocolReturnHistory } = await import('./pnlSimple')
+    const response = await getHoldingsProtocolReturnHistory(USER, '1y')
+    expect(response.summary.growthIsPartial).toEqual({ usd: false, eth: true, index: false })
+    expect(response.dataPoints[0]).toMatchObject({ growthWeightUsd: 0, growthWeightEth: null, growthIndex: 100 })
   })
 
   it('normalizes string decimals in cached portfolio growth metadata', async () => {
@@ -843,7 +851,7 @@ describe('getHoldingsProtocolReturnHistory', () => {
     )
   })
 
-  it.each(['disappears', 'recovers'])('rebuilds the whole Index when a price %s', async (change) => {
+  it.each(['disappears', 'recovers'])('rebuilds every growth chart when PPS %s', async (change) => {
     const firstDay = 1_800_000_000
     const secondDay = firstDay + 86_400
     const thirdDay = secondDay + 86_400
@@ -865,9 +873,17 @@ describe('getHoldingsProtocolReturnHistory', () => {
     expect(result.dataPoints.map((point) => point.growthIndex)).toEqual(
       change === 'disappears' ? [null, null, null] : [100, 100, 100]
     )
-    expect(result.summary.indexExcludedVaults).toEqual(
-      change === 'disappears' ? [{ chainId: 1, vaultAddress: VAULT, symbol: 'TST' }] : []
+    expect(result.dataPoints.map((point) => point.growthWeightUsd)).toEqual(
+      change === 'disappears' ? [null, null, null] : [0, 0, 0]
     )
+    expect(result.dataPoints.map((point) => point.growthWeightEth)).toEqual(
+      change === 'disappears' ? [null, null, null] : [0, 0, 0]
+    )
+    expect(result.summary.growthIsPartial).toEqual({
+      usd: change === 'disappears',
+      eth: change === 'disappears',
+      index: change === 'disappears'
+    })
     expect(debugLogMock).toHaveBeenCalledWith(
       'protocol-return-history',
       'rebuilt protocol return history',

--- a/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.test.ts
+++ b/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.test.ts
@@ -150,4 +150,29 @@ describe('selectProtocolReturnFamilySeriesCandidates', () => {
     expect(selected.map((series) => series.vaultAddress)).not.toContain('eth-growth-10')
     expect(selected.find((series) => series.vaultAddress === 'eth-growth-19')?.dataPoints[1]?.growthWeightEth).toBe(19)
   })
+
+  it.each(['position', 'index'] as const)('does not let excluded vaults displace eligible %s contributors', (mode) => {
+    const excluded = Array.from({ length: 16 }, (_, index) => {
+      const series = buildIsolatedSeries({
+        id: `excluded-${index}`,
+        mode,
+        window: '1y',
+        score: index < 8 ? 100 + index : -100 - index,
+        pointCount: 2
+      })
+      return {
+        ...series,
+        dataPoints: series.dataPoints.map((point) => ({
+          ...point,
+          growthWeightUsd: null,
+          growthIndexContribution: null
+        }))
+      }
+    })
+    const healthy = buildIsolatedSeries({ id: 'healthy', mode, window: '1y', score: 5, pointCount: 2 })
+
+    expect(
+      selectProtocolReturnFamilySeriesCandidates([...excluded, healthy], '1y').map((series) => series.vaultAddress)
+    ).toEqual(['healthy'])
+  })
 })

--- a/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.ts
+++ b/apps/yearn/src/server/lib/holdings/services/protocolReturnFamilySeries.ts
@@ -57,7 +57,7 @@ function isFiniteNumber(value: unknown): value is number {
 
 function buildPositionRankPoints(
   points: TProtocolReturnFamilyPoint[],
-  valueKey: 'growthUsd' | 'growthWeightUsd' | 'growthWeightEth' | 'growthIndexContribution'
+  valueKey: 'growthWeightUsd' | 'growthWeightEth' | 'growthIndexContribution'
 ): Array<{ value: number | null }> {
   const firstFiniteIndex = points.findIndex((point) => isFiniteNumber(point[valueKey]))
   if (firstFiniteIndex < 0 || points.length - firstFiniteIndex < 2) {
@@ -71,18 +71,6 @@ function buildPositionRankPoints(
   }
 
   return [{ value: 0 }, { value: lastValue - firstValue }]
-}
-
-function buildIndexRankPoints(points: TProtocolReturnFamilyPoint[]): Array<{ value: number | null }> {
-  const contributionPoints = buildPositionRankPoints(points, 'growthIndexContribution')
-  if (contributionPoints.some((point) => Math.abs(point.value ?? 0) > Number.EPSILON)) {
-    return contributionPoints
-  }
-
-  const baseValue = points.find((point) => isFiniteNumber(point.growthIndex))?.growthIndex
-  return points.map((point) => ({
-    value: baseValue && isFiniteNumber(point.growthIndex) ? (point.growthIndex / baseValue) * 100 : null
-  }))
 }
 
 /**
@@ -106,15 +94,11 @@ export function selectProtocolReturnFamilySeriesCandidates<TSeries extends TProt
       const limit = FAMILY_SERIES_WINDOW_LIMITS[window]
       const rankableSeries = preparedSeries.map((series) => {
         const points = limit >= series.sortedPoints.length ? series.sortedPoints : series.sortedPoints.slice(-limit)
-        const weightedPositionPoints = buildPositionRankPoints(points, 'growthWeightUsd')
-        const positionPoints = weightedPositionPoints.some((point) => Math.abs(point.value ?? 0) > Number.EPSILON)
-          ? weightedPositionPoints
-          : buildPositionRankPoints(points, 'growthUsd')
         return {
           originalIndex: series.originalIndex,
-          positionPoints,
+          positionPoints: buildPositionRankPoints(points, 'growthWeightUsd'),
           ethPoints: buildPositionRankPoints(points, 'growthWeightEth'),
-          indexPoints: buildIndexRankPoints(points)
+          indexPoints: buildPositionRankPoints(points, 'growthIndexContribution')
         }
       })
 


### PR DESCRIPTION
### Summary

Keep portfolio Index charts available when some vaults have incomplete valuation data, using a fixed subset of reliably valued vaults.

- Keep Index contributions aligned with the included subset and invalidate outdated history caches.
- Align partial-data warnings across USD, ETH, and Index without showing excluded-vault counts.
- Restore subtler chart colors and improve contribution stacking order.

### Test plan

Type checks, lint, and portfolio regression tests passed. Manually check partial-history wallets across 1Y/ALL and USD/ETH/Index views.

### Risk / impact

Index now represents the reliably valued subset when data is incomplete. No transaction-flow changes.