### PR TITLE
Fix overloaded timelock strategy calls

### DIFF
--- a/apps/yearn/src/server/lib/timelockStrategies/abi.ts
+++ b/apps/yearn/src/server/lib/timelockStrategies/abi.ts
@@ -68,6 +68,16 @@ export const strategyManagementAbi = [
   },
   {
     type: 'function',
+    name: 'add_strategy',
+    inputs: [
+      { name: 'new_strategy', type: 'address' },
+      { name: 'add_to_queue', type: 'bool' }
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
     name: 'update_max_debt_for_strategy',
     inputs: [
       { name: 'strategy', type: 'address' },
@@ -82,6 +92,17 @@ export const strategyManagementAbi = [
     inputs: [
       { name: 'strategy', type: 'address' },
       { name: 'target_debt', type: 'uint256' }
+    ],
+    outputs: [{ type: 'uint256' }],
+    stateMutability: 'nonpayable'
+  },
+  {
+    type: 'function',
+    name: 'update_debt',
+    inputs: [
+      { name: 'strategy', type: 'address' },
+      { name: 'target_debt', type: 'uint256' },
+      { name: 'max_loss', type: 'uint256' }
     ],
     outputs: [{ type: 'uint256' }],
     stateMutability: 'nonpayable'

--- a/apps/yearn/src/server/lib/timelockStrategies/decode.test.ts
+++ b/apps/yearn/src/server/lib/timelockStrategies/decode.test.ts
@@ -1,5 +1,7 @@
+import { encodeFunctionData, toFunctionSignature } from 'viem'
 import { describe, expect, it } from 'vitest'
 
+import { strategyManagementAbi } from './abi'
 import { getTimelockStrategyController } from './config'
 import { decodePendingTimelockStrategies, type TTimelockOperationStatus, type TTimelockScheduledCall } from './decode'
 
@@ -12,6 +14,13 @@ const UPDATE_MAX_DEBT_DATA =
   '0xb9ddcd68000000000000000000000000908244b6ef0e52911a380a5454aec0743598fb2000000000000000000000000000000000000000000000000000005af3107a4000'
 const UNKNOWN_DATA = '0x12345678'
 const TX_HASH = '0xa6e8a54c3ff514951bca921cc38af55278980937816e5d04cd2d88fcf406199c'
+const LIVE_OPERATION_ID = '0xe63a430741d287c67f94270539983b381e751464eb704dddcf7e2791adceeb7b'
+const LIVE_TX_HASH = '0xddff074807d813fbc600b0d42c23b457da751d422488926ee8971e17541c0d73'
+const YSWETH_VAULT = '0xAc37729B76db6438CE62042AE1270ee574CA7571'
+const WETH_VAULT = '0xd7a540ba3626c0aa66e7DB4088971d0CD64695B6'
+const YSUSDC_STRATEGY = '0x72978421a29d83Ca76E9E5A72EaBE2b363454596'
+const YSWETH_STRATEGY_A = '0x13f6Cb609959a43c3bE29407766A683b42e26D28'
+const YSWETH_STRATEGY_B = '0x5E8A9Acd00AdCED69b30D36929CbF7D4d4F9AE1F'
 
 const controller = getTimelockStrategyController(1)
 
@@ -59,7 +68,129 @@ const pendingStatus = new Map<`0x${string}`, TTimelockOperationStatus>([
   ]
 ])
 
+const livePendingStatus = new Map<`0x${string}`, TTimelockOperationStatus>([
+  [
+    LIVE_OPERATION_ID,
+    {
+      isPending: true,
+      isReady: false,
+      isDone: false,
+      timestamp: 1_789_485_011
+    }
+  ]
+])
+
+function buildLiveBatchCall({
+  args,
+  functionName,
+  index,
+  target
+}: {
+  args: readonly [`0x${string}`, boolean] | readonly [`0x${string}`, bigint]
+  functionName: 'add_strategy' | 'update_max_debt_for_strategy'
+  index: number
+  target: `0x${string}`
+}): TTimelockScheduledCall {
+  return {
+    operationId: LIVE_OPERATION_ID,
+    index,
+    target,
+    data: encodeFunctionData({ abi: strategyManagementAbi, functionName, args }),
+    delay: 604_800,
+    blockTimestamp: 1_788_911_411,
+    transactionHash: LIVE_TX_HASH
+  }
+}
+
+const liveBatchCalls = [
+  buildLiveBatchCall({ functionName: 'add_strategy', args: [YSUSDC_STRATEGY, false], index: 0, target: USD_YVAULT }),
+  buildLiveBatchCall({
+    functionName: 'update_max_debt_for_strategy',
+    args: [YSUSDC_STRATEGY, 2_500_000_000_000n],
+    index: 1,
+    target: USD_YVAULT
+  }),
+  buildLiveBatchCall({ functionName: 'add_strategy', args: [YSWETH_STRATEGY_A, true], index: 2, target: YSWETH_VAULT }),
+  buildLiveBatchCall({
+    functionName: 'update_max_debt_for_strategy',
+    args: [YSWETH_STRATEGY_A, 10_000_000_000_000_000_000_000n],
+    index: 3,
+    target: YSWETH_VAULT
+  }),
+  buildLiveBatchCall({ functionName: 'add_strategy', args: [YSWETH_STRATEGY_B, true], index: 4, target: YSWETH_VAULT }),
+  buildLiveBatchCall({
+    functionName: 'update_max_debt_for_strategy',
+    args: [YSWETH_STRATEGY_B, 10_000_000_000_000_000_000_000n],
+    index: 5,
+    target: YSWETH_VAULT
+  }),
+  buildLiveBatchCall({ functionName: 'add_strategy', args: [YSWETH_VAULT, true], index: 6, target: WETH_VAULT }),
+  buildLiveBatchCall({
+    functionName: 'update_max_debt_for_strategy',
+    args: [YSWETH_VAULT, 500_000_000_000_000_000_000n],
+    index: 7,
+    target: WETH_VAULT
+  }),
+  {
+    operationId: LIVE_OPERATION_ID,
+    index: 8,
+    target: '0xb3bd6B2E61753C311EFbCF0111f75D29706D9a41',
+    data: UNKNOWN_DATA,
+    delay: 604_800,
+    blockTimestamp: 1_788_911_411,
+    transactionHash: LIVE_TX_HASH
+  }
+] satisfies TTimelockScheduledCall[]
+
 describe('decodePendingTimelockStrategies', () => {
+  it('matches the supported strategy-management signatures in the verified vault ABI', () => {
+    expect(strategyManagementAbi.map((item) => toFunctionSignature(item))).toEqual([
+      'add_strategy(address)',
+      'add_strategy(address,bool)',
+      'update_max_debt_for_strategy(address,uint256)',
+      'update_debt(address,uint256)',
+      'update_debt(address,uint256,uint256)',
+      'set_default_queue(address[])'
+    ])
+  })
+
+  it('decodes both add_strategy overloads by selector', () => {
+    const legacyData = encodeFunctionData({
+      abi: strategyManagementAbi,
+      functionName: 'add_strategy',
+      args: [PENDING_STRATEGY]
+    })
+    const queueData = encodeFunctionData({
+      abi: strategyManagementAbi,
+      functionName: 'add_strategy',
+      args: [PENDING_STRATEGY, true]
+    })
+
+    expect(legacyData.slice(0, 10)).toBe('0xde7aeb41')
+    expect(queueData.slice(0, 10)).toBe('0xc2e73cca')
+  })
+
+  it('decodes the live mixed-vault batch scheduled in transaction 0xddff0748', () => {
+    const decodeForVault = (vaultAddress: `0x${string}`) =>
+      decodePendingTimelockStrategies({
+        controller: controller!,
+        vaultAddress,
+        scheduledCalls: liveBatchCalls,
+        operationStatuses: livePendingStatus
+      })
+
+    expect(decodeForVault(USD_YVAULT).map((item) => [item.strategyAddress, item.maxDebtRaw])).toEqual([
+      [YSUSDC_STRATEGY, '2500000000000']
+    ])
+    expect(decodeForVault(YSWETH_VAULT).map((item) => [item.strategyAddress, item.maxDebtRaw])).toEqual([
+      [YSWETH_STRATEGY_A, '10000000000000000000000'],
+      [YSWETH_STRATEGY_B, '10000000000000000000000']
+    ])
+    expect(decodeForVault(WETH_VAULT).map((item) => [item.strategyAddress, item.maxDebtRaw])).toEqual([
+      [YSWETH_VAULT, '500000000000000000000']
+    ])
+  })
+
   it('decodes the forwarded operation into one pending strategy candidate', () => {
     expect(controller).toBeDefined()
     const [candidate] = decodePendingTimelockStrategies({

--- a/apps/yearn/src/server/lib/timelockStrategies/decode.ts
+++ b/apps/yearn/src/server/lib/timelockStrategies/decode.ts
@@ -1,4 +1,4 @@
-import { decodeFunctionData, isAddressEqual, toFunctionSignature } from 'viem'
+import { decodeFunctionData, isAddressEqual, toFunctionSelector, toFunctionSignature } from 'viem'
 import { strategyManagementAbi } from './abi'
 import type { TPendingTimelockStrategy, TTimelockControllerConfig, TTimelockStrategyStatus } from './types'
 
@@ -62,7 +62,10 @@ type TDecodedUpdateMaxDebtCall = Extract<TDecodedManagementCall, { name: 'update
 function decodeManagementCall(call: TTimelockScheduledCall): TDecodedManagementCall | null {
   try {
     const decoded = decodeFunctionData({ abi: strategyManagementAbi, data: call.data })
-    const abiItem = strategyManagementAbi.find((item) => item.type === 'function' && item.name === decoded.functionName)
+    const selector = call.data.slice(0, 10)
+    const abiItem = strategyManagementAbi.find(
+      (item) => item.type === 'function' && toFunctionSelector(item) === selector
+    )
     const signature = abiItem ? toFunctionSignature(abiItem) : decoded.functionName
 
     if (decoded.functionName === 'add_strategy') {


### PR DESCRIPTION
### Summary
Pending strategy notifications were missing when a vault used the newer `add_strategy(address,bool)` overload. This change adds the verified vault management overloads and identifies decoded functions by their calldata selector.

It also adds regression coverage for the live multi-vault operation scheduled in transaction `0xddff074807d813fbc600b0d42c23b457da751d422488926ee8971e17541c0d73`.

### How to review
Review `abi.ts` first for the verified overloads, followed by the selector matching in `decode.ts`. The regression test models the scheduled USDC and WETH strategy additions and their maximum debt calls.

To test manually, open the yvUSD or yvWETH-2 vaults and confirm the Strategies tab shows a pending notification and a pending strategy row for the transactions in the timelock.

### Test plan
- [x] `bunx biome check apps/yearn/src/server/lib/timelockStrategies/abi.ts apps/yearn/src/server/lib/timelockStrategies/decode.ts apps/yearn/src/server/lib/timelockStrategies/decode.test.ts`
- [x] `bun run --cwd apps/yearn test -- src/server/lib/timelockStrategies`
- [x] `bun run tslint`
- [x] Production webpack build
- [x] Browser verification of the pending Strategies notification and row
- [x] Live API verification for all three affected vaults

### Risk / impact
This only changes read-only decoding for timelock notifications. It does not submit transactions or change vault state. Existing one-argument strategy calls remain supported. Reverting this PR restores the previous decoder behavior.